### PR TITLE
fix(cilium): point k8sServiceHost to control plane IP for worker node support

### DIFF
--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -91,7 +91,7 @@ l2announcements:
   enabled: true
 
 # -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
-k8sServiceHost: "localhost"
+k8sServiceHost: "10.42.2.20"
 # @schema
 # type: [string, integer]
 # @schema
@@ -121,13 +121,9 @@ gatewayAPI:
     # -- Configure whether the Envoy listeners should be exposed on the host network.
     enabled: false
 
-# NOTE - running with 1 replica instead of 2 because a 1 worker node is not able
-# to deploy 2 replicas on the same port.
-#
-# TODO(george): Delete this config once the cluster has more than 1 worker
 operator:
   # -- Number of replicas to run for the cilium-operator deployment
-  replicas: 1
+  replicas: 2
 
 hubble:
   # -- Enable Hubble (true by default).


### PR DESCRIPTION
## Problem

Worker node at `10.42.2.23` was `NotReady` because Cilium's `config` init container was stuck in CrashLoopBackOff, trying to connect to `https://localhost:6443`. Control plane nodes run an apiserver locally so this worked for them — but worker nodes don't.

## Root Cause

`k8sServiceHost: "localhost"` in Cilium values. The Cilium DaemonSet injects `KUBERNETES_SERVICE_HOST=localhost` into all pods on all nodes. On worker nodes there's no local apiserver, so the init container loops forever and CNI never initializes, leaving the node `NotReady`.

## Fix

- Change `k8sServiceHost` from `"localhost"` to `"10.42.2.20"` (primary control plane)
- Bump `operator.replicas` from `1` to `2` — the existing TODO comment said to do this once there's more than 1 worker node

## Verification

After merge + Flux reconcile, expect:
- Cilium pod on `talos-lmh-kyf` (10.42.2.23) config init container starts successfully
- CNI initializes on the worker node
- Node transitions to `Ready`