### PR TITLE
feat(reliability): resource budgets for busybox initContainers

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -44,6 +44,16 @@ spec:
             capabilities:
               drop:
                 - ALL
+          # Tiny budget so the pod stays Burstable alongside the main
+          # container. Closes the init-container portion of finding #7
+          # (docs/plans/2026-05-02-critique-remediation.md).
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -48,6 +48,15 @@ spec:
               rm -f /tmp/snapfifo
               mkfifo /tmp/snapfifo
               chmod 666 /tmp/snapfifo
+          # Tiny budget so the pod stays Burstable. Closes the init-container
+          # portion of finding #7 (docs/plans/2026-05-02-critique-remediation.md).
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
             - name: snapcast-tmp
               mountPath: /tmp
@@ -68,6 +77,13 @@ spec:
               rm -f /audio/spotify.fifo
               mkfifo /audio/spotify.fifo
               chmod 666 /audio/spotify.fifo
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
             - name: audio-pipes
               mountPath: /audio


### PR DESCRIPTION
## Summary

Closes the residual init-container portion of finding #7 in [the critique remediation plan](docs/plans/2026-05-02-critique-remediation.md). Three busybox shell-script init containers had no \`resources:\` block, leaving them BestEffort even when the main container is Burstable.

| App | initContainer | Purpose |
|---|---|---|
| homeassistant | \`init-files\` | Write empty YAML list (\`[]\`) into HA include files so they parse correctly |
| snapcast | \`init-fifo\` | mkfifo /tmp/snapfifo for the snapserver pipe |
| snapcast | \`init-spotify-fifo\` | mkfifo /audio/spotify.fifo for the librespot → snapserver bridge |

Each gets \`requests: { cpu: 10m, memory: 16Mi }\`, \`limits: { cpu: 100m, memory: 64Mi }\` — same shape as the \`memos\` \`init-dsn\` container in PR 2.1 (#406).

## Test plan

- [x] \`kustomize build\` passes for affected base + staging + production overlays
- [ ] After merge, pod restart shows the init phase completes inside budget (the actual workload is shell-fast, far below the limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)