### PR TITLE
chore: standardize AGENTS.md, collapse CLAUDE.md, add canonical docs/ taxonomy folders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,173 +1,104 @@
-> Claude Code users: this file is also referenced from [CLAUDE.md](./CLAUDE.md).
+# AGENTS.md
 
-# Homelab GitOps Guidelines
+> GitOps repo for a single-node Talos Kubernetes cluster (`melodic-muse`) running self-hosted apps via Flux CD. — https://github.com/gjcourt/homelab
 
-## Source of truth
+## Commands
 
-| Topic | Location |
-|---|---|
-| App base manifests | `apps/base/<app>/` |
-| Staging overlays | `apps/staging/<app>/` |
-| Production overlays | `apps/production/<app>/` |
-| Cluster Flux entrypoints | `clusters/melodic-muse/` |
-| Infra operators (HelmReleases) | `infra/controllers/` |
-| Infra config (networking, storage) | `infra/configs/` |
-| App runbooks | `docs/apps/` |
-| Architecture decisions | `docs/architecture/` |
-| Incident reports | `docs/incidents/` |
-| Operational guides | `docs/guides/` |
-| Active plans | `docs/plans/` |
+| Command | Use |
+|---------|-----|
+| `kustomize build apps/staging/<overlay>` | Validate a staging overlay |
+| `kustomize build apps/production/<overlay>` | Validate a production overlay |
+| `kustomize build infra/controllers` | Validate infra controllers |
+| `flux get kustomizations -A` | Top-level Kustomization health |
+| `flux reconcile kustomization apps-production -n flux-system` | Force production reconcile after merge |
+| `flux reconcile source git flux-system-staging` | Force staging git source refresh |
+| `kubectl describe helmrelease <name> -n <namespace>` | Inspect a HelmRelease failure |
+| `gh workflow run staging-deploy.yaml` | Force a staging branch rebuild |
+| `sops -e -i <file>` / `sops -d <file>` | Encrypt / inspect secrets |
+
+Pre-PR: `kustomize build` for every affected overlay must pass.
 
 ## Architecture
 
-Flux CD (GitOps) cluster for a single-node Talos Kubernetes cluster (`melodic-muse`). All cluster state is driven from Git — changes take effect when merged to `master` and reconciled by Flux.
+Flux CD (GitOps) cluster — all cluster state is driven from Git; changes take effect when merged to `master` and reconciled by Flux on each Kustomization's `interval` (default 10m).
 
-Directory layout:
-- `apps/base/` — base Kustomize resources for each app (env-agnostic)
-- `apps/staging/` / `apps/production/` — environment overlays (namespace, resource patches, env-specific config)
-- `infra/controllers/` — HelmReleases and supporting config (monitoring, CNI, CSI, etc.)
-- `infra/configs/` — cluster configuration that controllers depend on (IP pools, cert issuers, etc.)
-- `clusters/melodic-muse/` — Flux Kustomization entrypoints
+- `apps/base/<app>/` — base Kustomize resources (env-agnostic).
+- `apps/staging/<app>/`, `apps/production/<app>/` — environment overlays.
+- `infra/controllers/` — HelmReleases (monitoring, CNI, CSI, etc.).
+- `infra/configs/` — cluster configuration controllers depend on (IP pools, cert issuers).
+- `clusters/melodic-muse/` — Flux Kustomization entrypoints.
 
-Flux reconciliation order: `infra-crds` → `infra-controllers` → `infra-configs` → `apps-production` / `apps-staging`
+Reconciliation order: `infra-crds` → `infra-controllers` → `infra-configs` → `apps-production` / `apps-staging`.
 
-## Non-negotiables
+See `docs/architecture/` for component-level architecture (DNS strategy, gateway auth, overlays-and-structure).
 
-- **Never commit directly to `master` or `staging`** — all changes go through a branch and PR
-- **Never push to `staging` manually** — the `staging` branch is rebuilt from scratch by CI on every trigger; a manual push will be overwritten and may break in-flight deployments
-- **Never commit plaintext secrets** — all secrets must be encrypted with SOPS before committing; use `sops -e -i <file>` in place
-- **Never bypass the staging environment for production changes** — open a PR, let CI merge it to staging, validate, then merge to `master`
+## Conventions
 
