### PR TITLE
feat(overture): production k8s deployment + TrueNAS iSCSI storage class

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overture
+  namespace: overture
+  labels:
+    app: overture
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overture
+  template:
+    metadata:
+      labels:
+        app: overture
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: overture
+          image: ghcr.io/gjcourt/overture:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: overture-db-credentials
+                  key: password
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: overture-container-env
+                  key: DB_HOST
+            - name: DATABASE_URL
+              value: "postgres://app:$(DB_PASSWORD)@$(DB_HOST):5432/app?sslmode=disable"
+          envFrom:
+            - configMapRef:
+                name: overture-container-env
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true

--- a/apps/base/overture/kustomization.yaml
+++ b/apps/base/overture/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - namespace.yaml
+  - secret-ghcr.yaml
+  - service.yaml

--- a/apps/base/overture/namespace.yaml
+++ b/apps/base/overture/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: overture
+  labels:
+    http-ingress: "true"

--- a/apps/base/overture/secret-ghcr.yaml
+++ b/apps/base/overture/secret-ghcr.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:sLQhw86/zZPCJ7VwyX1174YdYqVfjAbR9FxuSqhN/SeT7QWeaU3DdTKpysmjW6SgSfx1j5Bglc+/GGSM1Un/9bv8Uy0WRoLnupgScyCtZoE8usF8MaFRhRzibd3jh5JZOqu+F++/3nf99+ENwT7bM+3Q3S5OzSyDPLT4sTOAzfM5W4+j/e1XvsA4x2j1h4u2yLWLCHBY7ACs0jj1h2GVpvHl6+4/r+Wy76oBwOM8rFkXtGqa9ajD8WRSIQq6ZBDCTXc4xgozWNYIKv0+z85KJUeYXiSbrYWebkaHIoQQH6vARmUh3JITFCVHcwxSyPBDcE0CR0GocuUFkcO2RuyWzWrgSR5YeMFXQMd1Z91r3xkyEnXN1tLfqw==,iv:MEMr8N4V49VuhoLKXcUgP6NfX3CZ/H+/5yZ/SIvw53Q=,tag:H0g+V+gZlZaJO8ebVvrYjA==,type:str]
+kind: Secret
+metadata:
+  name: ghcr-secret
+type: kubernetes.io/dockerconfigjson
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmbFg3c25IM0xOWDlhV0dM
+        OG43WUpHUjBhV254eXBPVzVFOW5qUk1UUlh3CkJvTkl0cytLaDE4d3RWdTFyRHZ4
+        R0E2VVJwL3A5QStRakRBdlgvUXA2M0UKLS0tIGtOcUhNNlRXQlJKUGtSOGhJTU9Q
+        WmlIdUFEejE2d2ZPSFIzRWdVc1V2ZUEK97vJuo8Hj86xhgj7ndiP1hJfovptQdJW
+        tYHAMvx61BFm5uBV2AB0QQRODKpdJcgGlLDOcz+RjHChHpUTuur0yA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-15T23:56:20Z"
+  mac: ENC[AES256_GCM,data:O5RnqsvsHV41Ru1+O0iFFQ1BRMr9hawCqvS18KghHMggeSCAXA+JDQpU8XCSvvHPNbpwaOnGpnG5oa6UBaveKwssscTqsrebFhRVdlRoOq+AZEaeba2qKA+YYp7YKLfrYBU6iQvp3AVJjhUulkPwD+2r9w01CURHvm+KR8ZYyUA=,iv:2MT+ocn5KZdTlrxm01OBF0PDm/l4ZhlzdJsjMeL2UgQ=,tag:lkUwEuLq4KwTwiaILkXDzQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.11.0

--- a/apps/base/overture/service.yaml
+++ b/apps/base/overture/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: overture
+  namespace: overture
+  labels:
+    app: overture
+spec:
+  type: ClusterIP
+  selector:
+    app: overture
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/apps/production/cloudflare-tunnel/configmap.yaml
+++ b/apps/production/cloudflare-tunnel/configmap.yaml
@@ -28,5 +28,11 @@ data:
         originRequest:
           originServerName: links.burntbytes.com
 
+      # Overture (acmeUSD scaffold)
+      - hostname: overture.burntbytes.com
+        service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
+        originRequest:
+          originServerName: overture.burntbytes.com
+
       # Catch-all returns 404
       - service: http_status:404

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - mealie
   - memos
   - navidrome
+  - overture
   - snapcast
   - synology-iscsi-monitor
   - vitals

--- a/apps/production/overture/configmap.yaml
+++ b/apps/production/overture/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: overture-container-env
+  namespace: overture-prod
+  labels:
+    app: overture
+    env: production
+data:
+  APP_PORT: "8080"
+  DB_HOST: overture-db-production-cnpg-v1-rw.overture-prod.svc.cluster.local
+  TEMPO_MODE: stub
+  TEMPO_BRIDGE_URL: ""

--- a/apps/production/overture/database.yaml
+++ b/apps/production/overture/database.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: overture-db-production-cnpg-v1
+  namespace: overture-prod
+spec:
+  description: Postgres cluster for the overture application (production)
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  instances: 3
+  inheritedMetadata:
+    labels:
+      app: overture-database
+      env: production
+      policy-type: "database"
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 5Gi
+    storageClass: truenas-iscsi-ssd
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      secret:
+        name: overture-db-credentials

--- a/apps/production/overture/httproute.yaml
+++ b/apps/production/overture/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: overture-http
+  namespace: overture-prod
+spec:
+  hostnames:
+    - overture.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: overture-https
+  namespace: overture-prod
+spec:
+  hostnames:
+    - overture.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: overture
+          port: 8080

--- a/apps/production/overture/kustomization.yaml
+++ b/apps/production/overture/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: overture-prod
+resources:
+  - ../../base/overture/
+  - configmap.yaml
+  - database.yaml
+  - httproute.yaml
+  - secret-db-credentials.yaml
+
+labels:
+  - pairs:
+      env: production
+      app.kubernetes.io/instance: production
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: overture
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: overture-prod

--- a/apps/production/overture/secret-db-credentials.yaml
+++ b/apps/production/overture/secret-db-credentials.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: overture-db-credentials
+    namespace: overture
+    labels:
+        app: overture
+        env: production
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:VNx/,iv:hs5ycVFtN4DcbP66cX7ICwOGikVc9X9TRm7U6PF4ZMM=,tag:cybfpnoubAj/fr2lNcBxvQ==,type:str]
+    password: ENC[AES256_GCM,data:8G+KK3VtUcLXSF6UI3snWbfKaLb5siXBKRCG4cCJvPY=,iv:zWpN4Wpt5KYc2npU4yMqDg2ZndT5z3dXT7Xob/GtCXw=,tag:e212fuIhw8ilYsdo6gip9g==,type:str]
+sops:
+    age:
+        - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDWFA4UnFka2FUMmZpd0NM
+            WXU3TU10KzdVQXNwNVRqcEZ0dEhJNWQ5U2tZClR6OHNFdEFXSnlLclhkaStHVkRx
+            U1Y2TDBrQUNPNVIvUW1Nck51N3dBR2cKLS0tIEhPWUlHM2h1T3dWdjFZcG1lU1RB
+            cHhLWUdUWnpYd1Z3Zzh5UWJhQnVMdHcKqsm/IRqnPecHqh6wA5ioO3JBIJkJkKAJ
+            aheWil5YG2jUc7AmvX0+2P3UGKYcsIb+OpZhgh3zRlOK8S3tq8TDGw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-29T18:04:43Z"
+    mac: ENC[AES256_GCM,data:zLq03uuWy+omCQD+VNyOtTaYp81CsK+3S1RvWosD+D0IfhMYqsntno8sn53ter1yf2C65hBIRLOkg8us6m8CCps5ZkCcu2darbI0qUvDsLesXuLxohIrfxzQ72qxEnuOcHazDE3xKNf4OiM0LZBTlflFCBshXQIjdz71ynZjJtA=,iv:aBr4lSbIOMvYqAo9tl7GOM+MWxdJihMiR4av1NxG98E=,tag:BX8l6L8Lkt+DBEpt4sdYKw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/infra/controllers/democratic-csi/kustomization.yaml
+++ b/infra/controllers/democratic-csi/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml
+
+configMapGenerator:
+  - name: democratic-csi-truenas-iscsi-helm-values
+    namespace: democratic-csi
+    files:
+      - values.yaml

--- a/infra/controllers/democratic-csi/namespace.yaml
+++ b/infra/controllers/democratic-csi/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: democratic-csi

--- a/infra/controllers/democratic-csi/release.yaml
+++ b/infra/controllers/democratic-csi/release.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: democratic-csi-truenas-iscsi
+  namespace: democratic-csi
+spec:
+  interval: 12h
+  chart:
+    spec:
+      chart: democratic-csi
+      version: ">=0.14.0 <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: democratic-csi
+        namespace: democratic-csi
+      interval: 12h
+  install:
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediationStrategy: uninstall
+  driftDetection:
+    mode: enabled
+  valuesFrom:
+    - kind: ConfigMap
+      name: democratic-csi-truenas-iscsi-helm-values

--- a/infra/controllers/democratic-csi/repository.yaml
+++ b/infra/controllers/democratic-csi/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: democratic-csi
+  namespace: democratic-csi
+spec:
+  interval: 12h
+  url: https://democratic-csi.github.io/charts

--- a/infra/controllers/democratic-csi/values.yaml
+++ b/infra/controllers/democratic-csi/values.yaml
@@ -1,0 +1,79 @@
+# democratic-csi TrueNAS SCALE iSCSI driver
+# Target: 10.42.2.10 (SSD-only NAS)
+#
+# Before this HelmRelease can reconcile successfully:
+#   1. Create the API key in TrueNAS UI → Settings → API Keys
+#   2. Note the ZFS pool name (e.g. "ssd") and create a dataset for iSCSI volumes
+#      (e.g. ssd/k8s/iscsi/vols and ssd/k8s/iscsi/snaps)
+#   3. Ensure iSCSI service is running in TrueNAS and note the portal group ID
+#   4. Replace TODO values below and SOPS-encrypt this file:
+#      sops --encrypt --encrypted-regex '^(driver)$' values.yaml > values.yaml.enc
+#      (or store the API key in a separate SOPS secret and inject via secretRef)
+
+csiDriver:
+  name: "org.democratic-csi.freenas-api-iscsi"
+
+storageClasses:
+  - name: truenas-iscsi-ssd
+    defaultClass: false
+    reclaimPolicy: Delete
+    volumeBindingMode: Immediate
+    allowVolumeExpansion: true
+    parameters:
+      fsType: ext4
+
+volumeSnapshotClasses: []
+
+controller:
+  driver:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+node:
+  driver:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+driver:
+  config:
+    driver: freenas-api-iscsi
+    httpConnection:
+      protocol: http
+      host: 10.42.2.10
+      port: 80
+      # TODO: Replace with actual TrueNAS API key
+      apiKey: "REPLACE_WITH_TRUENAS_API_KEY"
+    zfs:
+      # TODO: Adjust pool/dataset paths to match your TrueNAS layout
+      datasetParentName: ssd/k8s/iscsi/vols
+      detachedSnapshotsDatasetParentName: ssd/k8s/iscsi/snaps
+      datasetEnableQuotas: true
+      datasetEnableReservation: false
+      datasetPermissionsMode: "0777"
+      datasetPermissionsUser: 0
+      datasetPermissionsGroup: 0
+    iscsi:
+      # TODO: Verify portal IP and portal/initiator group IDs in TrueNAS
+      targetPortal: 10.42.2.10:3260
+      namePrefix: csi-
+      nameSuffix: "-ssd"
+      targetGroups:
+        - targetGroupPortalGroup: 1
+          targetGroupInitiatorGroup: 1
+          targetGroupAuthType: None
+      extentInsecureTpc: true
+      extentXenCompat: false
+      extentDisablePhysicalBlocksize: true
+      extentBlocksize: 512
+      extentRpm: SSD
+      extentAvailThreshold: 0

--- a/infra/controllers/kustomization.yaml
+++ b/infra/controllers/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - cert-manager
   - cilium
   - cnpg
+  - democratic-csi
   - kube-prometheus-stack
   - loki
   - mosquitto


### PR DESCRIPTION
## Summary

- **apps/base/overture**: Deployment, Service, Namespace, SOPS-encrypted `ghcr-secret` for `ghcr.io/gjcourt/overture`; health probes on `/healthz`
- **apps/production/overture**: CNPG 3-instance Postgres cluster (`overture-db-production-cnpg-v1`) on `truenas-iscsi-ssd` StorageClass, ConfigMap with stub-mode Tempo env vars, HTTPRoutes for `overture.burntbytes.com`, SOPS-encrypted DB credentials
- **apps/production/cloudflare-tunnel**: adds `overture.burntbytes.com` ingress rule routing through existing Cilium gateway
- **infra/controllers/democratic-csi**: HelmRelease for democratic-csi TrueNAS SCALE iSCSI driver

## Before merging — required actions

1. **TrueNAS API key**: edit `infra/controllers/democratic-csi/values.yaml`, replace `REPLACE_WITH_TRUENAS_API_KEY` with an API key generated at TrueNAS UI → Settings → API Keys
2. **ZFS dataset paths**: confirm `ssd/k8s/iscsi/vols` and `ssd/k8s/iscsi/snaps` exist (or adjust paths) on TrueNAS at `10.42.2.10`
3. **iSCSI portal group**: confirm portal group ID `1` and initiator group ID `1` match your TrueNAS iSCSI configuration
4. **Manual secret** (never in git): after merge + namespace creation, run:
   ```
   kubectl create secret generic overture-secrets \
     --namespace overture-prod \
     --from-literal=TEMPO_ISSUER_PRIVATE_KEY="0x..."
   ```
   (Only needed if switching to `TEMPO_MODE=real` later)

## Test plan

- [ ] TrueNAS API key filled in and values.yaml updated before merge
- [ ] After merge: `flux get kustomizations -A` shows `apps-production` and `infra-controllers` healthy
- [ ] `kubectl get cluster -n overture-prod` shows 3/3 CNPG instances ready
- [ ] `kubectl get pods -n overture-prod` shows overture pod Running
- [ ] `curl https://overture.burntbytes.com/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)