### PR TITLE
deploy: bump overture to 2026-05-01-12 (require wallet_sendCalls)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-10
+          image: ghcr.io/gjcourt/overture:2026-05-01-11
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-10
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-11
           ports:
             - containerPort: 9877
           env:

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-11
+          image: ghcr.io/gjcourt/overture:2026-05-01-12
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-11
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-12
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps overture and overture-bridge to 2026-05-01-12. Fixes P2P transfers to require Tempo Wallet SDK for on-chain signing — no bridge fallback.