### PR TITLE
deploy: bump overture to 2026-05-01-29

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-28
+          image: ghcr.io/gjcourt/overture:2026-05-01-29
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-28
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-29
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps both containers from `2026-05-01-28` → `2026-05-01-29`.

Built from [tempo-interview PR #74](https://github.com/gjcourt/tempo-interview/pull/74):
- `setAuthButtons`: hides Sign-in / Register buttons when wallet is active (prevents accidental wallet orphaning)
- Adversarial E2E test suite added (`e2e/`)
- Prometheus `/metrics` endpoint (already in -28, carried forward)

## PR checklist
- [x] Image tags are strictly increasing (28 → 29)
- [x] No secrets
- [x] No kustomize structure changes