### PR TITLE
docs(bgp): refine L2→BGP migration plan for 6-node cluster

### DIFF
--- a/docs/infra/cilium.md
+++ b/docs/infra/cilium.md
@@ -1,5 +1,7 @@
 # Cilium
 
+> **Migration in flight (2026-05-02):** LoadBalancer IP advertisement is moving from L2 Announcements to BGP peering with the UCGF. See [`docs/plans/bgp-rollout.md`](../plans/bgp-rollout.md). Update this doc when the migration completes.
+
 ## 1. Overview
 Cilium is the Container Network Interface (CNI) used in the homelab cluster. It provides high-performance networking, security, and observability using eBPF. It also serves as the LoadBalancer IPAM provider (replacing MetalLB) and the Gateway API controller.
 

--- a/docs/infra/ucgf-bgp-frr.conf
+++ b/docs/infra/ucgf-bgp-frr.conf
@@ -1,0 +1,8 @@
+! UniFi Cloud Gateway Fiber — FRR (vtysh) running config snapshot
+!
+! TODO: populate during Phase 1.2 of docs/plans/bgp-rollout.md
+! Capture with:
+!   ssh root@10.42.2.1 'vtysh -c "show running-config"' > docs/infra/ucgf-bgp-frr.conf
+!
+! Treat this file as the canonical reference. Diff against the live config
+! after every UniFi firmware upgrade — firmware updates may wipe /etc/frr/frr.conf.

--- a/docs/plans/bgp-rollout.md
+++ b/docs/plans/bgp-rollout.md
@@ -16,14 +16,24 @@ This plan is structured around four explicit constraints:
 3. **Per-phase rollback** — each phase has its own rollback procedure. There is no "big-bang revert" expectation.
 4. **Operator awareness** — every phase ends at a GO/NO-GO checkpoint. The next phase does not start until the operator explicitly approves.
 
-## Single-node reality
+## Topology
 
-The cluster has one Talos node today. BGP does **not** improve high availability in this state — only L2 leader election goes away. The wins are:
+The cluster is 6 nodes, all on the `10.42.2.0/24` LAN segment:
 
-- **Operational**: the gateway gets a routing table entry, not a learned ARP. `show ip route bgp` becomes a real diagnostic surface.
-- **Multi-node-readiness**: when a second node joins, the UCGF can ECMP-load-balance across nodes for free (no leader election, no failover delay). L2 cannot do this without external orchestration.
+| Node | Role | IP |
+|:-----|:-----|:---|
+| `talos-ykb-uir` | control-plane | `10.42.2.20` |
+| `talos-2mz-rfj` | control-plane | `10.42.2.21` |
+| `talos-v2l-hng` | control-plane | `10.42.2.22` |
+| `talos-lmh-kyf` | worker | `10.42.2.23` |
+| `talos-18u-ski` | worker | `10.42.2.24` |
+| `talos-kot-7x7` | worker | `10.42.2.25` |
 
-Frame the migration as paying down operational debt and unlocking growth, not as an HA upgrade.
+**Only the 3 worker nodes will peer with BGP.** Control-plane nodes carry the standard `node.kubernetes.io/exclude-from-external-load-balancers` label, so Cilium would skip them for service IP advertisement anyway. Establishing BGP sessions from idle CP nodes adds noise without benefit. The `nodeSelector` in `CiliumBGPClusterConfig` excludes them via the role label.
+
+End state: **3 BGP peers on the UCGF, 3 ECMP next-hops per LB IP.** Any single-worker BGP failure leaves traffic served by the other two — this migration produces real HA, not just operational hygiene.
+
+Future workers join automatically because the UCGF uses a `bgp listen range` rather than explicit per-node neighbors; no gateway change needed when the cluster grows.
 
 ## Current State
 
@@ -32,7 +42,8 @@ Frame the migration as paying down operational debt and unlocking growth, not as
 | Cilium version | 1.19.1 |
 | IP advertisement | L2 announcements (`CiliumL2AnnouncementPolicy`) |
 | LoadBalancer IP pool | `10.42.2.40` – `10.42.2.254` (`home-c-pool`) |
-| K8s node | `talos-ykb-uir` at `10.42.2.20` (single node) |
+| K8s nodes | 6 total: 3 CP (`.20`/`.21`/`.22`) + 3 worker (`.23`/`.24`/`.25`) |
+| BGP peers (planned) | 3 — one per worker node |
 | Router | UniFi Cloud Gateway Fiber at `10.42.2.1` |
 | Cilium BGP CRDs | Installed (storage version `v2`, `v2alpha1` still served) |
 | Cilium `bgpControlPlane` | `false` (default, not overridden) |
@@ -114,12 +125,19 @@ kubectl get crd | grep ciliumbgp
   - `ciliumbgppeerconfigs.cilium.io`
 - [ ] `kubectl get crd ciliumbgpclusterconfigs.cilium.io -o yaml | grep -A2 "name: v2"` shows `served: true` and `storage: true`.
 
-### 0.3 Baseline LoadBalancer IPs
+### 0.3 Baseline snapshots
 
-Capture today's LB IP map for the Phase 3 verification matrix:
+Capture both the LB IP map and the cluster topology for the Phase 3 verification matrix:
 
 ```bash
+# LoadBalancer IPs
 kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}{"/"}{.metadata.name}{": "}{.status.loadBalancer.ingress[*].ip}{"\n"}{end}' | sort
+
+# Node topology (which workers must peer)
+kubectl get nodes -o wide
+
+# Confirm CP nodes are excluded from LB advertisement
+kubectl get nodes -l node.kubernetes.io/exclude-from-external-load-balancers -o name
 ```
 
 Paste the output into the **Baseline appendix** at the end of this doc.
@@ -156,14 +174,20 @@ router bgp 65100
   bgp router-id 10.42.2.1
   no bgp ebgp-requires-policy
 
-  ! Peer with the Kubernetes node
-  neighbor 10.42.2.20 remote-as 65010
-  neighbor 10.42.2.20 description talos-ykb-uir
+  ! Dynamic peering — accept BGP from any LAN node asserting AS 65010.
+  ! Workers initiate the session; new nodes join automatically.
+  bgp listen range 10.42.2.0/24 peer-group K8S-NODES
+
+  neighbor K8S-NODES peer-group
+  neighbor K8S-NODES remote-as 65010
+  neighbor K8S-NODES description melodic-muse-worker
 
   address-family ipv4 unicast
-    neighbor 10.42.2.20 activate
-    neighbor 10.42.2.20 route-map K8S-LB-IN in
-    neighbor 10.42.2.20 route-map DENY-ALL out
+    neighbor K8S-NODES activate
+    neighbor K8S-NODES route-map K8S-LB-IN in
+    neighbor K8S-NODES route-map DENY-ALL out
+    ! ECMP across worker peers
+    maximum-paths 8
   exit-address-family
 
 ! Inbound: only accept /32s from the LB pool range
@@ -182,6 +206,8 @@ write memory
 **Why these choices:**
 - **AS 65100 ↔ 65010** — both in private 2-byte range (64512–65534).
 - **`no bgp ebgp-requires-policy`** — required on FRR 8+; without it, routes are silently dropped before route-map evaluation.
+- **`bgp listen range` + peer-group** — accepts incoming BGP from any node on the LAN segment that asserts AS 65010. Cleaner than 3 explicit `neighbor` entries; survives cluster growth automatically.
+- **`maximum-paths 8`** — installs all worker next-hops in the routing table for ECMP. Without this, FRR keeps only one path per prefix; you'd see BGP "best path" but no actual load balancing.
 - **`K8S-LB-IN` prefix-list** — restricts inbound to the LB pool range. A misconfigured cluster cannot push arbitrary routes (e.g. a default route) to the gateway.
 - **`DENY-ALL` outbound** — gateway must never advertise its own routes to the cluster; Cilium would install them.
 
@@ -198,13 +224,15 @@ scp root@10.42.2.1:/root/frr-bgp-baseline.conf ~/src/homelab/docs/infra/ucgf-bgp
 
 This file is checked into the repo as the canonical reference. Diff it against the live config any time you suspect drift (e.g., after a firmware upgrade).
 