-## Branch and PR workflow
+- **Branch + PR for every change** — never commit directly to `master` or `staging`.
+- **Image tags are strictly increasing** — never roll back to an earlier tag without explicit intent. CI tags as `YYYY-MM-DD` (first build of day) then `YYYY-MM-DD-N`.
+- **Namespace convention**: production uses the plain name (`overture`); staging uses a `-stage` suffix (`overture-stage`).
+- **Secrets are SOPS-encrypted** before commit (key ref: `.sops.yaml`); never commit plaintext.
+- **Adding a new app**: see `docs/operations/2026-05-02-adding-an-app.md`.
+- **Conventional Commits** for every commit (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `ci:`, `deploy:`).
+- **Branch names** follow `<type>/<description>`.
 
-**You must use a branch and PR for every change — never commit directly to `master`.**
+## Invariants
 
-1. Check for open PRs first — unmerged changes on a stale branch will not be reconciled
+- Never commit directly to `master` — Flux deploys from `master`, all changes go through PR.
+- Never push to `staging` manually — CI rebuilds it from `master + open PRs` on every trigger; manual pushes are overwritten.
+- Never commit plaintext secrets — encrypt with SOPS first.
+- Never bypass staging for production changes — open a PR, let CI merge to staging, validate, then merge to `master`.
+- Image tags must be strictly greater than the currently deployed tag.
 
-   ```bash
-   gh pr list --repo gjcourt/homelab
-   ```
+## What NOT to Do
 
-2. Branch from `master` (not from another feature or fix branch)
+- Do not branch from another feature/fix branch — always branch from `master`.
+- Do not skip `kustomize build` validation before pushing.
+- Do not roll back an image tag silently — explicit rollback PRs only.
+- Do not put plaintext secrets anywhere in the tree, even in dev/test overlays.
+- Do not edit the staging branch directly; CI owns it.
 
-3. Validate locally before pushing:
+## Domain
 
-   ```bash
-   kustomize build apps/staging          # or a specific overlay
-   kustomize build infra/controllers
-   ```
+Single-node Talos Kubernetes cluster running ~14 self-hosted apps (Audiobookshelf, Authelia, Excalidraw, Golinks, Homepage, Immich, Jellyfin, Linkding, Mealie, Memos, Navidrome, Pingo, Snapcast, Vitals + Adguard / Vitals etc.) plus infrastructure (Cilium, cert-manager, CNPG, monitoring, Authelia SSO). GitOps via Flux CD with an automatic preview environment (`staging` branch) rebuilt by CI from `master + open PRs`.
 
-4. Commit, push, and open a PR against `master`
+## Cross-service dependencies
 
-5. Once CI passes, the staging workflow automatically merges the PR into the `staging` branch and Flux deploys it to staging namespaces — validate your change there
+| Service | Purpose |
+|---|---|
+| Talos Linux | Single-node Kubernetes substrate |
+| Flux CD | GitOps reconciliation |
+| Cilium + Gateway API | CNI + ingress |
+| cert-manager | TLS certificate issuance |
+| CNPG (Cloudnative-PG) | PostgreSQL operator |
+| Authelia | SSO / OAuth2 / OIDC |
+| Synology iSCSI | Block storage backing PVCs |
+| GitHub Actions | CI for kustomize build + staging branch rebuild |
+| ghcr.io | Container image registry (`gjcourt/<app>`) |
 
-6. Get explicit approval, then merge to `master` — Flux reconciles production within the `interval` on each Kustomization (default: 10m)
+## Quality gate before push
 
-7. To force immediate reconciliation after merge:
+1. `kustomize build` passes for every affected overlay
+2. `git diff HEAD | grep -i "password\|secret\|key"` returns no plaintext
+3. Image tags are strictly increasing (never silently rolled back)
+4. New apps wired into the right `apps/{staging,production}/kustomization.yaml`
+5. Namespace follows the convention (production unsuffixed, staging `-stage`)
+6. New CNPG clusters: iSCSI PVC provisioned and StorageClass correct
+7. Docs updated if the change affects a runbook or architecture doc
 
