### PR TITLE
feat(security): pod security baseline for canary apps (PR 1.2)

### DIFF
--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -19,12 +19,15 @@ spec:
       labels:
         app: audiobookshelf
     spec:
-      # App runs as node user, limits the scope of pods to the same user.
+      # The upstream advplyr/audiobookshelf image has no USER directive (runs
+      # as root by default); we pin it to a non-root UID 1000 here. CONFIG_PATH
+      # and METADATA_PATH are overridden via configmap to point at PVC mounts
+      # owned by this UID via fsGroup.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000 # node user ID
-        runAsGroup: 1000 # node group ID
-        fsGroup: 1000 # node group ID
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
 
@@ -45,6 +48,7 @@ spec:
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -53,6 +57,11 @@ spec:
               mountPath: /usr/share/audiobookshelf/config
             - name: audiobookshelf-meta-data
               mountPath: /usr/share/audiobookshelf/metadata
+            # ffmpeg / Node write temp output (transcodes, intermediate
+            # thumbnails) under /tmp; required when readOnlyRootFilesystem is
+            # enabled.
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: audiobookshelf-data
           persistentVolumeClaim:
@@ -60,6 +69,5 @@ spec:
         - name: audiobookshelf-meta-data
           persistentVolumeClaim:
             claimName: audiobookshelf-meta-data-pvc
-
-
-
+        - name: tmp
+          emptyDir: {}

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -18,7 +18,16 @@ spec:
       labels:
         app: mealie
     spec:
+      # App runs as the upstream `abc` user (UID/GID 911) per the Mealie
+      # Dockerfile (https://github.com/mealie-recipes/mealie/blob/v3.16.0/docker/Dockerfile).
+      # When the entrypoint sees it is already running as 911 it skips the
+      # root-only chown branch and execs straight into the app, so a hard
+      # securityContext here is safe.
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 911
+        runAsGroup: 911
+        fsGroup: 911
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -33,10 +42,22 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: mealie-data
               mountPath: /app/data
+            # Mealie / FastAPI writes upload temp files and Python tempfiles
+            # under /tmp; required when readOnlyRootFilesystem is enabled.
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: mealie-data
           persistentVolumeClaim:
             claimName: mealie-data-pvc
+        - name: tmp
+          emptyDir: {}

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -18,7 +18,17 @@ spec:
       labels:
         app: memos
     spec:
+      # App runs as the upstream `nonroot` user (UID/GID 10001) per the Memos
+      # Dockerfile (https://github.com/usememos/memos/blob/main/scripts/Dockerfile).
+      # The entrypoint chown's /var/opt/memos only when started as root; running
+      # as 10001 directly skips that branch and execs the binary, so the
+      # readOnlyRootFilesystem container securityContext is safe. fsGroup is
+      # set to 10001 so the data PVC is group-owned by the app's group.
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
 
@@ -35,6 +45,11 @@ spec:
           volumeMounts:
             - name: memos-data
               mountPath: /var/opt/memos
+            # Go binary + entrypoint shell script need a writable /tmp
+            # (tempfile uploads, intermediate files); required when
+            # readOnlyRootFilesystem is enabled.
+            - name: tmp
+              mountPath: /tmp
 
           resources:
             requests:
@@ -44,7 +59,16 @@ spec:
               cpu: 500m
               memory: 256Mi
 
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
       volumes:
         - name: memos-data
           persistentVolumeClaim:
             claimName: memos-data-pvc
+        - name: tmp
+          emptyDir: {}

--- a/apps/production/memos/deployment-patch.yaml
+++ b/apps/production/memos/deployment-patch.yaml
@@ -30,6 +30,12 @@ spec:
                 secretKeyRef:
                   name: memos-db-credentials
                   key: password
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: dsn-volume
               mountPath: /dsn

--- a/apps/staging/memos/deployment-patch.yaml
+++ b/apps/staging/memos/deployment-patch.yaml
@@ -31,6 +31,12 @@ spec:
                 secretKeyRef:
                   name: memos-db-credentials
                   key: password
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: dsn-volume
               mountPath: /dsn


### PR DESCRIPTION
## Summary

Phase 1 / PR 1.2 of the homelab critique remediation plan
(`docs/plans/2026-05-02-critique-remediation.md`) — apply the pod
security baseline to the canary apps. Closes findings #5 and #6.

The baseline applied at `spec.template.spec.securityContext`:

