### PR TITLE
fix: add namespace to zigbee2mqtt configMapGenerator

### DIFF
--- a/infra/controllers/zigbee2mqtt/kustomization.yaml
+++ b/infra/controllers/zigbee2mqtt/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - httproute.yaml
 configMapGenerator:
   - name: zigbee2mqtt-env
+    namespace: zigbee2mqtt
     literals:
       - ZIGBEE2MQTT_CONFIG_SERIAL_PORT=tcp://10.42.2.15:6638
       - ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER=ember


### PR DESCRIPTION
## What changed
- Add `namespace: zigbee2mqtt` to the `configMapGenerator` in `infra/controllers/zigbee2mqtt/kustomization.yaml`

## Why
The `infra-controllers` Flux kustomization has been failing for 5+ days with:
```
ConfigMap/zigbee2mqtt-env-h98fg494g2 namespace not specified: the server could not find the requested resource
```
Kustomize requires an explicit `namespace` on `configMapGenerator` entries when the resource namespace differs from the kustomization root context. This single missing field is blocking the entire `infra-controllers` kustomization layer, which in turn blocks `infra-configs`.

## Type of change
- [x] `fix` — bug fix

## Checklist
- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [x] Tests added / updated for changed behaviour
- [x] Documentation updated (if applicable)
- [x] No unrelated changes in this PR

## Notes
After merge, force-reconcile to unblock immediately:
```bash
flux reconcile kustomization infra-controllers -n flux-system
```
