### PR TITLE
deploy(overture): bump image to 2026-05-01-30

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-29
+          image: ghcr.io/gjcourt/overture:2026-05-01-30
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-29
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-30
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps both containers to `2026-05-01-30` (built by [GHA run 25236436790](https://github.com/gjcourt/tempo-interview/actions/runs/25236436790) from PR #79).

**What's in this build:**
- Compliance event outbox (written atomically inside ledger transactions)
- Postgres audit log adapter + `/admin/audit-log` endpoint
- Sanctions screener port + empty-list adapter
- Reconciliation worker (30s background loop, Prometheus gauges)
- `/admin/*` role-based middleware (opt-in via `ADMIN_OPERATOR_KEY`)
- All three compliance/risk/failure-modes plans merged to main

**Images:**
- `ghcr.io/gjcourt/overture:2026-05-01-30`
- `ghcr.io/gjcourt/overture-bridge:2026-05-01-30`