### PR TITLE
deploy: bump overture to 2026-04-30-19

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-19
+          image: ghcr.io/gjcourt/overture:2026-05-01-14
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-19
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-14
           ports:
             - containerPort: 9877
           env:

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-18
+          image: ghcr.io/gjcourt/overture:2026-04-30-19
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-18
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-19
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bumps `overture` and `overture-bridge` from `2026-04-30-18` → `2026-04-30-19`
- Picks up [tempo-interview#49](https://github.com/gjcourt/tempo-interview/pull/49): updated hero copy, documented known Tempo SDK limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)