### PR TITLE
feat(maintainability): app.kubernetes.io/* labels rollout (PR 5.1) — closes critique remediation

### DIFF
--- a/apps/base/adguard/kustomization.yaml
+++ b/apps/base/adguard/kustomization.yaml
@@ -9,3 +9,10 @@ resources:
   - service-admin.yaml
   - service-headless.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: adguard
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/audiobookshelf/kustomization.yaml
+++ b/apps/base/audiobookshelf/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: audiobookshelf
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/authelia/kustomization.yaml
+++ b/apps/base/authelia/kustomization.yaml
@@ -7,6 +7,13 @@ resources:
   - serviceaccount.yaml
   - servicemonitor.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: authelia
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux
 configMapGenerator:
   - name: authelia-config
     namespace: authelia

--- a/apps/base/excalidraw/kustomization.yaml
+++ b/apps/base/excalidraw/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
   - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: excalidraw
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/golinks/kustomization.yaml
+++ b/apps/base/golinks/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: golinks
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/hermes/kustomization.yaml
+++ b/apps/base/hermes/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
   - configmap.yaml
   - serviceaccount.yaml
   - deployment.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: hermes
+      app.kubernetes.io/component: bot
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: homeassistant
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/homepage/kustomization.yaml
+++ b/apps/base/homepage/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
   - namespace.yaml
   - service.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: homepage
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/immich/kustomization.yaml
+++ b/apps/base/immich/kustomization.yaml
@@ -9,3 +9,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: immich
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/jellyfin/kustomization.yaml
+++ b/apps/base/jellyfin/kustomization.yaml
@@ -9,3 +9,10 @@ resources:
   - serviceaccount.yaml
   - storage.yaml
   - media/nfs-media.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: jellyfin
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: linkding
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/mealie/kustomization.yaml
+++ b/apps/base/mealie/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: mealie
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/memos/kustomization.yaml
+++ b/apps/base/memos/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: memos
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/navidrome/kustomization.yaml
+++ b/apps/base/navidrome/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: navidrome
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/overture/kustomization.yaml
+++ b/apps/base/overture/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - service.yaml
   - service-monitor.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: overture
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - serviceaccount.yaml
   - servicemonitor.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: signal-cli
+      app.kubernetes.io/component: messaging
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -8,3 +8,10 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: snapcast
+      app.kubernetes.io/component: audio
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/synology-iscsi-monitor/kustomization.yaml
+++ b/apps/base/synology-iscsi-monitor/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: synology-iscsi-monitor
+      app.kubernetes.io/component: monitor
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux
 
 configMapGenerator:
   - name: synology-iscsi-dashboard

--- a/apps/base/vitals/kustomization.yaml
+++ b/apps/base/vitals/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: vitals
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/docs/plans/2026-05-02-critique-remediation.md
+++ b/docs/plans/2026-05-02-critique-remediation.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: complete
 last_modified: 2026-05-03
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -48,7 +48,7 @@ Sorted by filing date (newest first).
 | [2026-05-02-hestia-gha-runner.md](2026-05-02-hestia-gha-runner.md) | `planned` | Self-hosted GHA runner on hestia for auto-deploy of Custom App compose changes |
 | [2026-05-02-hermes-bot-k8s.md](2026-05-02-hermes-bot-k8s.md) | `planned` | Hermes agent (Signal mode) deployed to melodic-muse so the bot is laptop-independent |
 | [2026-05-02-signal-cli-hermes-rollout.md](2026-05-02-signal-cli-hermes-rollout.md) | `superseded` | Signal-cli + signal-bridge stack to feed the Hermes agent (replaced by hermes-bot-k8s.md) |
-| [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | `in-progress` | IaC hardening — close the 22 findings from the 2026-05-02 critique |
+| [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | `complete` | IaC hardening — close the 22 findings from the 2026-05-02 critique |
 | [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | `planned` | Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio |
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | `planned` | Cardboard drawer insert design (75×32×12 cm) |
 | [2026-03-08-bgp-rollout.md](2026-03-08-bgp-rollout.md) | `planned` | Move LoadBalancer IP advertisement from L2 to BGP with the UCGF |


### PR DESCRIPTION
## Summary

- Adds the standard `app.kubernetes.io/{name,component,part-of,managed-by}` label set to every app under `apps/base/` via a kustomize `labels:` block with `includeSelectors: false`.
- `includeSelectors: false` is intentional: kustomize must NOT rewrite existing Deployment selectors (immutable on existing Deployments — would cause Flux to fail with `field is immutable` on update) or the matching Pod template labels.
- Legacy `app: <name>` labels are intentionally retained for one PR cycle so existing dashboards keep working; a follow-up PR removes the legacy label once dashboards have been migrated to the new label keys.
- `app.kubernetes.io/version` is **not** set here — better sourced from CI/image tag in a follow-up.

This is the final PR of the [critique-remediation plan](../tree/feat/k8s-standard-labels/docs/plans/2026-05-02-critique-remediation.md) — Phase 5 / PR 5.1, closing finding #21. With this PR, the plan status flips to `complete`.

## Per-app component classifications

| App | Component |
|---|---|
| adguard | `web` |
| audiobookshelf | `web` |
| authelia | `web` |
| excalidraw | `web` |
| golinks | `web` |
| hermes | `bot` |
| homeassistant | `web` |
| homepage | `web` |
| immich | `web` |
| jellyfin | `web` |
| linkding | `web` |
| mealie | `web` |
| memos | `web` |
| navidrome | `web` |
| overture | `web` |
| signal-cli | `messaging` |
| snapcast | `audio` |
| synology-iscsi-monitor | `monitor` |
| vitals | `web` |

## Why retain legacy `app: <name>` for one PR cycle

Per the plan: "Drop the legacy `app: <name>` label gradually; keep it for one PR cycle as both, then remove once dashboards confirm they query the new label." Removing the legacy label in this PR would break any Grafana dashboard or NetworkPolicy still selecting on `app=<name>`. The next PR (after dashboards confirm queries against the new keys) will remove it.

## Plan status flipped

- [x] `docs/plans/2026-05-02-critique-remediation.md` front-matter: `status: complete`, `last_modified: 2026-05-03`
- [x] `docs/plans/README.md` index entry: `complete`

## Test plan

- [x] `kustomize build apps/base/<app>` for each of the 19 apps — passes
- [x] `kustomize build apps/staging` — passes (6464 lines)
- [x] `kustomize build apps/production` — passes (7960 lines)
- [x] `kustomize build infra/controllers` — passes (7441 lines)
- [x] Spot-checked every workload's resolved manifest: selector still matches template labels (no kustomize rewrite of selectors); both legacy `app: <name>` and new `app.kubernetes.io/*` labels present on Deployment/StatefulSet metadata.
- [ ] After merge, watch Flux reconciliation: existing Deployments should rolling-update without `field is immutable` errors on `spec.selector`.
- [ ] Confirm `kubectl get pods -A -l app.kubernetes.io/managed-by=flux` returns every Flux-managed pod.

## Per-PR checklist

- [x] kustomize build passes for all affected overlays
- [x] No plaintext secrets in diff
- [x] No image-tag changes (label-only PR)
- [ ] Will validate in staging before production merge
- [x] Linked to plan Phase 5 / PR 5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)