### PR TITLE
chore(overture): deploy 2026-04-30-22

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-20
+          image: ghcr.io/gjcourt/overture:2026-04-30-22
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-20
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-22
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- fix: wire Tempo fee sponsor into browser SDK `Provider.create()` — gas no longer charged from user AcmeUSD
- feat: extract shared theme system; apply theming to admin page — `/admin` now responds to the 5-palette theme switcher

## Test plan
- [ ] Visit overture.burntbytes.com — theme switcher works on both `/` and `/admin`
- [ ] Onramp / transfer / offramp — no unexpected AcmeUSD deducted for gas

🤖 Generated with [Claude Code](https://claude.com/claude-code)