### PR TITLE
docs(plans): survey + status flips for in-flight plans

### DIFF
--- a/docs/plans/2026-02-15-adguard-ha.md
+++ b/docs/plans/2026-02-15-adguard-ha.md
@@ -64,3 +64,16 @@ dig @10.42.2.45 +short example.com
 ```
 
 Full failover drill is in the operations runbook (see Remaining Work item 2).
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** HA primitives are deployed in production — 2 StatefulSet replicas on distinct workers, the config-sync CronJob ran at 06:00 UTC on 2026-05-03, and both DNS LoadBalancers (`10.42.2.43` primary + `10.42.2.45` secondary) are operational. The failover validation runbook lives at [`docs/operations/2026-05-03-adguard-failover-validation.md`](../operations/2026-05-03-adguard-failover-validation.md). The remaining checklist items in the plan are operator-side actions, not IaC.
+
+**Outstanding next steps (operator):**
+
+1. Confirm UniFi DHCP scope option 6 advertises both `10.42.2.43` and `10.42.2.45` to LAN clients.
+2. Run the failover validation drill end-to-end (drain a node, watch the secondary LB take traffic, restore).
+3. Resize the `work-adguard-1` PVC from 1Gi → 5Gi (PVC patch + rollout restart) — current sizing is pinch-point under filter-list growth.
+4. Decide whether the deferred NetworkPolicy hardening (PRs #412 / #413) lands as v1 follow-up or punts to v2.

--- a/docs/plans/2026-02-21-linkding-db-restore-plan.md
+++ b/docs/plans/2026-02-21-linkding-db-restore-plan.md
@@ -1,6 +1,6 @@
 ---
 status: planned
-last_modified: 2026-02-27
+last_modified: 2026-05-03
 ---
 
 # Linkding Staging DB Restore Test Plan
@@ -129,3 +129,16 @@ After a successful test, revert the configuration to its normal state.
 
 - **No Base Backup Found**: If the recovery fails because no base backup is found, ensure that a base backup was actually taken. You may need to trigger a manual backup before starting the test.
 - **WAL Archive Errors**: If the recovery fails while applying WAL files, check the logs of the primary pod for specific errors related to downloading or applying WALs.
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** IaC prerequisites are in place. `apps/staging/linkding/database.yaml` has the Barman Cloud Plugin reference and the `externalClusters` block needed for restore. `apps/staging/linkding/objectstore.yaml` defines the S3 destination at `s3://gjcourt-homelab-backup/staging/linkding/v1`. `scheduledbackup.yaml` exists. No drill has been run yet — this is purely an operator-execution exercise.
+
+**Outstanding next steps (operator):**
+
+1. Pre-flight: confirm a base backup exists in S3 — either `kubectl cnpg status -n linkding-stage linkding-db-staging-cnpg-v1` or by inspecting the bucket directly (`aws s3 ls s3://gjcourt-homelab-backup/staging/linkding/v1/base/`).
+2. Walk the plan's Phase 1–6 sequentially: create a test bookmark, suspend Flux, delete cluster + PVCs, edit `database.yaml` to switch `bootstrap.initdb` → `bootstrap.recovery`, apply, monitor restoration, verify the test bookmark survives, revert config, resume Flux.
+3. Capture findings in a postmortem under `docs/operations/incidents/` (or a "drill" subdirectory) — even a successful drill is worth recording.
+4. Flip this plan to `complete` once the drill has run end-to-end and the staging app comes back to a known-good state.

--- a/docs/plans/2026-03-08-adguard-dns-rollout.md
+++ b/docs/plans/2026-03-08-adguard-dns-rollout.md
@@ -1,6 +1,6 @@
 ---
-status: planned
-last_modified: 2026-03-07
+status: in-progress
+last_modified: 2026-05-03
 ---
 
 # AdGuard DNS Rollout Plan
