### PR TITLE
fix(signal-cli): bump memory limit 512Mi → 1.5Gi to stop JVM OOM loop

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -50,10 +50,16 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 128Mi
+              memory: 512Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # signal-cli is a JVM app and OOMs the container on the
+              # 512Mi limit during sustained operation (observed 42 restarts
+              # over 6h with `java.lang.OutOfMemoryError: Java heap space`).
+              # 1.5Gi gives the JVM headroom for the heap + metaspace +
+              # native code with a single linked account; bump again if a
+              # second account is added.
+              memory: 1536Mi
         - name: signal-bridge
           image: ghcr.io/gjcourt/signal-bridge:2026-05-03
           env:


### PR DESCRIPTION
## Summary

signal-cli daemon has been CrashLoopBackOff for 6h+ with `java.lang.OutOfMemoryError: Java heap space` — 42 restarts. The 512Mi limit gave the JVM no realistic headroom for heap + metaspace + native code, even with a single linked account.

Bump request 128Mi → 512Mi and limit 512Mi → 1.5Gi. Inline rationale comment so the next operator doesn't shrink it back.

## How discovered

Tried to `signal-cli link` a second account; link kept dropping with `Connection closed!` after URI generation. The daemon's WebSocket was being killed by the OOMKiller mid-handshake. Logs confirm.

## Verification after merge

```
kubectl rollout status deploy/signal-cli -n signal-cli
kubectl get pod -n signal-cli  # 0 restarts after a few min
kubectl logs -n signal-cli deploy/signal-cli -c signal-cli --tail=10  # no OOM
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)