### PR TITLE
fix: revert llama-cpp to 8 threads

### DIFF
--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -18,7 +18,7 @@ services:
       --n-gpu-layers 99
       --parallel 1
       --cont-batching
-      --threads 9
+      --threads 8
       --temp 0.6
       --top-k 20
       --top-p 0.95


### PR DESCRIPTION
Testing the deploy pipeline — changing from 9 back to 8 threads.