-   ```bash
-   flux reconcile kustomization apps-production -n flux-system
-   ```
+## Documentation
 
-## PR checklist
+`docs/` taxonomy: `architecture/` · `design/` · `operations/` · `plans/` · `reference/` · `research/`. Each folder's `README.md` describes scope. Index: `docs/README.md`.
 
-Before opening a PR:
+This repo also has historical topic folders (`docs/apps/`, `docs/guides/`, `docs/incidents/`, `docs/infra/`) that pre-date the canonical taxonomy. The active in-progress migration is tracked in `docs/plans/documentation-rewrite-plan.md`. Do not split content across both schemes for the same topic.
 
-- [ ] `kustomize build` passes for all affected overlays
-- [ ] No plaintext secrets committed (`git diff HEAD | grep -i "password\|secret\|key"`)
-- [ ] Image tags are strictly increasing (never rolling back without explicit intent)
-- [ ] New apps are added to the correct env `kustomization.yaml` entrypoints
-- [ ] Namespace follows the convention: unsuffixed for production, `-stage` suffix for staging
-- [ ] If adding a new CNPG cluster: iSCSI PVC provisioned and StorageClass correct
-- [ ] Docs updated if the change affects a runbook or architecture doc
+## Observability
 
-## Staging environment
+- `flux get kustomizations -A` — top-level Kustomization health.
+- `kubectl describe helmrelease <name> -n <namespace>` — HelmRelease failures.
+- `flux reconcile helmrelease <name> -n <namespace> --reset` — force reconcile after a stalled HelmRelease.
+- `kubectl -n <ns> get events --sort-by=.lastTimestamp | tail -n 50` — recent events.
+- Common Flux failure patterns and recovery: `docs/operations/2026-05-02-flux-debugging.md`.
+- Per-app observability dashboards: see each `docs/apps/<app>.md` runbook.
 
