### PR TITLE
feat(security): per-app ServiceAccount + automount hygiene (PR 1.3)

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: adguard
     spec:
+      serviceAccountName: adguard
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       securityContext:
         seccompProfile:

--- a/apps/base/adguard/kustomization.yaml
+++ b/apps/base/adguard/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - service.yaml
   - service-admin.yaml
   - service-headless.yaml
+  - serviceaccount.yaml

--- a/apps/base/adguard/serviceaccount.yaml
+++ b/apps/base/adguard/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: adguard
+  namespace: adguard
+automountServiceAccountToken: false

--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: audiobookshelf
     spec:
+      serviceAccountName: audiobookshelf
+      automountServiceAccountToken: false
       # App runs as node user, limits the scope of pods to the same user.
       securityContext:
         runAsNonRoot: true

--- a/apps/base/audiobookshelf/kustomization.yaml
+++ b/apps/base/audiobookshelf/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/audiobookshelf/serviceaccount.yaml
+++ b/apps/base/audiobookshelf/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+automountServiceAccountToken: false

--- a/apps/base/authelia/deployment.yaml
+++ b/apps/base/authelia/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: authelia
     spec:
+      serviceAccountName: authelia
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         runAsNonRoot: true

--- a/apps/base/authelia/kustomization.yaml
+++ b/apps/base/authelia/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - servicemonitor.yaml
   - storage.yaml
 configMapGenerator:

--- a/apps/base/authelia/serviceaccount.yaml
+++ b/apps/base/authelia/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authelia
+  namespace: authelia
+automountServiceAccountToken: false

--- a/apps/base/excalidraw/deployment.yaml
+++ b/apps/base/excalidraw/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: excalidraw
     spec:
+      serviceAccountName: excalidraw
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/base/excalidraw/kustomization.yaml
+++ b/apps/base/excalidraw/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml

--- a/apps/base/excalidraw/serviceaccount.yaml
+++ b/apps/base/excalidraw/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: excalidraw
+  namespace: excalidraw
+automountServiceAccountToken: false

--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: golinks
     spec:
+      serviceAccountName: golinks
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-secret
       securityContext:

--- a/apps/base/golinks/kustomization.yaml
+++ b/apps/base/golinks/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - secret-ghcr.yaml
   - service.yaml
+  - serviceaccount.yaml

--- a/apps/base/golinks/serviceaccount.yaml
+++ b/apps/base/golinks/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: golinks
+  namespace: golinks
+automountServiceAccountToken: false

--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: homeassistant
     spec:
+      serviceAccountName: homeassistant
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/homeassistant/serviceaccount.yaml
+++ b/apps/base/homeassistant/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homeassistant
+  namespace: homeassistant
+automountServiceAccountToken: false

--- a/apps/base/homepage/serviceaccount.yaml
+++ b/apps/base/homepage/serviceaccount.yaml
@@ -5,3 +5,8 @@ metadata:
   namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
+# homepage is the only app that intentionally uses the Kubernetes API: the
+# cluster widget (see configmap.yaml widgets.yaml) lists pods/nodes/ingresses
+# via the API server. The ClusterRole + ClusterRoleBinding are defined in the
+# overlays (apps/{staging,production}/homepage/rbac.yaml).
+automountServiceAccountToken: true

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         app: immich
         component: server
     spec:
+      serviceAccountName: immich
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -86,6 +88,8 @@ spec:
         app: immich
         component: machine-learning
     spec:
+      serviceAccountName: immich
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -154,6 +158,8 @@ spec:
         app: immich
         component: redis
     spec:
+      serviceAccountName: immich
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/apps/base/immich/job-db-init.yaml
+++ b/apps/base/immich/job-db-init.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       name: immich-db-init
     spec:
+      serviceAccountName: immich
+      automountServiceAccountToken: false
       containers:
         - name: db-init
           image: postgres:18-alpine

