### PR TITLE
fix: correct llama-cpp compose file path in deploy workflow

### DIFF
--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -29,7 +29,7 @@ on:
         default: all
         options:
           - all
-          - llama
+          - llama-cpp
       dry_run:
         description: 'Connect, query, and diff without calling app.update'
         required: false
@@ -47,8 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: llama
-            file: hosts/hestia/llms/docker-compose-llama.yml
+          - name: llama-cpp
+            file: hosts/hestia/llms/docker-compose-llama-cpp.yml
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The deploy-hestia workflow matrix referenced `docker-compose-llama.yml` which doesn't exist. The actual file is `docker-compose-llama-cpp.yml`.

This caused `truenas-update-app.sh` to fail with exit code 66 (file not found) on every push to `docker-compose-llama-cpp.yml`, so updates never propagated to TrueNAS.

## Fix

- Matrix entry: `docker-compose-llama.yml` → `docker-compose-llama-cpp.yml`
- Matrix name: `llama` → `llama-cpp`
- workflow_dispatch dropdown: `llama` → `llama-cpp`
