### PR TITLE
chore(architecture): staging parity (PR 4.2)

### DIFF
--- a/apps/base/overture/README.md
+++ b/apps/base/overture/README.md
@@ -1,0 +1,34 @@
+# overture
+
+Application backend (`overture` + `overture-bridge` sidecar) for
+`overture.burntbytes.com`. The base manifests describe the workload, service
+account, ServiceMonitor, and ghcr image-pull secret. The production overlay
+adds a 3-instance CNPG Postgres cluster, S3-backed Barman backups, and the
+HTTPRoute.
+
+## No staging overlay
+
+This app intentionally has no `apps/staging/overture/` overlay.
+
+Reason: overture is a single-instance application whose production overlay
+provisions a 3-replica CNPG Postgres cluster, an S3 ObjectStore for WAL
+archiving, a scheduled backup, and a separate `tempo-bridge` sidecar with
+its own issuer signing key. Standing up a second copy in staging would
+duplicate all of that infrastructure (a second Postgres cluster on the same
+iSCSI SAN, a second S3 prefix, and a second tempo issuer keypair) for an
+app that has no concept of an environment-segmented user base. Production
+churn here is low; staging sees no incremental value beyond what
+`kustomize build apps/production/overture` already validates at PR time.
+
+To validate changes safely:
+- Run `kustomize build apps/production/overture` locally before pushing.
+- For schema changes, exercise the migration against a throwaway
+  CNPG cluster spun up via `kubectl apply` in a scratch namespace, then
+  delete it.
+- For tempo-bridge changes, build and run the image locally with
+  `docker run` and exercise the `/health` endpoint before bumping the
+  pinned digest in `deployment.yaml`.
+
+Phase 4 / PR 4.2 of the critique remediation plan
+(`docs/plans/2026-05-02-critique-remediation.md`) explicitly contemplates
+this exception.

--- a/apps/base/signal-cli/README.md
+++ b/apps/base/signal-cli/README.md
@@ -1,0 +1,37 @@
+# signal-cli
+
+`signal-cli` REST/JSON-RPC bridge that allows the cluster to send and
+receive Signal messages on behalf of a registered phone number. Used by
+`hermes-bot` and `signal-bridge` to deliver alerts.
+
+## Staging overlay caveat
+
+A thin staging overlay exists at `apps/staging/signal-cli/` and is wired
+into `apps/staging/kustomization.yaml`. It deploys the same workload into
+the `signal-cli-stage` namespace.
+
+**However**, the staging overlay is structural only — it does not (and
+cannot) register a Signal account. A Signal phone number can be linked to
+exactly one primary device at a time; binding the production number to a
+staging instance would unlink it from production. The staging overlay
+therefore deploys an unregistered `signal-cli` daemon that exercises the
+manifest and image plumbing but cannot send or receive real messages.
+
+If end-to-end staging validation is ever required, the path forward is
+to register a second Signal phone number and provision a separate
+`signal-cli-stage` PVC + bridge auth secret bound to it, rather than
+trying to share state with production.
+
+To validate workload-level changes (image bump, resource tweak, sidecar
+config) without touching production:
+- `kustomize build apps/staging/signal-cli` and let CI's staging branch
+  rebuild the deployment.
+- Confirm the staging Pod reaches `Running` and exposes the bridge port,
+  then merge to `master`.
+
+For changes that require an actually-registered Signal client, validate
+locally with `signal-cli` on a workstation against the production number
+(read-only operations) or against a second test number you control.
+
+Phase 4 / PR 4.2 of the critique remediation plan
+(`docs/plans/2026-05-02-critique-remediation.md`) reviewed this app.

--- a/apps/base/snapcast/README.md
+++ b/apps/base/snapcast/README.md
@@ -1,0 +1,24 @@
+# snapcast
+
+Snapcast multi-room audio server (`snapserver` + `snapweb`) with a
+`go-librespot` sidecar feeding the FIFO for Spotify Connect. Streams audio
+to Snapcast clients on the LAN.
+
+## Staging overlay
+
+A staging overlay exists at `apps/staging/snapcast/` and is wired into
+`apps/staging/kustomization.yaml`. It deploys the full stack into the
+`snapcast-stage` namespace, with a dedicated HTTPRoute and its own PVC for
+go-librespot Spotify state. The overlay is exercised by the staging branch
+on every reconcile.
+
+To validate changes:
+- `kustomize build apps/staging/snapcast` and `kustomize build
+  apps/production/snapcast` before pushing.
+- After merge, the staging branch rebuild lands the change in the
+  `snapcast-stage` namespace; verify the snapserver Pod reaches `Running`
+  and the HTTPRoute admits before merging to `master` for production.
+
+Phase 4 / PR 4.2 of the critique remediation plan
+(`docs/plans/2026-05-02-critique-remediation.md`) confirmed this app's
+staging overlay is sufficient and no further work was required.