--- a/apps/base/immich/kustomization.yaml
+++ b/apps/base/immich/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - job-db-init.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/immich/serviceaccount.yaml
+++ b/apps/base/immich/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: immich
+  namespace: immich
+automountServiceAccountToken: false

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: jellyfin
     spec:
+      serviceAccountName: jellyfin
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/base/jellyfin/kustomization.yaml
+++ b/apps/base/jellyfin/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml
   - media/nfs-media.yaml

--- a/apps/base/jellyfin/serviceaccount.yaml
+++ b/apps/base/jellyfin/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jellyfin
+  namespace: jellyfin
+automountServiceAccountToken: false

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: linkding
     spec:
+      serviceAccountName: linkding
+      automountServiceAccountToken: false
       # App runs as www-data user, limits the scope of pods to the same user.
       securityContext:
         runAsNonRoot: true

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/linkding/serviceaccount.yaml
+++ b/apps/base/linkding/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkding
+  namespace: linkding
+automountServiceAccountToken: false

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: mealie
     spec:
+      serviceAccountName: mealie
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/base/mealie/kustomization.yaml
+++ b/apps/base/mealie/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/mealie/serviceaccount.yaml
+++ b/apps/base/mealie/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mealie
+  namespace: mealie
+automountServiceAccountToken: false

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: memos
     spec:
+      serviceAccountName: memos
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/base/memos/kustomization.yaml
+++ b/apps/base/memos/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/memos/serviceaccount.yaml
+++ b/apps/base/memos/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: memos
+  namespace: memos
+automountServiceAccountToken: false

--- a/apps/base/navidrome/deployment.yaml
+++ b/apps/base/navidrome/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: navidrome
     spec:
+      serviceAccountName: navidrome
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         # UID 1028 is the owner of /volume1/family/audio/music on the Synology NAS

--- a/apps/base/navidrome/kustomization.yaml
+++ b/apps/base/navidrome/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/navidrome/serviceaccount.yaml
+++ b/apps/base/navidrome/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: navidrome
+  namespace: navidrome
+automountServiceAccountToken: false

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: overture
     spec:
+      serviceAccountName: overture
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-secret
       securityContext:

--- a/apps/base/overture/kustomization.yaml
+++ b/apps/base/overture/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - secret-ghcr.yaml
   - service.yaml
   - service-monitor.yaml
+  - serviceaccount.yaml

--- a/apps/base/overture/serviceaccount.yaml
+++ b/apps/base/overture/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: overture
+  namespace: overture
+automountServiceAccountToken: false

--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: signal-cli
     spec:
+      serviceAccountName: signal-cli
       automountServiceAccountToken: false
       containers:
         - name: signal-cli

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - servicemonitor.yaml
   - storage.yaml

--- a/apps/base/signal-cli/serviceaccount.yaml
+++ b/apps/base/signal-cli/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signal-cli
+  namespace: signal-cli
+automountServiceAccountToken: false

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: snapcast
     spec:
+      serviceAccountName: snapcast
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/snapcast/serviceaccount.yaml
+++ b/apps/base/snapcast/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapcast
+  namespace: snapcast
+automountServiceAccountToken: false

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: synology-iscsi-exporter
     spec:
+      serviceAccountName: synology-iscsi-monitor
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/apps/base/synology-iscsi-monitor/kustomization.yaml
+++ b/apps/base/synology-iscsi-monitor/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - prometheus-rule.yaml
   - script-cm.yaml
   - service.yaml
+  - serviceaccount.yaml
   - servicemonitor.yaml
 
 configMapGenerator:

--- a/apps/base/synology-iscsi-monitor/serviceaccount.yaml
+++ b/apps/base/synology-iscsi-monitor/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: synology-iscsi-monitor
+  namespace: synology-iscsi-monitor
+automountServiceAccountToken: false

--- a/apps/base/vitals/deployment.yaml
+++ b/apps/base/vitals/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: vitals
     spec:
+      serviceAccountName: vitals
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-secret
       securityContext:

--- a/apps/base/vitals/kustomization.yaml
+++ b/apps/base/vitals/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - secret-ghcr.yaml
   - service.yaml
