### PR TITLE
deploy: bump overture to 2026-05-01-11 (user-owned P2P transfers)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-10
+          image: ghcr.io/gjcourt/overture:2026-05-01-11
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-10
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-11
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
## Summary

Bumps  and  from `2026-05-01-10` → `2026-05-01-11`.

Picks up [tempo-interview#72](https://github.com/gjcourt/tempo-interview/pull/72): P2P transfers now use user-owned transactions via `wallet_sendCalls` (EIP-5792) with passkey signing. The issuer bridge no longer relays user-to-user transfers.