### PR TITLE
docs(plans,ops): refresh adguard HA plan and add failover validation runbook

### DIFF
--- a/docs/operations/2026-05-03-adguard-failover-validation.md
+++ b/docs/operations/2026-05-03-adguard-failover-validation.md
@@ -1,0 +1,133 @@
+---
+status: Stable
+last_modified: 2026-05-03
+---
+
+# AdGuard DNS — failover validation drill
+
+Confirm the homelab DNS keeps resolving when one AdGuard pod, one node, or one LoadBalancer IP is unavailable. Run quarterly or after material AdGuard / Cilium / Talos changes.
+
+Architecture context: [`docs/plans/2026-02-15-adguard-ha.md`](../plans/2026-02-15-adguard-ha.md).
+
+## Pre-flight (skip if you just made changes)
+
+```bash
+# Both replicas Ready and on different nodes
+kubectl -n adguard-prod get pods -l app.kubernetes.io/name=adguard -o wide
+
+# LBs have IPs
+kubectl -n adguard-prod get svc adguard adguard-dns-secondary
+
+# DNS works through both
+for ip in 10.42.2.43 10.42.2.45; do
+  echo "--- $ip ---"
+  dig @"$ip" +short +tries=1 +time=2 example.com || echo FAIL
+done
+```
+
+If any of the above fails, fix that first — don't run the failover drill on a degraded baseline.
+
+## Drill 1 — pod-level failure (no node loss)
+
+Kill `adguard-0` (the primary). Service should keep responding via `adguard-1`. Logs should land on `adguard-1` until `adguard-0` recovers.
+
+```bash
+# Note baseline
+PRIMARY_NODE=$(kubectl -n adguard-prod get pod adguard-0 -o jsonpath='{.spec.nodeName}')
+echo "primary on $PRIMARY_NODE"
+
+# Delete the primary pod
+kubectl -n adguard-prod delete pod adguard-0
+
+# Watch DNS keep responding (separate terminal recommended)
+while true; do
+  dig @10.42.2.43 +short +tries=1 +time=1 example.com >/dev/null && echo "$(date -u +%H:%M:%S) ok" || echo "$(date -u +%H:%M:%S) FAIL"
+  sleep 1
+done
+
+# Confirm pod recovers
+kubectl -n adguard-prod wait --for=condition=Ready pod/adguard-0 --timeout=2m
+```
+
+**Pass:** zero or transient (≤2s) FAIL lines during the kill→re-Ready window.
+**Fail:** sustained DNS failures = the LoadBalancer is still routing to the dead pod, or readiness probes don't gate traffic correctly. Investigate `kubectl -n adguard-prod describe svc adguard` and the Cilium BPF service map.
+
+## Drill 2 — node drain (one of two AdGuard nodes goes away)
+
+Drain the node hosting one of the AdGuard pods. The pod should reschedule on a different node (preferred anti-affinity, hard topology spread). DNS should keep responding.
+
+```bash
+# Pick the node hosting adguard-0
+TARGET=$(kubectl -n adguard-prod get pod adguard-0 -o jsonpath='{.spec.nodeName}')
+echo "draining $TARGET"
+
+kubectl drain "$TARGET" --ignore-daemonsets --delete-emptydir-data --force --timeout=2m
+
+# Watch DNS (continue the loop from Drill 1 in a separate terminal)
+# Confirm adguard-0 ends up on a different node
+kubectl -n adguard-prod wait --for=condition=Ready pod/adguard-0 --timeout=3m
+kubectl -n adguard-prod get pod adguard-0 -o wide
+
+# Restore
+kubectl uncordon "$TARGET"
+```
+
+**Pass:** DNS stays up; both pods end up on different nodes after the drain.
+**Fail:**
+- Pod can't schedule → not enough nodes free, or PVC is bound to a zone that no longer has nodes. Check `kubectl describe pod adguard-0` for scheduling events.
+- DNS goes down for >5s → Cilium endpoint update lag, or the LB is advertising the IP via L2 from the drained node only. Check `cilium-cli endpoint list` and confirm `service/adguard` has endpoints from a healthy node.
+
+## Drill 3 — primary DNS IP failure (force secondary client failover)
+
+Simulate the primary LB IP being unreachable from a client. Confirm clients fall back to the secondary IP.
+
+```bash
+# From a workstation that resolves via the homelab DNS, query the secondary directly
+dig @10.42.2.45 +short example.com
+
+# Then test client-side fallback by listing what your OS picked up via DHCP
+# macOS:
+scutil --dns | grep "nameserver\["
+# Linux:
+resolvectl status | grep "DNS Servers"
+# Windows:
+# ipconfig /all | findstr /R /C:"DNS Servers"
+```
+
+**Pass:** the OS shows BOTH `10.42.2.43` and `10.42.2.45` in its DNS server list. If only one shows, **UniFi DHCP scope options aren't handing out both** — fix in UniFi → Networks → LAN → DHCP → Network options → DNS Server.
+
+If you want to actively prove failover (rather than just confirm both are configured), block `10.42.2.43:53` on the workstation's firewall briefly and confirm OS-level DNS still resolves:
+
+```bash
+# macOS — block primary, observe secondary takes over
+sudo pfctl -e 2>/dev/null
+echo "block drop quick from any to 10.42.2.43" | sudo pfctl -f -
+dig +tries=1 +time=2 example.com  # should still work
+sudo pfctl -d  # restore
+```
+
+## Drill 4 — sync job validation
+
+Confirm the most recent `adguard-sync` Job succeeded and replica config matches origin.
+
+```bash
+# Most recent Job + status
+kubectl -n adguard-prod get jobs --sort-by=.metadata.creationTimestamp | tail -3
+LATEST=$(kubectl -n adguard-prod get jobs --sort-by=.metadata.creationTimestamp -o name | tail -1 | cut -d/ -f2)
+kubectl -n adguard-prod logs -l job-name="$LATEST" --tail=30
+```
+
+**Pass:** logs end with `INFO sync sync/sync.go:300 Sync done {...}` and no `ERROR` lines.
+**Fail:** common modes:
+- `401 Unauthorized` → `adguard-sync-credentials` Secret keys don't match the live AdGuard admin user (the gotcha from the original HA rollout — username is `george`, not `admin`).
+- `connect: connection refused` → `adguard-1` is down or the headless Service is misconfigured.
+
+## When everything passes
+
+Note the date in [`docs/plans/2026-02-15-adguard-ha.md`](../plans/2026-02-15-adguard-ha.md) `last_modified` so the next person knows it was recently validated.
+
+## Out of scope
+
+- **Multi-region / multi-cluster failover** — single cluster only.
+- **DNSSEC validation drill** — separate concern, not redundancy.
+- **Upstream resolver failure** (Cloudflare/Quad9 unreachable) — AdGuard handles this internally with multiple upstreams; not exercised here.