-### 1.3 Verify (peer is `Active`, not `Established`)
+### 1.3 Verify (no peers yet)
 
 ```bash
 vtysh -c "show bgp summary"
 ```
 
-Expected: `10.42.2.20` appears as `Active` — the cluster side is not yet configured. **Established at this stage means somebody else is peering. Investigate.**
+Expected: BGP instance is up but **no neighbors are listed yet** — the listen-range only learns peers as they connect. The cluster side is not configured, so nothing has connected. After Phase 2b, this output will list 3 dynamic peers (`*10.42.2.23`, `*10.42.2.24`, `*10.42.2.25` — leading `*` denotes a dynamically-learned peer).
+
+**If a peer is already Established, somebody else on the LAN is asserting AS 65010 — investigate before proceeding.**
 
 ### 1.4 Persistence note
 
@@ -236,7 +264,9 @@ The gateway returns to pre-Phase-1 state. No effect on cluster traffic (nothing 
 
 Both protocols coexist after this phase. **Zero disruption expected** — L2 continues advertising while BGP comes up.
 
-### 2.1 Helm values
+The phase is split into **2a (canary on one worker)** and **2b (expand to all workers)**. The canary catches a broken cluster-wide BGP config before it lands on all 3 workers. The shared YAML (`CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`) is created in 2a and reused unchanged in 2b.
+
+### 2a.1 Helm values
 
 Edit [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml) — add (do not remove `l2announcements`):
 
@@ -245,7 +275,21 @@ bgpControlPlane:
   enabled: true
 ```
 
-### 2.2 BGP peer configuration
+This is cluster-wide; it enables the BGP control plane on every Cilium agent. Whether a node *peers* is determined by `CiliumBGPClusterConfig` selector below.
+
+### 2a.2 Pick a canary worker
+
+Use `talos-lmh-kyf` (`10.42.2.23`) as the canary. Pick a node not currently scheduling the production gateway pods if possible; check with `kubectl get pods -A -o wide | grep gateway`.
+
+### 2a.3 Label the canary
+
+```bash
+kubectl label node talos-lmh-kyf bgp-canary=true
+```
+
+> This label is transient. It does not need to survive a node reboot — Phase 2b promotes to a role-based selector that matches all workers automatically. The canary label becomes irrelevant after 2b and is removed in 2b.4.
+
+### 2a.4 BGP peer configuration
 
 Create `infra/configs/cilium/bgp-peer-config.yaml`:
 
@@ -269,7 +313,7 @@ spec:
     restartTimeSeconds: 120
 ```
 
-### 2.3 BGP advertisement
+### 2a.5 BGP advertisement
 
 Create `infra/configs/cilium/bgp-advertisement.yaml`:
 
@@ -291,9 +335,9 @@ spec:
         matchLabels: {}
 ```
 
-### 2.4 BGP cluster configuration
+### 2a.6 BGP cluster configuration (canary selector)
 
-Create `infra/configs/cilium/bgp-cluster-config.yaml`:
+Create `infra/configs/cilium/bgp-cluster-config.yaml` with the canary-only selector:
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -301,9 +345,10 @@ kind: CiliumBGPClusterConfig
 metadata:
   name: homelab-bgp
 spec:
+  # Phase 2a: canary only. Phase 2b changes this to role-based exclusion.
   nodeSelector:
     matchLabels:
-      kubernetes.io/os: linux
+      bgp-canary: "true"
   bgpInstances:
     - name: homelab
       localASN: 65010
@@ -317,7 +362,7 @@ spec:
             kind: CiliumBGPPeerConfig
 ```
 
-### 2.5 Wire into kustomization
+### 2a.7 Wire into kustomization
 
 Edit [infra/configs/cilium/kustomization.yaml](../../infra/configs/cilium/kustomization.yaml):
 
@@ -332,64 +377,163 @@ resources:
   - load-balancer-ip-pool.yaml
 ```
 
-### 2.6 Commit, push, reconcile
+### 2a.8 Commit, push, reconcile
 
 ```bash
 git add infra/configs/cilium/ infra/controllers/cilium/values.yaml
-git commit -m "feat(cilium): enable BGP control plane alongside L2 announcements"
+git commit -m "feat(cilium): enable BGP control plane (canary on one worker)"
 git push
 flux reconcile kustomization infra-controllers -n flux-system --with-source
 flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-Wait for `cilium` DaemonSet rollout to complete (`bgpControlPlane: true` requires an agent restart).
+Wait for the `cilium` DaemonSet rollout to complete (`bgpControlPlane: true` triggers an agent restart on every node).
 
-### 2.7 Verify on cluster
+### 2a.9 Verify (one peer only)
+
+From the cluster:
 
 ```bash
-kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers
+# Canary worker should report Established
+kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=talos-lmh-kyf -o jsonpath='{.items[0].metadata.name}')" \
+  -- cilium-dbg bgp peers
+
+# Other workers should report no BGP instance configured
+for node in talos-18u-ski talos-kot-7x7; do
+  echo "=== $node ==="
+  kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=$node -o jsonpath='{.items[0].metadata.name}')" \
+    -- cilium-dbg bgp peers
+done
 ```
 
-Expected: peer `10.42.2.1` in `Established` state, `Uptime` increasing.
-
-### 2.8 Verify on UCGF
+From the UCGF:
 
 ```bash
-ssh root@10.42.2.1 'vtysh -c "show bgp ipv4 unicast"'
+ssh root@10.42.2.1 'vtysh -c "show bgp summary"'
+# Expected: 1 dynamic peer (*10.42.2.23) Established
+
 ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'
+# Expected: every baseline /32 with single next-hop 10.42.2.23
 ```
 
-Expected: every allocated LoadBalancer IP (from baseline) appears as a `/32` route with next-hop `10.42.2.20`.
+### 2a.10 Soak — 1 hour minimum
 
-### Phase 2 GO criteria
-- `cilium-dbg bgp peers` Established.
-- All baseline /32s present in `show ip route bgp` on the gateway.
-- `kubectl get ciliuml2announcementpolicy` still shows the L2 policy (we did not touch L2).
-- LAN client smoke test (any HTTPS endpoint, any DNS query) still works.
+Watch:
+- `cilium-dbg bgp peers` on the canary stays Established with monotonically increasing Uptime.
+- No correlated log errors on the canary's Cilium agent.
+- LAN client smoke test (`curl https://home.burntbytes.com`, `dig @10.42.2.43 …`) succeeds.
 
-### Phase 2 rollback
+### Phase 2a GO criteria
+- Canary peer Established for ≥1 hour without flap.
+- Other 5 nodes show no BGP activity.
+- L2 still active (`kubectl get ciliuml2announcementpolicy` returns 1 resource).
+
+### Phase 2a rollback
+
+Fast option: remove the canary label.
+```bash
+kubectl label node talos-lmh-kyf bgp-canary-
+```
+The canary's session drops within seconds; L2 carries traffic.
+
+Full option: revert the commit and push.
+```bash
+git revert HEAD
+git push
+flux reconcile kustomization infra-configs -n flux-system --with-source
+flux reconcile kustomization infra-controllers -n flux-system --with-source
+```
+
+---
+
+### 2b.1 Promote selector to all workers
+
+Edit `infra/configs/cilium/bgp-cluster-config.yaml` — replace the canary selector with role-based exclusion:
+
+```yaml
+spec:
+  # Phase 2b: every node EXCEPT control-plane nodes peers.
+  # Workers establish BGP; CP nodes are excluded (they wouldn't advertise
+  # anyway because of node.kubernetes.io/exclude-from-external-load-balancers).
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+```
+
+### 2b.2 Commit, push, reconcile
 
 ```bash
-# 1. Delete the BGP CRD instances
-kubectl delete -f infra/configs/cilium/bgp-cluster-config.yaml
-kubectl delete -f infra/configs/cilium/bgp-advertisement.yaml
-kubectl delete -f infra/configs/cilium/bgp-peer-config.yaml
-
-# 2. Revert the git changes
-git revert <commit-sha>
+git add infra/configs/cilium/bgp-cluster-config.yaml
+git commit -m "feat(cilium): promote BGP from canary to all workers"
 git push
-
-# 3. Disable BGP in helm (sets bgpControlPlane.enabled: false)
-#    Cilium agent restarts; L2 was never disabled, so traffic continues.
+flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-L2 was never touched. Traffic is uninterrupted throughout this rollback.
+The `CiliumBGPClusterConfig` change is hot-applied; no Cilium agent restart needed. The non-canary workers will initiate BGP within ~30s.
+
+### 2b.3 Verify (3 worker peers, ECMP)
+
+From the cluster:
+
+```bash
+# All 3 workers Established
+for node in talos-lmh-kyf talos-18u-ski talos-kot-7x7; do
+  echo "=== $node ==="
+  kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=$node -o jsonpath='{.items[0].metadata.name}')" \
+    -- cilium-dbg bgp peers
+done
+
+# CP nodes still report no BGP
+for node in talos-ykb-uir talos-2mz-rfj talos-v2l-hng; do
+  echo "=== $node ==="
+  kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=$node -o jsonpath='{.items[0].metadata.name}')" \
+    -- cilium-dbg bgp peers
+done
+```
+
+From the UCGF:
+
+```bash
+ssh root@10.42.2.1 'vtysh -c "show bgp summary"'
+# Expected: 3 dynamic peers Established (*10.42.2.23, .24, .25)
+
+ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'
+# Expected: each baseline /32 shows 3 next-hops (one per worker), e.g.:
+#   B>* 10.42.2.40/32 [20/0] via 10.42.2.23, eth0, weight 1
+#                       via 10.42.2.24, eth0, weight 1
+#                       via 10.42.2.25, eth0, weight 1
+```
+
+### 2b.4 Remove canary label (cleanup)
+
+```bash
+kubectl label node talos-lmh-kyf bgp-canary-
+```
+
+The canary worker keeps peering — it now matches the role-based selector instead.
+
+### Phase 2b GO criteria
+- 3 BGP peers Established on UCGF.
+- ECMP visible: `show ip route bgp` shows 3 next-hops per LB IP.
+- All baseline LB IPs reachable from a LAN client.
+- L2 still active (we did not touch L2).
+
+### Phase 2b rollback
+
+Three choices, in order of escalation:
+
+1. **Roll back to canary** — `git revert HEAD` (the 2b.1 commit). The selector returns to `bgp-canary: "true"`; only the canary peer remains. Re-add the canary label if it was removed in 2b.4.
+2. **Roll back to no-BGP** — Phase 2a rollback applied on top.
+3. L2 was never touched throughout. Traffic is uninterrupted in all rollback paths.
 
 ---
 
 ## Phase 3 — Soak
 
 **Minimum 4 hours. Recommended 24 hours.** Both L2 and BGP advertise the same /32s during this window. The goal is to catch flaps, leaks, or other instability before relying on BGP exclusively.
+
+Soak runs against the **full multi-node fleet** — all 3 worker peers must remain Established. Single-peer flaps are tolerable (other 2 workers still serve traffic) but unexpected; investigate before proceeding.
 
 ### 3.1 What to watch
 
@@ -405,7 +549,8 @@ L2 was never touched. Traffic is uninterrupted throughout this rollback.
 
 ### 3.2 GO criteria for Phase 4a
 
-- BGP `Established` continuously for the soak window (no flap events).
+- All 3 worker BGP sessions `Established` continuously for the soak window (no flap events).
+- `show ip route bgp` on the UCGF shows **3 next-hops per LB IP** for the entire window (ECMP holds).
 - Zero increase in 5xx or DNS-resolution-failure rate compared to baseline.
 - All baseline LB IPs still routable via BGP (verify by re-running the kubectl jsonpath query — IPs should match).
 
@@ -462,8 +607,15 @@ flux reconcile kustomization infra-configs -n flux-system --with-source
 kubectl get ciliuml2announcementpolicy
 # Expected: No resources found
 
-kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers
-# Expected: Established, unchanged Uptime (Cilium agent does not restart)
+# All 3 worker peers still Established with unchanged Uptime
+for node in talos-lmh-kyf talos-18u-ski talos-kot-7x7; do
+  echo "=== $node ==="
+  kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium --field-selector spec.nodeName=$node -o jsonpath='{.items[0].metadata.name}')" \
+    -- cilium-dbg bgp peers
+done
+
+ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'
+# Expected: still 3 next-hops per LB IP. ECMP holds — L2 removal did not perturb BGP routes.
 ```
 
 ### 4a.4 Force ARP refresh and test from LAN
