### PR TITLE
feat: signal TrueNAS Custom App — signal-cli + signal-bridge on hestia

### DIFF
--- a/hosts/hestia/signal/README.md
+++ b/hosts/hestia/signal/README.md
@@ -1,0 +1,161 @@
+# signal — Signal CLI + Bridge on hestia
+
+Runs the Signal messaging stack on TrueNAS hestia as a **TrueNAS Custom App**:
+
+| Service | Image | Role |
+|---------|-------|------|
+| `signal-cli` | `ghcr.io/asamk/signal-cli` | Signal daemon (JSON-RPC TCP on port 7583) |
+| `signal-bridge` | `ghcr.io/gjcourt/signal-bridge` | SSE+RPC bridge for Hermes (HTTP on port 8080) |
+
+**Hermes config**: `SIGNAL_HTTP_URL=http://10.42.2.10:8080`
+
+## Sync rule (canonical source = git)
+
+The YAML in this file is the source of truth. To apply a change:
+
+1. Edit `docker-compose.yml` here and open a PR.
+2. After merge, open SCALE UI → **Apps** → `signal` → **Edit**.
+3. Paste the updated YAML → **Save**. TrueNAS diff-applies and restarts containers as needed.
+
+Never edit the compose in the SCALE UI without updating git — that creates drift.
+
+## Bearer token
+
+Set `HERMES_AUTH_TOKEN` in the SCALE UI env-var section as a **masked input** — do not commit a real value to git.
+
+To rotate: **Edit App** → update `HERMES_AUTH_TOKEN` → **Save**. Supply the new token to the Hermes operator out-of-band.
+
+## Drift check
+
+```bash
+ssh truenas_admin@10.42.2.10 \
+  'docker inspect ix-signal-signal-bridge-1 \
+    --format "{{.Config.Image}}{{range .Config.Env}}\n{{.}}{{end}}"'
+```
+
+Compare the `HERMES_ALLOWED_ACCOUNTS` and image tag against `docker-compose.yml` in git.
+
+## Adding a second Signal account (multi-user)
+
+1. Link the device on the running daemon:
+   ```bash
+   ssh truenas_admin@10.42.2.10
+   docker exec ix-signal-signal-cli-1 \
+     signal-cli --config /var/lib/signal-cli link --name "Hestia Bridge"
+   ```
+   This prints a `tsdevice://` URI. Open Signal on the phone → Settings → Linked Devices → scan the QR code.
+
+2. Confirm the account is registered:
+   ```bash
+   docker exec ix-signal-signal-cli-1 \
+     ls /var/lib/signal-cli/data/
+   ```
+   The phone number (`+1xxx`) should appear.
+
+3. Update `HERMES_ALLOWED_ACCOUNTS` in SCALE UI → **Edit App** → add the number comma-separated → **Save**.
+
+No code changes required — the bridge polls all accounts listed in that env var.
+
+## Migration playbook (initial cutover from signal-cli-rest-api)
+
+### Pre-conditions
+
+- `hosts/hestia/signal/docker-compose.yml` is in git with correct image tags.
+- GHA workflow has published `ghcr.io/gjcourt/signal-bridge:<tag>`.
+- Bearer token is ready to set in SCALE UI.
+
+### Steps
+
+**1. Snapshot**
+```bash
+ssh truenas_admin@10.42.2.10
+sudo zfs list | grep ix-apps
+sudo zfs snapshot tank/.ix-apps@pre-signal-migration-$(date +%Y%m%d)
+```
+
+**2. Create operator-owned dataset**
+```bash
+sudo zfs create tank/apps/signal 2>/dev/null || true
+sudo mkdir -p /mnt/tank/apps/signal/data
+```
+
+**3. Copy identity data** (safe — old App still running)
+```bash
+sudo rsync -aHAX \
+  /mnt/.ix-apps/app_mounts/signal-cli-rest-api/config/ \
+  /mnt/tank/apps/signal/data/
+sudo chown -R 568:568 /mnt/tank/apps/signal/data
+```
+
+**4. Capture baseline**
+```bash
+docker exec ix-signal-cli-rest-api-signal-cli-rest-api-1 \
+  signal-cli -a +16179397251 listIdentities 2>&1 | wc -l
+```
+Record the count.
+
+**5. Stop old App**
+
+SCALE UI → **Apps** → `signal-cli-rest-api` → **Stop**.
+
+Confirm: `docker ps --filter name=signal-cli-rest-api` returns nothing.
+
+**6. Create new Custom App**
+
+SCALE UI → **Apps** → **Discover Apps** → **Custom App**:
+- **Name**: `signal`
+- **Compose YAML**: paste `hosts/hestia/signal/docker-compose.yml` with `<tag>` replaced by the published tag
+- **Environment** → add `HERMES_AUTH_TOKEN` as a masked value
+- **Install** → wait for status **Running**
+
+**7. Verify identity intact**
+```bash
+docker exec ix-signal-signal-cli-1 \
+  signal-cli -a +16179397251 listIdentities 2>&1 | wc -l
+```
+Must match step 4.
+
+**8. Verify Hermes endpoints**
+```bash
+curl -fsS http://10.42.2.10:8080/api/v1/check
+curl -fsS -N "http://10.42.2.10:8080/api/v1/events?account=+16179397251" \
+  -H "Authorization: Bearer $TOKEN"
+```
+First returns `{"status":"ok"}`. Second opens SSE stream (Ctrl-C after heartbeat).
+
+**9. Functional smoke**
+
+Send a Signal message TO `+16179397251` from a phone. The SSE stream should emit the message envelope. Reply via:
+```bash
+curl -fsS -X POST http://10.42.2.10:8080/api/v1/rpc \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"send","params":{"account":"+16179397251","recipient":["+1<test>"],"message":"smoke test"},"id":1}'
+```
+
+**10. Decommission**
+
+SCALE UI → `signal-cli-rest-api` → **Delete**. Keep the ZFS snapshot for 90 days.
+
+### Rollback (before step 10)
+
+SCALE UI → `signal` → **Stop** → `signal-cli-rest-api` → **Start**.
+The rsync in step 3 was a copy; the old data at `/mnt/.ix-apps/app_mounts/signal-cli-rest-api/config/` is untouched.
+
+## Upgrading signal-cli
+
+1. Check https://github.com/AsamK/signal-cli/releases for the latest image digest:
+   ```bash
+   docker pull ghcr.io/asamk/signal-cli:latest
+   docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/asamk/signal-cli:latest
+   ```
+2. Update the `image:` line in `docker-compose.yml` with the new digest, open a PR.
+3. After merge, paste updated YAML into SCALE UI.
+
+## Upgrading signal-bridge
+
+The GHA workflow publishes a new tag on every push to master that touches `images/signal-bridge/`. To upgrade:
+
+1. Note the new tag from the GHA run summary (format: `YYYY-MM-DD`).
+2. Update the `signal-bridge` `image:` line in `docker-compose.yml`, open a PR.
+3. After merge, paste updated YAML into SCALE UI.

