### PR TITLE
feat(reliability): revisionHistoryLimit + PDBs + priorityClassName (PR 2.4)

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   serviceName: adguard-headless
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: adguard

--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: audiobookshelf
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: audiobookshelf

--- a/apps/base/authelia/deployment.yaml
+++ b/apps/base/authelia/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: authelia
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: authelia

--- a/apps/base/excalidraw/deployment.yaml
+++ b/apps/base/excalidraw/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: excalidraw
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: excalidraw

--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: golinks
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: golinks

--- a/apps/base/golinks/kustomization.yaml
+++ b/apps/base/golinks/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/golinks/pdb.yaml
+++ b/apps/base/golinks/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: golinks
+  namespace: golinks
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: golinks

--- a/apps/base/hermes/deployment.yaml
+++ b/apps/base/hermes/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: hermes
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   strategy:
     type: Recreate
   selector:

--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: homeassistant
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: homeassistant

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: homepage
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: homepage

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     component: server
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: immich
@@ -76,6 +77,7 @@ metadata:
     component: machine-learning
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: immich
@@ -148,6 +150,7 @@ metadata:
     component: redis
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: immich

--- a/apps/base/immich/kustomization.yaml
+++ b/apps/base/immich/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - job-db-init.yaml
   - namespace.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/immich/pdb.yaml
+++ b/apps/base/immich/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: immich
+  namespace: immich
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: immich

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: jellyfin
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: jellyfin

--- a/apps/base/jellyfin/kustomization.yaml
+++ b/apps/base/jellyfin/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/jellyfin/pdb.yaml
+++ b/apps/base/jellyfin/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: jellyfin
+  namespace: jellyfin
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: jellyfin

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: linkding
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: linkding

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: mealie
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: mealie

--- a/apps/base/mealie/kustomization.yaml
+++ b/apps/base/mealie/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/mealie/pdb.yaml
+++ b/apps/base/mealie/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mealie
+  namespace: mealie
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: mealie

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: memos
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: memos

--- a/apps/base/navidrome/deployment.yaml
+++ b/apps/base/navidrome/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: navidrome
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: navidrome

--- a/apps/base/navidrome/kustomization.yaml
+++ b/apps/base/navidrome/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/navidrome/pdb.yaml
+++ b/apps/base/navidrome/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: navidrome
+  namespace: navidrome
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: navidrome

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: overture
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: overture

--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: signal-cli
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   strategy:
     type: Recreate
   selector:

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: snapcast
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: synology-iscsi-exporter
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: synology-iscsi-exporter

--- a/apps/base/vitals/deployment.yaml
+++ b/apps/base/vitals/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: vitals
 spec:
   replicas: 1
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: vitals

--- a/apps/base/vitals/kustomization.yaml
+++ b/apps/base/vitals/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/vitals/pdb.yaml
+++ b/apps/base/vitals/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: vitals
+  namespace: vitals
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: vitals

--- a/infra/controllers/cert-manager/values.yaml
+++ b/infra/controllers/cert-manager/values.yaml
@@ -3,6 +3,11 @@ crds:
   # as part of the Helm installation.
   enabled: true
 
+# Cluster-critical: cert-manager issues TLS for every Gateway listener and
+# webhook in the cluster.
+global:
+  priorityClassName: system-cluster-critical
+
 config:
   apiVersion: controller.config.cert-manager.io/v1alpha1
   kind: ControllerConfiguration

--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -2,6 +2,9 @@
 debug:
   enabled: true
 
+# Cluster-critical: Cilium agent is the network — eviction means everything dies.
+priorityClassName: system-node-critical
+
 ipam:
   # -- Configure IP Address Management mode.
   # ref: https://docs.cilium.io/en/stable/network/concepts/ipam/
@@ -124,6 +127,8 @@ gatewayAPI:
 operator:
   # -- Number of replicas to run for the cilium-operator deployment
   replicas: 2
+  # Cluster-critical: the operator manages identities and IP pools.
+  priorityClassName: system-node-critical
 
 hubble:
   # -- Enable Hubble (true by default).

--- a/infra/controllers/cnpg/values.yaml
+++ b/infra/controllers/cnpg/values.yaml
@@ -1,1 +1,6 @@
 # Helm values
+
+# Cluster-critical: the CNPG operator runs the database control plane for
+# every CNPG cluster. Evicting it during a pinch can stall all postgres
+# instances during the next reconcile.
+priorityClassName: system-cluster-critical

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -1156,7 +1156,7 @@ alertmanager:
 
     ## Priority class assigned to the Pods
     ##
-    priorityClassName: ""
+    priorityClassName: system-cluster-critical
 
     ## AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
     ##
