### PR TITLE
feat: renovate-automerge daily CronJob

### DIFF
--- a/infra/controllers/kustomization.yaml
+++ b/infra/controllers/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   # - pingo
   - promtail
   - renovate
+  - renovate-automerge
   - snapshot
   - synology-csi
   - vector

--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       app: mosquitto
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:

--- a/infra/controllers/renovate-automerge/configmap.yaml
+++ b/infra/controllers/renovate-automerge/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-automerge-env
+  namespace: renovate
+data:
+  GITHUB_REPO: gjcourt/homelab
+  EMAIL_TO: gjcourt@gmail.com
+  SMTP_HOST: smtp.gmail.com
+  SMTP_PORT: "587"

--- a/infra/controllers/renovate-automerge/cronjob.yaml
+++ b/infra/controllers/renovate-automerge/cronjob.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: renovate-automerge
+  namespace: renovate
+spec:
+  schedule: "0 8 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: automerge
+              image: python:3.13-slim
+              command: ["python3", "/scripts/automerge.py"]
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: secret-renovate-container-env
+                      key: RENOVATE_TOKEN
+              envFrom:
+                - configMapRef:
+                    name: renovate-automerge-env
+                - secretRef:
+                    name: secret-renovate-automerge-env
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+          volumes:
+            - name: script
+              configMap:
+                name: renovate-automerge-script
+          restartPolicy: Never

--- a/infra/controllers/renovate-automerge/kustomization.yaml
+++ b/infra/controllers/renovate-automerge/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - cronjob.yaml
+  - script-configmap.yaml
+  - secret.yaml

