### PR TITLE
feat(reliability): HelmRelease upgrade.remediation (PR 2.3)

### DIFF
--- a/infra/controllers/barman-cloud/release.yaml
+++ b/infra/controllers/barman-cloud/release.yaml
@@ -23,5 +23,9 @@ spec:
         name: cnpg
         namespace: cnpg-system
       interval: 12h
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
   driftDetection:
     mode: enabled

--- a/infra/controllers/cert-manager/release.yaml
+++ b/infra/controllers/cert-manager/release.yaml
@@ -18,6 +18,9 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      strategy: rollback
   driftDetection:
     mode: enabled
 

--- a/infra/controllers/cilium/release.yaml
+++ b/infra/controllers/cilium/release.yaml
@@ -17,6 +17,10 @@ spec:
       interval: 12h
   # CRDs are pre-installed by infra/crds/cilium (infra-crds Kustomization) and
   # managed by the Cilium operator at runtime; no Helm CRD ownership needed.
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
   driftDetection:
     mode: enabled
 

--- a/infra/controllers/cnpg/release.yaml
+++ b/infra/controllers/cnpg/release.yaml
@@ -20,6 +20,12 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    # uninstall (not rollback): the CNPG operator manages Cluster CRs that
+    # back PostgreSQL with StatefulSets; rollback on stuck StatefulSets is a
+    # known Flux failure mode. Uninstall + reinstall is safer for the operator.
+    remediation:
+      retries: 3
+      strategy: uninstall
 
   driftDetection:
     mode: enabled

--- a/infra/controllers/democratic-csi/release.yaml
+++ b/infra/controllers/democratic-csi/release.yaml
@@ -20,6 +20,9 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      strategy: rollback
 
   driftDetection:
     mode: enabled

--- a/infra/controllers/kube-prometheus-stack/release.yaml
+++ b/infra/controllers/kube-prometheus-stack/release.yaml
@@ -24,6 +24,12 @@ spec:
   upgrade:
     timeout: 60m
     crds: CreateReplace
+    # uninstall (not rollback): the chart creates StatefulSets for Prometheus
+    # and Alertmanager; rollback on stuck StatefulSets is a known Flux failure
+    # mode. Uninstall + reinstall is safer for this stack.
+    remediation:
+      retries: 3
+      strategy: uninstall
 
   driftDetection:
     mode: enabled

--- a/infra/controllers/promtail/release.yaml
+++ b/infra/controllers/promtail/release.yaml
@@ -16,6 +16,11 @@ spec:
         namespace: monitoring
       interval: 12h
 
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
+
   driftDetection:
     mode: enabled
 

--- a/infra/controllers/snapshot/release.yaml
+++ b/infra/controllers/snapshot/release.yaml
@@ -20,6 +20,9 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      strategy: rollback
 
   driftDetection:
     mode: enabled

--- a/infra/controllers/synology-csi/release.yaml
+++ b/infra/controllers/synology-csi/release.yaml
@@ -20,6 +20,9 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      strategy: rollback
 
   driftDetection:
     mode: enabled

--- a/infra/controllers/vector/release.yaml
+++ b/infra/controllers/vector/release.yaml
@@ -16,6 +16,11 @@ spec:
         namespace: monitoring
       interval: 12h
 
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback
+
   driftDetection:
     mode: enabled
 


### PR DESCRIPTION
## Summary

Closes finding #11 in `docs/plans/2026-05-02-critique-remediation.md` (Phase 2 / PR 2.3).

Adds `spec.upgrade.remediation` to every HelmRelease under `infra/controllers/` so a failed Helm upgrade automatically retries 3 times and either rolls back or uninstalls (instead of leaving the release stuck in `Failed`).

## HelmReleases changed

| HelmRelease | Strategy | Reasoning |
|---|---|---|
| `barman-cloud` | `rollback` | Plain Deployment-based CNPG-I plugin; rollback is safe. |
| `cert-manager` | `rollback` | Plain Deployments (controller, webhook, cainjector). |
| `cilium` | `rollback` | DaemonSet + Deployment; no StatefulSets. |
| `cnpg` | `uninstall` | Operator manages CNPG `Cluster` CRs backed by StatefulSets — rolling back the operator on stuck StatefulSets is a known Flux failure mode. Uninstall+reinstall is safer. |
| `democratic-csi` | `rollback` | CSI controller/node Deployments + DaemonSets. |
| `kube-prometheus-stack` | `uninstall` | Chart creates StatefulSets for Prometheus + Alertmanager — same stuck-StatefulSet failure mode as above. |
| `loki` | (unchanged) | Already uses `strategy: uninstall` for the same reason. |
| `promtail` | `rollback` | DaemonSet only. |
| `snapshot-controller` | `rollback` | Plain Deployment. |
| `synology-csi` | `rollback` | CSI controller + DaemonSet; no StatefulSets. |
| `vector` | `rollback` | DaemonSet only. |

`retries: 3` across the board.

11 of the 12 HelmReleases in the repo are touched by this PR. The plan referenced "18/20" — the actual current count is 12, of which `loki` already had remediation. All others now do.

## Test plan

- [x] `kustomize build infra/controllers/<name>/` passes for every touched controller.
- [x] `kustomize build infra/controllers` passes.
- [x] Built output shows `upgrade.remediation` rendered with the expected strategy on every HelmRelease.
- [ ] Soak: force a known-bad upgrade in staging (e.g. bump a chart to a known-broken version) and verify Flux remediates within 3 retries — deferred to a manual exercise per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)