### PR TITLE
feat: productionize signal-bridge for Hermes + multi-account

### DIFF
--- a/.github/workflows/build-signal-bridge.yml
+++ b/.github/workflows/build-signal-bridge.yml
@@ -1,0 +1,64 @@
+name: Build signal-bridge
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/signal-bridge/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/signal-bridge
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: images/signal-bridge
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### signal-bridge published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Update \`hosts/hestia/signal/docker-compose.yml\` to reference this tag, then paste into SCALE UI." >> $GITHUB_STEP_SUMMARY

--- a/images/signal-bridge/.gitignore
+++ b/images/signal-bridge/.gitignore
@@ -1,0 +1,3 @@
+signal-bridge
+signal-bridge-amd64
+signal-bridge-arm64

--- a/images/signal-bridge/Dockerfile
+++ b/images/signal-bridge/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.23-alpine AS builder
+
+ARG TARGETARCH=amd64
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o signal-bridge .
+
+FROM scratch
+
+COPY --from=builder /app/signal-bridge /signal-bridge
+
+EXPOSE 8080
+
+ENTRYPOINT ["/signal-bridge"]

--- a/images/signal-bridge/README.md
+++ b/images/signal-bridge/README.md
@@ -1,0 +1,87 @@
+# signal-bridge
+
+HTTP bridge between signal-cli's JSON-RPC TCP daemon and the SSE+JSON-RPC shape expected by [Hermes](https://hermes-agent.nousresearch.com/).
+
+## Architecture
+
+```
+Hermes ──HTTP──► signal-bridge:8080 ──TCP:7583──► signal-cli daemon
+                   ├── GET /api/v1/events   (SSE, per-account filtered)
+                   ├── POST /api/v1/rpc     (JSON-RPC relay)
+                   ├── GET /api/v1/check    (health — Hermes)
+                   ├── GET /v1/health       (health — legacy)
+                   └── GET /metrics         (Prometheus)
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SIGNAL_CLI_HOST` | `signal-cli` | Hostname of the signal-cli JSON-RPC daemon |
+| `SIGNAL_CLI_PORT` | `7583` | TCP port of the signal-cli daemon |
+| `LISTEN_ADDR` | `0.0.0.0` | Address to bind the HTTP server |
+| `LISTEN_PORT` | `8080` | Port to bind the HTTP server |
+| `HERMES_ALLOWED_ACCOUNTS` | _(none)_ | Comma-separated E.164 numbers allowed to use the bridge. Empty = deny all. Set `HERMES_ALLOW_ALL_USERS=true` to skip this check. |
+| `HERMES_ALLOW_ALL_USERS` | `false` | Bypass the account allowlist (useful for development) |
+| `HERMES_AUTH_TOKEN` | _(none)_ | Bearer token required on `/api/v1/events` and `/api/v1/rpc`. Empty = no auth. |
+| `POLL_INTERVAL` | `2s` | How often to poll signal-cli for new messages per account |
+| `HEARTBEAT_INTERVAL` | `30s` | SSE heartbeat cadence |
+
+## Endpoints
+
+### `GET /api/v1/events?account=+1xxx`
+
+SSE stream of inbound Signal messages for the given account. Requires `Authorization: Bearer <token>` if `HERMES_AUTH_TOKEN` is set. The `account` must be in `HERMES_ALLOWED_ACCOUNTS` (or `HERMES_ALLOW_ALL_USERS=true`).
+
+### `POST /api/v1/rpc`
+
+JSON-RPC relay to signal-cli. The request body is forwarded as-is after method-name normalization (`signal.send` → `send`, etc.). Validates `params.account` against the allowlist.
+
+### `GET /api/v1/check` / `GET /v1/health`
+
+Health check. Returns `{"status":"ok"}` when signal-cli is reachable, `{"status":"degraded"}` with HTTP 503 otherwise.
+
+## Multi-account setup
+
+1. Register each account on the signal-cli daemon (link device or provision directly).
+2. Set `HERMES_ALLOWED_ACCOUNTS=+16179397251,+1<second-number>` in the SCALE UI env-var section.
+3. Restart the signal-bridge container. The bridge polls each account independently.
+
+To link a second account (e.g. a family member's phone):
+
+```bash
+# On hestia — generates a QR-code URI the phone scans in Signal → Linked Devices
+docker exec ix-signal-signal-cli-1 \
+  signal-cli --config /var/lib/signal-cli link --name "Hestia Bridge"
+```
+
+After linking, the phone number appears in `/var/lib/signal-cli/data/`. Add it to `HERMES_ALLOWED_ACCOUNTS` and update the SCALE UI app config.
+
+## Dev loop
+
+```bash
+# Run signal-cli daemon locally (adjust the number)
+docker run --rm -p 7583:7583 \
+  -v "$PWD/testdata:/var/lib/signal-cli" \
+  ghcr.io/asamk/signal-cli \
+  daemon --tcp=0.0.0.0:7583 --receive-mode=on-connection
+
+# Build and run the bridge
+go build -o signal-bridge . && \
+  SIGNAL_CLI_HOST=localhost \
+  HERMES_ALLOWED_ACCOUNTS=+16179397251 \
+  ./signal-bridge
+
+# Test health
+curl http://localhost:8080/api/v1/check
+
+# Test SSE stream
+curl -N "http://localhost:8080/api/v1/events?account=+16179397251"
+```
+
+## Image build
+
+Images are published to `ghcr.io/gjcourt/signal-bridge` by the GHA workflow
+`.github/workflows/build-signal-bridge.yml` on every push to `master` that touches this directory.
+
+Tag format: `YYYY-MM-DD` (first build of the day) or `YYYY-MM-DD-N` (reruns).

--- a/images/signal-bridge/config.go
+++ b/images/signal-bridge/config.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	SignalCLIHost     string
+	SignalCLIPort     int
+	PollInterval      time.Duration
+	HeartbeatInterval time.Duration
+	ListenAddr        string
+	ListenPort        int
+	AllowedAccounts   []string
+	AllowAll          bool
+	AuthToken         string
+}
+
+func LoadConfig() Config {
+	c := Config{
+		SignalCLIHost:     envString("SIGNAL_CLI_HOST", "signal-cli"),
+		SignalCLIPort:     envInt("SIGNAL_CLI_PORT", 7583),
+		PollInterval:      envDuration("POLL_INTERVAL", 2*time.Second),
+		HeartbeatInterval: envDuration("HEARTBEAT_INTERVAL", 30*time.Second),
+		ListenAddr:        envString("LISTEN_ADDR", "0.0.0.0"),
+		ListenPort:        envInt("LISTEN_PORT", 8080),
+		AllowAll:          envBool("HERMES_ALLOW_ALL_USERS", false),
+		AuthToken:         envString("HERMES_AUTH_TOKEN", ""),
+	}
+
+	if raw := os.Getenv("HERMES_ALLOWED_ACCOUNTS"); raw != "" {
+		for _, a := range strings.Split(raw, ",") {
+			a = strings.TrimSpace(a)
+			if a != "" {
+				c.AllowedAccounts = append(c.AllowedAccounts, a)
+			}
+		}
+	}
+
+	return c
+}
+
+func (c Config) IsAccountAllowed(account string) bool {
+	if c.AllowAll {
+		return true
+	}
+	for _, a := range c.AllowedAccounts {
+		if a == account {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) CheckBearer(authHeader string) bool {
+	if c.AuthToken == "" {
+		return true
+	}
+	return authHeader == "Bearer "+c.AuthToken
+}
+
+func (c Config) SignalCLIAddr() string {
+	return fmt.Sprintf("%s:%d", c.SignalCLIHost, c.SignalCLIPort)
+}
+
+func envString(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	v, err := strconv.Atoi(os.Getenv(key))
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	v, err := time.ParseDuration(os.Getenv(key))
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/images/signal-bridge/go.mod
+++ b/images/signal-bridge/go.mod
@@ -1,0 +1,14 @@
+module github.com/gjcourt/signal-bridge
+
+go 1.23
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/prometheus/client_golang v1.19.1 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
+)

--- a/images/signal-bridge/go.sum
+++ b/images/signal-bridge/go.sum
@@ -1,0 +1,16 @@
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
+github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
+github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
+github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
+github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
+github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
+github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
+github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/images/signal-bridge/health.go
+++ b/images/signal-bridge/health.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+type healthHandler struct {
+	rpc     *SignalRPC
+	metrics *Metrics
+}
+
+type healthResponse struct {
+	Status  string            `json:"status"`
+	Signal  string            `json:"signal_cli"`
+	Uptime  float64           `json:"uptime_seconds"`
+	Details map[string]string `json:"details,omitempty"`
+}
+
+var startTime = time.Now()
+
+func (h *healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resp := healthResponse{
+		Status:  "ok",
+		Signal:  "unknown",
+		Uptime:  time.Since(startTime).Seconds(),
+		Details: make(map[string]string),
+	}
+
+	// Check signal-cli connectivity
+	_, err := h.rpc.getInfo()
+	if err != nil {
+		resp.Status = "degraded"
+		resp.Signal = "error"
+		resp.Details["signal_error"] = err.Error()
+		log.Printf("health: signal-cli check failed: %v", err)
+	} else {
+		resp.Signal = "ok"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if resp.Status != "ok" {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	json.NewEncoder(w).Encode(resp)
+}

--- a/images/signal-bridge/main.go
+++ b/images/signal-bridge/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func main() {
+	cfg := LoadConfig()
+	log.Printf("signal-bridge starting: signal-cli=%s poll=%s heartbeat=%s listen=%s:%d accounts=%v",
+		cfg.SignalCLIAddr(), cfg.PollInterval, cfg.HeartbeatInterval, cfg.ListenAddr, cfg.ListenPort, cfg.AllowedAccounts)
+
+	reg := prometheus.NewRegistry()
+	metrics := NewMetrics(reg)
+
+	rpc := NewSignalRPC(cfg, metrics)
+	if err := rpc.Connect(); err != nil {
+		log.Fatalf("failed to connect to signal-cli: %v", err)
+	}
+
+	hub := newSSEHub(cfg, metrics, rpc)
+	healthCheck := &healthHandler{rpc: rpc, metrics: metrics}
+
+	mux := http.NewServeMux()
+
+	mux.Handle("/api/v1/events", hub)
+
+	mux.HandleFunc("/api/v1/rpc", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		relayRPC(w, r, rpc, cfg)
+	})
+
+	// /api/v1/check is the Hermes health endpoint; /v1/health is kept for compatibility.
+	mux.HandleFunc("/api/v1/check", healthCheck.ServeHTTP)
+	mux.HandleFunc("/v1/health", healthCheck.ServeHTTP)
+
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		Registry: reg,
+	}))
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"status":"ok","service":"signal-bridge"}`)
+	})
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", cfg.ListenAddr, cfg.ListenPort),
+		Handler:      mux,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 0, // SSE connections have no write timeout
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		<-sigChan
+		log.Println("shutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			log.Fatalf("server shutdown error: %v", err)
+		}
+	}()
+
+	log.Printf("listening on %s:%d", cfg.ListenAddr, cfg.ListenPort)
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+	log.Println("server stopped")
+}

--- a/images/signal-bridge/metrics.go
+++ b/images/signal-bridge/metrics.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Metrics struct {
+	PollsTotal              *prometheus.CounterVec
+	MessagesTotal           prometheus.Counter
+	SSEConnections          prometheus.Gauge
+	SSEConnectionsTotal     prometheus.Counter
+	PollDuration            prometheus.Histogram
+	PollMessagesTotal       prometheus.Histogram
+	LastPollAge             prometheus.Gauge
+	LastMessageAge          prometheus.Gauge
+	RPCRequestsTotal        *prometheus.CounterVec
+	RPCDuration             prometheus.Histogram
+	TCPErrorsTotal          *prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		PollsTotal: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "signal_bridge_polls_total",
+				Help: "Total number of polls sent to signal-cli",
+			},
+			[]string{"status"},
+		),
+		MessagesTotal: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name: "signal_bridge_messages_total",
+				Help: "Total SSE message events sent to all clients",
+			},
+		),
+		SSEConnections: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "signal_bridge_sse_connections",
+				Help: "Current number of active SSE client connections",
+			},
+		),
+		SSEConnectionsTotal: promauto.With(reg).NewCounter(
+			prometheus.CounterOpts{
+				Name: "signal_bridge_sse_connections_total",
+				Help: "Total SSE connection openings (reconnects included)",
+			},
+		),
+		PollDuration: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "signal_bridge_poll_duration_seconds",
+				Help:    "Time to complete one poll roundtrip to signal-cli",
+				Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
+			},
+		),
+		PollMessagesTotal: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "signal_bridge_poll_messages_total",
+				Help:    "Number of messages returned per poll",
+				Buckets: []float64{0, 1, 2, 5, 10, 20, 50},
+			},
+		),
+		LastPollAge: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "signal_bridge_last_poll_age_seconds",
+				Help: "Seconds since the last successful poll",
+			},
+		),
+		LastMessageAge: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "signal_bridge_last_message_age_seconds",
+				Help: "Seconds since the last message event was emitted to SSE clients",
+			},
+		),
+		RPCRequestsTotal: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "signal_bridge_rpc_requests_total",
+				Help: "Total JSON-RPC requests relayed to signal-cli",
+			},
+			[]string{"method"},
+		),
+		RPCDuration: promauto.With(reg).NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "signal_bridge_rpc_duration_seconds",
+				Help:    "Time to complete each JSON-RPC request",
+				Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
+			},
+		),
+		TCPErrorsTotal: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "signal_bridge_tcp_errors_total",
+				Help: "TCP connection errors to signal-cli",
+			},
+			[]string{"error_type"},
+		),
+	}
+	return m
+}
+
+func (m *Metrics) RecordPoll(ok bool, duration time.Duration, msgCount int) {
+	if ok {
+		m.PollsTotal.WithLabelValues("ok").Inc()
+	} else {
+		m.PollsTotal.WithLabelValues("error").Inc()
+	}
+	m.PollDuration.Observe(duration.Seconds())
+	m.PollMessagesTotal.Observe(float64(msgCount))
+	m.LastPollAge.Set(0)
+}
+
+func (m *Metrics) RecordMessage() {
+	m.MessagesTotal.Inc()
+	m.LastMessageAge.Set(0)
+}
+
+func (m *Metrics) RecordRPC(method string, duration time.Duration) {
+	m.RPCRequestsTotal.WithLabelValues(method).Inc()
+	m.RPCDuration.Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordTCPError(errorType string) {
+	m.TCPErrorsTotal.WithLabelValues(errorType).Inc()
+}

--- a/images/signal-bridge/rpc_relay.go
+++ b/images/signal-bridge/rpc_relay.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type jsonRPCRequest struct {
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params,omitempty"`
+	ID      *int                   `json:"id,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   interface{} `json:"error,omitempty"`
+	ID      *int        `json:"id,omitempty"`
+}
+
+func relayRPC(w http.ResponseWriter, r *http.Request, rpc *SignalRPC, cfg Config) {
+	if !cfg.CheckBearer(r.Header.Get("Authorization")) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req jsonRPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error:   map[string]interface{}{"code": -32700, "message": "parse error"},
+		})
+		return
+	}
+
+	// Validate account against allowlist.
+	if len(cfg.AllowedAccounts) > 0 {
+		account, _ := req.Params["account"].(string)
+		if !cfg.IsAccountAllowed(account) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(jsonRPCResponse{
+				JSONRPC: "2.0",
+				Error:   map[string]interface{}{"code": -32603, "message": "account not allowed"},
+				ID:      req.ID,
+			})
+			return
+		}
+	}
+
+	// Map Hermes-style method names to signal-cli JSON-RPC methods.
+	method := req.Method
+	switch method {
+	case "signal.send":
+		method = "send"
+	case "signal.getInfo":
+		method = "getInfo"
+	case "signal.receive":
+		method = "receive"
+	}
+
+	result, err := rpc.call(method, req.Params)
+	w.Header().Set("Content-Type", "application/json")
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error:   map[string]interface{}{"code": -32603, "message": err.Error()},
+			ID:      req.ID,
+		})
+		return
+	}
+
+	json.NewEncoder(w).Encode(jsonRPCResponse{
+		JSONRPC: "2.0",
+		Result:  result,
+		ID:      req.ID,
+	})
+}

--- a/images/signal-bridge/signal_rpc.go
+++ b/images/signal-bridge/signal_rpc.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// JSON-RPC 2.0 types
+type rpcRequest struct {
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params,omitempty"`
+	ID      *int                   `json:"id,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+	ID      *int            `json:"id,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// SignalRPC manages a persistent TCP connection to signal-cli's JSON-RPC interface.
+type SignalRPC struct {
+	mu      sync.Mutex
+	conn    net.Conn
+	reader  *bufio.Reader
+	nextID  int
+	metrics *Metrics
+	config  Config
+	retry   time.Duration
+	lastErr error
+}
+
+func NewSignalRPC(cfg Config, metrics *Metrics) *SignalRPC {
+	return &SignalRPC{
+		config:  cfg,
+		metrics: metrics,
+		retry:   1 * time.Second,
+		nextID:  1,
+	}
+}
+
+func (s *SignalRPC) Connect() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.conn != nil {
+		s.conn.Close()
+	}
+
+	conn, err := net.DialTimeout("tcp", s.config.SignalCLIAddr(), 5*time.Second)
+	if err != nil {
+		s.metrics.RecordTCPError("dial")
+		s.lastErr = err
+		return fmt.Errorf("dial signal-cli: %w", err)
+	}
+
+	s.conn = conn
+	s.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (s *SignalRPC) call(method string, params map[string]interface{}) (json.RawMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.conn == nil {
+		if err := s.reconnectLocked(); err != nil {
+			return nil, err
+		}
+	}
+
+	id := s.nextID
+	s.nextID++
+
+	req := rpcRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+		ID:      &id,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	if _, err := s.conn.Write(append(data, '\n')); err != nil {
+		s.metrics.RecordTCPError("write")
+		s.conn.Close()
+		s.conn = nil
+		return nil, fmt.Errorf("write request: %w", err)
+	}
+
+	resp, err := s.readResponse()
+	if err != nil {
+		s.conn.Close()
+		s.conn = nil
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+
+	return resp.Result, nil
+}
+
+// receive fetches pending messages for the given account. Pass empty string to
+// use signal-cli's default account (single-account deployments only).
+func (s *SignalRPC) receive(account string) ([]map[string]interface{}, error) {
+	start := time.Now()
+
+	params := map[string]interface{}{
+		"maxMessages": 50,
+	}
+	if account != "" {
+		params["account"] = account
+	}
+
+	result, err := s.call("receive", params)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		s.metrics.RecordPoll(false, elapsed, 0)
+		return nil, err
+	}
+
+	var messages []map[string]interface{}
+	if err := json.Unmarshal(result, &messages); err != nil {
+		s.metrics.RecordPoll(false, elapsed, 0)
+		return nil, fmt.Errorf("unmarshal receive result: %w", err)
+	}
+
+	s.metrics.RecordPoll(true, elapsed, len(messages))
+	return messages, nil
+}
+
+func (s *SignalRPC) getInfo() (map[string]interface{}, error) {
+	start := time.Now()
+
+	result, err := s.call("getInfo", nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		s.metrics.RecordRPC("getInfo", elapsed)
+		return nil, err
+	}
+
+	var info map[string]interface{}
+	if err := json.Unmarshal(result, &info); err != nil {
+		s.metrics.RecordRPC("getInfo", elapsed)
+		return nil, fmt.Errorf("unmarshal getInfo result: %w", err)
+	}
+
+	s.metrics.RecordRPC("getInfo", elapsed)
+	return info, nil
+}
+
+func (s *SignalRPC) send(params map[string]interface{}) (json.RawMessage, error) {
+	start := time.Now()
+
+	result, err := s.call("send", params)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		s.metrics.RecordRPC("send", elapsed)
+		return nil, err
+	}
+
+	s.metrics.RecordRPC("send", elapsed)
+	return result, nil
+}
+
+func (s *SignalRPC) readResponse() (*rpcResponse, error) {
+	var rawLine []byte
+	for {
+		line, err := s.reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				if len(rawLine) == 0 {
+					return nil, fmt.Errorf("connection closed")
+				}
+				break
+			}
+			s.metrics.RecordTCPError("read")
+			return nil, fmt.Errorf("read: %w", err)
+		}
+		rawLine = append(rawLine, line...)
+	}
+
+	var resp rpcResponse
+	if err := json.Unmarshal(rawLine, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func (s *SignalRPC) reconnectLocked() error {
+	conn, err := net.DialTimeout("tcp", s.config.SignalCLIAddr(), 5*time.Second)
+	if err != nil {
+		s.metrics.RecordTCPError("dial")
+		s.lastErr = err
+		return fmt.Errorf("dial signal-cli: %w", err)
+	}
+
+	s.conn = conn
+	s.reader = bufio.NewReader(conn)
+	return nil
+}

--- a/images/signal-bridge/sse_handler.go
+++ b/images/signal-bridge/sse_handler.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// sseClient represents a single SSE subscriber.
+type sseClient struct {
+	id         string
+	account    string
+	done       chan struct{}
+	buffer     chan string
+	messages   chan map[string]interface{}
+	heartbeats chan time.Time
+}
+
+// sseHub manages multiple SSE client connections.
+type sseHub struct {
+	clients   map[string]*sseClient
+	mu        sync.RWMutex
+	metrics   *Metrics
+	config    Config
+	signalRPC *SignalRPC
+}
+
+func newSSEHub(cfg Config, metrics *Metrics, rpc *SignalRPC) *sseHub {
+	h := &sseHub{
+		clients:   make(map[string]*sseClient),
+		metrics:   metrics,
+		config:    cfg,
+		signalRPC: rpc,
+	}
+	go h.pollLoop()
+	go h.heartbeatLoop()
+	return h
+}
+
+func (h *sseHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.config.CheckBearer(r.Header.Get("Authorization")) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	account := r.URL.Query().Get("account")
+	if account == "" {
+		http.Error(w, "account parameter required", http.StatusBadRequest)
+		return
+	}
+
+	if !h.config.IsAccountAllowed(account) {
+		http.Error(w, "account not allowed", http.StatusForbidden)
+		return
+	}
+
+	accept := r.Header.Get("Accept")
+	if accept == "" || containsSSE(accept) {
+		h.handleSSE(w, r, account)
+	} else {
+		h.handleREST(w, r, account)
+	}
+}
+
+func (h *sseHub) handleSSE(w http.ResponseWriter, r *http.Request, account string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	clientID := fmt.Sprintf("%s-%d", account, time.Now().UnixNano())
+	client := &sseClient{
+		id:         clientID,
+		account:    account,
+		done:       make(chan struct{}),
+		buffer:     make(chan string, 100),
+		messages:   make(chan map[string]interface{}, 100),
+		heartbeats: make(chan time.Time, 10),
+	}
+
+	h.mu.Lock()
+	h.clients[clientID] = client
+	h.mu.Unlock()
+
+	h.metrics.SSEConnections.Inc()
+	h.metrics.SSEConnectionsTotal.Inc()
+
+	log.Printf("SSE: client %s connected (account=%s, total=%d)", clientID, account, len(h.clients))
+	defer func() {
+		close(client.done)
+		h.mu.Lock()
+		delete(h.clients, clientID)
+		h.mu.Unlock()
+		h.metrics.SSEConnections.Dec()
+		log.Printf("SSE: client %s disconnected (account=%s, total=%d)", clientID, account, len(h.clients))
+	}()
+
+	ctx := r.Context()
+
+	fmt.Fprintf(w, "retry: 3000\ndata: {\"type\":\"connected\",\"clientId\":\"%s\",\"timestamp\":%d}\n\n", clientID, time.Now().UnixMilli())
+	flusher.Flush()
+
+	// Drain any pre-buffered events.
+	for {
+		select {
+		case msg := <-client.buffer:
+			w.Write([]byte(msg))
+			flusher.Flush()
+		default:
+			goto sendLoop
+		}
+	}
+
+sendLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-client.messages:
+			data, _ := json.Marshal(msg)
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
+			h.metrics.RecordMessage()
+			flusher.Flush()
+		case <-client.done:
+			return
+		}
+	}
+}
+
+func (h *sseHub) handleREST(w http.ResponseWriter, r *http.Request, account string) {
+	messages, err := h.signalRPC.receive(account)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(messages)
+}
+
+// pollLoop polls each allowed account separately so messages are never cross-delivered.
+func (h *sseHub) pollLoop() {
+	ticker := time.NewTicker(h.config.PollInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		for _, account := range h.config.AllowedAccounts {
+			h.pollAccount(account)
+		}
+	}
+}
+
+func (h *sseHub) pollAccount(account string) {
+	messages, err := h.signalRPC.receive(account)
+	if err != nil {
+		log.Printf("poll error for %s: %v", account, err)
+		return
+	}
+
+	if len(messages) == 0 {
+		return
+	}
+
+	data, _ := json.Marshal(messages)
+	event := fmt.Sprintf("event: message\ndata: %s\n\n", data)
+
+	h.mu.RLock()
+	for _, client := range h.clients {
+		if client.account != account {
+			continue
+		}
+		select {
+		case client.buffer <- event:
+		default:
+			log.Printf("poll: buffer full for %s, dropping event", account)
+		}
+	}
+	for _, msg := range messages {
+		for _, client := range h.clients {
+			if client.account != account {
+				continue
+			}
+			select {
+			case client.messages <- msg:
+			default:
+			}
+		}
+	}
+	h.mu.RUnlock()
+}
+
+func (h *sseHub) heartbeatLoop() {
+	ticker := time.NewTicker(h.config.HeartbeatInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		event := "event: heartbeat\ndata: {\"type\":\"heartbeat\",\"timestamp\":" +
+			fmt.Sprintf("%d", time.Now().UnixMilli()) + "}\n\n"
+
+		h.mu.RLock()
+		for _, client := range h.clients {
+			select {
+			case client.buffer <- event:
+			default:
+			}
+		}
+		h.mu.RUnlock()
+	}
+}
+
+func containsSSE(accept string) bool {
+	return len(accept) >= len("text/event-stream") &&
+		accept[:len("text/event-stream")] == "text/event-stream"
+}