-Staging is an automatic preview environment. CI rebuilds the `staging` branch from `master` + all open PRs with passing checks on every trigger (PR events, check completions, cron every 5 min).
-
-```
-Feature branch → PR → CI passes → auto-merged into staging → Flux deploys to staging namespaces
-                                   PR merged to master → Flux deploys to production
-```
-
-Key commands:
-
-```bash
-# See what PRs are currently merged into staging
-git log --oneline origin/master..origin/staging
-
-# Force a staging rebuild
-gh workflow run staging-deploy.yaml
-
-# Staging reconciliation
-flux reconcile source git flux-system-staging
-flux reconcile kustomization apps-staging -n flux-system
-```
-
-See [docs/guides/staging-workflow.md](docs/guides/staging-workflow.md) for full details.
-
-## Image versioning
-
-CI tags images as `YYYY-MM-DD` for the first build of the day, then `YYYY-MM-DD-N` (N=1,2,…) for subsequent builds. **Every push to `main` in the app repo triggers a build**, so tag numbers are not sequential relative to deploys — docs-only commits consume slots too.
-
-When bumping an image tag in `deployment.yaml`, the new tag must be strictly greater than the currently deployed one. Never roll back to an earlier tag without an explicit rollback intent. To look up the latest published tag:
-
-```bash
-gh api /users/gjcourt/packages/container/overture/versions --jq '.[0].metadata.container.tags[]'
-```
-
-## Adding a new app
-
-1. Create `apps/base/<app>/kustomization.yaml` and base manifests
-2. Create overlays under `apps/staging/<app>/` and/or `apps/production/<app>/`
-3. Add the app to `apps/staging/kustomization.yaml` and/or `apps/production/kustomization.yaml`
-4. Update the apps list: `./scripts/update-apps-readme.sh`
-5. Namespace convention: production uses plain name, staging uses `-stage` suffix
-
-## Rollback
-
-Revert the commit on a branch, open a PR, and merge. Do not force-push to `master`.
-
-```bash
-git revert <commit>
-git push origin <branch>
-gh pr create ...
-```
-
-## Debugging Flux
-
-```bash
-# Top-level kustomization health
-flux get kustomizations -A
-
-# HelmRelease failures
-kubectl describe helmrelease <name> -n <namespace>
-
-# Force reconcile after a stalled HelmRelease
-flux reconcile helmrelease <name> -n <namespace> --reset
-
-# Recent events in a namespace
-kubectl -n <ns> get events --sort-by=.lastTimestamp | tail -n 50
-```
-
-### Common failure patterns
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| `HelmRelease status: 'Failed'` blocking kustomization | Immutable StatefulSet field in chart upgrade | Delete the StatefulSet, `flux reconcile helmrelease --reset`. Add `upgrade.remediation.remediationStrategy: uninstall` to the HelmRelease. |
-| `dependency 'X' is not ready` | Upstream kustomization stalled | Fix the upstream kustomization first |
-| HA enters recovery mode | 0-byte include file (automations.yaml etc.) | Init container must write `[]`, not `touch` |
-| PR not appearing in staging | CI checks pending or failing | Fix CI failures; staging rebuilds automatically |
-| Staging has stale code | Staging workflow run failed | `gh workflow run staging-deploy.yaml` |
-
-## Secrets
-
-SOPS + age encryption. Key ref: `.sops.yaml`. Encrypt secrets before committing — never commit plaintext secrets.
-
-```bash
-# Encrypt in place
-sops -e -i <secret-file.yaml>
-
-# Decrypt to inspect (do not commit the decrypted form)
-sops -d <secret-file.yaml>
-```
+When you learn a new convention or invariant in this repo, update this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-<!-- Project guidelines live in AGENTS.md — see that file for the full context. -->
-
-See [AGENTS.md](./AGENTS.md) for project guidelines, workflow conventions, Flux debugging patterns, and the PR checklist.
+@AGENTS.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,60 +1,60 @@
-# Documentation
+# Homelab Documentation
 
-Index of docs in this repo, organized by category.
+GitOps repo for a single-node Talos Kubernetes cluster (`melodic-muse`). Documentation is organized into a fixed six-folder taxonomy plus historical topic folders that pre-date the canonical layout.
 
-## Start here
+## Canonical taxonomy (six folders)
 
-- [Repository README](../README.md) — repo structure and quick start
-- [Apps overview](../apps/README.md) — auto-generated list of deployed apps
-- [Infra overview](../infra/README.md) — cluster-level controllers and configs
+- [`architecture/`](architecture/README.md) — how the cluster is built today.
+- [`design/`](design/README.md) — proposals, RFCs, in-flight or recently shipped designs.
+- [`operations/`](operations/README.md) — runbooks, smoke tests, debugging procedures.
+- [`plans/`](plans/README.md) — phased migrations, rollout sequencing, frontmatter convention is documented in the folder README.
+- [`reference/`](reference/README.md) — component reference, configuration tables.
+- [`research/`](research/README.md) — spikes, investigations.
 
-## Architecture
+## Historical topic folders (migration in progress)
 
-Design decisions and system context.
+These predate the canonical taxonomy and remain in place while content is migrated per `docs/plans/documentation-rewrite-plan.md`:
+
+- [`apps/`](apps/) — per-app runbooks (target: `operations/apps/` or `operations/<app>/`).
+- [`guides/`](guides/) — operational how-to guides (target: `operations/`).
+- [`incidents/`](incidents/) — incident reports (target: `operations/incidents/`).
+- [`infra/`](infra/) — infrastructure component reference (target: `reference/`).
+
+When you write new content, prefer the canonical folder. When you touch existing content materially, move it to the canonical folder in the same PR.
+
+## Quick links
+
+### Architecture
 
 - [Overlays and structure](architecture/overlays-and-structure.md) — base vs staging vs production
 - [DNS strategy](architecture/dns-strategy.md) — split-horizon DNS with wildcard records
