### PR TITLE
chore: establish hosts/ directory for TrueNAS-resident services

### DIFF
--- a/hosts/README.md
+++ b/hosts/README.md
@@ -1,0 +1,29 @@
+# hosts/
+
+Host-specific artifacts for services that run directly on physical or virtual hosts (not managed by Flux on melodic-muse).
+
+## Directory layout
+
+```
+hosts/
+  <hostname>/
+    README.md              # IP, SSH user, dataset paths, what runs here
+    <service>/
+      docker-compose.yml   # canonical source; operator pastes into SCALE UI or runs directly
+      README.md            # env vars, secrets, sync instructions, runbook
+```
+
+## Boundaries
+
+| Location | What lives here |
+|----------|----------------|
+| `hosts/` | docker-compose files, host-side scripts, and dataset-path docs for services deployed on specific hosts (TrueNAS, VMs) outside Kubernetes |
+| `apps/` | Kubernetes manifests for services managed by Flux on melodic-muse |
+| `images/` | Dockerfile + source for container images we author |
+| `infra/` | Cluster-level controllers, CRDs, and config for melodic-muse |
+
+## Sync policy
+
+For TrueNAS Custom Apps: the YAML in this directory is the canonical source of truth.
+To apply a change, open SCALE UI → Apps → `<app>` → Edit → paste the updated YAML → Save.
+Never edit the compose in the SCALE UI without updating git — that creates drift.

--- a/hosts/hestia/README.md
+++ b/hosts/hestia/README.md
@@ -1,0 +1,42 @@
+# hestia (TrueNAS SCALE)
+
+| Attribute | Value |
+|-----------|-------|
+| SSH | `truenas_admin@10.42.2.10` |
+| Role | NAS + GPU inference host |
+| OS | TrueNAS SCALE |
+| Docker | 29.0.4 (managed by TrueNAS Apps) |
+| Arch | x86_64 |
+
+## Services
+
+All services on hestia run as **TrueNAS Custom Apps** (SCALE UI → Apps → Custom App).
+The compose YAML in each subdirectory is the canonical source; paste into SCALE UI to deploy or update.
+
+| Service | Directory | Port | Notes |
+|---------|-----------|------|-------|
+| signal | `signal/` | 8080 | signal-cli daemon + signal-bridge SSE relay |
+| llms | `llms/` | varies | llama.cpp / vLLM inference (GPU box) |
+| monitoring | `monitoring/` | varies | nvtop and GPU metrics |
+
+## ZFS datasets
+
+Operator-owned datasets (survive App deletion):
+
+| Dataset | Mount | Used by |
+|---------|-------|---------|
+| `tank/apps/signal` | `/mnt/tank/apps/signal` | signal-cli identity data |
+
+## Common operations
+
+```bash
+# Check running apps
+ssh truenas_admin@10.42.2.10 'docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+
+# Check an app's env (drift detection)
+ssh truenas_admin@10.42.2.10 'docker inspect ix-<app>-<svc>-1 \
+  --format "{{.Config.Image}}{{range .Config.Env}}\n{{.}}{{end}}"'
+
+# Create a ZFS snapshot before risky changes
+ssh truenas_admin@10.42.2.10 'sudo zfs snapshot tank/apps/<dataset>@pre-change-$(date +%Y%m%d)'
+```

--- a/hosts/hestia/llms/README.md
+++ b/hosts/hestia/llms/README.md
@@ -1,0 +1,20 @@
+# llms — GPU inference on hestia
+
+LLM inference services for the GPU box on hestia (RTX 4090, 24 GB VRAM).
+
+## Services
+
+| File | Model | Notes |
+|------|-------|-------|
+| `docker-compose-llama.yml` | llama.cpp inference server | Preferred for 24 GB VRAM; GGUF quants |
+| `docker-compose-vllm.yml` | vLLM | Higher throughput; has caused OOM on 24 GB — prefer llama.cpp |
+
+## Deployment
+
+Both files are deployed as separate TrueNAS Custom Apps. Paste the relevant YAML into SCALE UI → Apps → Custom App.
+
+## GPU notes
+
+- 24 GB VRAM (RTX 4090) — prefer GGUF Q4/Q5 quants with llama.cpp over full-precision vLLM
+- vLLM has caused repeated OOM crashes on this hardware; use llama.cpp as default
+- For models exceeding 24 GB, use CPU offload with llama.cpp (`-ngl` to control GPU layers)