+  - serviceaccount.yaml

--- a/apps/base/vitals/serviceaccount.yaml
+++ b/apps/base/vitals/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vitals
+  namespace: vitals
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Implements [Phase 1 PR 1.3](../blob/master/docs/plans/2026-05-02-critique-remediation.md) of the homelab critique remediation plan: every app now has its own named `ServiceAccount` with `automountServiceAccountToken: false`, removing ambient API privilege from pods that don't need it. Closes plan findings **#4** and **#20**.

Each app's pod spec now sets:

```yaml
spec:
  serviceAccountName: <app>
  automountServiceAccountToken: false
```

The matching base `ServiceAccount` is declared with `automountServiceAccountToken: false` (belt-and-suspenders). Overlays inherit the base SA and rewrite the namespace via the existing `namespace: <app>-stage` Kustomize directive — no overlay edits required.

## App handling

| App | Treatment | Notes |
|---|---|---|
| adguard | standard | StatefulSet (the workload manifest is named `deployment.yaml`) |
| audiobookshelf | standard | |
| authelia | standard | |
| excalidraw | standard | |
| golinks | standard | |
| homeassistant | standard | Verified: no `hostNetwork`, normal pod spec; works with named SA |
| **homepage** | **special** | **`automountServiceAccountToken: true` on both the SA and the pod** — required for the cluster widget (`configmap.yaml` `widgets.yaml`) which lists pods/nodes/ingresses via the API. The `ClusterRole` + `ClusterRoleBinding` defined in `apps/{staging,production}/homepage/rbac.yaml` continue to scope what `homepage` can see. The base `ServiceAccount` already existed; this PR only adds an explicit `automountServiceAccountToken: true` and an inline comment documenting the intent. |
| immich | standard, multi-pod | Three Deployments (`immich-server`, `immich-machine-learning`, `immich-redis`) + the `immich-db-init` Job all share the `immich` ServiceAccount. |
| jellyfin | standard | |
| linkding | standard | |
| mealie | standard | |
| memos | standard | |
| navidrome | standard | |
| overture | standard | |
| **signal-cli** | **migrated** | Already had `automountServiceAccountToken: false` at the pod level but used the implicit default SA. Now uses the named `signal-cli` SA + SA-level `automountServiceAccountToken: false`. |
| **snapcast** | **migrated** | Same migration as signal-cli — pod-level automount=false was already there; added named `snapcast` SA. |
| synology-iscsi-monitor | standard | |
| vitals | standard | |

## Files

- 17 new `apps/base/<app>/serviceaccount.yaml` files (homepage's already existed; only its content was tweaked)
- 18 `apps/base/<app>/kustomization.yaml` updated (homepage's already references the SA)
- 18 `apps/base/<app>/deployment.yaml` updated (immich gets 3 patches in one file; statefulset for adguard)
- `apps/base/immich/job-db-init.yaml` updated to use the same shared `immich` SA

## Test plan

- [x] `kustomize build apps/base/<app>/` passes for all 18 apps
- [x] `kustomize build apps/staging/<app>/` passes for all apps with a staging overlay (16; overture and synology-iscsi-monitor have none)
- [x] `kustomize build apps/production/<app>/` passes for all 18 apps
- [x] `kustomize build apps/staging` passes at the aggregate level
- [x] `kustomize build apps/production` passes at the aggregate level
- [x] Confirmed staging namespace rewriting works (e.g., `apps/staging/signal-cli/` produces a SA in `signal-cli-stage`)
- [x] Confirmed homepage staging build still has `automountServiceAccountToken: true` on both the SA and the pod
- [ ] After merge to staging: each pod comes up healthy in staging; no 401/403 errors from removed API access (only `homepage` reads the API)
- [ ] After merge: `kubectl auth can-i --list --as=system:serviceaccount:<ns>:<app>` shows minimal/no permissions for non-homepage apps
- [ ] After merge: homepage cluster widget continues to render (or is intentionally disabled in the widget config)