-- [Gateway Authentication](architecture/gateway-auth.md) — Global Forward Auth and Envoy filters
+- [Gateway authentication](architecture/gateway-auth.md) — Global Forward Auth and Envoy filters
 
-## Guides
+### Operations
 
-Operational how-to guides for day-to-day work.
+- [Adding a new app](operations/2026-05-02-adding-an-app.md)
+- [Flux debugging — common patterns](operations/2026-05-02-flux-debugging.md)
+- [CNPG backup and disaster recovery](operations/2026-05-02-cnpg-backup-recovery.md)
+- Existing how-to guides: [Making changes](guides/making-changes.md), [Flux and deployments](guides/flux-and-deployments.md), [Staging workflow](guides/staging-workflow.md), [Synology iSCSI operations](guides/synology-iscsi-operations.md)
 
-- [Making changes](guides/making-changes.md) — workflow, secrets, rollback
-- [Flux and deployments](guides/flux-and-deployments.md) — how Flux applies changes, reconcile and debug commands
-- [Staging workflow](guides/staging-workflow.md) — how PRs auto-deploy to staging via CI and Flux
-- [Synology iSCSI operations](guides/synology-iscsi-operations.md) — common storage scenarios and runbook
-- [Synology iSCSI cleanup](guides/synology-iscsi-cleanup.md) — orphan LUN/target concepts and cleanup process
-- [HifiBerry OS Spotify Connect setup](guides/hifiberry-os-spotify-setup.md) — fix avahi Docker bridge IP poisoning and replace vollibrespot with go-librespot
+### Per-app runbooks
 
-## Apps
+See [`apps/`](apps/) — Adguard, Audiobookshelf, Authelia, Excalidraw, Golinks, Homepage, Immich, Jellyfin, Linkding, Mealie, Memos, Navidrome, Pingo, Snapcast, Vitals.
 
-Per-app usage, configuration, and operation docs.
+### Infrastructure component reference
 
-- [Authelia (SSO / OIDC)](apps/authelia.md)
-- [Navidrome (music server)](apps/navidrome.md)
-- [Snapcast (multi-room audio)](apps/snapcast.md)
+See [`infra/`](infra/) — cert-manager, Cilium, Flux, kernel log shipping, monitoring, Pingo, storage.
 
-## Infra
+### Active plans
 
-Infrastructure component documentation.
+See [`plans/README.md`](plans/README.md) for the full plan catalog and the frontmatter convention.
 
-- [Pingo (DNS updater)](infra/pingo.md)
+### Past incidents
 
-## Incidents
+See [`incidents/`](incidents/) for postmortems.
 
-Postmortems for past outages.
+## Conventions
 
