### PR TITLE
fix: correct llama-cpp TrueNAS deployment script

### DIFF
--- a/scripts/truenas-update-app.sh
+++ b/scripts/truenas-update-app.sh
@@ -38,10 +38,14 @@ if [ -z "${TRUENAS_API_KEY:-}" ]; then
   exit 78
 fi
 
-# Install websockets if missing. ubuntu-noble's python3 doesn't include it.
+# Install websockets and pyyaml if missing. ubuntu-noble's python3 doesn't include them.
 if ! python3 -c "import websockets" 2>/dev/null; then
   echo "+ pip install --quiet --user websockets" >&2
   python3 -m pip install --quiet --user --break-system-packages websockets >&2
+fi
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "+ pip install --quiet --user pyyaml" >&2
+  python3 -m pip install --quiet --user --break-system-packages pyyaml >&2
 fi
 
 export APP_NAME COMPOSE_FILE DRY_RUN
@@ -55,6 +59,7 @@ import ssl
 import sys
 
 import websockets
+import yaml
 
 
 APP_NAME = os.environ["APP_NAME"]
@@ -143,8 +148,9 @@ async def main() -> None:
         # Compose YAML field name varies across TrueNAS versions. Try the
         # common shapes and report what we find for the operator's benefit.
         current_yaml = (
-            app.get("custom_compose_config_string")
-            or app.get("custom_compose_config")
+            app.get("custom_compose_config")
+            or app.get("custom_compose_config_string")
+            or (app.get("config") or {}).get("custom_compose_config")
             or (app.get("config") or {}).get("custom_compose_config_string")
             or ""
         )
@@ -167,11 +173,14 @@ async def main() -> None:
             return
 
         # Apply.
+        # TrueNAS app.update expects custom_compose_config as a parsed dict
+        # (not a YAML string).  Pydantic validation rejects raw strings.
+        compose_dict = yaml.safe_load(new_yaml)
         log(f"calling app.update for '{APP_NAME}'")
         update = await call(
             ws,
             "app.update",
-            [APP_NAME, {"values": {"custom_compose_config_string": new_yaml}}],
+            [APP_NAME, {"custom_compose_config": compose_dict}],
             msg_id=3,
         )
         if "error" in update and update["error"]:


### PR DESCRIPTION
## Problem

The `truenas-update-app.sh` script had multiple issues preventing
deployment of the llama-cpp Custom App to TrueNAS:

- Used wrong field name (`custom_compose_config_string` instead of
  `custom_compose_config`) when reading the current compose config
- Wrapped app.update params in `{'values': ...}` which the API rejects
  (app.update expects config dict directly)
- Passed compose YAML as a raw string instead of a parsed dict
  (TrueNAS Pydantic validation rejects raw strings)
- Missing pyyaml dependency in the ubuntu-noble runner image

## Fix

The script now reads `custom_compose_config` first, passes it as a
parsed YAML dict to app.update, and installs pyyaml on the runner.

## Verification

Manual workflow_dispatch run confirmed successful:
- `compose change detected for 'llama-cpp' (0 → 1102 bytes)`
- `[SUCCESS] Update completed for 'llama-cpp'`