### PR TITLE
feat(signal-cli): add SOPS-encrypted bridge auth secret

### DIFF
--- a/apps/production/signal-cli/kustomization.yaml
+++ b/apps/production/signal-cli/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: signal-cli
 resources:
   - ../../base/signal-cli/
+  - secret-bridge-auth.yaml
 
 labels:
   - pairs:

--- a/apps/production/signal-cli/secret-bridge-auth.yaml
+++ b/apps/production/signal-cli/secret-bridge-auth.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: signal-bridge-auth
+  namespace: signal-cli
+type: Opaque
+stringData:
+  token: ENC[AES256_GCM,data:EuPP8S/wW7vZz1rkBxohtNMqbG+/Hi7WASZSSwGug7dUHwanXvBSBQMX3Q==,iv:niF+AU8wU0P6CQgif0EjO4ylzn7WGeZs1wbmv9SYWco=,tag:/bWruJnE52nxjSlJzI9brw==,type:str]
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHL1M4a0xDdDFSdGpXaitP
+        YkJ0U1FTcGU4WWwvcTJaVXd3SjJHMm01NkhzCmtZVjlVeU95ZWhHOStOLzZTbXJa
+        U0x2UHE3RGFHWUxER2lhdnRxa1NaRWcKLS0tIFRXbnYzWEtDTFJlaVZZZnF3RnMv
+        TWs4a0tkYlU2YlV6QTdLOGU0N3EwQnMKE6LlJtLze5DR05rFpFyiexRhF1RB0sQB
+        RH5a6WS7VbXK6WnJ7iFrbcsFDBCMD0rZWPl3JViNP33VgFAkxtgBiQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-03T00:51:39Z"
+  mac: ENC[AES256_GCM,data:4yRJiMjgHT/Hfz5VpBvYUV6T97f1Hhk7ey5HEv6hYqU7Q5SkkMDPtfpjgX9vOEo9DLsIObUcoj7/uDSHmgtEmYBrDIqvBU4oXkC6beKoDLW4XacRk7E6lIGGiuIm/XDqViNQmBgpFft85WooGJiupit7YSITKfYuabQgIrLRxRE=,iv:C1hE1S1V1Fsh04pj2P8hltU583FwygPPM1j1Fj5tMo0=,tag:/2AxokhqA+qdQBwW9Kg7Qg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.1


### PR DESCRIPTION
## Summary

Provides the production \`signal-bridge-auth\` Secret that PR #367 references via \`optional: true\` secretKeyRef. With this in place, the K8s signal-bridge enforces a bearer token on \`/api/v1/events\`, \`/api/v1/rpc\`, and \`/api/v1/check\`.

- 32-byte random token, base64url
- SOPS-encrypted with the homelab age key (\`age1lnrpvnh…samjjuw\`)
- Production-only — staging has no Secret because staging signal-cli isn't registered, and the bridge runs unauthenticated when the optional secretKeyRef is absent

## Files changed

- \`apps/production/signal-cli/secret-bridge-auth.yaml\` — new SOPS-encrypted Secret
- \`apps/production/signal-cli/kustomization.yaml\` — include the Secret as a resource

## Test plan

- [x] \`sops -d apps/production/signal-cli/secret-bridge-auth.yaml\` decrypts cleanly
- [x] \`kustomize build apps/production/signal-cli\` includes the Secret with correct labels and namespace
- [x] \`kustomize build apps/staging/signal-cli\` still passes (no Secret in staging)
- [x] \`grep -r <token-plaintext> .\` returns no matches — token is only in the encrypted file
- [ ] After merge: Hermes config updated with the same token (\`SIGNAL_AUTH_TOKEN\` or equivalent)
- [ ] After merge + #367: bridge logs show \`HERMES_AUTH_TOKEN\` is set and rejects unauthenticated requests with 401

## Coordination

This PR is independent of #367 but designed to compose with it:
- If #367 merges first, the bridge runs without auth until this Secret lands
- If this Secret lands first, the Secret sits unused until the deployment in #367 starts referencing it
- Both can merge in either order without breaking anything