### PR TITLE
feat(overture): set TEMPO_BROWSER_SDK_URL to wire passkey button

### DIFF
--- a/apps/production/overture/configmap.yaml
+++ b/apps/production/overture/configmap.yaml
@@ -10,4 +10,4 @@ data:
   APP_PORT: "8080"
   DB_HOST: overture-db-production-cnpg-v1-rw.overture-prod.svc.cluster.local
   TEMPO_MODE: stub
-  TEMPO_BRIDGE_URL: ""
+  TEMPO_BROWSER_SDK_URL: "https://esm.sh/@tempo-xyz/accounts"


### PR DESCRIPTION
## Summary

- Adds `TEMPO_BROWSER_SDK_URL: "https://esm.sh/@tempo-xyz/accounts"` to the overture production ConfigMap
- Removes the unused `TEMPO_BRIDGE_URL: ""` placeholder
- The `@tempo-xyz/accounts` Accounts SDK has no CDN bundle; `esm.sh` serves any npm package as browser-compatible ES module, making it suitable for the dynamic `import()` in the frontend

## What this enables

With `TEMPO_BROWSER_SDK_URL` set, `hasTempoEmbedSetup()` returns `true` on the app side (after the companion fix in tempo-interview PR #24), attaching a click listener to the "Create Tempo passkey" button. The flow then runs:

1. `sdk.Provider.create({ adapter: sdk.tempoWallet(), testnet: true })`
2. `provider.request({ method: "wallet_connect" })` — opens the Tempo passkey ceremony in the browser
3. On success, persists the wallet address via `POST /wallets`

## Test plan

- [ ] Merge tempo-interview PR #24 first (or deploy concurrently)
- [ ] After Flux reconciles, visit overture.burntbytes.com and click "Create Tempo passkey"
- [ ] Button should open the Tempo Wallet browser flow (passkey creation / sign-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)