### PR TITLE
fix(signal-bridge): fix readResponse deadlock and wire --config flag

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -23,15 +23,14 @@ spec:
           image: ghcr.io/asamk/signal-cli@sha256:23a808b97eaa65e15f09809e5644aedf33e838db833552dfe825ca52dcd0940e
           command:
             - /opt/signal-cli/bin/signal-cli
+            - --config
+            - /var/lib/signal-cli
             - daemon
             - --tcp
             - 0.0.0.0:7583
             - --receive-mode
             - on-connection
             - --ignore-stories
-          env:
-            - name: SIGNAL_CLI_CONFIG_DIR
-              value: /var/lib/signal-cli
           ports:
             - name: json-rpc
               containerPort: 7583
@@ -54,7 +53,7 @@ spec:
               cpu: 500m
               memory: 512Mi
         - name: signal-bridge
-          image: ghcr.io/gjcourt/signal-bridge:2026-05-02
+          image: ghcr.io/gjcourt/signal-bridge:2026-05-02-2
           env:
             - name: SIGNAL_CLI_HOST
               value: "127.0.0.1"

--- a/images/signal-bridge/signal_rpc.go
+++ b/images/signal-bridge/signal_rpc.go
@@ -184,24 +184,19 @@ func (s *SignalRPC) send(params map[string]interface{}) (json.RawMessage, error)
 }
 
 func (s *SignalRPC) readResponse() (*rpcResponse, error) {
-	var rawLine []byte
-	for {
-		line, err := s.reader.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				if len(rawLine) == 0 {
-					return nil, fmt.Errorf("connection closed")
-				}
-				break
-			}
-			s.metrics.RecordTCPError("read")
-			return nil, fmt.Errorf("read: %w", err)
+	// signal-cli sends one newline-terminated JSON object per response;
+	// the connection stays open, so we must not loop until EOF.
+	line, err := s.reader.ReadBytes('\n')
+	if err != nil {
+		if err == io.EOF {
+			return nil, fmt.Errorf("connection closed")
 		}
-		rawLine = append(rawLine, line...)
+		s.metrics.RecordTCPError("read")
+		return nil, fmt.Errorf("read: %w", err)
 	}
 
 	var resp rpcResponse
-	if err := json.Unmarshal(rawLine, &resp); err != nil {
+	if err := json.Unmarshal(line, &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause of signal-bridge CrashLoopBackOff**: `readResponse` in `signal_rpc.go` looped until EOF. After reading the first JSON-RPC response line from signal-cli, it blocked on a second `ReadBytes('\n')` while holding `SignalRPC.mu` — since signal-cli keeps the TCP connection open. The `pollLoop` holds the lock continuously, so the liveness probe's `getInfo()` call can never acquire it. Kubernetes sees the `/v1/health` probe time out three times (~44s) and kills the container.
- **Fix**: read exactly one newline-terminated JSON object per `readResponse` call.
- **Config fix**: `SIGNAL_CLI_CONFIG_DIR` env var is silently ignored by signal-cli 0.14.x. Replace it with the explicit `--config /var/lib/signal-cli` flag in the command args.
- **Image**: `ghcr.io/gjcourt/signal-bridge:2026-05-02-2` built from this fix and already pushed to GHCR.

## Test plan

- [ ] PR merges clean, kustomize build passes (CI)
- [ ] After Flux reconciles: `kubectl rollout status deployment/signal-cli -n signal-cli` completes
- [ ] `kubectl get pods -n signal-cli` shows `2/2 Running`
- [ ] `kubectl logs -n signal-cli -c signal-bridge -l app=signal-cli --tail=20` shows no health check errors
- [ ] Send a test Signal message to +16179397251 and verify receipt via bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)