### PR TITLE
feat(adguard): add secondary DNS LoadBalancer for UniFi backup

### DIFF
--- a/apps/production/adguard/kustomization.yaml
+++ b/apps/production/adguard/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - httproute.yaml
   - secret-adguard-container-env.yaml
   - secret-sync.yaml
+  - service-dns-secondary.yaml
 
 labels:
   - pairs:

--- a/apps/production/adguard/service-dns-secondary.yaml
+++ b/apps/production/adguard/service-dns-secondary.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: adguard-dns-secondary
+  namespace: adguard
+  labels:
+    app: adguard
+    app.kubernetes.io/name: adguard
+  annotations:
+    lbipam.cilium.io/ip-pool: home-c-pool
+    # Distinct sharing-key so this service gets a different IP from the primary
+    # `adguard` service (sharing-key: homelab). Both services select the same
+    # pods — second IP is for UniFi backup DNS.
+    lbipam.cilium.io/sharing-key: adguard-dns-secondary
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: adguard
+  ports:
+    - name: dns
+      port: 53
+      targetPort: dns
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      targetPort: dns-tcp
+      protocol: TCP


### PR DESCRIPTION
## Summary
- Production-overlay-only `Service` (`adguard-dns-secondary`) that selects the same `adguard` pods on port 53 (UDP/TCP)
- Distinct `lbipam.cilium.io/sharing-key: adguard-dns-secondary` forces Cilium to allocate a different IP from the primary `adguard` service (which uses sharing-key `homelab`)
- Cilium will auto-allocate the next free IP from `home-c-pool` (currently `10.42.2.45`)
- Both LoadBalancer IPs hit the same production pods → identical config, transparent failover for UniFi

## End state
| IP | Service | Ports | Pods |
|---|---|---|---|
| `10.42.2.43` | `adguard` (existing) | 53, 3000, 8080, 8443 | `adguard-prod` (×2) |
| `10.42.2.45` (auto) | `adguard-dns-secondary` (new) | 53 only | `adguard-prod` (×2, same pods) |

UniFi: primary `10.42.2.43`, backup `10.42.2.45`.

## Why a separate Service rather than tacking onto the existing one
- DNS-only ports on the backup keeps the admin UI on a single address
- Distinct sharing-key is the mechanism that yields a second IP — without it Cilium would just put the new ports on `10.42.2.43`
- Staging is untouched (overlay-scoped change)

## Test plan
- [ ] After merge + Flux reconcile, confirm `kubectl get svc -n adguard-prod adguard-dns-secondary` shows an IP from `home-c-pool` distinct from `10.42.2.43`
- [ ] `dig @<new-ip> example.com` returns a valid response
- [ ] `dig +tcp @<new-ip> example.com` works (verify TCP port 53 too)
- [ ] Verify ARP from a UniFi LAN port: `arping <new-ip>` resolves to the same node MAC as `10.42.2.43`'s pool peer
- [ ] Configure UniFi DNS: primary `10.42.2.43`, secondary `<new-ip>`; confirm clients resolve under both

🤖 Generated with [Claude Code](https://claude.com/claude-code)