### PR TITLE
feat(adguard): add CiliumNetworkPolicy hardening (inert until label flip)

### DIFF
--- a/apps/base/adguard/cronjob-sync.yaml
+++ b/apps/base/adguard/cronjob-sync.yaml
@@ -16,6 +16,10 @@ spec:
       activeDeadlineSeconds: 120
       backoffLimit: 1
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: adguardhome-sync
+            app.kubernetes.io/component: config-sync
         spec:
           restartPolicy: Never
           securityContext:

--- a/apps/base/adguard/kustomization.yaml
+++ b/apps/base/adguard/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - cronjob-sync.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - service.yaml
   - service-admin.yaml

--- a/apps/base/adguard/networkpolicy.yaml
+++ b/apps/base/adguard/networkpolicy.yaml
@@ -1,0 +1,149 @@
+---
+# Per-app CiliumNetworkPolicy for AdGuard Home — implements Step 4
+# (NetworkPolicy hardening) of docs/plans/2026-02-15-adguard-ha.md.
+#
+# This file is a no-op until the namespace gets labelled
+# `network-policies: enforced` (see infra/configs/network-policies/).
+# Land this file first; flip the label per-overlay (staging → production)
+# in follow-up PRs once the rules have been validated.
+#
+# Two policies live here:
+#   - adguard          → applies to the AdGuard StatefulSet pods
+#   - adguard-sync     → applies to the adguardhome-sync CronJob pods
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: adguard
+  namespace: adguard
+  labels:
+    app.kubernetes.io/name: adguard
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    AdGuard Home server: DNS open to LAN, admin UI gated to Gateway and
+    the in-namespace sync job, egress to kube-dns + upstream resolvers
+    + HTTPS for filter-list updates.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: adguard
+  ingress:
+    # DNS queries from LAN clients (anything outside the cluster).
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # DNS queries from inside the cluster (in case a Pod sets the AdGuard
+    # LB IP as its resolver). Cilium tags in-cluster traffic with the
+    # source pod's identity, not `world`.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Admin UI from the Gateway namespace (`default` — Cilium Gateway API).
+    # Matches the HTTPRoute that exposes adguard-admin externally.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: default
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8443"
+              protocol: TCP
+            - port: "3000"
+              protocol: TCP
+    # Sync CronJob (same namespace) — reads from primary on 8080, writes
+    # to replica via headless on 80.
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: adguardhome-sync
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # Kubelet probes (readiness/liveness). Cilium tags node-local traffic
+    # with the kube-system namespace identity.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  egress:
+    # kube-dns / CoreDNS for in-cluster Service resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Upstream resolvers for AdGuard's recursive lookups (53, DoH/443, DoT/853).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+            - port: "853"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: adguard-sync
+  namespace: adguard
+  labels:
+    app.kubernetes.io/name: adguardhome-sync
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    Config-sync CronJob: egress only to AdGuard pods (admin port + replica
+    HTTP) and kube-dns. No external egress.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: adguardhome-sync
+  egress:
+    # Reach AdGuard primary (8080) and replicas (80) inside the same namespace.
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: adguard
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # kube-dns for Service-name resolution (adguard-admin, adguard-headless).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Implements Step 4 (NetworkPolicy hardening) from [`docs/plans/2026-02-15-adguard-ha.md`](docs/plans/2026-02-15-adguard-ha.md). Adds two CiliumNetworkPolicies covering the AdGuard StatefulSet pods and the \`adguard-sync\` CronJob pods.

> **No behavioral change at merge time.** The policies are inert until the namespace gets the \`network-policies: enforced\` label, which activates the cluster-wide default-deny. Flipping the label is intentionally separate so the policy rules can be reviewed and (later) validated against live traffic before they bite.

## Two policies in `apps/base/adguard/networkpolicy.yaml`

### `adguard` (server pods)

| Direction | Allowed |
|---|---|
| Ingress | DNS 53 UDP+TCP from `world` (LAN) and `cluster` (in-cluster pods) |
| Ingress | Admin UI 8080/8443/3000 TCP from `default` namespace (Cilium Gateway) |
| Ingress | 80/8080 TCP from same-namespace pods labeled `app.kubernetes.io/name: adguardhome-sync` (the sync job) |
| Ingress | 80/443 TCP from `kube-system` (kubelet probes) |
| Egress | 53 UDP+TCP to `kube-dns` |
| Egress | 53/443/853/80 TCP/UDP to `world` (AdGuard recursive resolvers + filter-list HTTPS) |

### `adguard-sync` (CronJob pods)

| Direction | Allowed |
|---|---|
| Egress | 80/8080 TCP to same-namespace `app.kubernetes.io/name: adguard` (replica + admin) |
| Egress | 53 UDP+TCP to `kube-dns` |

No external egress for the sync job — keeps blast radius minimal.

## Pod-label support change

CronJob doesn't propagate `metadata.labels` to spawned pods by default, so the sync policy's endpointSelector wouldn't match anything. Added explicit pod-template labels to `cronjob-sync.yaml`:

```yaml
template:
  metadata:
    labels:
      app.kubernetes.io/name: adguardhome-sync
      app.kubernetes.io/component: config-sync
```

## Validation

```
kustomize build apps/base/adguard/        → 418 lines, both policies present
kustomize build apps/staging/adguard/     → OK
kustomize build apps/production/adguard/  → OK
```

## Rollout (follow-up PRs)

1. **Merge this PR** — policies land but are inert; nothing changes.
2. **Label staging**: \`apps/staging/adguard/kustomization.yaml\` adds a Namespace patch setting \`network-policies: enforced\`. Soak ≥24h, run failover validation drill from #410's runbook.
3. **Label production**: same patch on \`apps/production/adguard/kustomization.yaml\` after staging passes.

## Risks if mis-deployed

- If the namespace label flips before this PR's policies are correct, AdGuard goes silent for DNS clients (cluster-wide default-deny + insufficient policy = block all traffic). Mitigation: keep label and policies in separate PRs; revert the label PR if anything breaks.
- The \`world\` egress for filter-list HTTPS is broad — any pod-level compromise of AdGuard could exfil. Acceptable trade-off for AdGuard's actual workload (it really does talk to many TLDs for filter lists). If we later want to constrain, switch to FQDN-based egress with a known list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)