--- a/infra/controllers/renovate-automerge/script-configmap.yaml
+++ b/infra/controllers/renovate-automerge/script-configmap.yaml
@@ -1,0 +1,204 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-automerge-script
+  namespace: renovate
+data:
+  automerge.py: |
+    #!/usr/bin/env python3
+    """
+    Renovate automerge: merges digest/patch-only Renovate PRs with passing CI.
+    Non-minor PRs are reported by email to EMAIL_TO.
+    """
+    import json
+    import os
+    import re
+    import smtplib
+    import sys
+    import urllib.request
+    import urllib.error
+    from datetime import datetime
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    GITHUB_REPO  = os.environ.get("GITHUB_REPO", "gjcourt/homelab")
+    EMAIL_TO     = os.environ.get("EMAIL_TO", "gjcourt@gmail.com")
+    SMTP_HOST    = os.environ.get("SMTP_HOST", "smtp.gmail.com")
+    SMTP_PORT    = int(os.environ.get("SMTP_PORT", "587"))
+    SMTP_USER    = os.environ["SMTP_USER"]
+    SMTP_PASS    = os.environ["SMTP_PASS"]
+
+
+    def gh(path, method="GET", body=None):
+        url = "https://api.github.com" + path
+        data = json.dumps(body).encode() if body else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"token {GITHUB_TOKEN}")
+        req.add_header("Accept", "application/vnd.github.v3+json")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+
+
+    def is_renovate_pr(pr):
+        return (
+            pr["title"].startswith("chore(deps):")
+            or "renovate" in pr["user"]["login"].lower()
+        )
+
+
+    def classify_pr(pr):
+        """Return (safe: bool, reason: str) based on title and PR body."""
+        title = pr["title"].lower()
+
+        # Digest pins are always safe — content-addressed, same logical version.
+        if "digest" in title:
+            return True, "digest pin"
+
+        # Renovate includes an update-type column in its PR body table.
+        # Values: digest, pinDigest, pin, patch, minor, major, rollback
+        body = pr.get("body") or ""
+        types = re.findall(
+            r"\|\s*(major|minor|patch|digest|pin|pinDigest|rollback)\s*\|",
+            body,
+            re.IGNORECASE,
+        )
+        if types:
+            kinds = {t.lower() for t in types}
+            if kinds <= {"patch", "digest", "pin", "pindigest"}:
+                return True, "update type: " + ", ".join(sorted(kinds))
+            return False, "update type: " + ", ".join(sorted(kinds))
+
+        # Fallback: parse two version strings from title and compare.
+        versions = re.findall(r"\d+\.\d+(?:\.\d+)*", pr["title"])
+        if len(versions) >= 2:
+            a = [int(x) for x in versions[0].split(".")]
+            b = [int(x) for x in versions[-1].split(".")]
+            while len(a) < 3:
+                a.append(0)
+            while len(b) < 3:
+                b.append(0)
+            if a[0] != b[0]:
+                return False, f"major bump ({versions[0]} -> {versions[-1]})"
+            if a[1] != b[1]:
+                return False, f"minor bump ({versions[0]} -> {versions[-1]})"
+            return True, f"patch bump ({versions[0]} -> {versions[-1]})"
+
+        return False, "cannot determine update type"
+
+
+    def ci_passing(pr):
+        """True only when every completed check has succeeded."""
+        sha = pr["head"]["sha"]
+        try:
+            result = gh(f"/repos/{GITHUB_REPO}/commits/{sha}/check-runs")
+            runs = result.get("check_runs", [])
+            if not runs:
+                combined = gh(f"/repos/{GITHUB_REPO}/commits/{sha}/status")
+                state = combined.get("state", "")
+                return state in ("success", "pending")
+            completed = [r for r in runs if r["status"] == "completed"]
+            return all(r["conclusion"] == "success" for r in completed)
+        except Exception as exc:
+            print(f"    CI check error: {exc}", flush=True)
+            return False
+
+
+    def merge_pr(pr):
+        number = pr["number"]
+        try:
+            gh(
+                f"/repos/{GITHUB_REPO}/pulls/{number}/merge",
+                method="PUT",
+                body={"merge_method": "merge", "commit_title": pr["title"]},
+            )
+            return True
+        except urllib.error.HTTPError as exc:
+            print(f"    merge failed: {exc.code} {exc.reason}", flush=True)
+            return False
+
+
+    def send_report(merged, held):
+        lines = [
+            f"Renovate automerge -- {datetime.utcnow().strftime('%Y-%m-%d')}",
+            f"Repo: https://github.com/{GITHUB_REPO}",
+            "",
+        ]
+        if merged:
+            lines.append(f"Merged ({len(merged)}):")
+            for item in merged:
+                pr = item["pr"]
+                lines.append(f"  #{pr['number']}: {pr['title']}")
+                lines.append(f"    ({item['reason']})")
+            lines.append("")
+        if held:
+            lines.append(f"Needs review ({len(held)}):")
+            for item in held:
+                pr = item["pr"]
+                lines.append(f"  #{pr['number']}: {pr['title']}")
+                lines.append(f"    https://github.com/{GITHUB_REPO}/pull/{pr['number']}")
+                lines.append(f"    ({item['reason']})")
+            lines.append("")
+
+        body = "\n".join(lines)
+        subject = (
+            f"[homelab] renovate: {len(merged)} merged, {len(held)} pending review"
+        )
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = SMTP_USER
+        msg["To"] = EMAIL_TO
+        msg.attach(MIMEText(body, "plain"))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(SMTP_USER, SMTP_PASS)
+            server.sendmail(SMTP_USER, EMAIL_TO, msg.as_string())
+        print("Email sent.", flush=True)
+
+
+    def main():
+        run_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+        print(f"renovate-automerge {run_at}  repo={GITHUB_REPO}", flush=True)
+
+        prs = gh(f"/repos/{GITHUB_REPO}/pulls?state=open&per_page=100")
+        renovate = [pr for pr in prs if is_renovate_pr(pr)]
+        print(f"Open PRs: {len(prs)} total, {len(renovate)} from Renovate", flush=True)
+
+        merged, held = [], []
+
+        for pr in renovate:
+            print(f"\nPR #{pr['number']}: {pr['title']}", flush=True)
+            safe, reason = classify_pr(pr)
+            if not safe:
+                print(f"  -> hold: {reason}", flush=True)
+                held.append({"pr": pr, "reason": reason})
+                continue
+
+            print(f"  -> {reason}, checking CI ...", flush=True)
+            if not ci_passing(pr):
+                reason += " (CI not passing)"
+                print(f"  -> hold: {reason}", flush=True)
+                held.append({"pr": pr, "reason": reason})
+                continue
+
+            if merge_pr(pr):
+                print(f"  -> merged", flush=True)
+                merged.append({"pr": pr, "reason": reason})
+            else:
+                held.append({"pr": pr, "reason": reason + " (merge failed)"})
+
+        print(f"\nDone: {len(merged)} merged, {len(held)} held.", flush=True)
+
+        if merged or held:
+            try:
+                send_report(merged, held)
+            except Exception as exc:
+                print(f"Email failed: {exc}", file=sys.stderr, flush=True)
+                sys.exit(1)
+
+
+    if __name__ == "__main__":
+        main()

