### PR TITLE
fix(immich-stage): bump WAL archive path to /v3 to fix broken archiving

### DIFF
--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -42,13 +42,15 @@ spec:
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
-  # Note: uses /v2 path in S3 to avoid WAL conflicts from previous cluster system ID.
+  # Note: uses /v3 path in S3 (clean slate) — v2 WAL archiving broke ~2026-02-28 due to
+  # barman-cloud-check-wal-archive blocking on existing WAL ("Expected empty archive").
+  # serverName bumped to -v3 to ensure check-wal-archive sees a fresh path.
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: immich-db-staging-cnpg-v1-backup
-        serverName: immich-db-staging-cnpg-v1
+        serverName: immich-db-staging-cnpg-v1-v3
 
   bootstrap:
     initdb:
@@ -70,4 +72,4 @@ spec:
         name: barman-cloud.cloudnative-pg.io
         parameters:
           barmanObjectName: immich-db-staging-cnpg-v1-backup
-          serverName: immich-db-staging-cnpg-v1
+          serverName: immich-db-staging-cnpg-v1-v3

--- a/apps/staging/immich/objectstore.yaml
+++ b/apps/staging/immich/objectstore.yaml
@@ -1,5 +1,12 @@
 # ObjectStore for the Barman Cloud Plugin — immich staging.
-# Uses the /v2 path to avoid WAL archive conflicts from the previous cluster system ID.
+# Uses the /v3 path to avoid WAL archive conflicts from accumulated stale WAL in /v2.
+# History:
+#   /v1 — original path, abandoned due to WAL from a previous cluster system ID.
+#   /v2 — replacement path, but WAL archiving broke ~2026-02-28 (check-wal-archive
+#          started failing with "Expected empty archive" because existing WAL in the
+#          path blocks the barman safety check). pg_wal accumulated for ~7 weeks,
+#          filling the PVC (expanded 10Gi → 20Gi on 2026-04-18) and causing 5607 restarts.
+#   /v3 — clean slate; serverName bumped to immich-db-staging-cnpg-v1-v3 to match.
 # Defines where CNPG should store WAL archives and base backups in S3.
 # Referenced by the Cluster resource via plugins[].parameters.barmanObjectName.
 apiVersion: barmancloud.cnpg.io/v1
@@ -9,9 +16,8 @@ metadata:
   namespace: immich-stage
 spec:
   configuration:
-    # v2 path: the v1 path contains WAL from a previous cluster (different system
-    # ID), causing barman-cloud-check-wal-archive to fail. /v2 is a clean prefix.
-    destinationPath: s3://gjcourt-homelab-backup/staging/immich/v2
+    # v3 path: clean slate after /v2 accumulated stale WAL blocking barman-cloud-check-wal-archive.
+    destinationPath: s3://gjcourt-homelab-backup/staging/immich/v3
     s3Credentials:
       accessKeyId:
         name: immich-aws-creds-secret


### PR DESCRIPTION
## Problem

The barman-cloud-check-wal-archive safety check was blocking ALL WAL archiving since ~2026-02-28 with `Expected empty archive`. The `/v2` path already had WAL segments, causing the check to refuse archiving indefinitely.

**Root cause chain:**
1. `check-wal-archive` blocks when S3 path is non-empty (barman safety check)
2. `pg_wal` accumulated ~7 weeks of unarchived WAL (was 9.9G on 20G PVC)
3. Disk hit low-space threshold → CNPG refused to start → **5607 restarts**
4. PVC was expanded 10Gi → 20Gi, cluster recovered 2026-04-18T03:10Z
5. Archiving still broken → **will fill up again** without this fix

## Fix

Bump to `/v3` S3 path + `serverName: immich-db-staging-cnpg-v1-v3` to give `barman-cloud-check-wal-archive` a clean empty path, restoring WAL archiving.

**Note:** Loses PITR continuity from `/v2` (acceptable for staging).

## Verification

After merging + Flux reconcile, check:
```bash
kubectl get cluster -n immich-stage immich-db-staging-cnpg-v1 -o jsonpath='{.status.conditions}'
# Should show ContinuousArchiving: True within ~5 minutes
```