### PR TITLE
feat(security): pin third-party images by digest + imagePullSecrets audit (Phase 3)

### DIFF
--- a/apps/base/adguard/cronjob-sync.yaml
+++ b/apps/base/adguard/cronjob-sync.yaml
@@ -24,7 +24,8 @@ spec:
               type: RuntimeDefault
           containers:
             - name: adguardhome-sync
-              image: ghcr.io/bakito/adguardhome-sync:v0.9.0
+              # adguardhome-sync v0.9.0
+              image: ghcr.io/bakito/adguardhome-sync@sha256:a4e63e705c5602b7bdd5a9554615a78125521273a7aa5da5831517780a06aee4
               args: ["run", "--runOnStart", "--api-port", "0"]
               securityContext:
                 allowPrivilegeEscalation: false

--- a/apps/base/authelia/deployment.yaml
+++ b/apps/base/authelia/deployment.yaml
@@ -32,7 +32,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: authelia
-          image: authelia/authelia:4.39.19
+          # authelia 4.39.19
+          image: authelia/authelia@sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463
           args:
             - --config
             - /config/configuration.yaml

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -171,7 +171,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:8-alpine
+          # redis 8-alpine
+          image: redis@sha256:c5e375abb885e6b2021c0377879e4890bf76f9065b8922ffc113f2b226b9fc17
           args:
             - "--save"
             - ""

--- a/apps/base/immich/job-db-init.yaml
+++ b/apps/base/immich/job-db-init.yaml
@@ -15,7 +15,8 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: db-init
-          image: postgres:18-alpine
+          # postgres 18-alpine
+          image: postgres@sha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7
           command: ["/bin/sh", "-c"]
           args:
             - echo "Patch me"

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -34,7 +34,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        - image: ghcr.io/mealie-recipes/mealie:v3.16.0
+        # mealie v3.16.0
+        - image: ghcr.io/mealie-recipes/mealie@sha256:74496aed2c5055e3b7b6c4e1bb9b4f16b1f566601582b258a10bae851f19ac24
           name: mealie
           ports:
             - containerPort: 9000

--- a/apps/base/navidrome/deployment.yaml
+++ b/apps/base/navidrome/deployment.yaml
@@ -35,7 +35,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: navidrome
-          image: ghcr.io/navidrome/navidrome:0.61.2
+          # navidrome 0.61.2
+          image: ghcr.io/navidrome/navidrome@sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2
           ports:
             - containerPort: 4533
               name: http

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -33,7 +33,8 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: init-fifo
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -52,7 +53,8 @@ spec:
               mountPath: /tmp
 
         - name: init-spotify-fifo
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -26,7 +26,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: exporter
-          image: python:3.14-slim
+          # python 3.14-slim
+          image: python@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -23,7 +23,8 @@ spec:
           - 109 # render group
       initContainers:
         - name: oauth-config
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           command:
             - sh
             - -c

--- a/apps/production/memos/deployment-patch.yaml
+++ b/apps/production/memos/deployment-patch.yaml
@@ -15,7 +15,8 @@ spec:
             - auth.burntbytes.com
       initContainers:
         - name: init-dsn
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           command:
             - sh
             - -c

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -23,7 +23,8 @@ spec:
           - 109 # render group
       initContainers:
         - name: oauth-config
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           command:
             - sh
             - -c

--- a/apps/staging/memos/deployment-patch.yaml
+++ b/apps/staging/memos/deployment-patch.yaml
@@ -16,7 +16,8 @@ spec:
       initContainers:
         # Construct DSN from environment variables including CNPG password
         - name: init-dsn
-          image: busybox:1.37
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
           command:
             - sh
             - -c

--- a/infra/controllers/democratic-csi/truenas-api-proxy.yaml
+++ b/infra/controllers/democratic-csi/truenas-api-proxy.yaml
@@ -247,7 +247,8 @@ spec:
     spec:
       containers:
         - name: proxy
-          image: python:3.14-slim
+          # python 3.14-slim
+          image: python@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -19,7 +19,8 @@ spec:
     spec:
       containers:
         - name: mosquitto
