### PR TITLE
feat(overture): wire tempo-bridge sidecar for real on-chain Tempo operations

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -70,3 +70,38 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+        - name: tempo-bridge
+          image: ghcr.io/gjcourt/overture-bridge:latest
+          ports:
+            - containerPort: 9877
+          env:
+            - name: TEMPO_ISSUER_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: overture-secrets
+                  key: TEMPO_ISSUER_PRIVATE_KEY
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9877
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9877
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: false

--- a/apps/production/overture/configmap.yaml
+++ b/apps/production/overture/configmap.yaml
@@ -9,5 +9,6 @@ metadata:
 data:
   APP_PORT: "8080"
   DB_HOST: overture-db-production-cnpg-v1-rw.overture-prod.svc.cluster.local
-  TEMPO_MODE: stub
+  TEMPO_MODE: real
+  TEMPO_BRIDGE_URL: "http://localhost:9877"
   TEMPO_BROWSER_SDK_URL: "https://esm.sh/accounts"


### PR DESCRIPTION
## Summary

- Adds `tempo-bridge` as a sidecar container to the overture Deployment — it wraps viem/tempo for mint, burn, and send operations so the Go backend can call real Tempo Moderato testnet without embedding a Node.js runtime in Go
- Switches `TEMPO_MODE` from `stub` → `real` and sets `TEMPO_BRIDGE_URL=http://localhost:9877` so the Go `MoneyClient` routes to the sidecar
- `TEMPO_ISSUER_PRIVATE_KEY` is read from the `overture-secrets` k8s Secret (applied manually with kubectl, never committed to git)

## What this enables

With the bridge sidecar running, the full flow is real end-to-end:
1. Browser passkey flow → `wallet_connect` → wallet address persisted via `POST /wallets`
2. Onramp → `POST /onramps` → bridge `POST /mint` → real AcmeUSD minted on Moderato
3. Transfer → `POST /transfers` → bridge `POST /send` → real on-chain transfer
4. Offramp → `POST /offramps` → bridge `POST /burn` → real token burn

## Pre-requisites (manual, already done)

```bash
kubectl create secret generic overture-secrets \
  --namespace overture-prod \
  --from-literal=TEMPO_ISSUER_PRIVATE_KEY='0x...' \
  --dry-run=client -o yaml | kubectl apply -f -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)