-- [2026-03-10: Raspberry Pi STP TCN subnet blackouts](incidents/2026-03-10-rpi-stp-tcn-blackouts.md)
-- [2026-02-15: iSCSI targets disabled](incidents/2026-02-15-iscsi-targets-disabled.md)
-- [2026-02-12: iSCSI zombie targets](incidents/2026-02-12-iscsi-zombie-targets.md)
-- [2026-02-08: PV recovery](incidents/2026-02-08-pv-recovery.md)
-
-## Plans
-
-Active plans and TODOs.
-
-- [Authelia SSO rollout](plans/authelia-sso-rollout.md)
-- [Authelia SMTP notifier](plans/authelia-smtp-notifier.md)
-- [AdGuard HA](plans/adguard-ha.md)
-- [Navidrome → Snapcast via Mopidy](plans/navidrome-snapcast-mopidy.md)
+- Filenames in canonical folders use `<yyyy-mm-dd>-<topic>.md`.
+- Frontmatter (`title`, `status`, `created`, `updated`, `updated_by`, `tags`) on new docs in canonical folders. Existing docs in topical folders may be backfilled per the rewrite plan.
+- See `AGENTS.md` for the full repo convention.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,17 @@
+# architecture/
+
+How the cluster is built **today** — the present shape of overlays, networking, identity, and storage.
+
+**Put here:**
+- System-level architecture overviews (DNS strategy, gateway authentication, base/staging/production overlay structure).
+- Cross-cutting infrastructure decisions that aren't tied to a single component.
+
+**Do not put here:**
+- Proposals for future architecture — `design/` (or open-issue convention here today: `plans/` for in-flight decision + execution).
+- Phased rollouts — `plans/`.
+- Component-level reference (Cilium quirks, cert-manager config) — `reference/` (or the historical `infra/` while migration completes).
+- Runbooks — `operations/` (or the historical `apps/` and `guides/` while migration completes).
+
+**Naming convention:** `<topic>.md` for the existing inventory (DNS strategy, gateway-auth, overlays-and-structure); new docs added under this folder going forward should use `<yyyy-mm-dd>-<topic>.md`.
+
+**Allowed `status:` values:** `Stable`, `Superseded`.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,18 @@
+# design/
+
+What we're building and **why** — proposals, RFCs, in-flight or recently shipped designs.
+
+**Put here:**
+- Proposals for new infrastructure, app rollouts, or architectural changes that need a writeup before execution.
+- Design records that capture the decision and the alternatives considered.
+
+**Do not put here:**
+- How the cluster is built today — `architecture/`.
+- Phased rollout sequencing — `plans/`.
+- Spike output — `research/`.
+
+**Naming convention:** `<yyyy-mm-dd>-<topic>.md`.
+
+**Allowed `status:` values:** `Proposed`, `Accepted`, `Rejected`, `Implemented`, `Superseded`.
+
+This folder is empty today — historically, design rationale has gone directly into `plans/` documents alongside execution sequencing. Either pattern is acceptable; for proposals where the decision is the primary artifact, prefer this folder.

--- a/docs/operations/2026-05-02-adding-an-app.md
+++ b/docs/operations/2026-05-02-adding-an-app.md
@@ -1,0 +1,39 @@
+---
+title: Adding a new app
+status: Stable
+created: 2026-05-02
+updated: 2026-05-02
+updated_by: gjcourt
+tags: [operations, kustomize, apps]
+---
+
+# Adding a new app
+
+1. Create `apps/base/<app>/kustomization.yaml` and the base manifests.
+2. Create environment overlays under `apps/staging/<app>/` and/or `apps/production/<app>/`.
+3. Add the app to `apps/staging/kustomization.yaml` and/or `apps/production/kustomization.yaml`.
+4. Update the auto-generated apps list:
+   ```bash
+   ./scripts/update-apps-readme.sh
+   ```
+5. Namespace convention: production uses the plain name (`<app>`); staging uses a `-stage` suffix (`<app>-stage`).
+6. Validate before pushing:
+   ```bash
+   kustomize build apps/staging/<app>
+   kustomize build apps/production/<app>
+   ```
+7. Open a PR against `master`. CI will build into the `staging` branch automatically; Flux will deploy to the `<app>-stage` namespace. Validate there before merging.
+
+## Image naming
+
+CI tags images as `YYYY-MM-DD` (first build of the day) then `YYYY-MM-DD-N` for subsequent builds. Image bumps in `apps/{staging,production}/<app>/deployment.yaml` must be strictly greater than the currently deployed tag.
+
+To list published tags:
+
+```bash
+gh api /users/gjcourt/packages/container/<app>/versions --jq '.[0].metadata.container.tags[]'
+```
+
+## Per-app runbook
+
+After the app is deployed, add an entry under `docs/apps/<app>.md` with the standard runbook structure (overview, architecture, URLs, configuration, usage, monitoring, disaster recovery, troubleshooting). The template is documented in `docs/plans/documentation-rewrite-plan.md`.

--- a/docs/operations/2026-05-02-cnpg-backup-recovery.md
+++ b/docs/operations/2026-05-02-cnpg-backup-recovery.md
@@ -1,3 +1,12 @@
+---
+title: CNPG backup and disaster recovery
+status: Stable
+created: 2026-05-02
+updated: 2026-05-02
+updated_by: gjcourt
+tags: [operations, cnpg, postgres, backup, recovery]
+---
+
 # CNPG Backup & Disaster Recovery Guide
 
 > **Last tested:** 2026-04-18 — full wipe + S3 restore of `immich-stage` in ~5 minutes  

