### PR TITLE
chore(overture): bump to 2026-04-30-38

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-04-30-37
+          image: ghcr.io/gjcourt/overture:2026-04-30-38
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-37
+          image: ghcr.io/gjcourt/overture-bridge:2026-04-30-38
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Content-hash cache busting: static assets get `?v=<commithash>` and are cached for 1 year; HTML pages get `no-cache` so browsers always pick up fresh asset URLs after deploys.