### PR TITLE
chore(overture): bump to 2026-04-30-36

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-35
+          image: ghcr.io/gjcourt/overture:2026-04-30-36
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-35
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-36
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary
- Bump overture and overture-bridge to `2026-04-30-36`
- Fixes: multiple Tempo accounts in the same browser were sharing a single wallet
- Root cause was browser-scoped `user_id`; fix uses wallet address as `user_id` so identity is anchored to the Tempo passkey

## Test plan
- [ ] Connect Tempo account A → wallet created
- [ ] Disconnect → connect Tempo account B (different passkey) → different wallet
- [ ] Reconnect account A in a new tab → same wallet as first connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)