### PR TITLE
fix(infra): remove rollingUpdate from Recreate strategy deployments

### DIFF
--- a/infra/controllers/zigbee2mqtt/deployment.yaml
+++ b/infra/controllers/zigbee2mqtt/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       app: zigbee2mqtt
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary
- `zigbee2mqtt/deployment.yaml` had `rollingUpdate: null` alongside `type: Recreate` — Kubernetes dry-run rejects this combination, which has blocked `infra-controllers` → `infra-configs` reconciliation for 57 days
- Both mosquitto and zigbee2mqtt live deployments were manually patched to `Recreate` (removing the RollingUpdate defaults from an old apply)
- This PR removes the stale `rollingUpdate: null` line from the zigbee2mqtt YAML so future Flux reconciliations pass the dry-run

## Effect
- `infra-controllers` and `infra-configs` are now reconciling cleanly
- The overture Grafana dashboard ConfigMap (`overture-dashboard`) has been applied to the monitoring namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)