```yaml
runAsNonRoot: true
runAsUser: <image-default>
runAsGroup: <same>
fsGroup: <same>
seccompProfile:
  type: RuntimeDefault
```

Per-container at `spec.template.spec.containers[*].securityContext`:

```yaml
allowPrivilegeEscalation: false
readOnlyRootFilesystem: true
capabilities:
  drop:
    - ALL
```

## Apps baselined

| App | UID:GID | Source |
|---|---|---|
| `mealie` | 911:911 | Upstream `abc` user in [docker/Dockerfile](https://github.com/mealie-recipes/mealie/blob/v3.16.0/docker/Dockerfile) (`useradd -u 911 -U -d $MEALIE_HOME -s /bin/bash abc`). When started as 911 the entrypoint skips its root-only chown branch and execs straight into the app. |
| `memos` | 10001:10001 | Upstream `nonroot` user in [scripts/Dockerfile](https://github.com/usememos/memos/blob/main/scripts/Dockerfile) (`addgroup -g 10001 -S nonroot && adduser -u 10001 -S -G nonroot -h /var/opt/memos nonroot`). Entrypoint chown is skipped when not started as root. |
| `audiobookshelf` | 1000:1000 | Upstream [Dockerfile](https://github.com/advplyr/audiobookshelf/blob/master/Dockerfile) has no `USER` directive (runs as root by default). UID 1000 is the conventional "node" user for this image; CONFIG_PATH and METADATA_PATH are already overridden via configmap to PVC mounts that fsGroup makes group-writable for 1000. |

For each app I also added an `emptyDir` mount at `/tmp` because
`readOnlyRootFilesystem: true` makes the container root unwritable
and all three apps write tempfiles there (FastAPI uploads in mealie,
Go binary tempfiles + the entrypoint shell in memos, ffmpeg / Node
temp output in audiobookshelf). No other writable paths were needed
beyond the existing PVC mounts.

For `memos` I also added the same per-container baseline
(`drop: [ALL]`, `allowPrivilegeEscalation: false`,
`readOnlyRootFilesystem: true`) to the staging + production
`init-dsn` initContainer so the rendered pod is end-to-end compliant.

## App skipped

| App | Reason |
|---|---|
| `linkding` | Already has the entire pod-level baseline (`runAsNonRoot`, `runAsUser=33`, `runAsGroup=33`, `fsGroup=33`, `seccompProfile.RuntimeDefault`) and all container-level baseline fields except `readOnlyRootFilesystem`. Enabling that breaks Huey background tasks: supervisord writes `background_tasks.log` to the WORKDIR `/etc/linkding` (read-only with the baseline) and a control socket to `/var/run/supervisor.sock`. The plan's rule is "never disable the protection — always add a mount", but the safe fixes here either need an upstream patch (relocate logs/socket to a known writable path) or `LD_DISABLE_BACKGROUND_TASKS=true` (disables background bookmark archival/preview generation, an app-behavior change out of scope for this PR). Deferring to a follow-up PR. |

## Test plan

- [x] `kustomize build apps/base/{mealie,memos,audiobookshelf,linkding}/` passes
- [x] `kustomize build apps/staging/{mealie,memos,audiobookshelf,linkding}/` passes
- [x] `kustomize build apps/production/{mealie,memos,audiobookshelf,linkding}/` passes
- [x] `kustomize build apps/staging/` and `kustomize build apps/production/` pass
- [x] `git diff HEAD | grep -iE 'password|secret|token'` clean
- [x] No image tag rollbacks
- [ ] After merge: each canary app comes up clean in staging without `CrashLoopBackOff` from `readOnlyRootFilesystem` regressions
- [ ] After merge: `kubectl get pods -n {mealie-stage,memos-stage,audiobookshelf-stage} -o jsonpath='{.items[*].spec.securityContext}'` shows the baseline
- [ ] After staging soak (1 Flux reconcile cycle, ~10m): merge to master for production

## Per-PR checklist

- [x] kustomize build passes for all affected overlays
- [x] No plaintext secrets in diff (`git diff HEAD | grep -iE 'password|secret|token'`)
- [x] Image tags strictly increasing (or pinned by digest) — no image changes in this PR
- [ ] Tested in staging for at least one Flux reconcile cycle
- [x] Linked back to this plan's Phase / PR row (Phase 1 / PR 1.2, findings #5 + #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)