### PR TITLE
chore(overture): bump to 2026-04-30-35

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-34
+          image: ghcr.io/gjcourt/overture:2026-04-30-35
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-34
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-35
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bump overture and overture-bridge images to `2026-04-30-35`
- Reinstates `FindByUserID` fallback so users reconnecting with a new passkey address get their existing wallet back (fixes 409 on re-login)
- Removes reviewer_demo user_id/display_name form fields from UI (identity is anchored to Tempo passkey address)

## Test plan
- [ ] Connect passkey — wallet created successfully
- [ ] Re-connect with same passkey — same wallet returned
- [ ] Existing accounts (e.g. gjcourt+tempo-0001) no longer get 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)