### PR TITLE
chore: pin overture images to 2026-04-30-3

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-1
+          image: ghcr.io/gjcourt/overture:2026-04-30-3
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-1
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-3
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Pins `overture` and `overture-bridge` to `2026-04-30-3`
- Includes: passkey-auth TODO comments on mutating HTTP handlers + DESIGN.md §7.11 fix (address-based wallet idempotency)

## Test plan
- [ ] Flux reconciles and rollout completes
- [ ] https://overture.burntbytes.com/healthz returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)