### PR TITLE
chore(overture): deploy 2026-04-30-1 (wallet dashboard)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:latest
+          image: ghcr.io/gjcourt/overture:2026-04-29-1
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:latest
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-29-1
           ports:
             - containerPort: 9877
           env:

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-29-1
+          image: ghcr.io/gjcourt/overture:2026-04-30-1
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-29-1
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-1
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary

- Pins `overture` and `overture-bridge` to `2026-04-30-1`
- New build includes: connected-wallet dashboard (onramp / transfer / offramp / balance), stale footer note removed, real-mode stresstest benchmark docs

## What's in this release
- After `wallet_connect`, a dashboard appears with live balance, onramp (3-step), transfer, and offramp panels
- All backend flows (onramp, transfer, offramp) are wired end-to-end in the UI
- Benchmark doc updated with real-mode ceiling analysis and reproduce commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)