### PR TITLE
feat(security): hermes Phase 1 parity (SA + pod security baseline)

### DIFF
--- a/apps/base/hermes/deployment.yaml
+++ b/apps/base/hermes/deployment.yaml
@@ -17,13 +17,17 @@ spec:
       labels:
         app: hermes
     spec:
+      serviceAccountName: hermes
       automountServiceAccountToken: false
       securityContext:
         # Upstream image runs as the `hermes` user, UID 10000. fsGroup ensures
         # the iSCSI-mounted PVC is writable by that user without an init chown.
+        runAsNonRoot: true
         runAsUser: 10000
         runAsGroup: 10000
         fsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: hermes
           # nousresearch/hermes-agent:v2026.4.30 (linux/amd64)
@@ -37,6 +41,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: hermes-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: data
               mountPath: /opt/data

--- a/apps/base/hermes/kustomization.yaml
+++ b/apps/base/hermes/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - namespace.yaml
   - storage.yaml
   - configmap.yaml
+  - serviceaccount.yaml
   - deployment.yaml

--- a/apps/base/hermes/serviceaccount.yaml
+++ b/apps/base/hermes/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes
+  namespace: hermes
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Hermes was added to master after the Phase 1 canary agents (#395, #397, #398) started, so it missed:
- PR 1.3 per-app ServiceAccount + automountServiceAccountToken: false
- PR 1.2 pod security baseline (runAsNonRoot, seccompProfile, container caps drop)

This PR brings hermes to parity with the other 18 apps that landed in Phase 1.

## Changes

- New \`apps/base/hermes/serviceaccount.yaml\` — named SA with \`automountServiceAccountToken: false\`
- \`serviceAccountName: hermes\` set on the pod spec
- \`runAsNonRoot: true\` + \`seccompProfile: { type: RuntimeDefault }\` added at pod-level securityContext
- Container securityContext: \`allowPrivilegeEscalation: false\`, \`capabilities.drop: [ALL]\`

## Skipped

- \`readOnlyRootFilesystem: true\` — hermes-agent runs uv at startup and the upstream image's writable paths haven't been validated. Will be added in a follow-up after mapping required emptyDir mounts.

References \`docs/plans/2026-05-02-critique-remediation.md\` Phase 1.

## Test plan

- [x] \`kustomize build apps/base/hermes\`, \`apps/staging/hermes\`, \`apps/production/hermes\` all pass
- [ ] After merge: hermes pod restarts without CrashLoopBackOff in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)