### PR TITLE
chore(hermes,docs): conform to <app>-prod namespace convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ See `docs/architecture/` for component-level architecture (DNS strategy, gateway
 
 - **Branch + PR for every change** — never commit directly to `master` or `staging`.
 - **Image tags are strictly increasing** — never roll back to an earlier tag without explicit intent. CI tags as `YYYY-MM-DD` (first build of day) then `YYYY-MM-DD-N`.
-- **Namespace convention**: production uses the plain name (`overture`); staging uses a `-stage` suffix (`overture-stage`).
+- **Namespace convention**: production uses a `-prod` suffix (`golinks-prod`); staging uses a `-stage` suffix (`golinks-stage`). The base manifest declares the plain name (`golinks`) and each overlay patches `metadata.name`. Apps without a staging variant (`mosquitto`, `cloudflare-tunnel`, `synology-iscsi-monitor`, etc.) use the plain name.
 - **Secrets are SOPS-encrypted** before commit (key ref: `.sops.yaml`); never commit plaintext.
 - **Adding a new app**: see `docs/operations/2026-05-02-adding-an-app.md`.
 - **Conventional Commits** for every commit (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `ci:`, `deploy:`).

--- a/apps/production/hermes/kustomization.yaml
+++ b/apps/production/hermes/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: hermes
+namespace: hermes-prod
 resources:
   - ../../base/hermes/
 
@@ -9,3 +9,12 @@ labels:
       env: production
       app.kubernetes.io/instance: production
     includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: hermes
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: hermes-prod


### PR DESCRIPTION
## Summary

The cluster's actual namespace convention (across ~40 existing namespaces) is **production = `<app>-prod`**, staging = `<app>-stage`. AGENTS.md said "production uses the plain name" — the doc was wrong. Two fixes:

- **`AGENTS.md`** — rewrite the convention line to match reality, with a note that the base manifest uses the plain name and each overlay patches `metadata.name`.
- **`apps/production/hermes/kustomization.yaml`** — add the namespace rename patch from `hermes` → `hermes-prod`, matching the golinks/audiobookshelf/jellyfin/etc pattern.

## Verification

```
kustomize build apps/production/hermes/  → namespace: hermes-prod ✓
kustomize build apps/production/         → no errors
```

## Post-merge cleanup

Flux will create `hermes-prod` and leave `hermes` orphaned. After verifying the new pod is up:

```bash
kubectl delete ns hermes
```

The PVC in `hermes` namespace gets recreated empty in `hermes-prod` (no real session data yet, so safe).

## Out of scope (separate work)

- **`signal-cli` (production) → `signal-cli-prod`** — also non-conforming. Rename invalidates the linked Signal account on the PVC; needs operator decision and possibly a phone re-link. Flagged for a separate PR after coordination.
- **`homeassistant` and `homeassistant-prod` both running** — pre-existing duplicate namespaces, both with active pods. Out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)