### PR TITLE
feat(homepage): move speakers into media section

### DIFF
--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -11,6 +11,14 @@
         icon: navidrome.png
         href: https://music.burntbytes.com
         description: Music server and streamer
+    - Kitchen:
+        icon: mdi-speaker
+        href: http://10.42.2.38
+        description: HifiBerry OS – Kitchen
+    - Living Room:
+        icon: mdi-speaker
+        href: http://10.42.2.39
+        description: HifiBerry OS – Living Room
     - Snapcast:
         icon: mdi-speaker-multiple
         href: https://snapcast.burntbytes.com
@@ -76,16 +84,6 @@
         icon: mdi-dns
         href: https://vpn.burntbytes.com
         description: DNS updater for vpn.burntbytes.com
-
-- Music:
-    - Kitchen:
-        icon: mdi-speaker
-        href: http://10.42.2.38
-        description: HifiBerry OS – Kitchen
-    - Living Room:
-        icon: mdi-speaker
-        href: http://10.42.2.39
-        description: HifiBerry OS – Living Room
 
 - Monitoring:
     - Cluster Resources:

--- a/apps/staging/homepage/services.yaml
+++ b/apps/staging/homepage/services.yaml
@@ -11,6 +11,14 @@
         icon: navidrome.png
         href: https://music.stage.burntbytes.com
         description: Music server and streamer
+    - Kitchen:
+        icon: mdi-speaker
+        href: http://10.42.2.38
+        description: HifiBerry OS – Kitchen
+    - Living Room:
+        icon: mdi-speaker
+        href: http://10.42.2.39
+        description: HifiBerry OS – Living Room
     - Snapcast:
         icon: mdi-speaker-multiple
         href: https://snapcast.stage.burntbytes.com
@@ -76,16 +84,6 @@
         icon: mdi-dns
         href: https://vpn.burntbytes.com
         description: DNS updater for vpn.burntbytes.com
-- Music:
-    - Kitchen:
-        icon: mdi-speaker
-        href: http://10.42.2.38
-        description: HifiBerry OS – Kitchen
-    - Living Room:
-        icon: mdi-speaker
-        href: http://10.42.2.39
-        description: HifiBerry OS – Living Room
-
 - Monitoring:
     - Cluster Resources:
         icon: prometheus.png


### PR DESCRIPTION
## What changed
- moved Kitchen and Living Room entries from the separate Music section into the Media section
- placed Kitchen and Living Room above Snapcast in both production and staging homepage configs
- removed the now-empty standalone Music section

## Why
This matches the requested homepage organization so audio destinations live directly with the rest of the media stack.

## Type of change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI / build system
- [ ] `chore` — housekeeping

## Checklist
- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [x] Tests added / updated for changed behaviour
- [x] Documentation updated (if applicable)
- [x] No unrelated changes in this PR

## Notes
- Validated YAML parses successfully for both production and staging service definitions.
