### PR TITLE
chore(overture): bump to 2026-04-30-34

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-33
+          image: ghcr.io/gjcourt/overture:2026-04-30-34
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-33
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-34
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Per-browser unique user_id fix; 409 on wallet conflict.