### PR TITLE
deploy: bump overture to 2026-04-30-18

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-15
+          image: ghcr.io/gjcourt/overture:2026-04-30-18
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-15
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-18
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bumps `overture` and `overture-bridge` images from `2026-04-30-15` → `2026-04-30-18`
- Picks up [tempo-interview#48](https://github.com/gjcourt/tempo-interview/pull/48): split passkey buttons into **Sign in with passkey** and **Create new account** to fix the incognito modal re-render bug

## Test plan
- [ ] https://overture.burntbytes.com loads
- [ ] "Create new account" opens Tempo modal in incognito without re-rendering on email field focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)