### PR TITLE
deploy: bump overture to 2026-04-30-12

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-11
+          image: ghcr.io/gjcourt/overture:2026-04-30-12
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-11
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-12
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps both containers to `2026-04-30-12`.

Changes: wallet disconnect button + hide onboarding panel when connected (fixes no-logout and modal-loops-back-to-existing-account bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)