### PR TITLE
fix(signal-bridge): limit receive timeout to 1s to free mutex for health checks

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               cpu: 500m
               memory: 512Mi
         - name: signal-bridge
-          image: ghcr.io/gjcourt/signal-bridge:2026-05-02-3
+          image: ghcr.io/gjcourt/signal-bridge:2026-05-02-4
           env:
             - name: SIGNAL_CLI_HOST
               value: "127.0.0.1"

--- a/images/signal-bridge/signal_rpc.go
+++ b/images/signal-bridge/signal_rpc.go
@@ -124,6 +124,7 @@ func (s *SignalRPC) receive(account string) ([]map[string]interface{}, error) {
 
 	params := map[string]interface{}{
 		"maxMessages": 50,
+		"timeout":     1,
 	}
 	if account != "" {
 		params["account"] = account


### PR DESCRIPTION
## Summary

`signal-cli`'s `receive` RPC in `manual` mode blocks for a default ~5s waiting for new messages when the queue is empty. The `pollLoop` holds `SignalRPC.mu` for the full duration. The liveness probe calls `listAccounts()` which also needs `mu` — if the mutex is held when the probe fires, the 3s HTTP timeout elapses, counting as a failure. After 3 consecutive failures (~75s after startup), Kubernetes kills the container.

Fix: pass `"timeout": 1` in the `receive` RPC params. Each poll returns within 1s (with any messages that arrived), freeing the mutex for the next 1s before the next poll tick. The health check can always acquire the mutex within that window.

Image `ghcr.io/gjcourt/signal-bridge:2026-05-02-4` pushed to GHCR.

## Test plan

- [ ] CI passes
- [ ] `kubectl get pods -n signal-cli` shows `2/2 Running` after Flux reconcile
- [ ] No liveness probe failures in bridge logs
- [ ] Send a Signal message to +16179397251 and verify bridge receives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)