--- a/apps/base/synology-iscsi-monitor/README.md
+++ b/apps/base/synology-iscsi-monitor/README.md
@@ -1,0 +1,35 @@
+# synology-iscsi-monitor
+
+Prometheus exporter (Python + Paramiko) that SSHes into the Synology NAS at
+`10.42.2.11` to scrape iSCSI LUN / target / volume metrics, plus a Grafana
+dashboard and a PrometheusRule for SAN-side alerts.
+
+## No staging overlay
+
+This app intentionally has no `apps/staging/synology-iscsi-monitor/`
+overlay. AGENTS.md notes the same exception for namespace conventions
+("Apps without a staging variant ... use the plain name").
+
+Reason: the exporter is a singleton scraper aimed at a single piece of
+shared homelab infrastructure (one Synology NAS at one fixed IP, with one
+SSH user). Running a second instance in staging would:
+
+- double the SSH/scrape load on the NAS for no additional signal,
+- duplicate the firing of every PrometheusRule alert (the alerts describe
+  real SAN conditions, not per-environment app behavior), and
+- require either reusing the production SSH credential (defeating the
+  purpose of an isolated stage) or provisioning a second NAS account just
+  to satisfy parity.
+
+To validate changes safely:
+- Run `kustomize build apps/production/synology-iscsi-monitor` locally
+  before pushing.
+- For exporter script changes (`script-cm.yaml`), run the script against
+  the NAS from a workstation with the same `melodic-muse-app` SSH user and
+  inspect the `/metrics` output before merging.
+- For dashboard / PrometheusRule edits, render via
+  `kubectl apply --dry-run=server` against the production namespace.
+
+Phase 4 / PR 4.2 of the critique remediation plan
+(`docs/plans/2026-05-02-critique-remediation.md`) reviewed this app and
+chose Path B (documented exception) over a staging duplicate.

--- a/apps/production/cloudflare-tunnel/README.md
+++ b/apps/production/cloudflare-tunnel/README.md
@@ -1,0 +1,29 @@
+# cloudflare-tunnel
+
+`cloudflared` Deployment that establishes the production Cloudflare Tunnel
+(`production`) and proxies external hostnames (`*.burntbytes.com`) to the
+in-cluster gateway. Manifests live directly under `apps/production/` because
+this app has no staging counterpart — see below.
+
+## No staging overlay
+
+This app intentionally has no `apps/staging/cloudflare-tunnel/` overlay (and
+no `apps/base/cloudflare-tunnel/` base either; the manifests live directly
+under `apps/production/`).
+
+Reason: the tunnel is bound to a specific Cloudflare account, tunnel ID, and
+DNS records (`auth.burntbytes.com`, `links.burntbytes.com`,
+`overture.burntbytes.com`, etc.). Staging traffic in this homelab is not
+publicly exposed — staging hostnames resolve internally via the cluster
+gateway. Running a second `cloudflared` instance for staging would require
+provisioning a separate tunnel ID and credentials in Cloudflare, plus DNS
+records that don't exist (and aren't wanted) for the `-stage` namespace
+suffixes. The cost/value tradeoff doesn't justify the duplication.
+
+To validate changes safely, edit the configmap or deployment, run
+`kustomize build apps/production/cloudflare-tunnel`, and merge to `master`
+through a PR. Cloudflare exposes tunnel health under
+`http://cloudflared:2000/ready`; both replicas must report ready before
+external traffic recovers. If a config change might break ingress, gate it
+behind a temporary hostname first and validate via `cloudflared tunnel info`
+before flipping production hosts.


### PR DESCRIPTION
## Summary

Phase 4 / PR 4.2 of the critique remediation plan (`docs/plans/2026-05-02-critique-remediation.md`) — close finding #18 (5 apps in `apps/base/` lacking a staging overlay).

After auditing the current tree, three of the five apps already had staging overlays merged in earlier PRs (`signal-cli`, `snapcast`) — though `signal-cli`'s overlay carries a non-obvious functional caveat. The remaining three apps (`cloudflare-tunnel`, `overture`, `synology-iscsi-monitor`) each warrant a documented exception (Path B) rather than a duplicate staging instance.

This PR adds README files capturing the per-app rationale so the asymmetry is intentional and discoverable.

## Per-app decisions

| App | Path | Why |
|---|---|---|
| `cloudflare-tunnel` | B (no overlay) | Tunnel ID + Cloudflare DNS records are bound to one account; `-stage` hostnames don't exist publicly; staging traffic stays internal. README at `apps/production/cloudflare-tunnel/README.md` (no `apps/base/` exists for this app). |
| `overture` | B (no overlay) | Single-instance app whose production overlay provisions a 3-replica CNPG Postgres cluster, an S3 ObjectStore (Barman backups), and a `tempo-bridge` sidecar with its own issuer keypair. Duplicating that for staging is heavyweight with no incremental validation benefit. README at `apps/base/overture/README.md`. |
| `synology-iscsi-monitor` | B (no overlay) | Singleton Prometheus exporter SSHing into one shared NAS at `10.42.2.11`. A second instance would double scrape load and dup PrometheusRule alerts; AGENTS.md already lists this app as plain-namespace. README at `apps/base/synology-iscsi-monitor/README.md`. |
| `signal-cli` | A (overlay exists) + Path B documentation | Overlay at `apps/staging/signal-cli/` is wired in. **Caveat documented**: a Signal phone number can only be linked to one primary device at a time, so the staging Pod is structural-only — it deploys cleanly but cannot send/receive real messages without a separate registered number. README at `apps/base/signal-cli/README.md`. |
| `snapcast` | A (overlay exists) | Full staging overlay at `apps/staging/snapcast/` (httproute + deployment patch); validated in CI's staging branch on every reconcile. README at `apps/base/snapcast/README.md`. |

## Operator follow-up

None blocking. If end-to-end Signal validation in staging is ever wanted, the operator would need to register a second phone number and provision a separate `signal-cli-stage` SOPS-encrypted bridge auth secret bound to it — captured in `apps/base/signal-cli/README.md`.

## Test plan

- [x] `kustomize build apps/staging` passes (6005 lines, byte-identical to pre-change output)
- [x] `kustomize build apps/production` passes (7442 lines, byte-identical to pre-change output)
- [x] `kustomize build apps/base/{overture,synology-iscsi-monitor,signal-cli,snapcast}` each pass
- [x] `kustomize build apps/staging/{signal-cli,snapcast}` each pass
- [x] No plaintext secrets in diff
- [ ] After merge: `flux reconcile kustomization apps-staging -n flux-system` (no new namespaces expected; documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)