### PR TITLE
feat(renovate): add active repos to monitoring

### DIFF
--- a/infra/controllers/renovate/cronjob.yaml
+++ b/infra/controllers/renovate/cronjob.yaml
@@ -16,6 +16,14 @@ spec:
 
               args:
                 - gjcourt/homelab
+                - gjcourt/llmux
+                - gjcourt/tempo-interview
+                - gjcourt/drift
+                - gjcourt/Pingo
+                - gjcourt/golinks
+                - gjcourt/vitals
+                - gjcourt/soundbyte
+                - gjcourt/python-nginx-signing
 
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
## Summary

- Adds 8 active repos to the Renovate CronJob so dependency updates are tracked across all non-trivial projects

**Repos added:**
- `gjcourt/llmux`
- `gjcourt/tempo-interview`
- `gjcourt/drift`
- `gjcourt/Pingo`
- `gjcourt/golinks`
- `gjcourt/vitals`
- `gjcourt/soundbyte`
- `gjcourt/python-nginx-signing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)