### PR TITLE
fix: z2m coordinator IP + remove workday YAML platform

### DIFF
--- a/apps/base/homeassistant/configmap.yaml
+++ b/apps/base/homeassistant/configmap.yaml
@@ -24,13 +24,8 @@ data:
         - 10.42.2.0/24 # Trust Node Network (Envoy HostNetwork)
         - 127.0.0.1
   binary_sensors.yaml: |
-    # Workday sensor — used by automations to detect weekdays.
-    - platform: workday
-      country: US
-      province: CA
-      workdays: [mon, tue, wed, thu, fri]
-
     # Time-of-day sensors — used by nightlight and thermostat automations.
+    # Note: workday sensor must be configured via the UI (no longer supports YAML platform setup).
     - platform: tod
       name: Night
       after: sunset

--- a/infra/controllers/zigbee2mqtt/configmap.yaml
+++ b/infra/controllers/zigbee2mqtt/configmap.yaml
@@ -12,7 +12,7 @@ data:
       server: mqtt://mosquitto.mosquitto
     serial:
       adapter: ember
-      port: tcp://10.42.2.125:6638
+      port: tcp://10.42.2.15:6638
     frontend:
       port: 8080
     advanced:


### PR DESCRIPTION
Two small fixes following today's debugging session.

**zigbee2mqtt**: coordinator moved to `10.42.2.15` — z2m was crash-looping with `EHOSTUNREACH` against the old `10.42.2.125` address.

**homeassistant**: remove `workday` binary sensor from `binary_sensors.yaml`. The `workday` integration no longer supports YAML platform setup in modern HA versions and was causing a startup error. Configure it via the UI instead.