### PR TITLE
chore(overture): bump to 2026-04-30-37

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-36
+          image: ghcr.io/gjcourt/overture:2026-04-30-37
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-36
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-37
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Fixes stale JS cache: adds `Cache-Control: no-cache` to static assets so browsers revalidate after each deploy instead of serving 4-hour-old JS.