@@ -588,18 +740,28 @@ Update the frontmatter `status: planned` → `status: completed` and add a closi
 
 Run before any phase, then again after each cutover.
 
-| Test | Pre-cutover | Post-Phase 2 | Post-Phase 4a | Post-Phase 4b |
-|:-----|:-----------:|:------------:|:-------------:|:-------------:|
-| `dig @10.42.2.43 example.com +short` | ✓ | ✓ | ✓ | ✓ |
-| `curl -sk https://home.burntbytes.com` | ✓ | ✓ | ✓ | ✓ |
-| `curl -sk https://grafana.burntbytes.com` | ✓ | ✓ | ✓ | ✓ |
-| LAN client `arp -d <ip>; curl …` | ✓ (re-ARPs) | ✓ | ✓ (BGP route) | ✓ (BGP route) |
-| `vtysh -c "show ip route bgp"` shows /32s | empty | populated | populated | populated |
-| `kubectl get ciliuml2announcementpolicy` | 1 | 1 | 0 | 0 |
-| `cilium-dbg bgp peers` Established | n/a | yes | yes | yes |
-| Helm value `l2announcements.enabled` | true | true | true | false |
+| Test | Pre-cutover | Post-Phase 2a | Post-Phase 2b | Post-Phase 4a | Post-Phase 4b |
+|:-----|:-----------:|:-------------:|:-------------:|:-------------:|:-------------:|
+| `dig @10.42.2.43 example.com +short` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `curl -sk https://home.burntbytes.com` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `curl -sk https://grafana.burntbytes.com` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| LAN client `arp -d <ip>; curl …` | ✓ (re-ARPs) | ✓ | ✓ | ✓ (BGP route) | ✓ (BGP route) |
+| `vtysh -c "show bgp summary"` peer count | 0 | 1 | 3 | 3 | 3 |
+| `vtysh -c "show ip route bgp"` next-hops per LB IP | n/a | 1 | **3 (ECMP)** | 3 | 3 |
+| `cilium-dbg bgp peers` Established (per worker) | n/a | canary only | all 3 workers | all 3 workers | all 3 workers |
+| `cilium-dbg bgp peers` on CP nodes | n/a | none | none | none | none |
+| `kubectl get ciliuml2announcementpolicy` | 1 | 1 | 1 | 0 | 0 |
+| Helm value `l2announcements.enabled` | true | true | true | true | false |
 
-Any "no" in a column where "yes" is expected → STOP and rollback the most recent phase.
+**Resilience tests** (run after Phase 4a):
+
+| Test | Procedure | Expected |
+|:-----|:----------|:---------|
+| Single-worker drain | `kubectl drain talos-lmh-kyf --ignore-daemonsets --delete-emptydir-data` | UCGF removes that next-hop in ≤90s; LB IPs continue serving via the other 2 workers; `curl` smoke test still 200. Uncordon to restore. |
+| Cilium agent rolling restart | `kubectl rollout restart ds/cilium -n kube-system` | Per-pod BGP sessions reset one-by-one; graceful-restart keeps routes installed for 120s; LAN-side smoke test never fails. |
+| Single-worker BGP flap simulation | On worker, `iptables -I INPUT -p tcp --dport 179 -j DROP` for 30s, then revert | UCGF marks peer Idle within hold-time, removes that next-hop; ECMP drops to 2; traffic uninterrupted. After revert, peer re-Established. |
+
+Any "no" where "yes" is expected → STOP and roll back the most recent phase.
 
 ---
 