--- a/infra/controllers/renovate-automerge/secret.yaml
+++ b/infra/controllers/renovate-automerge/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-renovate-automerge-env
+  namespace: renovate
+stringData:
+  SMTP_USER: ENC[AES256_GCM,data:rlLiDva1JxxAFDIdCuQzZlk=,iv:682upu6YfdPRYDtczzPfIILPYKGt9WX9caMnbicH8Ic=,tag:iOQIT8HP2uaq3uK7NyRuVQ==,type:str]
+  SMTP_PASS: ENC[AES256_GCM,data:EXTSGAtAftOBGq4kmfq05vrQLAbLB2IVtClTc3nNUw==,iv:uPD+VD2ceDdedlqxyNz493qlCuqvRBLo3HZ50cfxyuI=,tag:cQ36t1CqCaswsfCy7H2ywQ==,type:str]
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVUxGMFo1MkZBT2Ztbkc5
+        Tm05R0xneGZhb2tYMnlRTnV4QVFoYTU5YnhZCndmelNUY0V1MzJxNzVZN0NNVFoy
+        NWJwQWFlK3ZKbDRtYzVKRnh4UzBqa00KLS0tIG1pVW5YNGhRRTQvUUVpWUZDblM3
+        Q2gzUVlkc2NOTUdyaXVnWWdCQUFrQVkKfLveOyNJPkd54yAsvsQZt51Xgrvj+92w
+        GporjYr+V2zWob/MpneZSb09A7msV/S1LRpmhvy4jBc8br5d76yy2g==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-01T18:46:31Z"
+  mac: ENC[AES256_GCM,data:CcRDfTyzYRriOhLESO1hH6JF0oe+lKxt4AUnGRPeuL9EU9xdqT3nd9/zuYcNEg/he+bu3E5npEU3SJOgU8trn0Y+6yxr3hDYBLgHJ+I87PMAs2OtfMdl4/Fg/taLP/OFobMh0CtJb76eDewGgH4HLxDF3y+HV9nDFADPmBacM9M=,iv:TjIj7wmywMaKZjzFBtexHP8/K6Z0F1anJLj06KO4IWQ=,tag:Q4ZYvimRWfo1Mium+Z1s7Q==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.1


### PR DESCRIPTION
## Summary

- Adds `infra/controllers/renovate-automerge/` — a daily CronJob (08:00 UTC) that walks open Renovate PRs and auto-merges safe ones
- **Auto-merges**: digest pins, patch-only bumps — with passing CI
- **Holds + emails**: minor/major bumps, unclassifiable PRs → sends a report to gjcourt@gmail.com
- Classification uses Renovate's own update-type column from the PR body, with a version-string fallback
- `GITHUB_TOKEN` reused from `secret-renovate-container-env` (RENOVATE_TOKEN) — no new GitHub secret needed
- Runs in the existing `renovate` namespace alongside the Renovate bot

## Before merging

Fill in the Gmail App Password in the SOPS secret:

```sh
sops infra/controllers/renovate-automerge/secret.yaml
# set SMTP_PASS to a Gmail App Password
# (myaccount.google.com/apppasswords)
```

## Test plan

- [ ] Set `SMTP_PASS` in secret via `sops`
- [ ] Trigger a manual job run: `kubectl create job --from=cronjob/renovate-automerge -n renovate test-run`
- [ ] Confirm logs show correct PR classification
- [ ] Confirm email arrives at gjcourt@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)