### PR TITLE
deploy: bump overture to 2026-04-30-20

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-18
+          image: ghcr.io/gjcourt/overture:2026-04-30-19
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-18
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-19
           ports:
             - containerPort: 9877
           env:

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-19
+          image: ghcr.io/gjcourt/overture:2026-04-30-20
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-19
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-20
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bumps `overture` and `overture-bridge` from `2026-04-30-19` → `2026-04-30-20`
- Picks up [tempo-interview#50](https://github.com/gjcourt/tempo-interview/pull/50): click-to-copy wallet ID/address, fix address overflow, fix paste into transfer-to field

🤖 Generated with [Claude Code](https://claude.com/claude-code)