### PR TITLE
fix: use recreate for RWO infra controller workloads

### DIFF
--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       app: mosquitto
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:

--- a/infra/controllers/zigbee2mqtt/deployment.yaml
+++ b/infra/controllers/zigbee2mqtt/deployment.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       app: zigbee2mqtt
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:


### PR DESCRIPTION
## What changed
- set `strategy.type: Recreate` and `rollingUpdate: null` for `infra/controllers/mosquitto/deployment.yaml`
- set `strategy.type: Recreate` and `rollingUpdate: null` for `infra/controllers/zigbee2mqtt/deployment.yaml`
- aligns Git with the live recovery applied during cluster rebalance after `.24`/`.25` returned

## Why
These are single-replica Deployments backed by RWO PVCs. During the rebalance/restart wave, they deadlocked under `RollingUpdate` because the replacement pod was created before the old pod released the volume. Setting `Recreate` prevents future restart/rebalance deadlocks for these workloads.

## Type of change
- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` — no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI / build system
- [ ] `chore` — housekeeping

## Checklist
- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [ ] Tests added / updated for changed behaviour
- [ ] Documentation updated (if applicable)
- [x] No unrelated changes in this PR

## Notes
- Live recovery has already been performed in-cluster.
- This PR is the durable GitOps follow-up so future Flux-applied rollouts use `Recreate` instead of `RollingUpdate`.
- Similar base-app fixes for other RWO singletons were already present on `master`; these two infra/controller workloads were the remaining uncovered cases.
