### PR TITLE
deploy(overture): bump image to 2026-05-01-31

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-29
+          image: ghcr.io/gjcourt/overture:2026-05-01-31
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-29
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-31
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Bumps both containers to `2026-05-01-31` (built by [GHA run 25237676265](https://github.com/gjcourt/tempo-interview/actions/runs/25237676265) from PR #80).

**What's in this build:**
- On-chain transaction IDs are now clickable links to the Tempo explorer
- Onramp and transfer success messages link to `$TEMPO_EXPLORER_URL/tx/<id>`
- Falls back to plain text when explorer URL is empty

**Images:**
- `ghcr.io/gjcourt/overture:2026-05-01-31`
- `ghcr.io/gjcourt/overture-bridge:2026-05-01-31`