### PR TITLE
chore(overture): bump image to 2026-04-30-16 (wallet signup fix)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-23
+          image: ghcr.io/gjcourt/overture:2026-04-30-16
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-23
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-16
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bumps overture and overture-bridge images from `2026-04-30-23` → `2026-04-30-16`
- Fixes signup 500: `POST /wallets` now returns the user's existing wallet when they re-register with a different Tempo address instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)