### PR TITLE
fix(signal-cli): harden K8s deployment — pin images, wire bridge multi-account, storage class

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: signal-cli
-          image: ghcr.io/asamk/signal-cli:latest
+          image: ghcr.io/asamk/signal-cli@sha256:23a808b97eaa65e15f09809e5644aedf33e838db833552dfe825ca52dcd0940e
           command:
             - /opt/signal-cli/bin/signal-cli
             - daemon
@@ -54,7 +54,7 @@ spec:
               cpu: 500m
               memory: 512Mi
         - name: signal-bridge
-          image: gjcourt/signal-bridge:latest
+          image: ghcr.io/gjcourt/signal-bridge:2026-05-02
           env:
             - name: SIGNAL_CLI_HOST
               value: "127.0.0.1"
@@ -68,6 +68,16 @@ spec:
               value: "0.0.0.0"
             - name: LISTEN_PORT
               value: "8080"
+            - name: HERMES_ALLOWED_ACCOUNTS
+              value: "+16179397251"
+            - name: HERMES_ALLOW_ALL_USERS
+              value: "false"
+            - name: HERMES_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: signal-bridge-auth
+                  key: token
+                  optional: true
           ports:
             - name: http
               containerPort: 8080

--- a/apps/base/signal-cli/storage.yaml
+++ b/apps/base/signal-cli/storage.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: synology-iscsi
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
## Summary

The signal-cli K8s deployment landed via #350 but has three latent issues that would prevent it from running once we cut over from the TrueNAS Custom App. This PR fixes them:

- **Bridge image broken** — referenced `gjcourt/signal-bridge:latest` (Docker Hub, doesn't exist). The GHA workflow at `.github/workflows/build-signal-bridge.yml` publishes to `ghcr.io/gjcourt/signal-bridge:YYYY-MM-DD`. Updated to `ghcr.io/gjcourt/signal-bridge:2026-05-02` (the most recent build).
- **signal-cli on `:latest`** — pinned by digest (`@sha256:23a808b9...`) to match the convention used in `hosts/hestia/signal/docker-compose.yml`.
- **Bridge multi-account env vars missing** — without `HERMES_ALLOWED_ACCOUNTS` or `HERMES_ALLOW_ALL_USERS=true`, the bridge's `IsAccountAllowed` rejects every account. Wired `+16179397251` (existing registered number) and an optional `HERMES_AUTH_TOKEN` secretKeyRef so the deployment is functional out of the box.
- **No storage class** — `storage.yaml` had no `storageClassName`, fell back to cluster default. Set to `synology-iscsi` (same pattern as `apps/base/adguard`).

The `signal-bridge-auth` Secret is referenced with `optional: true`, so the bridge starts without auth until a SOPS-encrypted Secret is added in a follow-up.

## Why now

Closes the gap between PR #350's K8s manifests and what's actually publishable. PR #351 (the planning doc that mirrored these manifests) was just closed as obsolete; this completes the implementation it described.

## Files changed

- \`apps/base/signal-cli/deployment.yaml\` — pin both images, wire multi-account env
- \`apps/base/signal-cli/storage.yaml\` — \`storageClassName: synology-iscsi\`

## Test plan

- [x] \`kustomize build apps/staging/signal-cli\` passes
- [x] \`kustomize build apps/production/signal-cli\` passes
- [x] \`git diff HEAD | grep -iE "password|secret|token|key"\` shows only existing \`automountServiceAccountToken: false\` and the secretKeyRef indirection — no plaintext
- [ ] Staging rollout: pod comes up, \`signal-cli\` daemon is reachable on TCP 7583, bridge \`/v1/health\` returns 200
- [ ] Production rollout: same, after registration data is migrated from TrueNAS PVC (separate cutover work)

## Follow-ups

- SOPS-encrypted \`signal-bridge-auth\` Secret with a real token
- Migrate signal-cli registration data from \`/mnt/tank/apps/signal/data\` (hestia) to the K8s PVC
- Once K8s cutover is complete, remove \`hosts/hestia/signal/\` and update \`docs/apps/signal-cli.md\`