### PR TITLE
docs: complete Phase 4 utility app documentation

### DIFF
--- a/docs/operations/apps/golinks.md
+++ b/docs/operations/apps/golinks.md
@@ -45,11 +45,11 @@ To verify GoLinks is working:
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:
-  - The PostgreSQL database is backed up to S3 (MinIO/AWS) using CNPG's Barman integration (Note: currently pending S3 credentials configuration).
+  - The PostgreSQL database is backed up continuously to `s3://gjcourt-homelab-backup/production/golinks` via the Barman Cloud Plugin (WAL archiving + daily base backups, gzip-compressed, 30-day retention).
 - **Restore Procedure**:
-  1. Uncomment the `recovery` section in the `database.yaml` CNPG `Cluster` definition.
+  1. Uncomment the `recovery` section in `apps/production/golinks/database.yaml`.
   2. Comment out the `initdb` section.
-  3. Apply the changes to bootstrap a new cluster from the backup.
+  3. Apply the changes; CNPG will bootstrap a new cluster from the S3 backup via PITR.
 
 ## 9. Troubleshooting
 - **Database Connection Errors**:

--- a/docs/operations/apps/linkding.md
+++ b/docs/operations/apps/linkding.md
@@ -43,12 +43,12 @@ To verify Linkding is working:
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:
-  - The PostgreSQL database is backed up to S3 (MinIO/AWS) using CNPG's Barman integration (Note: currently pending S3 credentials configuration).
-  - The `linkding-data-pvc` is backed up via Synology Snapshot Replication.
+  - The PostgreSQL database is backed up continuously to `s3://gjcourt-homelab-backup/production/linkding` via the Barman Cloud Plugin (WAL archiving + daily base backups, gzip-compressed, 30-day retention).
+  - The `linkding-data-pvc` (favicons, local data) is backed up via Synology Snapshot Replication.
 - **Restore Procedure**:
-  1. Uncomment the `recovery` section in the `database.yaml` CNPG `Cluster` definition.
+  1. Uncomment the `recovery` section in `apps/production/linkding/database.yaml`.
   2. Comment out the `initdb` section.
-  3. Apply the changes to bootstrap a new cluster from the backup.
+  3. Apply the changes; CNPG will bootstrap a new cluster from the S3 backup via PITR.
   4. Restore the `linkding-data-pvc` LUN via Synology DSM if necessary.
 
 ## 9. Troubleshooting

--- a/docs/operations/apps/memos.md
+++ b/docs/operations/apps/memos.md
@@ -5,8 +5,8 @@ Memos is an open-source, self-hosted memo hub with knowledge management and soci
 
 ## 2. Architecture
 Memos is deployed as a Kubernetes `Deployment` with a single replica in the `memos-prod` (and `memos-stage`) namespace.
-- **Database**: Uses a CloudNativePG (CNPG) PostgreSQL cluster (`memos-db-production-cnpg-v1`) with 3 instances for data storage.
-- **Storage**: A 1Gi PersistentVolumeClaim (`memos-data-pvc`) is mounted at `/var/opt/memos` for local file storage (attachments, exports).
+- **Database**: Uses a CloudNativePG (CNPG) PostgreSQL cluster (`memos-db-production-cnpg-v1`) with 3 instances for structured data (memo content, tags, user accounts, OIDC state). Enabled via `MEMOS_DRIVER: postgres`.
+- **Storage**: A 1Gi PersistentVolumeClaim (`memos-data-pvc`) is mounted at `/var/opt/memos` for file attachments and uploaded resources. Memos writes blobs to the local filesystem regardless of the database driver, so the PVC is required even with PostgreSQL.
 - **Networking**: Exposed via Cilium Gateway API (`HTTPRoute`).
 
 ## 3. URLs

--- a/docs/operations/apps/memos.md
+++ b/docs/operations/apps/memos.md
@@ -5,8 +5,8 @@ Memos is an open-source, self-hosted memo hub with knowledge management and soci
 
 ## 2. Architecture
 Memos is deployed as a Kubernetes `Deployment` with a single replica in the `memos-prod` (and `memos-stage`) namespace.
-- **Database**: Uses a CloudNativePG (CNPG) PostgreSQL cluster (`memos-db-production-cnpg-v1`) for data storage.
-- **Storage**: The application itself is stateless, relying entirely on the PostgreSQL database.
+- **Database**: Uses a CloudNativePG (CNPG) PostgreSQL cluster (`memos-db-production-cnpg-v1`) with 3 instances for data storage.
+- **Storage**: A 1Gi PersistentVolumeClaim (`memos-data-pvc`) is mounted at `/var/opt/memos` for local file storage (attachments, exports).
 - **Networking**: Exposed via Cilium Gateway API (`HTTPRoute`).
 
 ## 3. URLs
@@ -47,11 +47,12 @@ To verify Memos is working:
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:
-  - The PostgreSQL database is backed up to S3 (MinIO/AWS) using CNPG's Barman integration (Note: currently pending S3 credentials configuration).
+  - The PostgreSQL database is backed up continuously to `s3://gjcourt-homelab-backup/production/memos` via the Barman Cloud Plugin (WAL archiving + daily base backups, gzip-compressed, 30-day retention).
+  - The `memos-data-pvc` is backed up via Synology Snapshot Replication.
 - **Restore Procedure**:
