### PR TITLE
fix(zigbee2mqtt): change homeassistant from bool to object

### DIFF
--- a/infra/controllers/zigbee2mqtt/configmap.yaml
+++ b/infra/controllers/zigbee2mqtt/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: zigbee2mqtt
 data:
   configuration.yaml: |
-    homeassistant: true
+    homeassistant: {}
     permit_join: true
     mqtt:
       base_topic: zigbee2mqtt


### PR DESCRIPTION
## Problem

Zigbee2MQTT pod is running but refusing to start with:

```
Refusing to start because configuration is not valid, found the following errors:
- homeassistant must be object
```

## Root Cause

`configmap.yaml` had `homeassistant: true` (boolean). A recent Zigbee2MQTT version now requires this to be an object.

## Fix

Changed `homeassistant: true` → `homeassistant: {}` (empty object = enabled with defaults, preserves HA auto-discovery behavior).