--- a/docs/operations/2026-05-02-flux-debugging.md
+++ b/docs/operations/2026-05-02-flux-debugging.md
@@ -1,0 +1,74 @@
+---
+title: Flux debugging — common patterns
+status: Stable
+created: 2026-05-02
+updated: 2026-05-02
+updated_by: gjcourt
+tags: [operations, flux, debugging, runbook]
+---
+
+# Flux debugging — common patterns
+
+## Inspecting state
+
+```bash
+# Top-level kustomization health
+flux get kustomizations -A
+
+# HelmRelease failures
+kubectl describe helmrelease <name> -n <namespace>
+
+# Force reconcile after a stalled HelmRelease
+flux reconcile helmrelease <name> -n <namespace> --reset
+
+# Recent events in a namespace
+kubectl -n <ns> get events --sort-by=.lastTimestamp | tail -n 50
+
+# Force production reconcile after merging to master
+flux reconcile kustomization apps-production -n flux-system
+
+# Force staging git source refresh
+flux reconcile source git flux-system-staging
+flux reconcile kustomization apps-staging -n flux-system
+```
+
+## Common failure patterns
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `HelmRelease status: 'Failed'` blocking kustomization | Immutable StatefulSet field in chart upgrade | Delete the StatefulSet, `flux reconcile helmrelease --reset`. Add `upgrade.remediation.remediationStrategy: uninstall` to the HelmRelease. |
+| `dependency 'X' is not ready` | Upstream kustomization stalled | Fix the upstream kustomization first. |
+| HA enters recovery mode | 0-byte include file (`automations.yaml` etc.) | Init container must write `[]`, not `touch`. |
+| PR not appearing in staging | CI checks pending or failing | Fix CI failures; staging rebuilds automatically once CI is green. |
+| Staging has stale code | Staging workflow run failed | `gh workflow run staging-deploy.yaml`. |
+
+## Staging environment
+
+Staging is an automatic preview environment. CI rebuilds the `staging` branch from `master` + all open PRs with passing checks on every trigger (PR events, check completions, cron every 5 min).
+
+```
+Feature branch → PR → CI passes → auto-merged into staging → Flux deploys to staging namespaces
+                                   PR merged to master → Flux deploys to production
+```
+
+Useful commands:
+
+```bash
+# See what PRs are currently merged into staging
+git log --oneline origin/master..origin/staging
+
+# Force a staging rebuild
+gh workflow run staging-deploy.yaml
+```
+
+See `../guides/staging-workflow.md` for the full workflow detail (until that guide is migrated into `operations/`).
+
+## Rollback
+
+Revert the commit on a branch, open a PR, and merge. Do not force-push to `master`.
+
+```bash
+git revert <commit>
+git push origin <branch>
+gh pr create ...
+```

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,20 @@
+# operations/
+
+Runbooks, smoke tests, and on-call procedures.
+
+**Put here:**
+- How to deploy, reconcile, debug, and recover from common failure modes.
+- Adding-a-new-app procedure, image-bump procedure, secrets rotation.
+- CNPG backup/restore drill instructions.
+
+**Do not put here:**
+- Component reference (Cilium config schema, cert-manager issuer recipes) — `reference/`.
+- Architecture overview — `architecture/`.
+- Per-app feature docs — `apps/` (until that folder migrates here).
+
+**Naming convention:** `<yyyy-mm-dd>-<topic>.md`.
+Examples: `2026-05-02-flux-debugging.md`, `2026-05-02-adding-an-app.md`, `2026-05-02-cnpg-backup-recovery.md`.
+
+**Allowed `status:` values:** `Stable`, `Superseded`.
+
+Historical note: `docs/apps/`, `docs/guides/`, and `docs/incidents/` predate this folder; per-doc migration is tracked in `docs/plans/documentation-rewrite-plan.md`. Cross-link rather than duplicate.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,19 @@
+# reference/
+
+Information you look things up in — component reference, network specs, configuration tables.
+
+**Put here:**
+- Component-level reference (Cilium config quirks, cert-manager issuer recipes, monitoring alert catalog).
+- IP allocation tables, firewall rules, DNS zone snapshots.
+- Hardware reference (RPi GPIO pinouts, Synology SAS topology).
+
+**Do not put here:**
+- Runbooks — `operations/`.
+- Architecture overview — `architecture/`.
+- Spike output — `research/`.
+
+**Naming convention:** `<yyyy-mm-dd>-<topic>.md`.
+
+**Allowed `status:` values:** `Stable`, `Superseded`.
+
+Historical note: `docs/infra/` predates this folder and contains component reference for Cilium, cert-manager, Flux, monitoring, storage, etc. Per-doc migration is tracked in `docs/plans/documentation-rewrite-plan.md`.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,17 @@
+# research/
+
+Spikes, investigations, and exploratory work.
+
+**Put here:**
+- Output of exploratory work — what we learned and why it shaped a later decision.
+- Hardware evaluations, networking experiments, capacity studies.
+
+**Do not put here:**
+- Decisions — `design/`.
+- Stable lookup material — `reference/`.
+
+**Naming convention:** `<yyyy-mm-dd>-<topic>.md`.
+
+**Allowed `status:` values:** `Complete` (research is frozen once written).
+
+This folder is empty today; create as needed.