-          image: eclipse-mosquitto:2.0
+          # eclipse-mosquitto 2.0
+          image: eclipse-mosquitto@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268
           ports:
             - containerPort: 1883
               name: mqtt

--- a/infra/controllers/renovate-automerge/cronjob.yaml
+++ b/infra/controllers/renovate-automerge/cronjob.yaml
@@ -12,7 +12,8 @@ spec:
         spec:
           containers:
             - name: automerge
-              image: python:3.14-slim
+              # python 3.14-slim
+              image: python@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
               command: ["python3", "/scripts/automerge.py"]
               env:
                 - name: GITHUB_TOKEN

--- a/infra/controllers/snapshot/setup-snapshot-controller.yaml
+++ b/infra/controllers/snapshot/setup-snapshot-controller.yaml
@@ -25,7 +25,8 @@ spec:
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: k8s.gcr.io/sig-storage/snapshot-controller:v8.5.0
+          # snapshot-controller v8.5.0
+          image: k8s.gcr.io/sig-storage/snapshot-controller@sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8
           args:
             - "--v=5"
             - "--leader-election=false"

--- a/infra/controllers/synology-csi/speedtest.yaml
+++ b/infra/controllers/synology-csi/speedtest.yaml
@@ -26,7 +26,8 @@ spec:
     spec:
       containers:
         - name: read
-          image: ubuntu:resolute
+          # ubuntu:resolute
+          image: ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4
           command: ["dd", "if=/mnt/pv/test.img", "of=/dev/null", "bs=8k"]
           volumeMounts:
             - mountPath: "/mnt/pv"
@@ -52,7 +53,8 @@ spec:
     spec:
       containers:
         - name: write
-          image: ubuntu:resolute
+          # ubuntu:resolute
+          image: ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4
           command: ["dd", "if=/dev/zero", "of=/mnt/pv/test.img", "bs=1G", "count=1", "oflag=dsync"]
           volumeMounts:
             - mountPath: "/mnt/pv"


### PR DESCRIPTION
## Summary

Phase 3 of the [critique remediation plan](docs/plans/2026-05-02-critique-remediation.md) — image supply-chain discipline. Bundles PR 3.1 + PR 3.2.

