### PR TITLE
fix(democratic-csi): correct ZFS dataset path to main/k8s/melodic-muse/iscsi

### DIFF
--- a/infra/controllers/democratic-csi/secret-driver-config.yaml
+++ b/infra/controllers/democratic-csi/secret-driver-config.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: democratic-csi-driver-config
-  namespace: democratic-csi
+    name: democratic-csi-driver-config
+    namespace: democratic-csi
 type: Opaque
 stringData:
-  driver-config-file.yaml: ENC[AES256_GCM,data:omuYl15qcdeK71lu8bmzUqZ9xevap+hL6vgWEkqe6OjiUp+cdDZkOtQ+LC9XVQ5o+yx2/5JlJgZON60dWEkR6h7phjJFM9El1Ipsm1iy0GoHCMKcW3MuFHEO4Uaz2Zxkf43h4hA+7r+T5a5mR81pQRRNjTKzfaJCpF6x1jfHT6UOfSCCKV8V5O7eb0RKrTMrDQ42VUjpPCpTPF6CeESe0QFKEIX9J9Oh47nbtuvRp871p/D5IsSGm1rww+bYviwqN+nzBhnxhgyqcZqNmWJonb1XX4PIn18LGTZdpNhlnNYaNKSWJ9TZN5S6W8ooV3uTM7nhUfqqEyy+ytvB0IQrN4NZNe0ljLGLCmnzJ3T1cs2fLyRh1hEIdBzOJNOwZC1Dz1oujxMCgjX9UiJVqt8N8DgnMNcKL3oq9wTI+OogVjcLy31+/dZK91TlCfK/byyrkuf3D+VOJEIP0x+sHUKC33+uzI5jK61UY6P02OCC/HNCB/wjq63uwOZmhLDLH/jZl4FCYLmyHrkx3Z459ZFhAQbGPnAW4ledhyihzuoX8UIvqnhJPJUeP8xZAue8LBwTduLOtUsi2VIh+Wn7koRVffKBNHxMdpfzl5LAPJW5GfK0fSR3cz/raQoTlShL9VQ8lJdsojorRjCcyAx3xhRCuyZOwVXwjm/J+9bRL+exJDiGsrKuBP4cfx2nhs4dbnORVSS/Sm/UU3D74jYy9JMrTenMFO8Ez1L90TP9ocUf4HMkXq/D9Udiznuf4b8hN1BR6WmpU2OajqGrshYA+lKNUds3ptxomQg/tYm9fDBASE8iitqLv/l6ijUvhHg4a5Lgo5lagcRkFnrafsZuQVEqZwfXx0G+voYFsFo4j0Gcj4Aa8XZ1JHFLT4/nmk1+Ol4uJMQ6hpQHtdwhOMbAoEKZCHopFjG5oVxoeyMBs6apwQ8HkJEg9yIz3Mt0WTZICmWy5TwQE1CrBiD9GfywiebkF1ZavXr0+y7HcbZR+lKDz8D25IeDLetrbxfzQfQS9GCqlzsEFdmVY73bclxE6S2+oM/wjelCb2JYzHeJ4XeJxrgLBDvFoOaxt6zHwDuoqYakCaeSX8kkl8OjcVg/vzpS4+cIsVCWFNYVdMyBo+1hrsqmXljR/UMUPY49JWCO3l2TODy9JkAjHlKfMx+l5YIpdrEzo2uuDIP0UnmB1XgrTy2oK3ZoCcPJOhQgrSgdmBaVf0hFiblbCU/w/UL8YS3Q8zeAkKHtCkJdAIyTjPtT9MuLQlfREVnzm+/hr5GtaC79TyM5UZUFmU3du/Cl2vMTWCaoPghsHLT9zBqnAoqNX1FxhpP4/+6qIKgmYem/A8RAa0zgkMboBtY8Rc9FExT+qqhXjru/uk2+hmV8QsiPo77beeO2c1GJkYUeO8aCdM86QO2jK5KeDtuRwJ+gwhkCZ5bY2TqNATDKjw0yPedUEg3+Wj/lsbDZJZuioh/pr9pLMCaO8xsSt2QXeMTYokbMpcziiec3vGzuHEkGdmpMSUqivl+5wD/Bpt9acTmB6IYC/fSx9MojIy2VlRWeIlOKDSNv07vTnxQCpcDDd7dPr+c0V4xJpjxQSK+Sb/B1cm7ecEQDvzTWTX2q1KfT1m9KGRKO2ZTU7YUFt0HnqQaaembwjbHyXXsKANn7pI3qdbUULcVws8K39kiSGTRV5JygwDj9hXVJQ2w8oCimfLXzr5GDOBvlf6OlQWCS11AkdmbcV77mwE32n9VD+VwARnQHRW6nGBRD21fpopf43r7U5egxvE5Nb1zOAsnssW4bNTBXcJu1z3SvItw3j6AKBqR/Iq5tWWDQhbanWU00XRBjTVht78IyHpfUjbA+tU1S1wO2D7D+Px5qWidNNVhyN6cAr8pl0qbVZSiC++93W5ekCNSGhs6/OgGLqxtdwMs1HRR895M+Qm2+B363Zbxs7YaKj4GWXBhyliMJOKWEu4TwMz5Sqcqqn/3wArbleSdbGkuBOjwF34gKT7ermee010sAAg==,iv:ANGOw/TSvzNK2CgtxEwnHOjoURn8SvtqgxCqFBFO+gU=,tag:ejNZei07cgM5z/T2Q82B8Q==,type:str]
+    driver-config-file.yaml: ENC[AES256_GCM,data:YVH5KG+vgaOxTfAP/qvME9zcvR0Evm4sRf92P3WzAhez4SRp5eoQHekEL19WyFBVDcTz/jOK1OU2fPdHj7O4mPjybxuvUEC30QRZkhh3oRCZmxi/aqwfWIjTr/qi4a9/Z+z1CakHesBWne0eEzAPozamZ3Bjy3REHIflXtPrT0gYH4ckIU6hZZx/586f+WayIj9iI8StHpnIt3SlTRyv/SYq40PqsCM94dzeEuieJtQeD1DwGnjODUO3cJFYLjMkkT+0blgEI84cSZYYhRaOlT7UR3NsmU5dUBjrQcRLSBkthUXvcBq6NZ1ZlLaobXUexExMg7MmZB0CxornQM1A4zs9aZrVXhSMVHVNmOPvReWp3xYPAqos+HUu99qzeSxiMnVO0XKxd1hP6wSS+vq4xsIXgf4bHsLVfEJt9I15xAz8vGgXbYhnVyKvWiEB9Bnbm297kcH8P+6wMmf1I/hTuFWH6mv/UJ9GTMkuk1uQY7ASXMpgXtVl/Daxnc01baKResaahL+6pG1sKD2lPsvcap1GSym98AD7ONMt3iCj/gz0u1JPNZNUI6s896SQVvJQPVlKF3hkmclREO1Yl3XdDH1wHIpN4LG6az4TWeBg2fooFAwJIM6Tw3i+kHyOPLFkRW6zrxl0qZoQD9hgjnhzMHsaCx2VSYHfVzn3fpr/k1Bt0sTAoPirtlMc2MaA7XiSqYs/1qEJ33FA/G1wNlNbNF/EXC1Dhgiu1CRBkL8m/p9iH6CkQ2XnjedUqGl0cyUbbV/1OeuFWqnL5pJcSR+Tkq1P1j3SkyRza7eYQ65P3kRnIHxR3AeLymfOJ8NW13nBVmUahGJ2SNBY3Brt9bK7eTaDP0jRuw9kdVPmSSWoTEmsfGRpNNimMfAZpXRL9KxGBXojPqmkWi2fys5QdDOfzpE5/6NfPmkUM9mjNzExVvW1shyfNjm9xyy/RaPe+JdUzt7fSlRXbmi1OeE09FNYBeqSHXRe1pOkspGhuFjE7w4QxavKpOwZziRtayKNuiJSXIAS48TwPXPi9976cXD9NVXV2iWj+UXOHzxrzxjBhEqz842HnRndTctPXgKas9K8XJ6Pj7iaN/DrmtbM/vWb2ReV3bgPvDLtnIBhqsVCJQ0xCcGYc9u6KLvesE1qK43Y4cue7LutG62IFE8UOloZSr1EhJM8rshD3mWFTMipnag0nXbRI+XYhhjQMA+EvxbSPcbVmNNrrwlFYUIjgHP7bDjSbRJ7XDw7nV0k8hvJUg0D0AoWQJAnP7zDcrMB9NwG+eZZgU8E4xGEdCswam05GigmoE7c/WJfInH6z8j3FZMpPMT2ebGGQv6WaS4UkKssr7gIByQJQI1bWxJ8RvO1ekiNueHYd/SPlKgxmXEbYHaQOgQRBylpKJ+fmEGBXuF4XuggZOWLCX1s3SRWhpnCz7vMSkWIMDGKCqa1xdtwVqDSIPNib8oQQ/bFi7t8RvKRySOvpjUcREbVPnQaxv9ziaFQLiBhsu1qsFr0lrOJJrgrM651bZkQPyfMUbdRCCFV1eoCtVBpJ+4sw9/3G9/g8RdFC+y4K52FOZyYx3GlSDooWpW0BCebOkltf6CzKwVTbVyH6zTmqZr77plCUdOsTYlRXqMy9RAZqOvTWYGPivLZY2iCr+ZMjZ89dNeMTb2bi6M2w69SwP6ouGJ2j4WAPr6v8Z73p4EXBkKjoUbq9u+6W+64mW9lOzZfDsW41zzYKsLdY4lRnXLuMX6xNxqG2wJ96jO7BPrs4LrWHg3WV+fmP7/snc+CXaw7xUn9E7IM2fLaUl0KOBHq/qfie5dCPdqFK9yaCg3gskhsI4g7JBrAlRYDn4pMxHETairEiqylsLJF0+Fm+lRdqMn3AB7EY+G0IbIqvwF7BsBBp1pAl+kdKYOhMLwFjLswQx+ALQEJXMs5bnz2HsS+t50YamPogBStGrEb3iJhkTgaewDxQjS6OnqNVWdm01QWs9oo02ru+rHtrQkopC+TBZEiwZk/n/yNOCLl9RPlwq0vMbGOgS8dCkpe5oEmcLpX,iv:UF1gEXGTlT2+9jy2f0Sqg71dGOVYKPC0mrjLaOi53II=,tag:o3duRlnPY0onhJp+s7IfMA==,type:str]
 sops:
-  age:
-    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSG1YRjVONERpMnVFTktJ
-        eVZSQWZhcXVtdEQ1eDhSZERCcllIU2d6Z1ZFCk5NUU5lZXc0ZHhyM3RSbngrZmxD
-        Y1ovaUh4YkNnVFVZSGtGS1F6WHV6VUUKLS0tIDA2aEFSR0ZxQk0xbWtNOE1ZS25M
-        K3ZoVTlHaFdvMDRvcDI0MjNieFpIK0kKC93R3cMh3clvO2z5rw2tpjtptwiBvNsx
-        sJgDraydtZRbNHK8psJ2NTcLtWbyU0aEB3iODg+KabAAjR5YUU+3GQ==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-29T20:20:25Z"
-  mac: ENC[AES256_GCM,data:heJLmLEnHXGTfwFicKEvK43OjArUzhAPMB1V6XB3IFnnuQdviKd49tMmKn9zb7xgV/5AvxmYyk3vbuVFTbFD5nYodzq44qkDfjHy0AuLVJAvw0gplgAh27qfs00K7PHlqdmeN5wlfHULyarn8gY/43Wze2u9RePkkkDXSEmotmk=,iv:YoK4JpDDhNb0NKesHrajFkR9QQMu/KxfeyHP4pSRUDo=,tag:YQd7m/4MOSfeo73WudWMcw==,type:str]
-  encrypted_regex: ^(data|stringData)$
-  version: 3.12.1
+    age:
+        - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBocEhVTk1reEQxZGgydGVJ
+            RTNpNmRjcFFKVDhxbStFWEZTMDhxT1MvalY4CjJ5WnA5NHF2K3RNYTFDcHlvSjBI
+            N2psR2k3ZjBxV21aOXFmbThJbFZzbVkKLS0tIFlNSE5Ecmd5QzBvaXZsb1ZUc2tY
+            MUxkKzdReHVkWUE4SVNLSGFGZHhTUFEKnqSNFqBqR/X08oQMZIYPYPqDbRXUgqS8
+            2MGtxQeJ+IA8rQy69gH/tVbjJDbTYeN/Z0iX5Jxp4hv6bp/RaULrRg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-29T20:53:20Z"
+    mac: ENC[AES256_GCM,data:XuJ+2DUZpO6Wokzv2PYXpoHfvCwZnUH+1Vhqhj62uASdB4UewEfem5EWv3S49tMEAj/YYavC4Mgp9j9PWIjyRFdQXgWepT/Jj4rSr8S5qYpTtOytTooKXaWkB+vcnJ1BXbilDrg/BOPAY/ViF6+/6+qE/CE39xWFcGYfMQp5T6Y=,iv:Or3oTgSs01CP+/UZlrjnpoU4ktFm3IwaHURJvxW0lpU=,tag:/vdEmDyP/5822Il78iz9xQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
## Problem

The democratic-csi provisioner was failing with:
```
cannot create 'main/k8s/iscsi/pvc-...': permission denied
```

The driver config had `datasetParentName: main/k8s/iscsi` but the actual existing dataset tree on TrueNAS is at `/mnt/main/k8s/melodic-muse/iscsi`.

## Fix

Updated `secret-driver-config.yaml` (SOPS encrypted):
- `datasetParentName`: `main/k8s/iscsi` → `main/k8s/melodic-muse/iscsi`
- `detachedSnapshotsDatasetParentName`: `main/k8s/snapshots` → `main/k8s/melodic-muse/snapshots`

## Expected outcome

After merge + Flux reconcile:
- democratic-csi provisioner creates PVCs under the correct ZFS dataset
- `overture-db-production-cnpg-v1-1` PVC binds
- CNPG cluster comes up
- overture pod connects to DB and starts serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)