@@ -3120,7 +3120,7 @@ prometheusOperator:
     unhealthyPodEvictionPolicy: AlwaysAllow
 
   ## Assign a PriorityClassName to pods if set
-  # priorityClassName: ""
+  priorityClassName: system-cluster-critical
 
   ## Define Log Format
   # Use logfmt (default) or json logging
@@ -4489,7 +4489,7 @@ prometheus:
 
     ## Priority class assigned to the Pods
     ##
-    priorityClassName: ""
+    priorityClassName: system-cluster-critical
 
     ## Thanos configuration allows configuring various aspects of a Prometheus server in a Thanos environment.
     ## This section is experimental, it may change significantly without deprecation notice in any release.

--- a/infra/controllers/loki/values.yaml
+++ b/infra/controllers/loki/values.yaml
@@ -1,5 +1,10 @@
 deploymentMode: SingleBinary
 
+# Cluster-critical: Loki holds the cluster log archive; eviction during a
+# pinch loses ingestion until reschedule.
+global:
+  priorityClassName: system-cluster-critical
+
 loki:
   auth_enabled: false
   limits_config:


### PR DESCRIPTION
Phase 2 PR 2.4 of the critique remediation plan
([docs/plans/2026-05-02-critique-remediation.md](docs/plans/2026-05-02-critique-remediation.md)).
Closes findings #12 (revisionHistoryLimit), #13 (PDBs), #14 (priorityClassName).

## 1. revisionHistoryLimit: 5

Added `spec.revisionHistoryLimit: 5` (peer of `replicas`) to every workload in `apps/base/`:

- adguard (StatefulSet — included for consistency)
- audiobookshelf, authelia, excalidraw, golinks, hermes, homeassistant, homepage, jellyfin, linkding, mealie, memos, navidrome, overture, signal-cli, snapcast, synology-iscsi-monitor, vitals
- immich — three Deployments (immich-server, immich-machine-learning, immich-redis), all updated

No deployment had `revisionHistoryLimit` already set.

## 2. PodDisruptionBudgets

New `apps/base/<app>/pdb.yaml` (and corresponding `kustomization.yaml` wiring) for each HA-relevant app. All target single-replica Deployments → `maxUnavailable: 0` so node drains pause until the replacement pod is up:

| App | maxUnavailable | selector |
|---|---|---|
| immich | 0 | `app: immich` (covers server + ML + redis) |
| jellyfin | 0 | `app: jellyfin` |
| mealie | 0 | `app: mealie` |
| navidrome | 0 | `app: navidrome` |
| vitals | 0 | `app: vitals` |
| golinks | 0 | `app: golinks` |

`apps/base/adguard/pdb.yaml` already exists (`minAvailable: 1`) — left untouched.

## 3. priorityClassName

| Chart | Class | values key(s) used |
|---|---|---|
| cilium (agent) | `system-node-critical` | `priorityClassName` (top-level) |
| cilium (operator) | `system-node-critical` | `operator.priorityClassName` |
| cnpg (operator) | `system-cluster-critical` | `priorityClassName` (top-level — chart sets it on the controller Deployment) |
| cert-manager | `system-cluster-critical` | `global.priorityClassName` (applies to controller, webhook, cainjector, startupapicheck) |
| kube-prometheus-stack | `system-cluster-critical` | `prometheusOperator.priorityClassName`, `prometheus.prometheusSpec.priorityClassName`, `alertmanager.alertmanagerSpec.priorityClassName` |
| loki | `system-cluster-critical` | `global.priorityClassName` (overrides for all loki components) |

`kustomize build infra/controllers` confirms each rendered ConfigMap carries the override.

## Skipped

- **CNPG Cluster CRs (`spec.priorityClassName: system-cluster-critical`)** on per-app `database.yaml` resources. Touching app overlays for this would expand scope significantly; deferred to a follow-up per the plan's guidance.
- **ThanosRuler `priorityClassName`** (kube-prometheus-stack values line 5365). Not in use on this cluster.
- **kube-state-metrics / prometheus-node-exporter** subchart `priorityClassName` overrides. Subchart values omitted to keep the diff focused on the cluster-critical workloads named in the plan; can be added in a follow-up.

## Validation

- [x] `kustomize build apps/base/<each>/` for all 19 base apps
- [x] `kustomize build apps/staging`
- [x] `kustomize build apps/production`
- [x] `kustomize build infra/controllers`
- [x] No plaintext secrets in diff (`git diff HEAD | grep -iE 'password|secret|token'` matches only filename references)
- [x] Image tags strictly increasing — N/A (no image bumps in this PR)
- [ ] Tested in staging for at least one Flux reconcile cycle
- [x] Linked back to plan Phase / PR row

🤖 Generated with [Claude Code](https://claude.com/claude-code)