### PR TITLE
docs: hermes runbook + hestia auto-deploy procedure

### DIFF
--- a/docs/operations/apps/hermes.md
+++ b/docs/operations/apps/hermes.md
@@ -1,0 +1,124 @@
+# Hermes
+
+## 1. Overview
+Hermes is the [Hermes Agent](https://hermes-agent.nousresearch.com/) from NousResearch deployed in Signal-only mode. It runs as a long-lived gateway that listens for direct messages from allow-listed phone numbers, forwards each conversation to a local LLM, and replies back over Signal. It is the "always-on" companion to the operator's laptop-bound Hermes CLI — the laptop instance is for interactive use; this cluster instance is the one a phone can DM at any hour.
+
+## 2. Architecture
+Single-replica `Deployment` (Recreate strategy — sessions don't cluster, only one process should write checkpoints). The container does not expose any HTTP listener; readiness/liveness use a `pgrep -f 'hermes gateway'` exec probe.
+
+```
+phone (Signal) ──► signal-cli (k8s pod) ──► signal-bridge (sidecar :8080) ──► hermes-bot (k8s pod)
+                                                                                       │
+                                                                                       ▼
+                                                                       llama.cpp on hestia (10.42.2.10:8000)
+                                                                                       │
+                                                                                       ▼
+                                                                                response back through the same chain
+```
+
+- **Image**: upstream `nousresearch/hermes-agent` (Debian 13.4, Python 3.13 via uv, runs as UID 10000), digest-pinned in `apps/base/hermes/deployment.yaml`.
+- **Storage**: 5 GiB iSCSI PVC mounted at `/opt/data` (`HERMES_HOME`) for sessions, checkpoints, memory, skills, cron, logs, and the upstream-seeded `config.yaml`. `securityContext.fsGroup: 10000` lets the non-root process write to the volume.
+- **Inference**: direct to llama.cpp on hestia at `http://10.42.2.10:8000/v1`. No llmux hop — the `hermes` chat template emits clean tool calls.
+- **Signal transport**: in-cluster ClusterIP at `http://signal-cli-bridge.signal-cli.svc.cluster.local:8080`. Auth boundary is the network layer (no public ingress on signal-bridge), not HTTP — the Hermes Signal adapter does not currently send `Authorization: Bearer …`.
+- **No HTTPRoute / Gateway entry**: bot has no public surface.
+
+## 3. URLs
+None. Hermes has no HTTP listener and no Gateway entry. To talk to the bot, DM `+16179397251` on Signal from an allow-listed number.
+
+## 4. Configuration
+
+### Environment variables (ConfigMap `hermes-config`)
+Loaded via `envFrom`. Edit `apps/base/hermes/configmap.yaml`.
+
+| Var | Purpose |
+|---|---|
+| `SIGNAL_HTTP_URL` | signal-bridge endpoint inside the cluster |
+| `SIGNAL_ACCOUNT` | bot's Signal phone number (`+16179397251`) |
+| `SIGNAL_HOME_CHANNEL` | E.164 Hermes treats as the bot's "home" thread |
+| `SIGNAL_HOME_CHANNEL_NAME` | display name for the home channel |
+| `SIGNAL_IGNORE_STORIES` | drop Signal stories from the inbox stream |
+| `SIGNAL_ALLOWED_USERS` | CSV E.164 allow-list — only these can DM the bot |
+| `SIGNAL_GROUP_ALLOWED_USERS` | CSV E.164 — empty means group messages are ignored entirely |
+| `HERMES_ACCEPT_HOOKS` | `1` — auto-approve unseen shell hooks (no operator at the keyboard) |
+| `PYTHONUNBUFFERED` | `1` — flush stdout/stderr immediately for responsive logs |
+
+### Hermes core config (ConfigMap `hermes-config-yaml`)
+Mounted at `/opt/data/config.yaml`. Edit `apps/base/hermes/configmap.yaml` (second document). Defines the model + provider, toolset list, agent limits, checkpoint retention, prompt caching, code-execution mode, logging.
+
+The upstream image seeds `/opt/data/config.yaml` from `cli-config.yaml.example` on first boot if the file is absent. Mounting our own ConfigMap key here ensures fixed configuration regardless of PVC state.
+
+### Toolsets (in `config.yaml`)
+- `hermes-signal` — Signal platform toolset (DM listener)
+- `file` — read-only file ops
+- `web` — web browsing
+
+`terminal` is **intentionally omitted** in v1 to limit blast radius. To opt in, add it to the `toolsets:` list in the ConfigMap and reconcile.
+
+### Secrets
+None at present. Inference is local to the LAN; no API keys are needed. If a remote provider is added later, it goes in a SOPS-encrypted Secret consumed via env (e.g., `OPENAI_API_KEY`).
+
+## 5. Usage Instructions
+
+### Talking to the bot
+DM `+16179397251` on Signal from an allow-listed number (currently `+16179397251` and `+14153089014` per `SIGNAL_ALLOWED_USERS`). The bot replies in the same DM.
+
+### Adding an allowed user
+1. Edit the `SIGNAL_ALLOWED_USERS` CSV in `apps/base/hermes/configmap.yaml` (E.164 format, `+1...`).
+2. Commit + PR + merge.
+3. Flux reconciles → restart hermes pod (`kubectl rollout restart -n hermes deployment/hermes`) — env-var changes don't auto-roll.
+
+### Switching the model
+1. Edit `model.default` in the `hermes-config-yaml` ConfigMap (`apps/base/hermes/configmap.yaml`).
+2. If the new model needs a different `base_url` (e.g., switching from llama.cpp to vLLM), update that too.
+3. Commit, merge, restart.
+
+### Managing the bot's Signal account
+The bot doesn't manage its own Signal account — `signal-cli` does, and registering/unregistering Signal accounts is a separate operation against the `signal-cli` pod's PVC. See `docs/operations/2026-05-03-signal-cli-account-management.md` for the linking/registration procedure.
+
+## 6. Testing
+
+```bash
+# Pod up and steady?
+kubectl get pod -n hermes
+
+# Has it logged a successful Signal SSE registration?
+kubectl logs -n hermes deploy/hermes | grep -i "signal\|connected\|registered"
+
+# PVC utilization (should stay <50% with auto_prune on)
+kubectl exec -n hermes deploy/hermes -- df -h /opt/data
+```
+
+Round-trip: DM the bot from your phone, confirm a reply lands within ~30s for a trivial prompt. If the reply takes longer or never arrives, walk down the chain in section 9.
+
+## 7. Monitoring & Alerting
+- **Metrics**: Hermes does not expose Prometheus metrics. The pod's CPU/memory show up in the generic Application Health dashboard via the `app: hermes` label.
+- **Logs**: structured to stdout.
+  ```bash
+  kubectl logs -n hermes deploy/hermes -f
+  ```
+  Hot signals to grep for: `ERROR`, `signal`, `model`, `tool_use`. The agent emits a turn-by-turn structure that's verbose under `verbose: true`.
+- **Restart count**: a non-zero `RESTARTS` in `kubectl get pod -n hermes` over a 24h window suggests OOM (bump memory limit) or signal-bridge connectivity flapping.
+
+## 8. Disaster Recovery
+- **Backup strategy**:
+  - `apps/base/hermes/configmap.yaml` (env + `config.yaml`) is in Git.
+  - The PVC at `/opt/data` holds session history, checkpoints, and memory. With `checkpoints.auto_prune: true` + `retention_days: 7` it stays bounded; underlying iSCSI snapshots on Synology are the recovery surface for catastrophic loss.
+- **Restore procedure**:
+  - PVC loss: delete the pod and PVC, re-apply Flux. The pod re-seeds `/opt/data/config.yaml` from the mounted ConfigMap key on first boot. Conversation history and any cron-built artifacts are gone — bot returns with a clean memory.
+  - ConfigMap regression: revert the offending commit, Flux reconciles, restart the pod.
+
+## 9. Troubleshooting
+
+- **Bot offline / not responding to DMs**: walk the chain.
+  1. Is `hermes` pod `Running`? `kubectl get pod -n hermes`. If `CrashLoopBackOff`, check logs.
+  2. Is `signal-cli` pod `Running` in the `signal-cli` namespace? The bot can't receive without it.
+  3. Is llama.cpp on hestia reachable? `kubectl exec -n hermes deploy/hermes -- curl -s http://10.42.2.10:8000/v1/models | head`. If empty, GPU host is down.
+  4. Are you on the allow-list? `kubectl get cm -n hermes hermes-config -o jsonpath='{.data.SIGNAL_ALLOWED_USERS}'`.
+
+- **Slow replies (>60s on trivial prompts)**: usually llama.cpp queue depth or model swap. Check hestia GPU utilization (`ssh truenas_admin@10.42.2.10 'nvidia-smi'`).
+
+- **PVC full**: check `df -h /opt/data` in the pod. If approaching 100%, `checkpoints.max_snapshots` may be too high or `auto_prune` got disabled. Edit the `hermes-config-yaml` ConfigMap to tighten retention; restart.
+
+- **`hermes gateway` process not detected by probe**: the readiness probe greps for `hermes gateway` in the process table. If the binary crashed and tini hasn't restarted it, the pod will be marked NotReady within `30 * 3 = 90s`. Logs will show the crash cause; livenessProbe (5min grace) will then trigger a restart.
+
+- **Auth issues to signal-bridge**: `HERMES_AUTH_TOKEN` is currently *not* sent by the upstream Hermes Signal adapter. The signal-bridge accepts unauthenticated requests from in-cluster traffic (NetworkPolicy is the only barrier). If a non-Hermes caller is added later that requires auth, that's a future patch on both sides.

--- a/hosts/hestia/README.md
+++ b/hosts/hestia/README.md
@@ -11,7 +11,7 @@
 ## Services
 
 All services on hestia run as **TrueNAS Custom Apps** (SCALE UI → Apps → Custom App).
-The compose YAML in each subdirectory is the canonical source; paste into SCALE UI to deploy or update.
+The compose YAML in each subdirectory is the canonical source.
 
 | Service | Directory | Port | Notes |
 |---------|-----------|------|-------|
@@ -19,6 +19,32 @@ The compose YAML in each subdirectory is the canonical source; paste into SCALE 
 | llms | `llms/` | varies | llama.cpp / vLLM inference (GPU box) |
 | monitoring | `monitoring/` | varies | nvtop and GPU metrics |
 | gha-runner | `actions-runner/` | — | Self-hosted GitHub Actions runner; auto-deploys other hestia apps |
+
+## Deploying changes
+
+Once the GHA runner is online (see [`actions-runner/README.md`](actions-runner/README.md)),
+edits to `hosts/hestia/<app>/docker-compose*.yml` are applied automatically:
+
+1. Open a PR with the compose change.
+2. Merge to `master`.
+3. The `Deploy hestia Custom Apps` workflow ([`.github/workflows/deploy-hestia.yml`](../../.github/workflows/deploy-hestia.yml)) fires on push, scoped to `hosts/hestia/**/docker-compose*.yml`.
+4. The self-hosted runner on hestia executes [`scripts/truenas-update-app.sh`](../../scripts/truenas-update-app.sh), which calls TrueNAS's WebSocket `app.update` API with the new compose. The corresponding container restarts.
+5. Verify via the workflow run in GitHub Actions and `docker ps` on hestia.
+
+**Adding a new app**: drop `hosts/hestia/<new-app>/docker-compose.yml` in this tree, then add a matrix entry in `.github/workflows/deploy-hestia.yml` whose `name:` matches the Custom App name in SCALE UI exactly. The first deploy of a brand-new app still needs the operator to paste the compose into SCALE UI once (chicken-and-egg — the runner can't create an app that doesn't yet exist, only update one). Subsequent edits flow through the runner.
+
+**Excluded from the workflow**: the runner itself (`actions-runner/`). A compose change that recreates the runner's own container would kill the workflow mid-flight. Runner upgrades stay manual.
+
+### Manual fallback
+
+If the runner is offline or the change targets the runner itself:
+
+1. Open SCALE UI → Apps → `<app>` → Edit.
+2. Paste the new compose YAML.
+3. Save.
+4. Verify with `docker ps` and the app's healthcheck.
+
+Plan: [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../docs/plans/2026-05-02-hestia-gha-runner.md).
 
 ## ZFS datasets
 


### PR DESCRIPTION
## Summary

Two D-deliverables in one bundled docs PR.

### Hermes runbook (closes D5 of [`hermes-bot-k8s`](docs/plans/2026-05-02-hermes-bot-k8s.md))

New \`docs/operations/apps/hermes.md\`. Follows the standard 9-section app runbook template:

1. Overview
2. Architecture (ASCII chain: phone → signal-cli → signal-bridge → hermes-bot → llama.cpp)
3. URLs (none — bot has no public surface)
4. Configuration (env ConfigMap, hermes-config-yaml mount, toolset rationale, secrets)
5. Usage (DM, allow-list edits, model switching, Signal account note pointing to the existing 2026-05-03-signal-cli-account-management.md)
6. Testing (pod state, signal connectivity, PVC utilization, round-trip DM)
7. Monitoring & alerting (no Prometheus metrics; CPU/memory via the generic Application Health dashboard)
8. DR (config in Git; PVC loss tolerated, conversation history is ephemeral)
9. Troubleshooting (chain-walk for offline bot, slow replies, PVC full, probe failures)

### Hestia auto-deploy (closes D4 of [\`hestia-gha-runner\`](docs/plans/2026-05-02-hestia-gha-runner.md))

\`hosts/hestia/README.md\` updated to document the new automated flow:
- Drops the implicit "paste into SCALE UI" instruction from the services table
- Adds a "Deploying changes" section walking through merge → workflow → runner → \`scripts/truenas-update-app.sh\` → \`app.update\`
- Documents the chicken-and-egg first-deploy case (still manual paste once)
- Documents the runner exclusion (workflow doesn't redeploy itself)
- Keeps the manual SCALE-UI fallback for runner-offline cases

## What's still outstanding for the two plans

- **hermes-bot-k8s**: 48h staging soak + production sign-off (operator).
- **hestia-gha-runner**: operator pastes the runner compose into SCALE UI once, sets the two masked env vars, then verifies with a no-op compose change.

Both plans flip to \`complete\` once those operator-side steps land.

## Test plan

- [x] No code changes, no kustomize impact
- [ ] Skim each doc for accuracy before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)