### PR TITLE
fix: remove rollingUpdate: null from mosquitto Recreate strategy

### DIFF
--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       app: mosquitto
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary
- `infra-controllers` Flux kustomization was failing dry-run validation on the mosquitto Deployment because `rollingUpdate: null` is forbidden when `strategy.type` is `Recreate`
- This blocked `infra-configs` (which depends on `infra-controllers`), preventing the overture Grafana dashboard ConfigMap from ever being applied to the cluster
- Fix: remove the `rollingUpdate: null` line — the field must be absent, not null, for `Recreate` strategy

## Root cause chain
```
infra-controllers FAILS (mosquitto dry-run invalid)
  → infra-configs NOT READY (dependency not satisfied)
    → overture-dashboard ConfigMap never applied
      → Grafana dashboard missing
```

## Test plan
- [ ] Flux `infra-controllers` kustomization reconciles successfully
- [ ] Flux `infra-configs` kustomization reconciles successfully  
- [ ] `kubectl get configmap overture-dashboard -n monitoring` returns the ConfigMap
- [ ] Grafana shows the "Overture (AcmeUSD)" dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)