### PR TITLE
deploy: bump overture to 2026-05-01-13 (revert transfer to issuer-relay)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-12
+          image: ghcr.io/gjcourt/overture:2026-05-01-13
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-12
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-13
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps overture and overture-bridge to 2026-05-01-13. Reverts transfer flow back to issuer-relay path to fix wallet_sendCalls stack overflow error.