### PR TITLE
feat(hermes): production overlay (D4) — skip staging soak

### DIFF
--- a/apps/production/hermes/kustomization.yaml
+++ b/apps/production/hermes/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: hermes
+resources:
+  - ../../base/hermes/
+
+labels:
+  - pairs:
+      env: production
+      app.kubernetes.io/instance: production
+    includeSelectors: false

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - cloudflare-tunnel
   - excalidraw
   - golinks
+  - hermes
   - homeassistant
   - homepage
   - immich


### PR DESCRIPTION
## Summary

D4 of [`docs/plans/2026-05-02-hermes-bot-k8s.md`](docs/plans/2026-05-02-hermes-bot-k8s.md). Deploys hermes-bot to the production `hermes` namespace, pointed at the working production signal-cli (`+16179397251`).

> **Stacks on #391** (D2/D3). After #391 merges to master, GitHub auto-retargets this PR. Or do `gh pr edit 392 --base master` manually.

## Why D4 ships without a staging soak

The plan originally called for a ≥48h staging soak before production. During staging verification of #391 we hit a blocker that's not fixable from this side:

| | Production (`signal-cli` ns) | Staging (`signal-cli-stage` ns) |
|---|---|---|
| Pod | `Running 2/2` | `CrashLoopBackOff` |
| Account | `+16179397251` linked | `Failed to read local accounts list` (none ever linked) |

`signal-cli-stage` needs a QR-code link from a real phone before it can run, and Hermes Gateway has no graceful degradation — if any platform fails to connect, it exits. So staging hermes-bot is blocked on operator phone interaction.

Trade-offs for going straight to production (Option C from the discussion):
- **+** Bot becomes laptop-independent immediately (the actual goal).
- **+** Hermes-bot manifests already proved structurally correct in staging — image pulls, container starts, Hermes Gateway loads config + attempts platform connection. The only thing that didn't happen was a successful Signal handshake (because the *staging* signal-cli was the problem, not the bot).
- **−** No isolated soak phase. Worst case is "bot replies oddly to your own DMs" — observable, reversible, low blast radius.
- **−** First contact happens on the real Signal channel.

## What's in this PR

- `apps/production/hermes/kustomization.yaml` — minimal overlay (namespace stays `hermes`, production labels applied). Base ConfigMap already points `SIGNAL_HTTP_URL` at production signal-cli, so no env-var override needed.
- `apps/production/kustomization.yaml` — `hermes` added alphabetically.

## What's intentionally not changing from base

- Single replica, `Recreate` strategy.
- 5 GiB iSCSI PVC at `/opt/data`.
- Image: `nousresearch/hermes-agent@sha256:b28c9b33...` (v2026.4.30).
- Toolsets: `[hermes-signal, file, web]` — no `terminal` until we've watched it run for a while.
- `max_snapshots: 10`, `auto_prune: true`, INFO log level.

## Validation

```
kustomize build apps/production/hermes/    → 176 lines (1 ns + 1 PVC + 2 ConfigMaps + 1 Deployment)
kustomize build apps/production/           → 6954 lines (full prod tree, no errors)
```

## Verification after merge

1. `kubectl wait --for=condition=Ready pod -l app=hermes -n hermes -- timeout=5m`
2. `kubectl logs -n hermes deploy/hermes` — expect:
   - "Hermes Gateway Starting..."
   - "signal connected" (no `signal failed to connect` error)
   - first inbound message logged when you DM `+16179397251`
3. **DM the bot from your phone** → expect a reply
4. **Stop the laptop hermes process** → bot continues to respond. Confirms laptop independence.
5. `kubectl exec -n hermes deploy/hermes -- df -h /opt/data` → PVC < 5% used initially.

## What follows

| | When | What |
|---|---|---|
| D5 | After 24h of observation | `docs/operations/apps/hermes.md` runbook reflecting actual production behavior |
| Soak follow-up | After 48h | Decide whether to opt `terminal` toolset in or keep restricted; tune `max_snapshots` based on PVC growth |
| signal-cli-stage | Whenever convenient | Link a Signal device so we can soak future hermes-bot changes properly |

## Rollback

If hermes-bot misbehaves after merge:
```
kubectl scale deploy hermes -n hermes --replicas=0
```
The bot stops; the PVC and signal-cli stay intact. Re-enable the laptop hermes process for Signal coverage. Open a revert PR for the manifests if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)