### PR TITLE
feat(hestia): self-hosted GHA runner Custom App (D1)

### DIFF
--- a/hosts/hestia/README.md
+++ b/hosts/hestia/README.md
@@ -18,6 +18,7 @@ The compose YAML in each subdirectory is the canonical source; paste into SCALE 
 | signal | `signal/` | 8080 | signal-cli daemon + signal-bridge SSE relay |
 | llms | `llms/` | varies | llama.cpp / vLLM inference (GPU box) |
 | monitoring | `monitoring/` | varies | nvtop and GPU metrics |
+| gha-runner | `actions-runner/` | — | Self-hosted GitHub Actions runner; auto-deploys other hestia apps |
 
 ## ZFS datasets
 
@@ -26,6 +27,7 @@ Operator-owned datasets (survive App deletion):
 | Dataset | Mount | Used by |
 |---------|-------|---------|
 | `tank/apps/signal` | `/mnt/tank/apps/signal` | signal-cli identity data |
+| `main/apps/actions-runner` | `/mnt/main/apps/actions-runner` | runner registration + workspace |
 
 ## Common operations
 

--- a/hosts/hestia/actions-runner/README.md
+++ b/hosts/hestia/actions-runner/README.md
@@ -1,0 +1,81 @@
+# actions-runner — self-hosted GitHub Actions runner
+
+Self-hosted GHA runner that lives on hestia and applies hestia Custom App compose changes via the TrueNAS WebSocket API. See [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../../docs/plans/2026-05-02-hestia-gha-runner.md) for the full design.
+
+| Attribute | Value |
+|-----------|-------|
+| Image | `myoung34/github-runner` (digest-pinned) |
+| Runner name | `hestia` |
+| Labels | `hestia`, `truenas` |
+| Workflow target | `gjcourt/homelab` (push to `master`, paths `hosts/hestia/**/docker-compose*.yml`) |
+| Persistence | `/mnt/main/apps/actions-runner/work` |
+
+## One-time bootstrap
+
+The runner is the *only* hestia Custom App that gets pasted into SCALE UI by hand. From its first successful registration onward, every other `hosts/hestia/**` change is applied by the workflow it executes.
+
+1. **Create a GitHub PAT** with `repo` scope (classic PAT) or a GitHub App installation token with `actions:write` + `metadata:read` on `gjcourt/homelab`. Long-lived; the runner mints its own short-lived registration token at startup.
+2. **Create a TrueNAS API key** — SCALE UI → Settings → API Keys → Add → name it `gha-runner`, copy the value (shown once).
+3. **Pre-create the persistence dataset on hestia**:
+   ```bash
+   ssh truenas_admin@10.42.2.10
+   sudo zfs list main/apps 2>/dev/null || sudo zfs create main/apps
+   sudo mkdir -p /mnt/main/apps/actions-runner/work
+   ```
+4. **Add the Custom App in SCALE UI**:
+   - Apps → Discover Apps → Custom App
+   - Application Name: `gha-runner`
+   - Compose YAML: paste the contents of `docker-compose.yml` from this directory
+   - Environment → set as masked values:
+     - `ACCESS_TOKEN` = the PAT from step 1
+     - `TRUENAS_API_KEY` = the API key from step 2
+   - Click **Install**
+5. **Verify** — within ~30s the runner should appear at `https://github.com/gjcourt/homelab/settings/actions/runners` with status **Idle** and labels `hestia`, `truenas`.
+
+## Operations
+
+### Token rotation
+
+- **`ACCESS_TOKEN`** (PAT/App): regenerate in GitHub, then SCALE UI → Apps → `gha-runner` → Edit → update env var → Save. SCALE recreates the container; the runner re-registers automatically.
+- **`TRUENAS_API_KEY`**: rotate in SCALE UI → Settings → API Keys, then update the env var the same way.
+
+### Drift detection
+
+```bash
+ssh truenas_admin@10.42.2.10 'docker inspect ix-gha-runner-runner-1 \
+  --format "{{.Config.Image}}{{println}}{{range .Config.Env}}{{println .}}{{end}}"'
+```
+
+Diff against `docker-compose.yml` in this directory. Image digest and env var keys (not values) should match.
+
+### Pause the runner
+
+SCALE UI → Apps → `gha-runner` → Stop. Workflows queue at GitHub until restart.
+
+### Re-register from scratch
+
+Delete `/mnt/main/apps/actions-runner/work/.runner` on hestia; restart the app. The runner will mint a fresh registration token via `ACCESS_TOKEN`.
+
+## Image upgrades
+
+Update the digest pin in `docker-compose.yml`. Once the workflow (D2/D3) is live, the merge to `master` will auto-deploy. Until then, paste the new YAML into SCALE UI by hand.
+
+To find the current digest of a tag:
+
+```bash
+docker manifest inspect myoung34/github-runner:ubuntu-noble \
+  | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Runner never appears in GitHub | Bad `ACCESS_TOKEN` | Check container logs: `docker logs ix-gha-runner-runner-1`; regenerate PAT |
+| Runner offline after reboot | Persistence missing | Confirm `/mnt/main/apps/actions-runner/work` exists and is writable |
+| Workflow hangs | Runner busy/stuck | SCALE UI → Stop → Start; or check `docker logs` for last action |
+| `truenas-update-app.sh` (D3) returns 401 | Bad `TRUENAS_API_KEY` | Rotate the key, update env var |
+
+## Graduation path
+
+When ≥2 self-hosted-runner workflows exist or this Custom App becomes a maintenance burden, replace with [`actions-runner-controller`](https://github.com/actions/actions-runner-controller) running in `melodic-muse`. See [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../../docs/plans/2026-05-02-hestia-gha-runner.md#graduation-path--option-2b-actions-runner-controller-in-talos) for the migration steps.

--- a/hosts/hestia/actions-runner/docker-compose.yml
+++ b/hosts/hestia/actions-runner/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  runner:
+    image: myoung34/github-runner@sha256:420562d49d14c7ea25cbb320b4d582d7f05ecf57ffd010cc9f2d746e33abcb9b
+    container_name: gha-runner
+    restart: unless-stopped
+    environment:
+      REPO_URL: https://github.com/gjcourt/homelab
+      RUNNER_NAME: hestia
+      RUNNER_SCOPE: repo
+      LABELS: hestia,truenas
+      RUNNER_WORKDIR: /tmp/runner-work
+      EPHEMERAL: "false"
+      DISABLE_AUTO_UPDATE: "true"
+      # ACCESS_TOKEN: a long-lived PAT (classic) or GitHub App installation
+      # token with `actions:write` + `metadata:read` on this repo. The runner
+      # entrypoint exchanges it for a registration token at startup so the
+      # operator never has to refresh the 1-hour expiring token by hand.
+      # Do NOT commit a value here; set in SCALE UI as a masked env var.
+      ACCESS_TOKEN: ""
+      # TRUENAS_API_KEY: API key created in SCALE UI → Settings → API Keys.
+      # Used by the workflow's `truenas-update-app.sh` (D3) to call the
+      # WebSocket API and update Custom App compose configs.
+      # Do NOT commit a value here; set in SCALE UI as a masked env var.
+      TRUENAS_API_KEY: ""
+    volumes:
+      - /mnt/main/apps/actions-runner/work:/tmp/runner-work
+      - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f Runner.Listener > /dev/null || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s


### PR DESCRIPTION
## Summary

D1 of [`docs/plans/2026-05-02-hestia-gha-runner.md`](docs/plans/2026-05-02-hestia-gha-runner.md). Adds the runner Custom App compose + README. Subsequent PRs (D2/D3) wire the workflow that uses it to auto-deploy hestia compose changes via the TrueNAS WebSocket API.

## What's in this PR

- `hosts/hestia/actions-runner/docker-compose.yml` — `myoung34/github-runner` (digest-pinned to `ubuntu-noble`), labels `hestia,truenas`, persistence at `/mnt/main/apps/actions-runner/work`, healthcheck on `Runner.Listener`. Docker socket mounted for broader runner usability later.
- `hosts/hestia/actions-runner/README.md` — bootstrap (one-time SCALE paste with `ACCESS_TOKEN` PAT + `TRUENAS_API_KEY`), token rotation, drift detection, troubleshooting, graduation path to ARC.
- `hosts/hestia/README.md` — adds `gha-runner` to the service table and `main/apps/actions-runner` to the dataset table.

## Bootstrap (manual, one-time)

Per the plan: this is the *only* hestia app where the SCALE UI paste persists. From its first registration onward, every future `hosts/hestia/**/docker-compose*.yml` change is applied by the workflow it executes (D2/D3, follow-up PR).

Steps documented in [the new README](hosts/hestia/actions-runner/README.md#one-time-bootstrap):
1. Create GitHub PAT (`repo` scope) or GitHub App installation token
2. Create TrueNAS API key (SCALE UI → Settings → API Keys)
3. Pre-create `/mnt/main/apps/actions-runner/work` (`zfs create main/apps`)
4. Paste compose into SCALE UI Custom App; set `ACCESS_TOKEN` + `TRUENAS_API_KEY` as masked env vars
5. Verify runner appears at `https://github.com/gjcourt/homelab/settings/actions/runners`

## Test plan

- [ ] `docker compose -f hosts/hestia/actions-runner/docker-compose.yml config` validates (✓ confirmed locally)
- [ ] After bootstrap, runner shows status **Idle** at the GitHub Settings → Actions → Runners page
- [ ] Killing the Custom App and restarting brings the runner back online without re-registration (registration cached in PVC)
- [ ] No workflow fires yet — that's D2/D3

## What follows after this lands

| # | What | When |
|---|---|---|
| D2 | `.github/workflows/deploy-hestia.yml` | After D1 bootstrap is verified online |
| D3 | `scripts/truenas-update-app.sh` | Same PR as D2 |
| D4 | Operator docs flip in `hosts/hestia/README.md` | After a no-op llama compose edit round-trips through the runner |

🤖 Generated with [Claude Code](https://claude.com/claude-code)