--- a/docs/plans/2026-02-15-adguard-ha.md
+++ b/docs/plans/2026-02-15-adguard-ha.md
@@ -1,87 +1,66 @@
 ---
-status: planned
-last_modified: 2026-02-27
+status: in-progress
+last_modified: 2026-05-03
 ---
 
-# TODO: AdGuard Home HA (DNS + UI-driven config)
+# AdGuard Home — high availability
 
-This repo is structured so staging uses a `-stage` suffix and production has no suffix (desired end-state). Today, AdGuard overlays are:
+Make the homelab DNS resolver tolerant to a single-node loss without breaking client lookups.
 
-- Staging: `adguard-stage`
-- Production: `adguard-prod` (consider renaming to `adguard` later if you want strict consistency)
+## Current state (2026-05-03)
 
-## Current state (April 2026)
+The HA primitives are deployed in production. Two AdGuard pods are scheduled on different nodes, a CronJob keeps their config in sync, and a second LoadBalancer DNS IP is allocated for client failover.
 
-- AdGuard is a StatefulSet with per-pod PVCs:
-  - `config` PVC stores `AdGuardHome.yaml`
-  - `work` PVC stores query logs/statistics
-- UI traffic is pinned to the primary pod (`adguard-0`) via `adguard-admin`
-- DNS is exposed via a single `LoadBalancer` service (`10.42.2.43` in prod)
-- `adguard-sync` CronJob is enabled in both prod and staging and is intended to sync config from `adguard-0` to replicas
+| Piece | State | Notes |
+|-------|-------|-------|
+| `apps/base/adguard/` StatefulSet, replicas | base=1, prod-overlay patches to 2 ✓ | per-pod PVCs (`config-adguard-0/1`, `work-adguard-0/1`) |
+| Pod spread | `podAntiAffinity (preferred)` + `topologySpreadConstraints (ScheduleAnyway)` ✓ | both running on distinct workers (`talos-2mz-rfj`, `talos-kot-7x7`) |
+| `adguard-sync` CronJob | enabled in base, schedule `0 */6 * * *` ✓ | last run 2026-05-03 06:00 UTC, status `Sync done` |
+| Sync credentials | `adguard-sync-credentials` Secret in prod overlay ✓ | username `george`, not `admin` (gotcha caught earlier) |
+| Primary DNS LB IP | `10.42.2.43` ✓ | `service/adguard` |
+| Secondary DNS LB IP | `10.42.2.45` ✓ | `service/adguard-dns-secondary` (added 2026-05-02) |
+| UI is one-writer | `service/adguard-admin` (ClusterIP, pinned to `adguard-0`) ✓ | sync job reads from this; replicas never receive direct writes |
 
