### PR TITLE
fix(adguard): remove immutable volumeClaimTemplates from StatefulSet patch

### DIFF
--- a/apps/production/adguard/kustomization.yaml
+++ b/apps/production/adguard/kustomization.yaml
@@ -32,16 +32,3 @@ patches:
         name: adguard
       spec:
         replicas: 2
-        volumeClaimTemplates:
-          - metadata:
-              name: config
-            spec:
-              resources:
-                requests:
-                  storage: 1Gi
-          - metadata:
-              name: work
-            spec:
-              resources:
-                requests:
-                  storage: 5Gi


### PR DESCRIPTION
## Problem

After merging #298, `apps-production` kustomization got stuck:

```
StatefulSet.apps "adguard" is invalid: spec: Forbidden: updates to statefulset spec
for fields other than 'replicas', 'ordinals', 'template'... are forbidden
```

This blocked `adguard-1` from ever starting (StatefulSet stayed at `replicas: 1`).

## Root Cause

`volumeClaimTemplates` is an immutable StatefulSet field — it cannot be patched on an existing StatefulSet.

## Fix

- Remove the `volumeClaimTemplates` section from the kustomize patch (keep `replicas: 2`)
- Expanded `work-adguard-0` PVC from 1Gi → 5Gi directly via `kubectl patch pvc` (resize already in progress)

After this merges and Flux reconciles, `adguard-1` should start and join the cluster.