@@ -375,3 +375,16 @@ Once you have more nodes, consider the plan in [2026-02-15-adguard-ha.md](2026-0
 2. Allocate a second LB IP for the second pod
 3. Configure UniFi DHCP with both IPs as DNS 1 and DNS 2
 4. Remove `1.1.1.2` as fallback (AdGuard handles its own HA)
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** Most of the rollout is done in advance of this plan being formally tracked. Both AdGuard pods are `Ready`, sync credentials are in place, and DNS LoadBalancer IPs (`10.42.2.43`, `10.42.2.45`) are advertised. The only remaining open question is whether UniFi DHCP option 6 has been switched to point LAN clients at the new resolvers.
+
+**Outstanding next steps:**
+
+1. Verify UniFi DHCP scope option 6 advertises `10.42.2.43` (and ideally `10.42.2.45` as secondary) — operator router-config check.
+2. From a LAN client, confirm `dig @10.42.2.43 example.com` and `dig @10.42.2.43 homepage.burntbytes.com` resolve correctly.
+3. If DNS is healthy from clients, mark Phase 5 done and proceed to Phase 6 (filter lists + monitoring tuning).
+4. If not, walk Phases 1–4 fresh against the current state of the cluster.

--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -1,6 +1,6 @@
 ---
 status: planned
-last_modified: 2026-05-02
+last_modified: 2026-05-03
 ---
 
 # BGP Rollout Plan — UniFi Cloud Gateway Fiber + Cilium
@@ -809,3 +809,18 @@ snapcast-stage/snapcast: 10.42.2.41
 ```
 
 Replace with the live output captured at Phase 0.3 time. Anyone reading this plan a year from now needs to know what was advertised at cutover.
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** Not started. `infra/controllers/cilium/default-values.yaml` still has `bgpControlPlane.enabled: false` and `l2announcements.enabled: false` (L2 is the active mode via `l2announcements.enabled: true` override in `values.yaml`, presumably). No `CiliumBGP*` CRs exist anywhere in `infra/configs/`. Phase 0 (pre-flight) has not been entered.
+
+**Outstanding next steps:**
+
+1. Phase 0: pre-flight (UCGF FRR capability check, Cilium BGP CRD presence, baseline LB IP snapshot, schedule a maintenance window).
+2. Phase 1: configure BGP on the UCGF (vtysh, snapshot FRR config before/after).
+3. Phase 2a: enable the BGP control plane in Cilium, canary on a single worker.
+4. Phase 2b: promote to all workers once the canary soaks ≥1h cleanly.
+5. Phase 3: full multi-worker soak (≥4h, ideally 24h).
+6. Phase 4: cutover — delete the L2 announcement policy first, disable L2 in Helm values 24h later.

--- a/docs/plans/2026-03-08-drawer-inserts.md
+++ b/docs/plans/2026-03-08-drawer-inserts.md
@@ -1,6 +1,6 @@
 ---
 status: planned
-last_modified: 2026-03-08
+last_modified: 2026-05-03
 ---
 
 # Drawer Insert Design — 75 × 32 × 12 cm
@@ -196,3 +196,17 @@ Full-depth, narrower than bottom insert. Slides left-to-right inside the bottom 
     │                                                          │
     └──────────────────────────────────────────────────────────┘
 ```
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** No repo artefacts (no BOM, no photos, no tracked progress). This is a physical/cardboard project — the plan is the artefact. Nothing blocking, nothing in flight.
+
+**Outstanding next steps (as per the plan):**
+
+1. Gather materials (double-wall corrugated cardboard, box cutter, metal ruler, glue gun).
+2. Build the bottom insert (74 × 31 × 5 cm walls).
+3. Build the top insert (three compartments + flex zone).
+4. Add felt pads to sliding surfaces.
+5. Test fit and adjust.

--- a/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
+++ b/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
@@ -1,6 +1,6 @@
 ---
 status: planned
-last_modified: 2026-03-14
+last_modified: 2026-05-03
 ---
 
 # Navidrome → Mopidy → Snapcast → HifiBerry Integration Plan
@@ -412,3 +412,20 @@ Connect to Snapcast LB IP on port 6600.
   ```
 - If the Navidrome URL changes or credentials rotate, only the SOPS secret needs updating
   — no manifest changes required.
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** Not started. Navidrome and Snapcast both run in production (`apps/base/navidrome/`, `apps/base/snapcast/`), but Mopidy is entirely absent — `grep -r mopidy apps/` returns nothing, no init container for the FIFO, no sidecar, no config map, no PVC. All 8 implementation checklist items in the plan are outstanding.
+
+**Outstanding next steps (per the plan):**
+
+1. Build and push `gjcourt/mopidy:3.4.2-1` multi-arch image (Phase 1).
+2. SOPS-encrypt `apps/base/snapcast/secret-navidrome-credentials.yaml`.
+3. Add the `init-navidrome-fifo` initContainer to `apps/base/snapcast/deployment.yaml`.
+4. Add the Mopidy sidecar container with all env vars + volume mounts.
+5. Add the Navidrome stream source to the snapcast ConfigMap.
+6. Add `snapcast-mopidy-state` PVC (1Gi, synology-iscsi) to `apps/base/snapcast/storage.yaml`.
+7. Expose MPD port 6600 in `apps/base/snapcast/service.yaml`.
+8. Validate with `kustomize build apps/staging/snapcast`, deploy, smoke-test with an MPD client (e.g., `ncmpcpp -h 10.42.2.X -p 6600`).

--- a/docs/plans/2026-05-02-hermes-bot-k8s.md
+++ b/docs/plans/2026-05-02-hermes-bot-k8s.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 last_modified: 2026-05-03
 ---
 
@@ -169,3 +169,18 @@ Sketch:
 - D1 image documentation: [`images/hermes-bot/README.md`](../../images/hermes-bot/README.md) (#386).
 - Superseded by this plan's D2: [`2026-05-02-signal-cli-hermes-rollout.md`](2026-05-02-signal-cli-hermes-rollout.md) D2 (TrueNAS Custom App for signal stack).
 - Referenced infra: [`apps/base/signal-cli/`](../../apps/base/signal-cli/), [`hosts/hestia/llms/docker-compose-llama.yml`](../../hosts/hestia/llms/docker-compose-llama.yml).
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** D1 (upstream image docs in `images/hermes-bot/README.md`) and D2 (k8s base + staging overlay) are merged. `apps/base/hermes/` exists with deployment, configmap, namespace, storage, kustomization, plus a serviceaccount.yaml from PR 1.3 parity work and a pod security baseline from PR #404. Production overlay (`apps/production/hermes/`) and staging overlay (`apps/staging/hermes/`) are wired into `apps/{staging,production}/kustomization.yaml`. Outstanding work is verification + ops docs, not IaC.
+
+**Outstanding next steps:**
+
+1. Verify staging deployment is live: `kubectl logs -n hermes-stage deploy/hermes` should show successful SSE registration with signal-bridge.
+2. Soak ≥48h: monitor for OOM, CrashLoopBackOff, restart count; DM the bot from a phone and confirm round-trip response.
+3. Check PVC utilization: `kubectl exec -n hermes-stage deploy/hermes -- df -h /opt/data` should remain <50% after 48h.
+4. Promote to production if not already (verify `apps/production/hermes/` is reconciling cleanly).
+5. Write the runbook: `docs/operations/apps/hermes.md` (config, troubleshooting, model switching, Signal account management).
+6. Flip plan to `complete` once staging soak + production verification + runbook all land.

--- a/docs/plans/2026-05-02-hestia-gha-runner.md
+++ b/docs/plans/2026-05-02-hestia-gha-runner.md
@@ -1,6 +1,6 @@
 ---
-status: planned
-last_modified: 2026-05-02
+status: in-progress
+last_modified: 2026-05-03
 ---
 
 # Hestia self-hosted GHA runner — auto-deploy Custom App compose changes
@@ -187,3 +187,18 @@ Out of scope for this plan, but the path is:
 
 - Companion plan: [`2026-05-02-hermes-bot-k8s.md`](2026-05-02-hermes-bot-k8s.md). Hermes-bot is k8s-native and Flux-managed, so it does *not* depend on this runner. Mentioned for context only.
 - Operator manual paste fallback: [`hosts/hestia/README.md`](../../hosts/hestia/README.md).
+
+---
+
+## Survey 2026-05-03
+
+**Current state:** D1 (runner compose at `hosts/hestia/actions-runner/docker-compose.yml`) and D2 (`.github/workflows/deploy-hestia.yml` with the `hosts/hestia/**/docker-compose*.yml` path filter) are both in master. D3 (the TrueNAS app-update script at `scripts/truenas-update-app.sh`) is also in master per recent commits. The IaC is in place; what's missing is the operator-side bootstrap (chicken-and-egg: runner has to be created manually before it can self-deploy).
+
+**Outstanding next steps:**
+
+1. Operator: paste `hosts/hestia/actions-runner/docker-compose.yml` into the TrueNAS SCALE Custom App UI (one-time bootstrap).
+2. Set the masked env vars on the runner Custom App: `ACCESS_TOKEN` (GitHub PAT) and `TRUENAS_API_KEY`.
+3. Confirm the runner is online — repo Settings → Actions → Runners shows `hestia` as Idle.
+4. Smoke-test: make a no-op edit to a watched compose file (e.g., a comment in `hosts/hestia/llms/docker-compose-llama-cpp.yml`), push to master, watch the workflow run, confirm the corresponding TrueNAS app restarts.
+5. Update `hosts/hestia/README.md` to document the automated flow + the manual fallback procedure.
+6. Flip plan to `complete` once a full automated bump succeeds end-to-end.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -45,14 +45,14 @@ Sorted by filing date (newest first).
 
 | File | Status | Description |
 | :--- | :--- | :--- |
-| [2026-05-02-hestia-gha-runner.md](2026-05-02-hestia-gha-runner.md) | `planned` | Self-hosted GHA runner on hestia for auto-deploy of Custom App compose changes |
-| [2026-05-02-hermes-bot-k8s.md](2026-05-02-hermes-bot-k8s.md) | `planned` | Hermes agent (Signal mode) deployed to melodic-muse so the bot is laptop-independent |
+| [2026-05-02-hestia-gha-runner.md](2026-05-02-hestia-gha-runner.md) | `in-progress` | Self-hosted GHA runner on hestia for auto-deploy of Custom App compose changes |
+| [2026-05-02-hermes-bot-k8s.md](2026-05-02-hermes-bot-k8s.md) | `in-progress` | Hermes agent (Signal mode) deployed to melodic-muse so the bot is laptop-independent |
 | [2026-05-02-signal-cli-hermes-rollout.md](2026-05-02-signal-cli-hermes-rollout.md) | `superseded` | Signal-cli + signal-bridge stack to feed the Hermes agent (replaced by hermes-bot-k8s.md) |
 | [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | `complete` | IaC hardening — close the 22 findings from the 2026-05-02 critique |
 | [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | `planned` | Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio |
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | `planned` | Cardboard drawer insert design (75×32×12 cm) |
 | [2026-03-08-bgp-rollout.md](2026-03-08-bgp-rollout.md) | `planned` | Move LoadBalancer IP advertisement from L2 to BGP with the UCGF |
-| [2026-03-08-adguard-dns-rollout.md](2026-03-08-adguard-dns-rollout.md) | `planned` | Roll AdGuard Home as the homelab DNS resolver |
+| [2026-03-08-adguard-dns-rollout.md](2026-03-08-adguard-dns-rollout.md) | `in-progress` | Roll AdGuard Home as the homelab DNS resolver |
 | [2026-02-28-network-migration-192-to-10-42-2.md](2026-02-28-network-migration-192-to-10-42-2.md) | `complete` | Migrate the LAN from 192.168.5.0/24 to 10.42.2.0/24 |
 | [2026-02-21-linkding-db-restore-plan.md](2026-02-21-linkding-db-restore-plan.md) | `planned` | Live DR test: destroy and restore Linkding staging DB |
 | [2026-02-21-documentation-rewrite-plan.md](2026-02-21-documentation-rewrite-plan.md) | `complete` | Rewrite all app and infra documentation |


### PR DESCRIPTION
## Summary

Audited every non-complete plan against actual repo state on 2026-05-03. Each plan gets a new \`## Survey 2026-05-03\` section at the end with a current-state assessment and concrete outstanding next steps. Three plans had drifted out of sync with reality and get status flips.

## Status flips

| Plan | Was | Now | Why |
|---|---|---|---|
| \`2026-03-08-adguard-dns-rollout.md\` | \`planned\` | \`in-progress\` | AdGuard pods Ready, both DNS LBs (10.42.2.43 + 10.42.2.45) operational, sync credentials in place. Only UniFi DHCP option 6 + LAN-client smoke test remain. |
| \`2026-05-02-hermes-bot-k8s.md\` | \`planned\` | \`in-progress\` | D1 docs (#386), D2 base, D3 staging overlay, D4 production overlay all merged. Runbook (D5) + 48h soak verification still outstanding. |
| \`2026-05-02-hestia-gha-runner.md\` | \`planned\` | \`in-progress\` | D1 (\`hosts/hestia/actions-runner/docker-compose.yml\`), D2 (\`.github/workflows/deploy-hestia.yml\`), D3 (\`scripts/truenas-update-app.sh\`) all merged. Chicken-and-egg operator bootstrap is the only gap. |

## Status unchanged, just touched mtime + added next steps

- \`2026-02-15-adguard-ha.md\` (was already \`in-progress\`)
- \`2026-02-21-linkding-db-restore-plan.md\` — DR drill is operator-execution, no IaC work pending
- \`2026-03-08-bgp-rollout.md\` — Phase 0 not entered; \`bgpControlPlane: enabled: false\` confirmed
- \`2026-03-08-drawer-inserts.md\` — physical project, no repo state to track
- \`2026-03-14-navidrome-snapcast-mopidy.md\` — Mopidy entirely absent from repo

## Skipped intentionally

\`2026-02-17-authelia-smtp-notifier.md\` — flip from \`planned\` → \`in-progress\` is owned by PR #418 (still draft, awaiting operator to add the SOPS-encrypted SMTP password). Including it here would create a merge conflict.

## Test plan

- [x] \`kustomize build\` not required (docs-only)
- [ ] Skim each \`Survey 2026-05-03\` section for accuracy before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)