--- a/hosts/hestia/llms/docker-compose-llama.yml
+++ b/hosts/hestia/llms/docker-compose-llama.yml
@@ -1,0 +1,43 @@
+services:
+  llama-qwen36-35b:
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    container_name: llama-qwen36-35b
+    restart: unless-stopped
+    volumes:
+      - /mnt/main/ai/models/gguf:/models
+    ports:
+      - "8000:8080"
+    command: >
+      -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf
+      --alias "Qwen3.6-35B-A3B"
+      --host 0.0.0.0
+      --port 8080
+      --ctx-size 409600
+      --cache-type-k q8_0
+      --cache-type-v q8_0
+      --n-gpu-layers 99
+      --parallel 1
+      --cont-batching
+      --threads 8
+      --temp 0.6
+      --top-k 20
+      --top-p 0.95
+      --min-p 0
+      --presence-penalty 0
+      --repeat-penalty 1
+      --chat-template-kwargs '{"preserve_thinking":true}'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities:
+                - gpu
+                - utility
+              count: all
+              driver: nvidia
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s

--- a/hosts/hestia/llms/docker-compose-vllm.yml
+++ b/hosts/hestia/llms/docker-compose-vllm.yml
@@ -1,0 +1,55 @@
+services:
+  vllm:
+    command:
+      - '-c'
+      - >-
+        echo "=== START $(date) ===" >> /root/.cache/huggingface/vllm.log 2>&1;
+        exec vllm serve Qwen/Qwen3.5-27B-GPTQ-Int4 --served-model-name
+        qwen3.5-27b --host 0.0.0.0 --port 8000 --quantization gptq
+        --dtype float16 --gpu-memory-utilization 0.75 --max-model-len 16384
+        --enable-chunked-prefill --max-num-seqs 4 --enforce-eager --enable-auto-tool-choice
+        --tool-call-parser hermes --trust-remote-code >>
+        /root/.cache/huggingface/vllm.log 2>&1
+    container_name: vllm
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities:
+                - gpu
+                - utility
+              count: all
+              driver: nvidia
+    entrypoint:
+      - /bin/bash
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ""  # set in SCALE UI env-var section (masked); do not commit a real token here
+      NCCL_P2P_DISABLE: '1'
+      OMP_NUM_THREADS: '8'
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+      TOKENIZERS_PARALLELISM: 'false'
+    healthcheck:
+      interval: 30s
+      retries: 5
+      start_period: 600s
+      test:
+        - CMD
+        - curl
+        - '-f'
+        - http://localhost:8000/health
+      timeout: 10s
+    image: vllm/vllm-openai:latest
+    ipc: host
+    ports:
+      - '8000:8000'
+    restart: unless-stopped
+    shm_size: 16gb
+    ulimits:
+      memlock:
+        hard: -1
+        soft: -1
+      stack:
+        hard: 67108864
+        soft: 67108864
+    volumes:
+      - /mnt/main/ai/models:/root/.cache/huggingface

--- a/hosts/hestia/monitoring/README.md
+++ b/hosts/hestia/monitoring/README.md
@@ -1,0 +1,13 @@
+# monitoring — GPU metrics on hestia
+
+GPU utilization monitoring for the 4090 on hestia.
+
+## Services
+
+| File | Purpose |
+|------|---------|
+| `docker-compose-nvtop.yml` | nvtop — interactive GPU process viewer |
+
+## Deployment
+
+Deploy as a TrueNAS Custom App. Paste the YAML into SCALE UI → Apps → Custom App.

--- a/hosts/hestia/monitoring/docker-compose-nvtop.yml
+++ b/hosts/hestia/monitoring/docker-compose-nvtop.yml
@@ -1,0 +1,17 @@
+services:
+  nvtop:
+    image: onmoon/nvtop
+    container_name: nvtop
+    stdin_open: true
+    tty: true
+    pid: host
+    privileged: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities:
+                - gpu
+                - utility
+              count: all
+              driver: nvidia


### PR DESCRIPTION
## Summary

Creates `hosts/` top-level directory to hold docker-compose and runbooks for services running directly on TrueNAS/VMs (outside Kubernetes Flux management).

- `hosts/README.md` — boundary convention (hosts vs apps vs images vs infra)
- `hosts/hestia/README.md` — SSH details (`truenas_admin@10.42.2.10`), ZFS dataset paths, service inventory
- `hosts/hestia/llms/` — llama.cpp and vLLM compose files (HuggingFace token redacted; supply via SCALE UI)
- `hosts/hestia/monitoring/` — nvtop compose file
- `misc/` deleted — superseded by `hosts/`; stale dbus-mode signal-cli draft removed

## Test plan

- [ ] No Kubernetes manifests changed — no kustomize build needed
- [ ] `ls misc/` returns nothing (directory removed)
- [ ] `hosts/hestia/llms/docker-compose-{llama,vllm}.yml` present
- [ ] `hosts/hestia/monitoring/docker-compose-nvtop.yml` present
- [ ] `grep hf_ hosts/hestia/llms/docker-compose-vllm.yml` returns nothing (token redacted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)