--- a/hosts/hestia/signal/docker-compose.yml
+++ b/hosts/hestia/signal/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  signal-cli:
+    # Pinned digest — update when upgrading. Check https://github.com/AsamK/signal-cli/releases
+    image: ghcr.io/asamk/signal-cli@sha256:23a808b97eaa65e15f09809e5644aedf33e838db833552dfe825ca52dcd0940e
+    restart: unless-stopped
+    user: "568:568"   # matches UID/GID of the existing signal-cli-rest-api data
+    command:
+      - daemon
+      - --tcp=0.0.0.0:7583
+      - --receive-mode=on-connection
+      - --ignore-stories
+    volumes:
+      # Operator-owned dataset — survives App deletion. Pre-create on TrueNAS:
+      #   sudo zfs create tank/apps/signal
+      #   sudo mkdir -p /mnt/tank/apps/signal/data
+      #   sudo chown -R 568:568 /mnt/tank/apps/signal/data
+      - /mnt/tank/apps/signal/data:/var/lib/signal-cli
+    networks: [signal-net]
+
+  signal-bridge:
+    # Tag published by .github/workflows/build-signal-bridge.yml on push to master.
+    # Update this tag in SCALE UI when a new image is available.
+    image: ghcr.io/gjcourt/signal-bridge:2026-05-01
+    restart: unless-stopped
+    environment:
+      SIGNAL_CLI_HOST: signal-cli
+      SIGNAL_CLI_PORT: "7583"
+      LISTEN_ADDR: "0.0.0.0"
+      LISTEN_PORT: "8080"
+      # Comma-separated E.164 numbers permitted to use the bridge.
+      # Add wife's number here after linking her device (see README).
+      HERMES_ALLOWED_ACCOUNTS: "+16179397251"
+      # Bearer token — set as masked env var in SCALE UI. Do NOT commit a real value here.
+      HERMES_AUTH_TOKEN: ""
+    ports:
+      - "10.42.2.10:8080:8080"
+    depends_on:
+      signal-cli:
+        condition: service_started
+    networks: [signal-net]
+
+networks:
+  signal-net: {}


### PR DESCRIPTION
## Summary

Adds `hosts/hestia/signal/` with the compose YAML and full runbook for deploying the Signal messaging stack as a TrueNAS Custom App on hestia (`truenas_admin@10.42.2.10`), replacing the existing `signal-cli-rest-api` (bbernhard, REST-only).

**This PR is deployable once PR #362 (signal-bridge) is merged and its GHA workflow has published an image.** Update the `signal-bridge` tag from `2026-05-01` → the actual published tag before deploying.

## What's included

- `docker-compose.yml` — Custom-App-compatible (no `build:`, no `secrets:`, no `container_name`):
  - `signal-cli` pinned by digest (`ghcr.io/asamk/signal-cli@sha256:23a808b...`)
  - `signal-bridge` image tag placeholder — operator updates in SCALE UI
  - `HERMES_AUTH_TOKEN` left blank — operator fills via SCALE UI masked env-var input
  - `HERMES_ALLOWED_ACCOUNTS: "+16179397251"` — add wife's number after linking device
  - Port bound to `10.42.2.10:8080` (LAN-only)
  - Volume at `/mnt/tank/apps/signal/data` (operator-owned ZFS dataset, survives App deletion)

- `README.md` covers:
  - Sync rule (git is canonical; operator pastes into SCALE UI to apply changes)
  - Bearer token rotation
  - Drift detection via `docker inspect`
  - **Multi-user account registration** (link additional phones via `signal-cli link`)
  - Full migration playbook (10-step cutover from `signal-cli-rest-api` with rollback)
  - Upgrade procedures for both images

## Test plan

- [ ] `docker compose -f hosts/hestia/signal/docker-compose.yml config` validates without error
- [ ] No plaintext secrets in the YAML (`grep -r "hf_\|Bearer \|password" hosts/hestia/signal/` returns nothing sensitive)
- [ ] After PR #362 merges + GHA runs: update tag and execute migration playbook on hestia
- [ ] Post-cutover: `signal-cli listIdentities | wc -l` matches pre-cutover baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)