### PR TITLE
deploy(overture): bump image to 2026-05-02

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: overture
-          image: ghcr.io/gjcourt/overture:2026-05-01-31
+          image: ghcr.io/gjcourt/overture:2026-05-02
           ports:
             - containerPort: 8080
           env:
@@ -71,7 +71,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
         - name: tempo-bridge
-          image: ghcr.io/gjcourt/overture-bridge:2026-05-01-31
+          image: ghcr.io/gjcourt/overture-bridge:2026-05-02
           ports:
             - containerPort: 9877
           env:


### PR DESCRIPTION
Built from gjcourt/tempo-interview PR #81 by GHA run 25238848987. Fix admin 0x tx references as clickable explorer links.