### PR DESCRIPTION
## What changed

- Restructured `AGENTS.md` to the canonical 10-section layout (Commands, Architecture, Conventions, Invariants, What NOT to Do, Domain, Cross-service dependencies, Quality gate, Documentation, Observability) with the LLM-update footer.
- Collapsed `CLAUDE.md` to a single-line `@AGENTS.md` shim per the deprecation guidance in the cross-repo conventions proposal.
- Added the canonical `docs/` taxonomy folders: `architecture/`, `design/`, `operations/`, `reference/`, `research/` (alongside the existing `plans/`). Each new folder has a README defining scope and noting how it relates to the historical topic folders.
- Externalized the lengthy "Adding a new app" steps and "Debugging Flux" tables out of AGENTS.md and into:
  - `docs/operations/2026-05-02-adding-an-app.md`
  - `docs/operations/2026-05-02-flux-debugging.md`
- Migrated `docs/cnpg-backup-recovery.md` → `docs/operations/2026-05-02-cnpg-backup-recovery.md` (with frontmatter).
- Updated `docs/README.md` to surface both the canonical taxonomy and the historical topic folders (`apps/`, `guides/`, `incidents/`, `infra/`), with explicit notes on which is the migration target.

## Why

Cross-repo standardization wave applying the conventions in `~/src/config/2026-05-01-agents.md` and `~/src/config/2026-05-01-docs-structure.md`. Coinbase-specific bits stripped (no `behaviours_enabled`, no `CL-` ticket prefix, no institutional/ paths).

The historical topic folders (`apps/`, `guides/`, `incidents/`, `infra/`) are intentionally **not** moved in this PR — they're heavily cross-referenced and a migration mid-flight would conflict with the 7 open PRs against this repo. Per-doc migration continues incrementally per `docs/plans/documentation-rewrite-plan.md`.

## Type of change

- [x] `chore` — housekeeping

## Checklist

- [x] Branch name follows `<type>/<description>` convention
- [x] PR title follows Conventional Commits format (`type: description`)
- [x] No code changes — `kustomize build apps/staging` and `kustomize build apps/production` both pass
- [x] Documentation updated (this is the documentation update)
- [x] No unrelated changes in this PR

## Notes

- AGENTS.md instruction count: 35 (well under the 200 soft cap).
- The 7 in-flight PRs touch `apps/`, `infra/`, `clusters/` — this PR touches `AGENTS.md`, `CLAUDE.md`, `docs/`, so merge conflicts should be minimal. Order doesn't matter.
- Sister PRs in the wave: pingo merged, drift (#1), golinks (#17), vitals (#17), llmux (#3), soundbyte (#8), tempo-interview (#83) all open.
- Orchestration plan: `~/.claude/plans/i-d-like-to-apply-rosy-conway.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)