@@ -614,21 +776,21 @@ Private 2-byte AS range: 64512–65534. 4-byte: 4200000000–4294967294.
 
 ---
 
-## Multi-node considerations (future)
+## Future cluster growth
 
-When a second Talos node joins:
+The `bgp listen range 10.42.2.0/24` on the UCGF and the `node-role.kubernetes.io/control-plane: DoesNotExist` selector in `CiliumBGPClusterConfig` together make new workers self-service:
 
-- The `nodeSelector` (`kubernetes.io/os: linux`) on `CiliumBGPClusterConfig` matches all nodes — each gets a BGP session with the UCGF automatically.
-- The UCGF learns multiple next-hops for each LB IP and ECMP-load-balances across nodes. No gateway config changes.
-- L2 leader-election failures stop being a relevant failure mode (they already don't apply post-this-migration, but conceptually noted).
+- A new worker node joins the cluster on `10.42.2.x` → matches the role-based selector → Cilium initiates BGP → UCGF accepts via the listen range → ECMP path-count grows by one. No homelab repo change needed.
+- A new control-plane node joins → matched by the role exclusion → no BGP session, as desired.
 
-If you want explicit control over which nodes peer, add a `bgp-policy: active` node label and switch `nodeSelector` to `matchLabels: {bgp-policy: active}`. Apply the label via Talos machine config so it survives node restarts:
+If a future requirement demands BGP from CP nodes (e.g., advertising pod CIDRs from CP), revisit the selector and reason about whether the `exclude-from-external-load-balancers` label still does the right thing for service IPs.
 
-```yaml
-machine:
-  nodeLabels:
-    bgp-policy: active
-```
+## Out of scope
+
+- **`k8sServiceHost: "10.42.2.20"` SPOF.** [`infra/controllers/cilium/values.yaml`](../../infra/controllers/cilium/values.yaml) hardcodes Cilium's API-server endpoint to one CP node IP. With 3 CP nodes, this is a SPOF for Cilium → kube-apiserver. **Not part of this migration.** File a follow-up issue; consider switching to `k8sServiceHost: "auto"` or a CP VIP.
+- **`externalTrafficPolicy: Local`.** All LB services use `Cluster`. Switching to `Local` preserves source IP and avoids the second hop, but reduces ECMP path count to "nodes hosting the backing pod." Separate decision; not part of BGP migration.
+- **BGP authentication (MD5 / TCP-AO).** Skipped — the cluster and gateway share a private LAN segment with no untrusted peers. Add later if multiple BGP speakers are introduced.
+- **Pod CIDR / Egress Gateway via BGP.** Out of scope; this migration only changes how LB IPs are advertised.
 
 ---
 

--- a/docs/plans/bgp-rollout.md
+++ b/docs/plans/bgp-rollout.md
@@ -1,11 +1,29 @@
 ---
 status: planned
-last_modified: 2026-03-10
+last_modified: 2026-05-02
 ---
 
-# BGP Rollout Plan — Unifi Cloud Gateway Fiber + Cilium
+# BGP Rollout Plan — UniFi Cloud Gateway Fiber + Cilium
 
-Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kubernetes node and the Unifi Cloud Gateway Fiber (UCGF). This gives the router real routing table entries for LoadBalancer IPs instead of relying on gratuitous ARP, improving reliability, observability, and multi-node readiness.
+Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kubernetes node and the UniFi Cloud Gateway Fiber (UCGF). The router gets real routing-table entries for LoadBalancer IPs instead of relying on gratuitous ARP — better reliability, observability, and multi-node readiness.
+
+## Operator constraints
+
+This plan is structured around four explicit constraints:
+
+1. **Safe** — every commit is reversible; failures at any phase have a documented backout.
+2. **Minimum disruption** — L2 and BGP coexist for the entire validation window. Disruption risk is concentrated in a single CRD deletion (Phase 4a) which is instantly reversible by re-applying the file.
+3. **Per-phase rollback** — each phase has its own rollback procedure. There is no "big-bang revert" expectation.
+4. **Operator awareness** — every phase ends at a GO/NO-GO checkpoint. The next phase does not start until the operator explicitly approves.
+
+## Single-node reality
+
+The cluster has one Talos node today. BGP does **not** improve high availability in this state — only L2 leader election goes away. The wins are:
+
+- **Operational**: the gateway gets a routing table entry, not a learned ARP. `show ip route bgp` becomes a real diagnostic surface.
+- **Multi-node-readiness**: when a second node joins, the UCGF can ECMP-load-balance across nodes for free (no leader election, no failover delay). L2 cannot do this without external orchestration.
+
+Frame the migration as paying down operational debt and unlocking growth, not as an HA upgrade.
 
 ## Current State
 
@@ -15,29 +33,31 @@ Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kuberne
 | IP advertisement | L2 announcements (`CiliumL2AnnouncementPolicy`) |
 | LoadBalancer IP pool | `10.42.2.40` – `10.42.2.254` (`home-c-pool`) |
 | K8s node | `talos-ykb-uir` at `10.42.2.20` (single node) |
-| Router | Unifi Cloud Gateway Fiber at `10.42.2.1` |
-| Cilium BGP CRDs | Installed (part of CRD bundle) but unused |
+| Router | UniFi Cloud Gateway Fiber at `10.42.2.1` |
+| Cilium BGP CRDs | Installed (storage version `v2`, `v2alpha1` still served) |
 | Cilium `bgpControlPlane` | `false` (default, not overridden) |
 | Gateway API | Enabled, Cilium is the controller |
 
-### Files Involved
+### Files involved
 
 | File | Purpose |
 |:-----|:--------|
 | [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml) | Helm values — `l2announcements.enabled: true` |
 | [infra/configs/cilium/l2-announcement-policy.yaml](../../infra/configs/cilium/l2-announcement-policy.yaml) | `CiliumL2AnnouncementPolicy` resource |
 | [infra/configs/cilium/load-balancer-ip-pool.yaml](../../infra/configs/cilium/load-balancer-ip-pool.yaml) | `CiliumLoadBalancerIPPool` (kept as-is) |
+| [infra/configs/cilium/kustomization.yaml](../../infra/configs/cilium/kustomization.yaml) | Adds new BGP resources, removes L2 in 4a |
+| [docs/infra/ucgf-bgp-frr.conf](../infra/ucgf-bgp-frr.conf) | Snapshot of UCGF FRR running config (filled in during Phase 1) |
 
 ---
 
-## Target State
+## Target state
 
 ```
                     BGP Peering (eBGP)
                     AS 65100 ◄──────► AS 65010
 
 ┌──────────────────┐                   ┌──────────────────────┐
-│  Unifi Cloud      │                   │  Kubernetes Node     │
+│  UniFi Cloud      │                   │  Kubernetes Node     │
 │  Gateway Fiber    │                   │  (talos-ykb-uir)     │
 │                  │  10.42.2.1:179     │  10.42.2.20:179      │
 │  AS 65100        │◄─────────────────►│  AS 65010            │
@@ -50,49 +70,88 @@ Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kuberne
 └──────────────────┘                   └──────────────────────┘
 ```
 
-- **Router (UCGF):** AS 65100 — receives routes, installs them in its routing table
-- **K8s node:** AS 65010 — advertises LoadBalancer IPs via Cilium BGP Control Plane
-- **IP pool:** Unchanged (`10.42.2.40` – `10.42.2.254`)
+- **Router (UCGF):** AS 65100 — receives routes, installs them in its routing table.
+- **K8s node:** AS 65010 — advertises LoadBalancer IPs via Cilium BGP control plane.
+- **IP pool:** unchanged (`10.42.2.40` – `10.42.2.254`).
 
 ---
 
-## Prerequisites
+## Phase 0 — Pre-flight gate (BLOCKING)
 
-- [ ] SSH access to Unifi Cloud Gateway Fiber (root via `ssh root@10.42.2.1`)
-- [ ] Verify FRRouting (FRR) is available on UCGF (`vtysh --version` or `which frr`)
-- [ ] Confirm the UCGF firmware supports BGP (UniFi OS 4.x+ with FRR)
-- [ ] Plan a maintenance window — LoadBalancer IPs will be briefly unreachable during cutover
+**No git changes happen until every checkbox below is satisfied.** Aborting at this phase costs nothing.
 
----
-
-## Phase 1: Enable BGP on the Unifi Cloud Gateway Fiber
-
-The UCGF runs FRRouting (FRR) under the hood. BGP must be configured via SSH since the UniFi controller UI does not expose BGP settings.
-
-### 1.1 SSH into the gateway
+### 0.1 UCGF capability
 
 ```bash
 ssh root@10.42.2.1
-```
-
-### 1.2 Check FRR availability
-
-```bash
 vtysh -c "show version"
 ```
 
-If `vtysh` is not found, check for `/usr/lib/frr/` or `/etc/frr/`. On newer UniFi OS firmware (4.x+), FRR should be present.
+- [ ] FRR is present and reports a version string.
+- [ ] Dry-run BGP acceptance:
+  ```text
+  vtysh
+  configure terminal
+  router bgp 65100
+  exit
+  no router bgp 65100
+  end
+  ```
+  No errors → vtysh can accept BGP commands. **Abort if it errors.**
+- [ ] Record current UCGF firmware version in this PR's description (so post-firmware-upgrade FRR-loss is detectable).
 
-### 1.3 Configure BGP via vtysh
+### 0.2 Cluster capability
 
 ```bash
+kubectl get crd | grep ciliumbgp
+```
+
+- [ ] All five CRDs present:
+  - `ciliumbgpadvertisements.cilium.io`
+  - `ciliumbgpclusterconfigs.cilium.io`
+  - `ciliumbgpnodeconfigoverrides.cilium.io`
+  - `ciliumbgpnodeconfigs.cilium.io`
+  - `ciliumbgppeerconfigs.cilium.io`
+- [ ] `kubectl get crd ciliumbgpclusterconfigs.cilium.io -o yaml | grep -A2 "name: v2"` shows `served: true` and `storage: true`.
+
+### 0.3 Baseline LoadBalancer IPs
+
+Capture today's LB IP map for the Phase 3 verification matrix:
+
+```bash
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}{"/"}{.metadata.name}{": "}{.status.loadBalancer.ingress[*].ip}{"\n"}{end}' | sort
+```
+
+Paste the output into the **Baseline appendix** at the end of this doc.
+
+### 0.4 Maintenance window
+
+- [ ] Pick a 1-hour window for Phases 4a/4b. Phases 1–3 are non-disruptive and can be done at any time.
+- [ ] Notify household / users that LAN may have brief DNS/HTTPS hiccups during the window if BGP cutover is rough.
+
+### Phase 0 GO criteria
+All checkboxes above are ticked, baseline LB IPs are captured. Otherwise: **STOP** and resolve before proceeding.
+
+### Phase 0 rollback
+None — no changes have been made.
+
+---
+
+## Phase 1 — Configure BGP on the UCGF
+
+The UCGF runs FRRouting (FRR). BGP is configured via SSH; the UniFi controller UI does not expose BGP.
+
+### 1.1 SSH and apply config
+
+```bash
+ssh root@10.42.2.1
 vtysh
 ```
 
 ```text
 configure terminal
 
-! Create the BGP instance with the gateway's AS number
+! BGP instance with the gateway's AS number
 router bgp 65100
   bgp router-id 10.42.2.1
   no bgp ebgp-requires-policy
@@ -101,134 +160,149 @@ router bgp 65100
   neighbor 10.42.2.20 remote-as 65010
   neighbor 10.42.2.20 description talos-ykb-uir
 
-  ! Accept all routes from the k8s node (LoadBalancer IPs)
   address-family ipv4 unicast
     neighbor 10.42.2.20 activate
-    neighbor 10.42.2.20 route-map ALLOW-ALL in
+    neighbor 10.42.2.20 route-map K8S-LB-IN in
     neighbor 10.42.2.20 route-map DENY-ALL out
   exit-address-family
 
-! Route maps
-route-map ALLOW-ALL permit 10
+! Inbound: only accept /32s from the LB pool range
+ip prefix-list K8S-LB-IPS seq 10 permit 10.42.2.0/24 ge 32 le 32
 
+route-map K8S-LB-IN permit 10
+  match ip address prefix-list K8S-LB-IPS
+
+! Outbound: never advertise gateway routes back to k8s
 route-map DENY-ALL deny 10
 
 end
 write memory
 ```
 
-**Key decisions:**
-- **AS 65100** for the gateway (private AS range 64512–65534)
-- **AS 65010** for the k8s cluster
-- **`no bgp ebgp-requires-policy`** — required on FRR 8+ or routes are silently dropped
-- **`DENY-ALL` outbound** — the gateway should not advertise its own routes to k8s
-- **`ALLOW-ALL` inbound** — accept all LoadBalancer IP advertisements from k8s
+**Why these choices:**
+- **AS 65100 ↔ 65010** — both in private 2-byte range (64512–65534).
+- **`no bgp ebgp-requires-policy`** — required on FRR 8+; without it, routes are silently dropped before route-map evaluation.
+- **`K8S-LB-IN` prefix-list** — restricts inbound to the LB pool range. A misconfigured cluster cannot push arbitrary routes (e.g. a default route) to the gateway.
+- **`DENY-ALL` outbound** — gateway must never advertise its own routes to the cluster; Cilium would install them.
 
-### 1.4 Verify the peer is configured (before k8s side is ready)
+### 1.2 Snapshot the running config
+
+```bash
+vtysh -c "show running-config" > /root/frr-bgp-baseline.conf
+```
+
+From a workstation:
+```bash
+scp root@10.42.2.1:/root/frr-bgp-baseline.conf ~/src/homelab/docs/infra/ucgf-bgp-frr.conf
+```
+
+This file is checked into the repo as the canonical reference. Diff it against the live config any time you suspect drift (e.g., after a firmware upgrade).
+
+### 1.3 Verify (peer is `Active`, not `Established`)
 
 ```bash
 vtysh -c "show bgp summary"
 ```
 
-The peer `10.42.2.20` should appear as `Active` (not `Established` yet — the k8s side isn't configured).
+Expected: `10.42.2.20` appears as `Active` — the cluster side is not yet configured. **Established at this stage means somebody else is peering. Investigate.**
 
-### 1.5 Persistence across firmware upgrades
+### 1.4 Persistence note
 
-> **Warning:** UniFi gateway configuration via SSH does **not survive firmware upgrades** by default. FRR config written via `write memory` persists across reboots but may be lost during major firmware updates.
+`write memory` persists across reboots. **Firmware upgrades may wipe `/etc/frr/frr.conf`.** After every UCGF firmware upgrade, re-apply this config from `docs/infra/ucgf-bgp-frr.conf`.
 
-Options for persistence:
-1. **`/etc/frr/frr.conf`** — Check if this file is preserved. Back it up.
-2. **UniFi boot script** — Place a script in `/etc/udm-boot.d/` (if supported) or use a cron `@reboot` job to re-apply the config.
-3. **Document the config** — Keep the vtysh commands in this plan so they can be re-applied after upgrades.
+### Phase 1 GO criteria
+- `show bgp summary` lists the peer as `Active`.
+- `frr-bgp-baseline.conf` is committed.
+- Operator confirms Phase 2 may begin.
 
-Create a backup:
-```bash
-vtysh -c "show running-config" > /root/frr-bgp-backup.conf
+### Phase 1 rollback
+
+```text
+vtysh
+configure terminal
+no router bgp 65100
+no ip prefix-list K8S-LB-IPS
+no route-map K8S-LB-IN
+no route-map DENY-ALL
+end
+write memory
 ```
+
+The gateway returns to pre-Phase-1 state. No effect on cluster traffic (nothing was peering yet).
 
 ---
 
-## Phase 2: Enable Cilium BGP Control Plane
+## Phase 2 — Enable Cilium BGP control plane
 
-### 2.1 Update Cilium Helm values
+Both protocols coexist after this phase. **Zero disruption expected** — L2 continues advertising while BGP comes up.
 
-Edit [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml):
+### 2.1 Helm values
+
+Edit [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml) — add (do not remove `l2announcements`):
 
 ```yaml
-# Add this section:
 bgpControlPlane:
   enabled: true
 ```
 
-> **Do NOT remove `l2announcements.enabled: true` yet.** Both can coexist during the transition. L2 will continue working while BGP is being validated.
-
-### 2.2 Create BGP peer configuration
+### 2.2 BGP peer configuration
 
 Create `infra/configs/cilium/bgp-peer-config.yaml`:
 
 ```yaml
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPPeerConfig
 metadata:
   name: ucgf-peer
 spec:
-  # Timers (seconds)
   timers:
     holdTimeSeconds: 90
     keepAliveTimeSeconds: 30
     connectRetryTimeSeconds: 120
   transport:
-    # Use default BGP port 179
     peerPort: 179
   families:
     - afi: ipv4
       safi: unicast
-  # Graceful restart helps during Cilium agent restarts
   gracefulRestart:
     enabled: true
     restartTimeSeconds: 120
 ```
 
-### 2.3 Create BGP advertisement
+### 2.3 BGP advertisement
 
 Create `infra/configs/cilium/bgp-advertisement.yaml`:
 
 ```yaml
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement
 metadata:
   name: lb-ip-advertisement
+  labels:
+    advertise: lb-ips
 spec:
   advertisements:
     - advertisementType: Service
       service:
-        # Advertise allocated LoadBalancer IPs
         addresses:
           - LoadBalancerIP
+      # Empty matchLabels = match all services with a LoadBalancer IP.
       selector:
-        # Match all services (no filter)
-        matchExpressions:
-          - key: somekey
-            operator: NotIn
-            values: ["never-match"]
-      attributes:
-        # No communities needed for a simple single-peer setup
-        communities: []
+        matchLabels: {}
 ```
 
-### 2.4 Create BGP cluster configuration
+### 2.4 BGP cluster configuration
 
 Create `infra/configs/cilium/bgp-cluster-config.yaml`:
 
 ```yaml
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPClusterConfig
 metadata:
   name: homelab-bgp
 spec:
   nodeSelector:
     matchLabels:
-      # Match all nodes (Talos labels)
       kubernetes.io/os: linux
   bgpInstances:
     - name: homelab
@@ -243,7 +317,7 @@ spec:
             kind: CiliumBGPPeerConfig
 ```
 
-### 2.5 Update Kustomization
+### 2.5 Wire into kustomization
 
 Edit [infra/configs/cilium/kustomization.yaml](../../infra/configs/cilium/kustomization.yaml):
 
@@ -254,92 +328,112 @@ resources:
   - bgp-advertisement.yaml
   - bgp-cluster-config.yaml
   - bgp-peer-config.yaml
-  - l2-announcement-policy.yaml   # Keep during transition
+  - l2-announcement-policy.yaml   # kept during transition
   - load-balancer-ip-pool.yaml
 ```
 
-> Resources are alphabetically sorted per repo conventions.
-
----
-
-## Phase 3: Validate BGP Peering
-
-### 3.1 Commit and push the Cilium changes
+### 2.6 Commit, push, reconcile
 
 ```bash
 git add infra/configs/cilium/ infra/controllers/cilium/values.yaml
-git commit -m "Enable Cilium BGP control plane alongside L2 announcements"
+git commit -m "feat(cilium): enable BGP control plane alongside L2 announcements"
 git push
+flux reconcile kustomization infra-controllers -n flux-system --with-source
+flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-Wait for Flux to reconcile (~2 minutes).
+Wait for `cilium` DaemonSet rollout to complete (`bgpControlPlane: true` requires an agent restart).
 
-### 3.2 Verify Cilium BGP agent status
+### 2.7 Verify on cluster
 
 ```bash
-# Check BGP peering state from Cilium
 kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers
 ```
 
-Expected output should show the UCGF peer (`10.42.2.1`) in `Established` state.
+Expected: peer `10.42.2.1` in `Established` state, `Uptime` increasing.
 
-### 3.3 Verify routes on the gateway
-
-```bash
-ssh root@10.42.2.1
-vtysh -c "show bgp ipv4 unicast"
-```
-
-You should see `/32` routes for each allocated LoadBalancer IP with next-hop `10.42.2.20`.
-
-### 3.4 Verify routes on the gateway routing table
+### 2.8 Verify on UCGF
 
 ```bash
-vtysh -c "show ip route bgp"
+ssh root@10.42.2.1 'vtysh -c "show bgp ipv4 unicast"'
+ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'
 ```
 
-Each LoadBalancer IP should appear as a BGP route pointing to `10.42.2.20`.
+Expected: every allocated LoadBalancer IP (from baseline) appears as a `/32` route with next-hop `10.42.2.20`.
 
-### 3.5 Test connectivity
+### Phase 2 GO criteria
+- `cilium-dbg bgp peers` Established.
+- All baseline /32s present in `show ip route bgp` on the gateway.
+- `kubectl get ciliuml2announcementpolicy` still shows the L2 policy (we did not touch L2).
+- LAN client smoke test (any HTTPS endpoint, any DNS query) still works.
 
-From a LAN client (not on the k8s node), verify that LoadBalancer services are still reachable:
+### Phase 2 rollback
 
 ```bash
-# Test production gateway
-curl -sk https://home.burntbytes.com
+# 1. Delete the BGP CRD instances
+kubectl delete -f infra/configs/cilium/bgp-cluster-config.yaml
+kubectl delete -f infra/configs/cilium/bgp-advertisement.yaml
+kubectl delete -f infra/configs/cilium/bgp-peer-config.yaml
 
-# Test a few specific services
-curl -sk https://links.burntbytes.com
-curl -sk https://vitals.burntbytes.com
+# 2. Revert the git changes
+git revert <commit-sha>
+git push
+
+# 3. Disable BGP in helm (sets bgpControlPlane.enabled: false)
+#    Cilium agent restarts; L2 was never disabled, so traffic continues.
 ```
 
-At this point, **both L2 and BGP are advertising the same IPs**. Traffic may use either path depending on ARP cache state. This is fine — the goal is to validate BGP before removing L2.
+L2 was never touched. Traffic is uninterrupted throughout this rollback.
 
 ---
 
-## Phase 4: Remove L2 Announcements
+## Phase 3 — Soak
 
-Only proceed once BGP peering is `Established` and routes are confirmed on the gateway.
+**Minimum 4 hours. Recommended 24 hours.** Both L2 and BGP advertise the same /32s during this window. The goal is to catch flaps, leaks, or other instability before relying on BGP exclusively.
 
-### 4.1 Remove the L2 announcement policy
+### 3.1 What to watch
 
-Delete `infra/configs/cilium/l2-announcement-policy.yaml`.
+- `kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers` — peer must remain `Established`. Note the `Uptime` at start of soak.
+- Cilium agent logs:
+  ```bash
+  kubectl logs -n kube-system -l k8s-app=cilium --tail=200 | grep -i 'bgp\|error'
+  ```
+- Prometheus (if scraping Cilium):
+  - `cilium_bgp_session_state{}` — must equal 6 (Established) for the duration.
+  - `cilium_bgp_peers` — must equal 1.
+- Synthetic probe — a curl loop against `https://home.burntbytes.com` from a LAN client every 30 seconds, or rely on existing blackbox-exporter alerts.
 
-### 4.2 Disable L2 in Cilium Helm values
+### 3.2 GO criteria for Phase 4a
 
-Edit [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml):
+- BGP `Established` continuously for the soak window (no flap events).
+- Zero increase in 5xx or DNS-resolution-failure rate compared to baseline.
+- All baseline LB IPs still routable via BGP (verify by re-running the kubectl jsonpath query — IPs should match).
 
-```yaml
-# Change:
-l2announcements:
-  enabled: false    # was: true
+### 3.3 NO-GO conditions (abort and rollback to Phase 2)
+
+- Any BGP session flap (uptime resets).
+- Cilium agent CPU or memory spikes correlated with BGP activity.
+- Gateway shows missing prefixes.
+- LAN client probe failures attributable to routing.
+
+### Phase 3 rollback
+Same as Phase 2 rollback. No state change happened in Phase 3.
+
+---
+
+## Phase 4a — Remove the L2 announcement policy
+
+This is the cutover. **Single CRD deletion. Instantly reversible.**
+
+After this phase, L2 announcements stop. UCGF ARP cache for LB IPs ages out (~5 min default on UniFi). LAN clients re-learn via BGP-installed routes.
+
+### 4a.1 Delete the policy file
+
+```bash
+rm infra/configs/cilium/l2-announcement-policy.yaml
 ```
 
-Or remove the `l2announcements` section entirely.
-
-### 4.3 Update Kustomization
-
-Edit `infra/configs/cilium/kustomization.yaml` — remove `l2-announcement-policy.yaml`:
+Edit `infra/configs/cilium/kustomization.yaml` — remove the `l2-announcement-policy.yaml` line:
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -351,131 +445,205 @@ resources:
   - load-balancer-ip-pool.yaml
 ```
 
-### 4.4 Commit, push, and reconcile
+> Leave `l2announcements.enabled: true` in Helm values. We disable it in 4b after a 24h watch window.
+
+### 4a.2 Commit, push, reconcile
 
 ```bash
-git add -A infra/configs/cilium/ infra/controllers/cilium/values.yaml
-git commit -m "Remove L2 announcements, BGP is now the sole advertisement method"
+git add -A infra/configs/cilium/
+git commit -m "feat(cilium): remove L2 announcement policy (BGP-only advertisement)"
 git push
+flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-### 4.5 Verify L2 is gone
+### 4a.3 Verify
 
 ```bash
 kubectl get ciliuml2announcementpolicy
-# Should return: No resources found
+# Expected: No resources found
 
-# Verify BGP is still working
 kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers
+# Expected: Established, unchanged Uptime (Cilium agent does not restart)
 ```
 
-### 4.6 Full connectivity test
+### 4a.4 Force ARP refresh and test from LAN
+
+From a LAN client (NOT the k8s node, NOT the UCGF):
 
 ```bash
-# Flush ARP cache on a LAN client to ensure traffic uses BGP routes
-sudo arp -d 10.42.2.40 2>/dev/null
+# Flush ARP for the production gateway IP, then re-test
+sudo arp -d 10.42.2.40 2>/dev/null || true
+sudo arp -d 10.42.2.43 2>/dev/null || true   # AdGuard primary
 
 curl -sk https://home.burntbytes.com
-curl -sk https://links.burntbytes.com
-curl -sk https://vitals.burntbytes.com
-curl -sk https://grafana.burntbytes.com
+dig @10.42.2.43 example.com +short
 ```
 
----
+Run the **Test plan** matrix below.
 
-## Phase 5: Post-Cutover Hardening
+### Phase 4a GO criteria
+All test-plan rows in the "Post-Phase 4a" column pass.
 
-### 5.1 Add BGP route filtering (optional)
-
-On the gateway, restrict accepted prefixes to only the LoadBalancer pool range:
-
-```text
-vtysh
-configure terminal
-
-ip prefix-list K8S-LB-IPS seq 10 permit 10.42.2.40/32 ge 32 le 32
-ip prefix-list K8S-LB-IPS seq 20 permit 10.42.2.41/32 ge 32 le 32
-! ... or use a range:
-ip prefix-list K8S-LB-IPS seq 10 permit 10.42.2.0/24 ge 32 le 32
-
-route-map K8S-ONLY permit 10
-  match ip address prefix-list K8S-LB-IPS
-
-router bgp 65100
-  address-family ipv4 unicast
-    neighbor 10.42.2.20 route-map K8S-ONLY in
-  exit-address-family
-
-end
-write memory
-```
-
-### 5.2 Monitoring
-
-Add alerting for BGP session drops:
+### Phase 4a rollback
 
 ```bash
-# Quick check — peer should be Established
-kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers | grep -i established
+# Restore the file from the previous commit
+git revert HEAD
+git push
+flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-Consider adding a Prometheus alert via the Cilium agent metrics:
-- `cilium_bgp_peers` (gauge, number of peers)
-- `cilium_bgp_session_state` (per-peer state)
-
-### 5.3 Document the change
-
-Update [docs/architecture/](../../docs/architecture/) with a note that the cluster uses BGP for LoadBalancer IP advertisement instead of L2 ARP.
+Within 1–2 minutes, the L2 policy is re-applied and ARP announcements resume. **This is the safety net.** Use it without hesitation if anything looks wrong — the cost is one extra commit to revert later.
 
 ---
 
-## Rollback Plan
+## Phase 4b — Disable L2 in Helm values (cosmetic)
 
-If BGP is not working correctly after Phase 4 (L2 removed):
+Run after **24 hours** of clean operation post-4a. No traffic effect — `l2announcements: enabled: true` does nothing without a `CiliumL2AnnouncementPolicy` resource. This step is for hygiene: future Cilium upgrades shouldn't carry L2 logic that nothing uses.
 
-1. **Re-enable L2 immediately:**
-   ```bash
-   # Quick fix — re-apply the L2 policy directly
-   kubectl apply -f - <<EOF
-   apiVersion: cilium.io/v2alpha1
-   kind: CiliumL2AnnouncementPolicy
-   metadata:
-     name: l2-announcement-policy-staging
-     namespace: kube-system
-   spec:
-     externalIPs: true
-     loadBalancerIPs: true
-   EOF
-   ```
+### 4b.1 Update Helm values
 
-2. **Re-enable in Helm values:**
-   ```yaml
-   l2announcements:
-     enabled: true
-   ```
+Edit [infra/controllers/cilium/values.yaml](../../infra/controllers/cilium/values.yaml):
 
-3. **Revert the git changes and push.**
+```yaml
+l2announcements:
+  enabled: false   # was true
+```
 
-L2 and BGP can coexist, so re-enabling L2 does not require disabling BGP. Services will be reachable via whichever path works first.
+Or remove the block entirely.
+
+### 4b.2 Commit, push, reconcile
+
+```bash
+git add infra/controllers/cilium/values.yaml
+git commit -m "chore(cilium): disable l2announcements helm flag (already unused)"
+git push
+flux reconcile kustomization infra-controllers -n flux-system --with-source
+```
+
+Cilium DaemonSet rolls. ~30s gap during pod replacement. Expect zero traffic impact (BGP keeps advertising via graceful-restart).
+
+### 4b.3 Verify
+
+```bash
+kubectl rollout status ds/cilium -n kube-system
+kubectl exec -n kube-system ds/cilium -- cilium-dbg bgp peers
+# Established, Uptime resets to seconds (after rollout)
+```
+
+Run the **Test plan** matrix one more time, "Post-Phase 4b" column.
+
+### Phase 4b GO criteria
+All test-plan rows in the "Post-Phase 4b" column pass.
+
+### Phase 4b rollback
+
+```bash
+git revert HEAD
+git push
+flux reconcile kustomization infra-controllers -n flux-system --with-source
+```
+
+Re-enables the Helm flag. Without the policy file (still removed) it has no effect, but the option is back if needed.
 
 ---
 
-## ASN Reference
+## Phase 5 — Hardening and docs
+
+### 5.1 Monitoring
+
+Cilium exposes BGP metrics on its existing `/metrics` endpoint. Add Prometheus rules:
+
+```yaml
+# infra/configs/alerts/bgp.yaml (illustrative)
+groups:
+  - name: cilium-bgp
+    rules:
+      - alert: CiliumBGPSessionDown
+        expr: cilium_bgp_session_state != 6
+        for: 2m
+        labels: { severity: warning }
+        annotations:
+          summary: "Cilium BGP peer not Established"
+          description: "Peer {{ $labels.peer }} state {{ $value }}; LB IPs may be unreachable from outside the node."
+      - alert: CiliumBGPNoPeers
+        expr: absent(cilium_bgp_peers) or cilium_bgp_peers < 1
+        for: 5m
+        labels: { severity: critical }
+        annotations:
+          summary: "Cilium has no BGP peers"
+```
+
+### 5.2 Update infra docs
+
+Edit [docs/infra/cilium.md](../infra/cilium.md) — replace any "L2 announcements" wording with "BGP peering with the UCGF (AS 65010 ↔ 65100)". Reference `docs/infra/ucgf-bgp-frr.conf`.
+
+### 5.3 Mark this plan completed
+
+Update the frontmatter `status: planned` → `status: completed` and add a closing date. Move detailed phase content to an appendix or leave intact for future reference / multi-node expansion.
+
+---
+
+## Test plan matrix
+
+Run before any phase, then again after each cutover.
+
+| Test | Pre-cutover | Post-Phase 2 | Post-Phase 4a | Post-Phase 4b |
+|:-----|:-----------:|:------------:|:-------------:|:-------------:|
+| `dig @10.42.2.43 example.com +short` | ✓ | ✓ | ✓ | ✓ |
+| `curl -sk https://home.burntbytes.com` | ✓ | ✓ | ✓ | ✓ |
+| `curl -sk https://grafana.burntbytes.com` | ✓ | ✓ | ✓ | ✓ |
+| LAN client `arp -d <ip>; curl …` | ✓ (re-ARPs) | ✓ | ✓ (BGP route) | ✓ (BGP route) |
+| `vtysh -c "show ip route bgp"` shows /32s | empty | populated | populated | populated |
+| `kubectl get ciliuml2announcementpolicy` | 1 | 1 | 0 | 0 |
+| `cilium-dbg bgp peers` Established | n/a | yes | yes | yes |
+| Helm value `l2announcements.enabled` | true | true | true | false |
+
+Any "no" in a column where "yes" is expected → STOP and rollback the most recent phase.
+
+---
+
+## ASN reference
 
 | Entity | ASN | Notes |
 |:-------|:----|:------|
-| Unifi Cloud Gateway Fiber | 65100 | Private ASN, chosen arbitrarily |
+| UniFi Cloud Gateway Fiber | 65100 | Private ASN, chosen arbitrarily |
 | Kubernetes cluster | 65010 | Private ASN, chosen arbitrarily |
 
-Private AS range: 64512–65534 (2-byte) or 4200000000–4294967294 (4-byte).
+Private 2-byte AS range: 64512–65534. 4-byte: 4200000000–4294967294.
 
 ---
 
-## Multi-Node Considerations (Future)
+## Multi-node considerations (future)
 
-If more nodes are added to the cluster:
+When a second Talos node joins:
 
-- Each node will automatically establish a BGP session with the UCGF (matched by the `nodeSelector` in `CiliumBGPClusterConfig`)
-- The gateway will learn multiple next-hops for the same LoadBalancer IP and can ECMP load-balance across nodes
-- This is a significant advantage over L2 announcements, which require leader election and only one node can respond to ARP for a given IP
-- No changes needed to the gateway BGP config — it already accepts any peer from AS 65010
+- The `nodeSelector` (`kubernetes.io/os: linux`) on `CiliumBGPClusterConfig` matches all nodes — each gets a BGP session with the UCGF automatically.
+- The UCGF learns multiple next-hops for each LB IP and ECMP-load-balances across nodes. No gateway config changes.
+- L2 leader-election failures stop being a relevant failure mode (they already don't apply post-this-migration, but conceptually noted).
+
+If you want explicit control over which nodes peer, add a `bgp-policy: active` node label and switch `nodeSelector` to `matchLabels: {bgp-policy: active}`. Apply the label via Talos machine config so it survives node restarts:
+
+```yaml
+machine:
+  nodeLabels:
+    bgp-policy: active
+```
+
+---
+
+## Baseline appendix
+
+> Filled in during Phase 0.3.
+
+```
+# kubectl get svc -A -o jsonpath='...' (paste output here)
+default/cilium-gateway-app-gateway-production: 10.42.2.40
+default/cilium-gateway-app-gateway-staging: 10.42.2.42
+adguard-prod/adguard: 10.42.2.43
+adguard-stage/adguard: 10.42.2.42
+snapcast-prod/snapcast: 10.42.2.44
+snapcast-stage/snapcast: 10.42.2.41
+```
+
+Replace with the live output captured at Phase 0.3 time. Anyone reading this plan a year from now needs to know what was advertised at cutover.


### PR DESCRIPTION
## Summary

Rewrites `docs/plans/bgp-rollout.md` end-to-end. Two commits:
1. **Refine** — single-node plan tightened (per-phase rollback, v2 API, Phase 0 pre-flight, Phase 4 split, test matrix, soak window).
2. **Multi-node** — adapts the plan to today's 6-node cluster (3 CP + 3 worker). Adds a canary stage, switches FRR to peer-group/listen-range, expects ECMP across 3 worker next-hops.

## End-state target

| | Before | After |
|---|---|---|
| LB IP advertisement | L2 announce (ARP) | BGP peering, eBGP |
| BGP sessions | 0 | 3 (one per worker) |
| ECMP paths per LB IP | n/a (single advertiser) | 3 |
| HA failure mode | L2 leader election | Drop a node → drop one ECMP path; traffic continues |
| New worker joins | no LB advertisement until L2 leader fails over | self-service via `bgp listen range` |

## Rollout shape

```
 Phase 0  pre-flight gate     no commits      verify FRR, CRDs, capture baseline
 Phase 1  UCGF FRR config     out-of-band     peer-group + listen-range, prefix-list
 Phase 2a Cilium BGP canary   git commit      one labeled worker peers; 1h soak
 Phase 2b Cilium BGP fleet    git commit      role-based selector; all 3 workers
 Phase 3  soak                no commits      4h min / 24h recommended; ECMP holds
 Phase 4a delete L2 policy    git commit      single CRD removal; ARP ages out
 (24h watch)
 Phase 4b disable L2 helm     git commit      cosmetic; no traffic effect
 Phase 5  hardening           git commit      Prom alerts, docs flip
```

L2 and BGP coexist for the entire window from Phase 2a through Phase 4a. Disruption risk is concentrated in Phase 4a (single CRD deletion, instantly revertable).

## Multi-node specifics

- **Workers only peer.** CP nodes have `node.kubernetes.io/exclude-from-external-load-balancers` — Cilium would skip them anyway. `nodeSelector: matchExpressions: [{key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}]`.
- **Canary stage**: a `bgp-canary=true` node label gates Phase 2a to one worker. Phase 2b promotes to the role-based selector. Catches a broken cluster-wide BGP config before fleet rollout.
- **UCGF uses dynamic listen-range**: `bgp listen range 10.42.2.0/24 peer-group K8S-NODES`. New workers self-service.
- **`maximum-paths 8`** on UCGF installs all worker next-hops; without it FRR keeps a single best path and ECMP doesn't kick in.

## Resilience tests added

- Single-worker drain — UCGF removes that next-hop, traffic continues via the other 2.
- Rolling Cilium restart — graceful-restart keeps routes installed; LAN-side smoke test never fails.
- BGP flap simulation via iptables — peer goes Idle, ECMP drops to 2, reverts cleanly.

## Out of scope (flagged in doc)

- `k8sServiceHost: "10.42.2.20"` SPOF — file follow-up.
- `externalTrafficPolicy: Local` — separate decision.
- BGP MD5 / TCP-AO auth — private LAN; defer.

## Test plan
- [ ] Reviewer can answer "How many BGP peers does the UCGF expect?" → 3 (workers only)
- [ ] Reviewer can answer "What if Phase 2 enable breaks BGP fleet-wide?" → 2a canary catches it on one worker first
- [ ] Reviewer can answer "When can I delete L2?" → after Phase 3 soak (4h min, 24h recommended) with all 3 workers Established + ECMP holding
- [ ] No actual cluster changes in this PR (docs-only); migration executes phase-by-phase post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)