### PR TITLE
feat(adguard): enable network-policies enforcement in staging

### DIFF
--- a/apps/staging/adguard/kustomization.yaml
+++ b/apps/staging/adguard/kustomization.yaml
@@ -29,6 +29,14 @@ patches:
       - op: replace
         path: /metadata/name
         value: adguard-stage
+      # Opt staging into the cluster-wide default-deny scaffolding from
+      # infra/configs/network-policies/. With this label set, the
+      # CiliumClusterwideNetworkPolicy `default-deny` blocks all traffic
+      # to pods in this namespace except what the per-app
+      # CiliumNetworkPolicy (apps/base/adguard/networkpolicy.yaml) allows.
+      - op: add
+        path: /metadata/labels/network-policies
+        value: enforced
   - target:
       kind: StatefulSet
       name: adguard


### PR DESCRIPTION
## Summary

Flips on the cluster-wide default-deny for the \`adguard-stage\` namespace by adding the \`network-policies: enforced\` label via overlay patch. The allow rules from #412 then become load-bearing.

> **Stacks on #412**. After #412 merges, GitHub auto-retargets this PR's base to \`master\`. Or rebase manually with \`git rebase --onto master feat/adguard-network-policy feat/adguard-staging-network-policy-label\`.

## What's in this PR

\`apps/staging/adguard/kustomization.yaml\` — extends the existing Namespace patch with one extra JSON-Patch op:

\`\`\`yaml
- op: add
  path: /metadata/labels/network-policies
  value: enforced
\`\`\`

Production overlay is untouched. \`kustomize build apps/production/adguard/\` confirmed: no \`network-policies\` label on \`adguard-prod\`.

## Verification after merge

Once Flux reconciles \`apps-staging\`:

\`\`\`bash
# Label is present
kubectl get ns adguard-stage --show-labels | grep network-policies

# AdGuard pods still Ready
kubectl -n adguard-stage get pod -l app.kubernetes.io/name=adguard -o wide

# DNS still resolves through whatever LB the staging service exposes
kubectl -n adguard-stage get svc adguard
# Then dig from a workstation: dig @<staging-LB-IP> +short example.com

# Admin UI still reachable through staging HTTPRoute
kubectl -n adguard-stage get httproute

# Sync CronJob's next run logs cleanly
kubectl -n adguard-stage logs -l job-name=$(kubectl -n adguard-stage get jobs -o name | tail -1 | cut -d/ -f2) --tail=30
\`\`\`

## Failure modes & mitigation

| Symptom | Cause | Fix |
|---|---|---|
| AdGuard pods CrashLoop on probe failure | NetworkPolicy missing \`kube-system\` ingress on probe port | Update \`networkpolicy.yaml\` with the missing port; re-merge |
| Sync job fails with timeout to \`adguard-admin:8080\` | Sync pod label not matching the policy's endpointSelector | Verify CronJob pod template has \`app.kubernetes.io/name: adguardhome-sync\` (added in #412) |
| External DNS clients fail | Service-level forwarding broken — Cilium identity for LAN DNS clients should be \`world\`, allowed in #412 | If still broken, temporarily revert this PR; the policies stay inert |

**Rollback**: revert this PR. The label drops, default-deny no longer applies, traffic flows freely again. Inert policies from #412 stay in place.

## Soak before promoting to production

After this lands, watch \`adguard-stage\` for ≥24h. Run the failover validation runbook from #410 against staging once it's there. If clean, open the production label-flip PR (mirror this patch on \`apps/production/adguard/kustomization.yaml\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)