### PR TITLE
deploy: bump overture to 2026-04-30-15

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-12
+          image: ghcr.io/gjcourt/overture:2026-04-30-15
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-12
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-15
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps to `2026-04-30-15`: 5 themes + glass buttons + nav theme switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)