- **PR 3.1 (finding #1, `:latest` tags)** — already closed by prior post-2026-05-02 image bumps. `grep -rE 'image:.*:latest' apps/ infra/` returns nothing.
- **PR 3.2 (finding #16, third-party tag-only images)** — pin every third-party image to an immutable `@sha256:` digest with a comment preserving the human-readable tag.
- **PR 3.2 (finding #15, `imagePullSecrets`)** — audited; no changes needed (all gjcourt images that lack a secret are public).

First-party `gjcourt/*` images intentionally remain tag-pinned per `AGENTS.md` — CI guarantees date-tag immutability.

## Images pinned

| Image | Original tag | Digest pinned | Resolver |
|---|---|---|---|
| `busybox` | `1.37` | `sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e` | `docker buildx imagetools inspect` |
| `python` | `3.14-slim` | `sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033` | `docker buildx imagetools inspect` |
| `redis` | `8-alpine` | `sha256:c5e375abb885e6b2021c0377879e4890bf76f9065b8922ffc113f2b226b9fc17` | `docker buildx imagetools inspect` |
| `postgres` | `18-alpine` | `sha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7` | `docker buildx imagetools inspect` |
| `authelia/authelia` | `4.39.19` | `sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463` | `docker buildx imagetools inspect` |
| `ghcr.io/mealie-recipes/mealie` | `v3.16.0` | `sha256:74496aed2c5055e3b7b6c4e1bb9b4f16b1f566601582b258a10bae851f19ac24` | `docker buildx imagetools inspect` |
| `eclipse-mosquitto` | `2.0` | `sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268` | `docker buildx imagetools inspect` |
| `k8s.gcr.io/sig-storage/snapshot-controller` | `v8.5.0` | `sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8` | `docker buildx imagetools inspect` |
| `ghcr.io/navidrome/navidrome` | `0.61.2` | `sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2` | `docker buildx imagetools inspect` |
| `ubuntu` | `resolute` | `sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4` | `docker buildx imagetools inspect` |
| `ghcr.io/bakito/adguardhome-sync` | `v0.9.0` | `sha256:a4e63e705c5602b7bdd5a9554615a78125521273a7aa5da5831517780a06aee4` | `docker buildx imagetools inspect` |

(17 image references touched across 17 files — `busybox` shows up 6 times across snapcast, memos, immich init containers; `python` 3 times across synology-iscsi-monitor, renovate-automerge, truenas-api-proxy; `ubuntu` 2 times across speedtest jobs.)

All previously-pinned third-party digests were re-verified against the registry and still resolve.

## `imagePullSecrets` audit (finding #15)

Apps already declaring `imagePullSecrets: [{name: ghcr-secret}]` and a `secret-ghcr.yaml` in their kustomization (4 — plan said 3):

- `apps/base/golinks` — `ghcr.io/gjcourt/golinks` (private)
- `apps/base/vitals` — `ghcr.io/gjcourt/vitals` (private)
- `apps/base/overture` — `ghcr.io/gjcourt/overture`, `ghcr.io/gjcourt/overture-bridge` (both private)
- `infra/controllers/pingo` — `ghcr.io/gjcourt/pingo` (private, was missed in plan)

Apps with `gjcourt/*` images but no `imagePullSecrets`:

- `apps/base/signal-cli` — `ghcr.io/gjcourt/signal-bridge` — **PUBLIC** (anonymous pull returns HTTP 200), no secret needed.
- `apps/base/snapcast` — `gjcourt/snapcast`, `gjcourt/go-librespot` — both PUBLIC on Docker Hub (anonymous pull returns HTTP 200), no secret needed.

Privacy verified by anonymous Bearer-token request to each registry's `manifests/<tag>` endpoint:

```
ghcr.io/gjcourt/vitals          -> UNAUTHORIZED  (private, secret in place)
ghcr.io/gjcourt/golinks         -> UNAUTHORIZED  (private, secret in place)
ghcr.io/gjcourt/overture        -> UNAUTHORIZED  (private, secret in place)
ghcr.io/gjcourt/overture-bridge -> UNAUTHORIZED  (private, secret in place)
ghcr.io/gjcourt/pingo           -> UNAUTHORIZED  (private, secret in place)
ghcr.io/gjcourt/signal-bridge   -> HTTP 200      (PUBLIC, no secret needed)
docker.io/gjcourt/snapcast      -> HTTP 200      (PUBLIC, no secret needed)
docker.io/gjcourt/go-librespot  -> HTTP 200      (PUBLIC, no secret needed)
```

**No `imagePullSecrets` changes are required** — current state is correct. All private images already have secrets; all images without secrets are publicly pullable.

## Out of scope

- Helm chart `image:` blocks in `infra/controllers/kube-prometheus-stack/values.yaml` — chart-managed image configuration is governed by chart version pinning (see AGENTS.md), not raw `image: <name>:<tag>` references.
- First-party `gjcourt/*` images — kept date-tagged per AGENTS.md (CI guarantees immutability).
- No version bumps; only digest resolution of currently-tagged versions.

## Test plan

- [x] `kustomize build apps/staging` passes
- [x] `kustomize build apps/production` passes
- [x] `kustomize build infra/controllers` passes
- [x] `kustomize build apps/base/<each-changed-app>` passes (adguard, authelia, immich, mealie, memos, navidrome, snapcast, synology-iscsi-monitor)
- [x] All 27 pinned digests resolve via `docker buildx imagetools inspect` (the 17 newly pinned + 10 previously pinned)
- [x] No plaintext secrets in diff
- [ ] After merge: `kubectl describe pod <p>` shows the resolved digest matches the pinned value for each affected workload
- [ ] No `ImagePullBackOff` after one Flux reconcile cycle (10m)

## Plan checklist

- [x] kustomize build passes for all affected overlays
- [x] No plaintext secrets in diff
- [x] Image tags strictly increasing (or pinned by digest) — pinned by digest, no version changes
- [ ] Tested in staging for at least one Flux reconcile cycle (post-merge)
- [x] Linked back to plan's Phase 3 (PR 3.1 + PR 3.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)