### PR TITLE
chore: add AGENTS.md and standardize PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,24 @@
 ## What changed
-<!-- concise list of changes -->
+<!-- Concise bullet list of changes made -->
 
 ## Why
-<!-- What problem does this solve? -->
+<!-- What problem does this solve? Link any related issues (Fixes #N) -->
+
+## Type of change
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — no behaviour change
+- [ ] `docs` — documentation only
+- [ ] `test` — tests only
+- [ ] `ci` — CI / build system
+- [ ] `chore` — housekeeping
+
+## Checklist
+- [ ] Branch name follows `<type>/<description>` convention
+- [ ] PR title follows Conventional Commits format (`type: description`)
+- [ ] Tests added / updated for changed behaviour
+- [ ] Documentation updated (if applicable)
+- [ ] No unrelated changes in this PR
 
 ## Notes
-<!-- screenshots, instructions, or other context -->
+<!-- Screenshots, deployment steps, or anything else reviewers need to know -->


### PR DESCRIPTION
## What changed
- Add `AGENTS.md` with repository overview, structure, build commands, and architecture guidelines
- Standardize `.github/pull_request_template.md` across all repos

## Why
AI coding agents (Claude Code, Copilot, etc.) load `AGENTS.md` automatically to understand repo conventions before making changes. A consistent PR template ensures all PRs are easy to review and follow the same format.

## Type of change
- [x] `docs` — documentation only
- [x] `ci` — CI / build system

## Checklist
- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [x] Tests added / updated for changed behaviour
- [x] Documentation updated (if applicable)
- [x] No unrelated changes in this PR

## Notes
Part of a sweep to add agent-friendly documentation and standardize PR workflows across all repos.
