### PR TITLE
fix(signal-bridge): disable auth to fix SSE connection loop

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -72,11 +72,7 @@ spec:
             - name: HERMES_ALLOW_ALL_USERS
               value: "false"
             - name: HERMES_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: signal-bridge-auth
-                  key: token
-                  optional: true
+              value: ""
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Problem

Hermes signal adapter does not send Bearer token in SSE requests, but signal-bridge required it via `HERMES_AUTH_TOKEN`. This caused a ~2s reconnect loop:

1. Hermes connects to `/api/v1/events?account=...`
2. Signal-bridge returns 401 "unauthorized"
3. Hermes' httpx client treats 4xx as successful streams (no exception raised)
4. Adapter logs "Signal SSE: connected" (entered the async block)
5. Reads "unauthorized" as SSE data → JSON parse fails → silently ignored
6. Stream ends → reconnect after backoff → repeat

Result: no messages ever delivered to Hermes.

## Fix

Set `HERMES_AUTH_TOKEN: ""` which disables the Bearer check in signal-bridge (empty token = allow all). Since signal-bridge runs in an isolated K8s namespace with no external access, auth is not necessary.

## Verification

After merge, check:
- Signal-bridge logs show "SSE: client connected" and stays connected
- Hermes gateway.log shows stable SSE connection (no rapid reconnects)
- Incoming Signal messages appear in Hermes