### PR DESCRIPTION
## Summary

Tracks and productionizes `images/signal-bridge/` — a Go service that wraps signal-cli's JSON-RPC daemon and exposes the SSE+JSON-RPC shape expected by Hermes (NousResearch agent platform).

**Multi-account support** is the headline change: the bridge now polls each allowed account independently and fans SSE events only to subscribers of that account, so two users (e.g. primary + wife) never see each other's messages.

### Go source changes

- **`config.go`**: `AllowedAccounts []string` from `HERMES_ALLOWED_ACCOUNTS` (comma-separated E.164 numbers), `AllowAll bool` from `HERMES_ALLOW_ALL_USERS`, `AuthToken string` from `HERMES_AUTH_TOKEN`; default `SIGNAL_CLI_HOST` changed from k8s cluster DNS → `signal-cli` (compose service name)
- **`signal_rpc.go`**: `receive(account string)` — passes account in JSON-RPC params for per-account daemon polling
- **`sse_handler.go`**: `sseClient` gains `account` field; `pollLoop` iterates `AllowedAccounts` and calls `pollAccount` for each; fan-out filters by `client.account`; `ServeHTTP` validates bearer token and account allowlist
- **`rpc_relay.go`**: validates bearer token and `params.account` against allowlist before relaying
- **`main.go`**: passes `cfg` to `relayRPC`; registers `/api/v1/check` (Hermes health endpoint) alongside existing `/v1/health`

### New files

- **`Dockerfile`**: single-arch amd64 multi-stage build (`golang:1.23-alpine` → `scratch`); removes the `Dockerfile.amd64` shortcut
- **`.gitignore`**: excludes pre-built binaries (`signal-bridge`, `signal-bridge-amd64`)
- **`README.md`**: env vars reference, endpoint docs, multi-account registration steps, dev loop
- **`.github/workflows/build-signal-bridge.yml`**: builds and pushes `ghcr.io/gjcourt/signal-bridge:YYYY-MM-DD` on push to master; merging this PR triggers the first image build

## Test plan

- [ ] `go build ./...` in `images/signal-bridge/` succeeds (no compiler errors)
- [ ] GHA workflow run completes after merge → `docker manifest inspect ghcr.io/gjcourt/signal-bridge:<date>` succeeds
- [ ] `curl localhost:8080/api/v1/check` returns `{"status":"ok"}` against a local signal-cli daemon
- [ ] `curl -N "localhost:8080/api/v1/events?account=+16179397251"` opens SSE stream and emits heartbeat
- [ ] Unrecognized account returns HTTP 403
- [ ] Missing/wrong bearer token returns HTTP 401 when `HERMES_AUTH_TOKEN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)