-  1. Uncomment the `recovery` section in the `database.yaml` CNPG `Cluster` definition.
+  1. Uncomment the `recovery` section in `apps/production/memos/database.yaml`.
   2. Comment out the `initdb` section.
-  3. Apply the changes to bootstrap a new cluster from the backup.
+  3. Apply the changes; CNPG will bootstrap a new cluster from the S3 backup via PITR.
 
 ## 9. Troubleshooting
 - **Database Connection Errors**:

--- a/docs/operations/apps/vitals.md
+++ b/docs/operations/apps/vitals.md
@@ -44,11 +44,11 @@ To verify Vitals is working:
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:
-  - The PostgreSQL database is backed up to S3 (MinIO/AWS) using CNPG's Barman integration (Note: currently pending S3 credentials configuration).
+  - The PostgreSQL database is backed up continuously to `s3://gjcourt-homelab-backup/production/vitals` via the Barman Cloud Plugin (WAL archiving + daily base backups, gzip-compressed, 30-day retention).
 - **Restore Procedure**:
-  1. Uncomment the `recovery` section in the `database.yaml` CNPG `Cluster` definition.
+  1. Uncomment the `recovery` section in `apps/production/vitals/database.yaml`.
   2. Comment out the `initdb` section.
-  3. Apply the changes to bootstrap a new cluster from the backup.
+  3. Apply the changes; CNPG will bootstrap a new cluster from the S3 backup via PITR.
 
 ## 9. Troubleshooting
 - **Database Connection Errors**:

--- a/docs/plans/2026-02-21-documentation-rewrite-plan.md
+++ b/docs/plans/2026-02-21-documentation-rewrite-plan.md
@@ -1,6 +1,6 @@
 ---
-status: in-progress
-last_modified: 2026-02-27
+status: complete
+last_modified: 2026-05-02
 ---
 
 # Documentation Rewrite Plan
@@ -69,12 +69,12 @@ Rewrite documentation for media and data-heavy applications:
 
 Rewrite documentation for utility applications:
 
-*   [ ] `docs/operations/apps/memos.md`: Database backups and SSO integration.
-*   [ ] `docs/operations/apps/linkding.md`: Database backups and SSO integration.
-*   [ ] `docs/operations/apps/mealie.md`: Database backups and SSO integration.
-*   [ ] `docs/operations/apps/golinks.md`: Database backups and SSO integration.
-*   [ ] `docs/operations/apps/excalidraw.md`: Usage and configuration.
-*   [ ] `docs/operations/apps/vitals.md`: Database backups and SSO integration.
+*   [x] `docs/operations/apps/memos.md`: Database backups and SSO integration.
+*   [x] `docs/operations/apps/linkding.md`: Database backups and SSO integration.
+*   [x] `docs/operations/apps/mealie.md`: Database backups and SSO integration.
+*   [x] `docs/operations/apps/golinks.md`: Database backups and SSO integration.
+*   [x] `docs/operations/apps/excalidraw.md`: Usage and configuration.
+*   [x] `docs/operations/apps/vitals.md`: Database backups and SSO integration.
 
 ## Review and Maintenance
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -55,7 +55,7 @@ Sorted by filing date (newest first).
 | [2026-03-08-adguard-dns-rollout.md](2026-03-08-adguard-dns-rollout.md) | `planned` | Roll AdGuard Home as the homelab DNS resolver |
 | [2026-02-28-network-migration-192-to-10-42-2.md](2026-02-28-network-migration-192-to-10-42-2.md) | `complete` | Migrate the LAN from 192.168.5.0/24 to 10.42.2.0/24 |
 | [2026-02-21-linkding-db-restore-plan.md](2026-02-21-linkding-db-restore-plan.md) | `planned` | Live DR test: destroy and restore Linkding staging DB |
-| [2026-02-21-documentation-rewrite-plan.md](2026-02-21-documentation-rewrite-plan.md) | `in-progress` | Rewrite all app and infra documentation |
+| [2026-02-21-documentation-rewrite-plan.md](2026-02-21-documentation-rewrite-plan.md) | `complete` | Rewrite all app and infra documentation |
 | [2026-02-21-cnpg-backup-upgrade.md](2026-02-21-cnpg-backup-upgrade.md) | `complete` | Migrate CNPG backups to Barman Cloud Plugin |
 | [2026-02-21-cluster-health-dashboards-plan.md](2026-02-21-cluster-health-dashboards-plan.md) | `in-progress` | Grafana cluster health dashboard suite |
 | [2026-02-21-app-health-dashboards-plan.md](2026-02-21-app-health-dashboards-plan.md) | `in-progress` | Grafana application health dashboards |


### PR DESCRIPTION
## Summary

- Fix stale DR sections in `memos`, `linkding`, `golinks`, and `vitals` runbooks: replace "pending S3 credentials" with the actual active Barman Cloud Plugin backup paths (`s3://gjcourt-homelab-backup/production/<app>`, 30-day retention, gzip)
- Fix memos architecture description: add the 1Gi PVC at `/var/opt/memos` which was missing
- Mark all Phase 4 tasks complete in `2026-02-21-documentation-rewrite-plan.md`; flip plan status → `complete`
- Update plans README index entry to `complete`

## Test plan

- [ ] Verify each updated doc matches the actual `database.yaml` / `objectstore.yaml` in the production overlay
- [ ] Confirm plans README table reflects `complete` for the documentation rewrite plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)