### PR TITLE
feat(reliability): health probes baseline (PR 2.2)

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -65,6 +65,18 @@ spec:
               path: /
             initialDelaySeconds: 10
             periodSeconds: 5
+          # AdGuard's filter/rules processing can pause the HTTP listener for
+          # several seconds during scheduled rule reloads. Use a TCP probe on
+          # the admin port (HTTP probe could trigger a redirect/302 that we
+          # don't want flapping liveness on) with extra-tolerant thresholds
+          # (failureThreshold: 6 over periodSeconds: 30 = 3 min before kill).
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 20m

--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -41,6 +41,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: audiobookshelf-container-env
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 13378
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m

--- a/apps/base/excalidraw/deployment.yaml
+++ b/apps/base/excalidraw/deployment.yaml
@@ -25,6 +25,14 @@ spec:
           image: excalidraw/excalidraw@sha256:20ffa04668e19616bb0c1b3632849e5cd96e0bc7a1336b73d9d072667f2c2854
           ports:
             - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: 5m

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -32,6 +32,14 @@ spec:
               value: gethomepage.dev # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
           ports:
             - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: 5m

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -60,6 +60,18 @@ spec:
           securityContext:
             privileged: true # Required for GPU access
 
+          # Readiness only — Jellyfin's startup time is highly variable on
+          # first-run library scans; a startupProbe + tight livenessProbe is
+          # tracked separately (#22, deferred).
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+
           # Resource limits - generous for transcoding bursts
           resources:
             requests:

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -54,6 +54,15 @@ spec:
             - name: linkding-data
               mountPath: /etc/linkding/data
 
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+
           resources:
             requests:
               cpu: 10m

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -37,6 +37,14 @@ spec:
           name: mealie
           ports:
             - containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /api/app/about
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -53,6 +53,15 @@ spec:
             - name: tmp
               mountPath: /tmp
 
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5230
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+
           resources:
             requests:
               cpu: 10m

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -47,6 +47,16 @@ spec:
           ports:
             - containerPort: 8000
               name: metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            # The exporter installs paramiko/prometheus_client via pip on
+            # startup before listening, so allow a generous initial delay.
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

Implements **Phase 2 PR 2.2** of `docs/plans/2026-05-02-critique-remediation.md` — fills in the sparsest health-probe gaps without bundling the deferred app-side and timing-sensitive work.

Closes findings:
- **#8 (Moderate)** — sparse health probes across apps
- **#10 (Moderate)** — adguard missing livenessProbe
- **#22 (Minor)** — partially; immich/jellyfin startupProbes deferred

## Apps modified + probes added

| App | Probe | Endpoint / Mode | Notes |
|---|---|---|---|
| `apps/base/adguard/deployment.yaml` | livenessProbe | TCP on `http` (port 80) | `failureThreshold: 6, periodSeconds: 30` per plan; tolerant of filter-rule reload pauses. TCP avoids 302-redirect flapping that an HTTP probe could pick up. |
| `apps/base/audiobookshelf/deployment.yaml` | readinessProbe | HTTP `/healthcheck` on 13378 | |
| `apps/base/excalidraw/deployment.yaml` | readinessProbe | HTTP `/` on 80 | nginx static — `/` is the safest endpoint. |
| `apps/base/homepage/deployment.yaml` | readinessProbe | HTTP `/` on 3000 | |
| `apps/base/jellyfin/deployment.yaml` | readinessProbe | HTTP `/health` on `http` | Jellyfin's `/health` is public. No livenessProbe (transcode/scan workloads can hold the event loop briefly). startupProbe deferred per #22. |
| `apps/base/linkding/deployment.yaml` | readinessProbe | HTTP `/health` on 9090 | |
| `apps/base/mealie/deployment.yaml` | readinessProbe | HTTP `/api/app/about` on 9000 | Anonymous-readable Mealie API. |
| `apps/base/memos/deployment.yaml` | readinessProbe | HTTP `/healthz` on 5230 | |
| `apps/base/synology-iscsi-monitor/deployment.yaml` | readinessProbe | HTTP `/metrics` on `metrics` (8000) | `initialDelaySeconds: 30` because the container `pip install`s on start before listening. |

## Apps explicitly skipped

| App | Reason |
|---|---|
| `golinks` (finding #9) | Liveness and readiness need to be split (`/health/live` vs `/health/ready`). That requires an **app-side** change to expose distinct endpoints; out of scope for this manifest-only PR. Tracked in the plan as "split probes" — deferred to a follow-up that touches the golinks repo. |
| `homeassistant` | No anonymous health endpoint. `/` redirects to onboarding/login; `/api/*` requires a long-lived access token, and embedding one only for the kubelet probe would expand the secret blast radius. Skip until a kubelet-friendly endpoint exists. |
| immich `livenessProbe` improvements + jellyfin `startupProbe` (finding #22) | Deferred to a follow-up. Per the plan, these need careful timing tuning and live observation (10-minute startups, model-loading bursts) that's safer to land separately. |

## Why no `livenessProbe` on most apps

Per the plan: **"a flapping liveness is worse than no liveness"**. A liveness probe was added only to adguard (where the plan calls it out specifically) because adguard's filtering pauses are well-understood. For the others, no distinct liveness signal exists today, so I left `livenessProbe` off rather than copy the readiness URL.

## Probe shapes

Standard readiness: `initialDelaySeconds: 5, periodSeconds: 10, timeoutSeconds: 3, failureThreshold: 3` (synology-iscsi-monitor, jellyfin, and adguard livenessProbe override these where the workload requires extra tolerance).

## Validation

- [x] `kustomize build apps/base/<app>/` passes for every modified app
- [x] `kustomize build apps/staging/<app>/` and `apps/production/<app>/` pass for every modified app (jellyfin emits a pre-existing `patchesStrategicMerge` deprecation warning unrelated to this PR)
- [x] `git diff HEAD | grep -iE 'password|secret|token'` returns nothing
- [x] No image tag changes
- [x] Linked back to plan: Phase 2 PR 2.2 in `docs/plans/2026-05-02-critique-remediation.md`

## Plan checklist

- [x] kustomize build passes for all affected overlays
- [x] No plaintext secrets in diff
- [x] Image tags strictly increasing (or pinned by digest) — N/A, no image changes
- [ ] Tested in staging for at least one Flux reconcile cycle — pending merge to `staging` via CI
- [x] Linked back to this plan's Phase / PR row

## Test plan

- [ ] Merge triggers staging branch rebuild
- [ ] Watch `kubectl describe pod -n <ns> <pod>` for each modified app — confirm probe definitions appear and pods stay Ready
- [ ] Watch for any unexpected pod restarts in the 30 minutes after staging reconcile (especially adguard, given the new livenessProbe)
- [ ] If staging stays clean, merge to `master` and watch the same in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)