### PR TITLE
deploy: bump overture to 2026-04-30-11

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-3
+          image: ghcr.io/gjcourt/overture:2026-04-30-11
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-3
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-11
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps both containers to the latest image tag built from [gjcourt/tempo-interview@main](https://github.com/gjcourt/tempo-interview).

Changes in this image:
- Rate limiting middleware (global 300 req/s, per-IP 20 req/s)
- Two-persona UI (user `/` and admin `/admin`)
- Boulevardier CSS theme
- Wallet transaction history endpoint
- Admin liabilities events endpoint
- Readability + naming pass
- Stale MemoryLedger references removed from docs
- `/critique` Claude Code command added to project

🤖 Generated with [Claude Code](https://claude.com/claude-code)