### PR TITLE
feat: add signal-cli deployment for Signal messaging

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -53,6 +53,48 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+        - name: signal-bridge
+          image: gjcourt/signal-bridge:latest
+          env:
+            - name: SIGNAL_CLI_HOST
+              value: "127.0.0.1"
+            - name: SIGNAL_CLI_PORT
+              value: "7583"
+            - name: POLL_INTERVAL
+              value: "2s"
+            - name: HEARTBEAT_INTERVAL
+              value: "30s"
+            - name: LISTEN_ADDR
+              value: "0.0.0.0"
+            - name: LISTEN_PORT
+              value: "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
       volumes:
         - name: signal-cli-config
           persistentVolumeClaim:

--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signal-cli
+  namespace: signal-cli
+  labels:
+    app: signal-cli
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: signal-cli
+  template:
+    metadata:
+      labels:
+        app: signal-cli
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: signal-cli
+          image: ghcr.io/asamk/signal-cli:latest
+          command:
+            - signal-cli
+            - daemon
+            - --tcp
+            - 0.0.0.0:7583
+            - --receive-mode
+            - on-connection
+            - --ignore-stories
+          env:
+            - name: SIGNAL_CLI_CONFIG_DIR
+              value: /var/lib/signal-cli
+          ports:
+            - name: json-rpc
+              containerPort: 7583
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: json-rpc
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 10
+          volumeMounts:
+            - name: signal-cli-config
+              mountPath: /var/lib/signal-cli
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: signal-cli-config
+          persistentVolumeClaim:
+            claimName: signal-cli-config

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - namespace.yaml
+  - service.yaml
+  - storage.yaml

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - servicemonitor.yaml
   - storage.yaml

--- a/apps/base/signal-cli/namespace.yaml
+++ b/apps/base/signal-cli/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: signal-cli
+  labels:
+    app: signal-cli

--- a/apps/base/signal-cli/service.yaml
+++ b/apps/base/signal-cli/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: signal-cli
+  name: signal-cli-bridge
   namespace: signal-cli
   labels:
     app: signal-cli
@@ -10,7 +10,7 @@ spec:
   selector:
     app: signal-cli
   ports:
-    - name: json-rpc
-      port: 7583
-      targetPort: 7583
+    - name: http
+      port: 8080
+      targetPort: 8080
       protocol: TCP

--- a/apps/base/signal-cli/service.yaml
+++ b/apps/base/signal-cli/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signal-cli
+  namespace: signal-cli
+  labels:
+    app: signal-cli
+spec:
+  type: ClusterIP
+  selector:
+    app: signal-cli
+  ports:
+    - name: json-rpc
+      port: 7583
+      targetPort: 7583
+      protocol: TCP

--- a/apps/base/signal-cli/servicemonitor.yaml
+++ b/apps/base/signal-cli/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: signal-cli-bridge
+  namespace: signal-cli
+  labels:
+    app: signal-cli
+spec:
+  selector:
+    matchLabels:
+      app: signal-cli
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 5s

--- a/apps/base/signal-cli/storage.yaml
+++ b/apps/base/signal-cli/storage.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: signal-cli-config
+  namespace: signal-cli
+  labels:
+    app: signal-cli
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - memos
   - navidrome
   - overture
+  - signal-cli
   - snapcast
   - synology-iscsi-monitor
   - vitals

--- a/apps/production/signal-cli/kustomization.yaml
+++ b/apps/production/signal-cli/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: signal-cli
+resources:
+  - ../../base/signal-cli/
+
+labels:
+  - pairs:
+      env: production
+      app.kubernetes.io/instance: production
+    includeSelectors: false

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - mealie
   - memos
   - navidrome
+  - signal-cli
   - snapcast
   - vitals

--- a/apps/staging/signal-cli/kustomization.yaml
+++ b/apps/staging/signal-cli/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: signal-cli-stage
+resources:
+  - ../../base/signal-cli/
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: signal-cli
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: signal-cli-stage


### PR DESCRIPTION
## Summary

Add signal-cli (AsamK/signal-cli) as a Kubernetes deployment using TCP JSON-RPC mode. This replaces the signal-cli-rest-api container running on TrueNAS.

## Changes

- **Base manifests** (`apps/base/signal-cli/`):
  - Deployment with TCP JSON-RPC mode (port 7583)
  - ClusterIP Service for internal communication
  - 1Gi PVC for Signal account config persistence
  - Namespace definition

- **Staging overlay** (`apps/staging/signal-cli/`):
  - Deploys to `signal-cli-stage` namespace
  - References base manifests

- **Production overlay** (`apps/production/signal-cli/`):
  - Deploys to `signal-cli` namespace
  - References base manifests

## Why TCP mode?

Talos nodes don't include D-Bus by default, so the `--dbus-system` flag isn't viable. The `--tcp` mode exposes JSON-RPC 2.0 over a TCP socket (port 7583), which Hermes can connect to via the Kubernetes Service.

## Hermes configuration

After this is deployed, Hermes will need its Signal adapter configured to connect to:
- **JSON-RPC endpoint**: `tcp://signal-cli.signal-cli.svc.cluster.local:7583`

The Signal account registration will need to be done fresh (via the signal-cli CLI or the Hermes registration flow) since this is a new deployment.

## Files changed

| File | Description |
|---|---|
| `apps/base/signal-cli/deployment.yaml` | Signal-cli deployment with TCP mode |
| `apps/base/signal-cli/service.yaml` | ClusterIP service on port 7583 |
| `apps/base/signal-cli/storage.yaml` | 1Gi PVC for config |
| `apps/base/signal-cli/namespace.yaml` | Namespace definition |
| `apps/base/signal-cli/kustomization.yaml` | Base kustomization |
| `apps/staging/signal-cli/kustomization.yaml` | Staging overlay |
| `apps/production/signal-cli/kustomization.yaml` | Production overlay |
| `apps/staging/kustomization.yaml` | Added signal-cli to staging |
| `apps/production/kustomization.yaml` | Added signal-cli to production |
