### PR TITLE
feat(adguard): prepare prod HA rollout

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -20,6 +20,22 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: adguard
+                topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: adguard
       containers:
         - name: adguard
           image: adguard/adguardhome@sha256:f29c58a91f79387cbbbb042e140814f58e830d457d44af03d662c8df43db9dea

--- a/apps/production/adguard/kustomization.yaml
+++ b/apps/production/adguard/kustomization.yaml
@@ -22,3 +22,26 @@ patches:
       - op: replace
         path: /metadata/name
         value: adguard-prod
+  - target:
+      kind: StatefulSet
+      name: adguard
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: adguard
+      spec:
+        replicas: 2
+        volumeClaimTemplates:
+          - metadata:
+              name: config
+            spec:
+              resources:
+                requests:
+                  storage: 1Gi
+          - metadata:
+              name: work
+            spec:
+              resources:
+                requests:
+                  storage: 5Gi

--- a/apps/production/adguard/secret-sync.yaml
+++ b/apps/production/adguard/secret-sync.yaml
@@ -5,22 +5,22 @@ metadata:
   namespace: adguard-prod
 type: Opaque
 stringData:
-  ORIGIN_USERNAME: ENC[AES256_GCM,data:KA84JKU=,iv:dP3Li5AACXfpMEK82bgQI6VpzCGPOzOvJifv1LBV71I=,tag:SljGA7xosR29bJxyN1/ufg==,type:str]
-  ORIGIN_PASSWORD: ENC[AES256_GCM,data:Q9DdJqnnInw/AwRB51M6B048Og==,iv:PUItRCNele7KXoU/7jiA7hZm8FC+lmnvWhyb+xS7vyE=,tag:1rUTSJvIKY2D7DKTq0SZCg==,type:str]
-  REPLICA1_USERNAME: ENC[AES256_GCM,data:0BWe97w=,iv:UeTz/Exk3MbC32DW7xElvVGo3GYphdfC+SCSy9ox0f8=,tag:bQVVZuC1gbkrXSg0/i/TOg==,type:str]
-  REPLICA1_PASSWORD: ENC[AES256_GCM,data:IKsDGNg2mnTvXGeNtEm9KEhr2Q==,iv:cY6pluxVYTp/sBIP8i268qaFy3NjcrVSWxzakj2Z/+w=,tag:2VYulSezwTTsbgoGD7caAQ==,type:str]
+  ORIGIN_USERNAME: ENC[AES256_GCM,data:9uWN9ZlW,iv:qaxeJjD+yPSX8caW/pxD9sw9JkApCqZd0zvSEAjUL2M=,tag:5U9fU9OZMKrwBtMFtlyw1A==,type:str]
+  ORIGIN_PASSWORD: ENC[AES256_GCM,data:/cN9tmkbqdKe7addueXLROEH5g==,iv:/IwEjSyp2HHZMZOeWxnkKMM/i29fmz0YLjgI7hmnbeI=,tag:XC7D95m6uvvIccfE9LyDBg==,type:str]
+  REPLICA1_USERNAME: ENC[AES256_GCM,data:2H4YmWwj,iv:J1mkW9x7jARIc4Bb8A9s2jUBQAeNcpZrR+o18khhUhs=,tag:uPayBS6epFpCLBIIxLgczw==,type:str]
+  REPLICA1_PASSWORD: ENC[AES256_GCM,data:EdbNEAoNTEIhgtcym8tkrewYTg==,iv:aIcE+Qll+XF2mWZWar/7YT7ldFSx6GPMQ4qlElPK+LI=,tag:UOALVzDyX+wqlQSe/pU0nw==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRWIva3lLMzd0N2NTNmpL
-        SlYwajMvNXZDRDgwR2d1cktZS3RTVk1HSVZjCkRrb2FDRmV1UVh0MFBONnpidEZH
-        S2NJeWpEaSt5ZEVkVkpZUW5OMVIwZHcKLS0tIDRsNll2RnN3Y29vY3RyVVlBT2xy
-        dDNDcHZKczR6SG1ObTRZWUNpcGxkcWMKUyoTM8Qppa+B9s5IKoKZvgopLpkXvR4k
-        76J6dMcBzJDau5hQKbj0meKXbGhtkEyw1jpnF7z1iwgZppfOQ5ndcQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByZnFBbDlFVXhhZm8veTJ3
+        RWFodHRtcnRyYmhGcnZIMXBiQkFRRnlYWDBvCkFVdUt6ZEF0b21XNzdvSyt1MEg1
+        c3IvNFFjSU5JQ0Ryb3VsV29CcW9ZbWsKLS0tIFEyYnhndnhwRmQ5MElzOEVOY1NY
+        VzdLRThoaHJubi9WN1J0Q1ZNRE0yTE0KMwwlxcoWUdh9yV2o9iM+u8w+qQlkfzCL
+        FLHB4enL9s2xTc7QI3OfYXs39GqSO5yThiDQVuFG2SyebAxlxELs8w==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-19T04:04:59Z"
-  mac: ENC[AES256_GCM,data:4lUsQEKBE4bUnGQsjG7B/fabzB7Bp6nO5tAyeT92IZP8ns7patj//o8+qkNUHAVvV8fMJ+BLWyMw3c5QoaAARofMIX9goKupGVPTk+TwIabURLg5NPLClpBtsc+GkFZkqigOvZWF9kIw8Qt0i6dbvAgrt5Rp3olZBXDaa7QwxOA=,iv:cTufGl+Ky4B8jhsIsr60ZMkEvY9Fv1vZxD776ecX3b0=,tag:QlZUhLPuqCFS4+m9L8WCAA==,type:str]
+  lastmodified: "2026-04-24T18:11:21Z"
+  mac: ENC[AES256_GCM,data:6WZC0+kmP0N9oB0vaSjytQv7fpm2Nko3FyTKa231OnW5jBecmE9PphEFoXvWKjg6F7nIwJeAB8tg5Sc2pZAmXvEVlfIKnIMnQ5D7pB/qIwqwjBpRIQIEBQCl6w6m8Z522gbjRvw9Vy4wSP+RKVp58IDlwEfqrcoznmASFE/nKtU=,iv:VKqxBMcSMB6iBMc8o10OiIHayfq+7PtgKBNL2fnIORc=,tag:6/hkgzvjtk9Vh9e6pSD0lA==,type:str]
   encrypted_regex: ^(data|stringData)$
-  version: 3.11.0
+  version: 3.12.1

--- a/apps/staging/adguard/secret-sync.yaml
+++ b/apps/staging/adguard/secret-sync.yaml
@@ -5,22 +5,22 @@ metadata:
   namespace: adguard-stage
 type: Opaque
 stringData:
-  ORIGIN_USERNAME: ENC[AES256_GCM,data:joX+ZTs=,iv:8PR1pKTAHmaMkU1U3bByrfbx6hkguU6LekyUUJZFPm8=,tag:1l0QKdv5dYl965hoRadovg==,type:str]
-  ORIGIN_PASSWORD: ENC[AES256_GCM,data:bW14Z1JOKyOVovhYuJPR4Ardjw==,iv:naEPdoILlFLg1qegWwHP9GDhgp2hr6epghBiMosyUV4=,tag:ba6osMxk5INdqmOhosXYcw==,type:str]
-  REPLICA1_USERNAME: ENC[AES256_GCM,data:zkMdSsc=,iv:F9bN20M0JQhYs3Gau+yUUZj7vqWqTtuMq4Hiq2SxEko=,tag:eLT0LHgmztzaHZYnEDDAWw==,type:str]
-  REPLICA1_PASSWORD: ENC[AES256_GCM,data:tOJtj3StrYOpGTYjdjRragxj5g==,iv:uhlR/EXB7HKC/Pgcmmzwd2qeSRBsmUmawLplJ0SOuxQ=,tag:B9LhScNw9Sn/HbwvcMOXBA==,type:str]
+  ORIGIN_USERNAME: ENC[AES256_GCM,data:fYaxJVT5,iv:BcxHGuTEhq44ZKWKHTesFOHyKtni4nctnQV0+bNHdjs=,tag:hfJiE8yJy8PM2rY/13kDWg==,type:str]
+  ORIGIN_PASSWORD: ENC[AES256_GCM,data:mxaX5/mL0BgDVHhJeBKHWeCR3A==,iv:oDCzm9EM/H/g5F756y5ABD0uBqdQMpepRpFnSoAiL9I=,tag:JWR03PystWv/ap5ZnEHAmA==,type:str]
+  REPLICA1_USERNAME: ENC[AES256_GCM,data:/Z9nSNWa,iv:ijnk3G0vC80PA1rBvxab8AqExOERAcPC9sgjEw8pD30=,tag:d8G+eaLZ2fs4BLIvOT95DQ==,type:str]
+  REPLICA1_PASSWORD: ENC[AES256_GCM,data:zyhQAUeAr++0TxzG78ApdBQw+g==,iv:eo9hbkIXkbz2UtrHtFaZOihe6qBS8fEBEwFJ6qPe/Yw=,tag:a/dAEkFoYP/w8p7rhS7I/A==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTUVpoSk9oU05vM3lrcThl
-        K3FEempUKzI2a2Vna0V6c3RDV2hwTzIxWEZzCjZWQnE0YWVjR2RaZUUyQzJMbU1u
-        T0hjeE4rTDkxQWdXVGE1ZlF2eDFUd28KLS0tIGpCNk9TcUsvaU5KQXVrTFRwTmtF
-        eGV5WFY5ajN2K0VEYy93am1RVXFqRjQK+zL5RLmOZRU0Vxi2GeBcjfA8UXXd2vcC
-        3bmMDb2ZKtFQQqYrHLtuBRHYDfS8j3DX6mGXVZ+4Oe4C5EcQLt9cng==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXZXErMHljMldid3Z4KzZV
+        WkIxSzkra3dwbm45ZU5Nc3ZrKzN0cWtreEZzClA2SzlyVGFadUxic0I2QVluZDhl
+        SjRXRWk2WkhuVDdUZ2w3V3lwYVdEMjAKLS0tIEtFOUJNdE9OOUEvOHhSSzV5MUZN
+        NjMrQUFILzN3amtCWlhvOWpyZG4zYjAKkxFBHhzAFmshdnQndP8g6AiBsHcpviK4
+        LDwgRF+9YVfKi5Midb8CwUx4h2VbNexfy4xlhJyrmW5AtJ461mbh4A==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-19T04:03:09Z"
-  mac: ENC[AES256_GCM,data:+dFDreHi/pJ6Iwud33T4z8Vhs3GqMXduIMwIqIu4HrPxpJLPh1nOrKsOKvlnxppog7LNPAYtBACWt4P5UFfU4ONNRQvmD5ZoCT+8OB+7mm1bYLipyKL8wVIeZXY9RyIog9b4krSbzcKrJKbU0D0uBPPGkTxndt5JWGNHXHjwONM=,iv:R7Qq8J57Ro9/1pkN0zDKKr0Bt+PotKj3kyMFqC/Tu/4=,tag:tMGevBFj0tQdcSkvEIXxuQ==,type:str]
+  lastmodified: "2026-04-24T18:11:21Z"
+  mac: ENC[AES256_GCM,data:hW2NUQBGmUg1PBFRS7KdXXgrrmp4Qpd29cS39tSq+DN8HHxzzgHAsUcULoPdT4YtZrdI/aOJOQJJe+WiwXnPMTJT2e8P8Z2UvD/U52Gp1W6Kj82kscX4SxhG2YomoMHA56OZGfoq0G4ZQWolGQdkV8A7lvRWo6dco/TYkiK2x74=,iv:dMn2QLliHWZxWLY/y+LJj2h9Z626xUhwS0tsuNPwTjM=,tag:b1fammvL1c1O/bHCu4GjBw==,type:str]
   encrypted_regex: ^(data|stringData)$
-  version: 3.11.0
+  version: 3.12.1

--- a/docs/plans/adguard-ha.md
+++ b/docs/plans/adguard-ha.md
@@ -10,17 +10,20 @@ This repo is structured so staging uses a `-stage` suffix and production has no 
 - Staging: `adguard-stage`
 - Production: `adguard-prod` (consider renaming to `adguard` later if you want strict consistency)
 
-## Current state (already implemented)
+## Current state (April 2026)
 
-- AdGuard is a StatefulSet with per-pod PVCs (scales cleanly):
-  - apps/base/adguard/deployment.yaml
-- UI traffic is pinned to the primary pod (`adguard-0`) via a dedicated service:
-  - apps/base/adguard/service-admin.yaml
-  - Staging UI host `adguard-stage.burntbytes.com` routes to `adguard-admin`
-- DNS is exposed via a single `LoadBalancer` service (UDP/TCP 53):
-  - apps/base/adguard/service.yaml
-- PDB exists to reduce disruption risk:
-  - apps/base/adguard/pdb.yaml
+- AdGuard is a StatefulSet with per-pod PVCs:
+  - `config` PVC stores `AdGuardHome.yaml`
+  - `work` PVC stores query logs/statistics
+- UI traffic is pinned to the primary pod (`adguard-0`) via `adguard-admin`
+- DNS is exposed via a single `LoadBalancer` service (`10.42.2.43` in prod)
+- `adguard-sync` CronJob is enabled in both prod and staging and is intended to sync config from `adguard-0` to replicas
+
+## Important prerequisite discovered during HA rollout
+
+Before scaling replicas, `adguard-sync` credentials must match the live AdGuard admin user. The live username is `george` (not `admin`). If sync fails with `401 Unauthorized`, replicas will not receive the primary config.
+
+Production also needed a larger `work` volume because query logs filled the original 1Gi PVC.
 
 ## Why “one-writer UI” matters
 


### PR DESCRIPTION
## What changed
- fix AdGuard sync credentials to use the live `george` username in prod and staging
- scale production AdGuard to 2 replicas
- expand production AdGuard `work` PVC request from 1Gi to 5Gi
- add anti-affinity and topology spread constraints so AdGuard replicas prefer different nodes
- update the AdGuard HA plan doc with the rollout prerequisites discovered during debugging

## Why
AdGuard redundancy was blocked by two issues:
1. `adguard-sync` was failing with `401 Unauthorized` because the repo secret still used `admin`, while the live AdGuard instances use `george`
2. production `/opt/adguardhome/work` was 100% full on a 1Gi PVC

This PR fixes the sync prerequisite, gives production more room for query logs/statistics, and prepares the StatefulSet to run safely across multiple nodes.

## Type of change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI / build system
- [ ] `chore` — housekeeping

## Checklist
- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [x] Tests added / updated for changed behaviour
- [x] Documentation updated (if applicable)
- [x] No unrelated changes in this PR

## Notes
- Validated rendered kustomizations with `kubectl kustomize apps/production/adguard` and `kubectl kustomize apps/staging/adguard`
- Verified live root cause before changing secrets: current AdGuard admin username is `george`, not `admin`
- After merge/reconcile, verify:
  - PVC expansion completes for `work-adguard-0`
  - `adguard-1` starts and lands on a different node
  - `adguard-sync` succeeds without 401s
  - `kubectl get endpoints -n adguard-prod adguard` shows both pods