-## Important prerequisite discovered during HA rollout
+Functionally, DNS will survive losing either AdGuard pod or the node it's on as long as both LB IPs are wired into UniFi DHCP scope options.
 
-Before scaling replicas, `adguard-sync` credentials must match the live AdGuard admin user. The live username is `george` (not `admin`). If sync fails with `401 Unauthorized`, replicas will not receive the primary config.
+## Remaining work
 
-Production also needed a larger `work` volume because query logs filled the original 1Gi PVC.
+| # | Item | Priority | Notes |
+|---|------|----------|-------|
+| 1 | **Verify UniFi hands out both DNS servers** | high | Operator-side router config. UniFi DHCP scope option 6 should list `10.42.2.43, 10.42.2.45`. Check at UniFi → Networks → LAN → DHCP → Network options. |
+| 2 | **Failover validation runbook** | high | Document a repeatable drill: drain `talos-X`, confirm DNS still resolves through `dig @10.42.2.45 example.com`, restore. See [`docs/operations/2026-05-03-adguard-failover-validation.md`](../operations/2026-05-03-adguard-failover-validation.md) (added in the same PR as this refresh). |
+| 3 | **Resize `work-adguard-1` from 1Gi → 5Gi** | medium | Mismatch with `work-adguard-0` (5Gi). Query log history on replica is capped early. StatefulSet `volumeClaimTemplate` is immutable, so this is a manual `kubectl patch pvc` + `kubectl rollout restart` cycle (Synology iSCSI supports volume expansion). |
+| 4 | **NetworkPolicy hardening** | medium | Restrict ingress to `adguard-admin` to the sync job + Gateway pods only. Restrict ingress to `adguard-headless` (replica admin port 80) to the sync job only. Add `network-policies: enforced` label on `adguard-prod` so the cluster-wide default-deny applies. |
+| 5 | **Cilium BGP advertisement of LB IPs** | low | Tracked in [`2026-03-08-bgp-rollout.md`](2026-03-08-bgp-rollout.md). Until BGP is in place, both DNS IPs are advertised via L2 announcements which is fine for the LAN but limits failover to nodes in the same broadcast domain. |
+| 6 | **Consider strict naming consistency** | defer | Earlier draft said "rename `adguard-prod` → `adguard` later if you want strict consistency." That suggestion contradicts the cluster's actual `<app>-prod` convention (see `AGENTS.md`). Keep `adguard-prod`. |
 
-## Why “one-writer UI” matters
+## Why "one-writer UI" matters
 
-AdGuard Home has no built-in multi-master config reconciliation.
-The safe pattern is:
+AdGuard Home has no built-in multi-master config reconciliation. The pattern is:
 
-- Only one UI endpoint (primary) is reachable for humans
-- A sync job copies config from primary to replicas
+- Only one UI endpoint (the primary, `adguard-0` via `adguard-admin` Service) is reachable for humans.
+- The `adguard-sync` CronJob (`ghcr.io/bakito/adguardhome-sync`) copies config from primary to replicas every 6 hours.
+- DHCP sync is intentionally disabled (`FEATURES_DHCP_*=false`) — UniFi handles DHCP.
 
-## Next steps when you have 6 nodes + more IPs (UniFi)
+Editing config on a replica directly will be silently overwritten on the next sync cycle. Always edit through `adguard-admin`.
 
-### 1) Scale AdGuard safely (single DNS IP)
+## Validation
 
-- Edit replicas in your overlay (staging first):
-  - apps/staging/adguard/… (StatefulSet `spec.replicas`)
-- Set `replicas: 2` (or `3`) and ensure pods land on different nodes:
-  - Add `topologySpreadConstraints` or pod anti-affinity in the StatefulSet
-  - Goal: `adguard-0`, `adguard-1`, … run on different nodes
-- Confirm DNS continues working during a node reboot:
-  - `kubectl -n adguard-stage get endpoints adguard` should show multiple endpoints
+When you resume after a change, the smoke check:
 
