### PR TITLE
feat(hestia): convert llama.cpp from raw docker to Custom App

### DIFF
--- a/hosts/hestia/llms/README.md
+++ b/hosts/hestia/llms/README.md
@@ -4,17 +4,24 @@ LLM inference services for the GPU box on hestia (RTX 4090, 24 GB VRAM).
 
 ## Services
 
-| File | Model | Notes |
-|------|-------|-------|
-| `docker-compose-llama.yml` | llama.cpp inference server | Preferred for 24 GB VRAM; GGUF quants |
-| `docker-compose-vllm.yml` | vLLM | Higher throughput; has caused OOM on 24 GB — prefer llama.cpp |
+| File | Custom App | Image | Model |
+|------|------------|-------|-------|
+| `docker-compose-llama.yml` | `llama` | `ghcr.io/ggml-org/llama.cpp:server-cuda` (digest-pinned) | Qwen3.6-35B-A3B (GGUF IQ4_NL) on `/mnt/main/ai/models/gguf` |
+| `docker-compose-vllm.yml` | `vllm` | (see file) | (see file) — keep stopped on 24 GB VRAM; OOM-prone |
 
 ## Deployment
 
-Both files are deployed as separate TrueNAS Custom Apps. Paste the relevant YAML into SCALE UI → Apps → Custom App.
+Each file is deployed as a separate **TrueNAS Custom App**. Paste the YAML into SCALE UI → Apps → Custom App. The compose YAML in git is the canonical source — never edit the SCALE UI copy without updating git first.
 
 ## GPU notes
 
 - 24 GB VRAM (RTX 4090) — prefer GGUF Q4/Q5 quants with llama.cpp over full-precision vLLM
 - vLLM has caused repeated OOM crashes on this hardware; use llama.cpp as default
 - For models exceeding 24 GB, use CPU offload with llama.cpp (`-ngl` to control GPU layers)
+
+## Updating the model
+
+1. Drop the new GGUF into `/mnt/main/ai/models/gguf/` on hestia
+2. Edit `docker-compose-llama.yml` — update the `-m` arg and `--alias`
+3. PR + merge
+4. SCALE UI → Apps → `llama` → Edit → paste → Save (TrueNAS will recreate the container)

--- a/hosts/hestia/llms/docker-compose-llama.yml
+++ b/hosts/hestia/llms/docker-compose-llama.yml
@@ -1,7 +1,7 @@
 services:
-  llama-qwen36-35b:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
-    container_name: llama-qwen36-35b
+  llama:
+    image: ghcr.io/ggml-org/llama.cpp@sha256:a8c56356fbfde209910b8098d0a060f4b84997f23b65491df3f2b61fae91dd7b
+    container_name: llama
     restart: unless-stopped
     volumes:
       - /mnt/main/ai/models/gguf:/models
@@ -9,7 +9,7 @@ services:
       - "8000:8080"
     command: >
       -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf
-      --alias "Qwen3.6-35B-A3B"
+      --alias Qwen3.6-35B-A3B
       --host 0.0.0.0
       --port 8080
       --ctx-size 409600


### PR DESCRIPTION
## ⚠️ Post-merge cutover checklist

Run these on hestia **after** this PR merges. The Custom App will not exist in SCALE UI until the manual paste step.

- [ ] SSH into hestia and remove the raw container:
      ```bash
      ssh truenas_admin@10.42.2.10
      docker stop llama-qwen36-27b
      docker rm   llama-qwen36-27b
      ```
- [ ] (Optional) Free disk: `docker rmi ghcr.io/ggml-org/llama.cpp:server-cuda`
- [ ] Open SCALE UI → **Apps** → **Discover** → **Custom App**
- [ ] Name it `llama`
- [ ] Paste the contents of `hosts/hestia/llms/docker-compose-llama.yml` from this PR's branch (or master, post-merge) into the compose editor
- [ ] Save → wait for status to reach **Running**
- [ ] Verify: `curl http://10.42.2.10:8000/health` returns 200
- [ ] Confirm `llama` appears as a Custom App in SCALE UI alongside `signal-cli-rest-api`, `nvtop`, etc.

---

## Summary

Convert the raw `llama-qwen36-27b` docker container on hestia into a TrueNAS Custom App. Captures the actual running config (verified via `docker inspect`), pins the image by digest, and renames to a clean `llama` Custom App that aligns with how the other apps appear in SCALE UI.

## Discrepancy resolved

The running raw container was named `llama-qwen36-27b` but its `-m` arg loaded `Qwen3.6-35B-A3B-UD-IQ4_NL.gguf` — a **35B model**, not 27B. The new Custom App is just `llama` (model rev tracked in the compose, not the container name).

## What changed

- `hosts/hestia/llms/docker-compose-llama.yml`:
  - Service + container name: `llama-qwen36-35b` → `llama`
  - Image: `ghcr.io/ggml-org/llama.cpp:server-cuda` → digest-pinned (`@sha256:a8c5635…`)
  - Args verified to match the actually-running container
- `hosts/hestia/llms/README.md`: clarified Custom App naming and documented the model-update workflow

## Out of scope

- The `vllm` Custom App in SCALE UI (currently stopped) — its compose stays as-is
- The `ollama` Custom App in SCALE UI (stopped) — left as-is per operator direction; not captured in repo