### PR TITLE
fix(zigbee2mqtt): use homeassistant.enabled format

### DIFF
--- a/infra/controllers/zigbee2mqtt/configmap.yaml
+++ b/infra/controllers/zigbee2mqtt/configmap.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: zigbee2mqtt
 data:
   configuration.yaml: |
-    homeassistant: {}
+    homeassistant:
+      enabled: true
     permit_join: true
     mqtt:
       base_topic: zigbee2mqtt


### PR DESCRIPTION
Follow-up to #299. Z2M v2.9.2 rejects `homeassistant: {}` as invalid — it must have `enabled: true` set. Sourced from the migration script in `/app/dist/util/settingsMigration.js` which converts `homeassistant: true` → `{enabled: true}`.