-### 2) Enable configuration sync (CronJob)
+```bash
+# Both pods Ready?
+kubectl -n adguard-prod get statefulset,pods -o wide
 
-A disabled-by-default CronJob manifest exists here:
+# Both LBs have endpoints?
+kubectl -n adguard-prod get svc,endpoints | grep -E 'adguard\b|dns-secondary'
 
-- apps/base/adguard/cronjob-sync.yaml
+# Sync ran cleanly recently?
+kubectl -n adguard-prod logs -l job-name=$(kubectl -n adguard-prod get jobs -o name | tail -1 | cut -d/ -f2) --tail=20
 
-To enable it later:
+# DNS resolves through both LBs?
+dig @10.42.2.43 +short example.com
+dig @10.42.2.45 +short example.com
+```
 
-- Add the CronJob file to the overlay `resources:` (staging first)
-- Create a secret named `adguard-sync-credentials` in the AdGuard namespace with keys:
-  - `ORIGIN_USERNAME`, `ORIGIN_PASSWORD`
-  - `REPLICA1_USERNAME`, `REPLICA1_PASSWORD`
-
-Notes:
-- The CronJob uses `ORIGIN_URL=http://adguard-admin:8080` so it always reads from the primary.
-- DHCP sync is disabled by default (`FEATURES_DHCP_* = false`).
-
-### 3) Move from single DNS IP → two DNS IPs (best client failover)
-
-When you can allocate more LB IPs:
-
-- Expand your Cilium LB IP pool (or add a second pool) so you have at least two addresses
-- Deploy a second AdGuard service/IP (or a second AdGuard instance if you want strict isolation)
-- Configure UniFi DHCP to hand out BOTH DNS servers (primary + secondary)
-
-### 4) Hardening checklist
-
-- Confirm health checks:
-  - readiness probe OK (the Service should stop sending traffic to unhealthy pods)
-- Add resource requests/limits if needed
-- Consider NetworkPolicies:
-  - Only allow sync job to reach replica admin endpoints
-  - Only allow the UI route to reach `adguard-admin`
-
-## Quick validation commands (when you resume)
-
-- `kubectl -n adguard-stage get statefulset,svc,pdb`
-- `kubectl -n adguard-stage get pods -o wide`
-- `kubectl -n adguard-stage get endpoints adguard`
-- `kubectl -n adguard-stage describe httproute adguard-https`
+Full failover drill is in the operations runbook (see Remaining Work item 2).


### PR DESCRIPTION
## Summary

The HA plan from Feb is mostly done — production cluster has 2 replicas on distinct nodes, sync CronJob ran cleanly 3.5h ago, secondary DNS LoadBalancer is live at \`10.42.2.45\`. Plan doc was stale. This PR aligns the plan with reality and adds a failover validation runbook so the redundancy can be re-proven on a cadence.

## Live state confirmed

| | Live | Manifest |
|---|---|---|
| Replicas | \`adguard-0\` on \`talos-2mz-rfj\`, \`adguard-1\` on \`talos-kot-7x7\` | base=1, prod overlay patches to 2 |
| Sync | last \`Sync done\` 2026-05-03 06:00 UTC | cronjob \`0 */6 * * *\` enabled in base |
| Primary DNS | \`service/adguard\` 10.42.2.43 | \`apps/base/adguard/service.yaml\` |
| Secondary DNS | \`service/adguard-dns-secondary\` 10.42.2.45 | \`apps/production/adguard/service-dns-secondary.yaml\` |
| One-writer UI | \`service/adguard-admin\` ClusterIP | base |

## What this PR changes

- **\`docs/plans/2026-02-15-adguard-ha.md\`** — status \`planned\` → \`in-progress\`. Replaces the four-step prescriptive plan with a current-state table and a prioritized remaining-work table. Drops the suggestion to rename \`adguard-prod\` → \`adguard\` (contradicts the cluster's \`<app>-prod\` convention).
- **\`docs/operations/2026-05-03-adguard-failover-validation.md\`** — four-drill runbook:
  1. Pod-level kill (delete \`adguard-0\`, watch DNS stay up via \`adguard-1\`).
  2. Node drain (drain the node hosting one pod, watch reschedule).
  3. Force client-side IP failover (block primary on workstation, confirm secondary takes over).
  4. Sync job validation (latest Job logs end with \`Sync done\`).
  Each drill has a pass/fail criterion and next-step diagnostics.

No manifests changed.

## Remaining work surfaced in the plan

- **UniFi DHCP option-6 audit** — high (operator router config).
- **\`work-adguard-1\` PVC resize** 1Gi → 5Gi to match \`adguard-0\` — medium.
- **NetworkPolicy hardening** for \`adguard-admin\` and \`adguard-headless\` — medium.
- **BGP advertisement of LB IPs** — deferred to the BGP rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)