### PR TITLE
feat(reliability): close BestEffort QoS gap (PR 2.1)

### DIFF
--- a/apps/production/memos/deployment-patch.yaml
+++ b/apps/production/memos/deployment-patch.yaml
@@ -36,6 +36,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+          # Small but non-zero so the pod stays Burstable (not BestEffort)
+          # alongside the main container's requests/limits. Plan PR 2.1.
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
             - name: dsn-volume
               mountPath: /dsn

--- a/apps/staging/memos/deployment-patch.yaml
+++ b/apps/staging/memos/deployment-patch.yaml
@@ -37,6 +37,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+          # Small but non-zero so the pod stays Burstable (not BestEffort)
+          # alongside the main container's requests/limits. Plan PR 2.1.
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
             - name: dsn-volume
               mountPath: /dsn


### PR DESCRIPTION
## Summary

Closes the BestEffort QoS gap (finding #3) per `docs/plans/2026-05-02-critique-remediation.md` Phase 2 PR 2.1.

When PR 2.1 was scoped, the four named offenders were `authelia`, `excalidraw`, `linkding`, and `memos`. Walking the current tree shows the security and pod-baseline PRs that landed earlier in this remediation already set `requests` + `limits` on the main container of all four apps, so their pods are already `Burstable`. The single residual gap was the `init-dsn` initContainer added by the memos production and staging overlays, which had no resources at all and so contributed to a sloppy QoS posture.

This PR adds small but non-zero requests + limits to that initContainer so the entire pod (init + main) is consistently `Burstable`, matching the plan's guidance for init containers.

## Apps modified

| Overlay | Container | Requests | Limits |
|---|---|---|---|
| `apps/production/memos` | `init-dsn` (init) | `cpu: 10m, memory: 16Mi` | `cpu: 100m, memory: 64Mi` |
| `apps/staging/memos` | `init-dsn` (init) | `cpu: 10m, memory: 16Mi` | `cpu: 100m, memory: 64Mi` |

## Already covered (skipped, documented per plan)

These four apps were named in finding #3 but already have `requests` + `limits` on their main containers from prior security/baseline PRs, so they are already `Burstable` (never `BestEffort`):

| App | Container | Requests | Limits | Source |
|---|---|---|---|---|
| `apps/base/authelia/deployment.yaml` | `authelia` | `cpu: 20m, memory: 128Mi` | `cpu: 500m, memory: 512Mi` | already in base |
| `apps/base/excalidraw/deployment.yaml` | `excalidraw` | `cpu: 5m, memory: 64Mi` | `cpu: 200m, memory: 128Mi` | already in base |
| `apps/base/linkding/deployment.yaml` | `linkding` | `cpu: 10m, memory: 256Mi` | `cpu: 500m, memory: 512Mi` | already in base |
| `apps/base/linkding/deployment.yaml` | `migrate` (init) | `cpu: 10m, memory: 128Mi` | `cpu: 200m, memory: 256Mi` | already in base |
| `apps/base/memos/deployment.yaml` | `memos` | `cpu: 10m, memory: 64Mi` | `cpu: 500m, memory: 256Mi` | already in base |

## Deferred to follow-up PR

Finding #7 (~15 apps with `requests` but no `limits`) is intentionally **not** addressed in this PR — the plan calls for the canary to focus on closing the BestEffort gap first. A follow-up PR will fill `limits` on the broader app set after this lands cleanly in staging.

## Plan reference

- `docs/plans/2026-05-02-critique-remediation.md` Phase 2 / PR 2.1
- Finding #3 (Major): authelia, excalidraw, linkding, memos missing requests
- Finding #7 (Moderate): ~15 deployments have `requests` but no `limits` — deferred

## Test plan

- [x] `kustomize build apps/base/{authelia,excalidraw,linkding,memos}` passes
- [x] `kustomize build apps/staging/{authelia,excalidraw,linkding,memos}` passes
- [x] `kustomize build apps/production/{authelia,excalidraw,linkding,memos}` passes
- [x] `git diff HEAD | grep -iE 'password|secret|token'` returns nothing
- [ ] Post-merge: `kubectl get pod -n authelia -l app=authelia -o jsonpath='{.items[*].status.qosClass}'` returns `Burstable`
- [ ] Post-merge: `kubectl get pod -n excalidraw -l app=excalidraw -o jsonpath='{.items[*].status.qosClass}'` returns `Burstable`
- [ ] Post-merge: `kubectl get pod -n linkding -l app=linkding -o jsonpath='{.items[*].status.qosClass}'` returns `Burstable`
- [ ] Post-merge: `kubectl get pod -n memos -l app=memos -o jsonpath='{.items[*].status.qosClass}'` returns `Burstable`
- [ ] Post-merge: no app reports QoS class `BestEffort`

## Per-PR checklist

- [x] kustomize build passes for all affected overlays
- [x] No plaintext secrets in diff (`git diff HEAD | grep -iE 'password|secret|token'`)
- [x] Image tags strictly increasing (or pinned by digest) — N/A, no image changes
- [ ] Tested in staging for at least one Flux reconcile cycle
- [x] Linked back to plan's Phase 2 / PR 2.1