### PR TITLE
feat(snapcast): Mopidy sidecar for Navidrome streaming (Phases 2-7)

### DIFF
--- a/apps/base/snapcast/config/snapserver.conf
+++ b/apps/base/snapcast/config/snapserver.conf
@@ -8,6 +8,11 @@ source = pipe:///tmp/snapfifo?name=default&sampleformat=48000:16:2&codec=flac
 # Sample format matches Snapcast's librespot/go-librespot expectations (44.1kHz).
 source = pipe:///audio/spotify.fifo?name=spotify&sampleformat=44100:16:2&codec=flac&mode=read
 
+# Navidrome (via mopidy + mopidy-subidy sidecar). Mopidy writes raw PCM at
+# 44.1kHz / S16LE / stereo to this FIFO; snapserver reads it as a stream
+# and clients can subscribe via the Snapweb UI or Snapcast clients.
+source = pipe:///audio/navidrome.fifo?name=navidrome&sampleformat=44100:16:2&codec=flac&mode=read
+
 [http]
 # Serve Snapweb (built-in UI) via the snapserver http port (1780)
 doc_root = /usr/share/snapserver/snapweb/

--- a/apps/base/snapcast/configmap-mopidy.yaml
+++ b/apps/base/snapcast/configmap-mopidy.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mopidy-config
+  namespace: snapcast
+  labels:
+    app: snapcast
+data:
+  # Mounted at /etc/mopidy/mopidy.conf in the mopidy sidecar. The sidecar's
+  # entrypoint runs `envsubst` to expand the ${NAVIDROME_*} env vars from the
+  # navidrome-credentials Secret before invoking mopidy.
+  mopidy.conf: |
+    [core]
+    data_dir = /mopidy-state
+    cache_dir = /tmp/mopidy-cache
+
+    [logging]
+    verbosity = 0
+
+    [mpd]
+    enabled = true
+    # Listen on all interfaces inside the pod; the snapcast Service exposes
+    # port 6600 to LAN clients (Symfonium, MALP, ncmpcpp, etc.).
+    hostname = ::
+    port = 6600
+
+    [subidy]
+    url = ${NAVIDROME_URL}
+    username = ${NAVIDROME_USER}
+    password = ${NAVIDROME_PASSWORD}
+    # Navidrome implements OpenSubsonic — the 1.16.1 API surface is what
+    # mopidy-subidy targets.
+    api_version = 1.16.1
+
+    [file]
+    enabled = false
+
+    [local]
+    enabled = false
+
+    [audio]
+    # Pipe raw PCM into the shared FIFO that snapserver reads. The full
+    # GStreamer pipeline is required so the bytes on the wire are raw S16LE
+    # at 44.1kHz/stereo — `filesink` alone would emit a container format that
+    # snapserver cannot parse.
+    output = audioresample ! audioconvert ! audio/x-raw,rate=44100,channels=2,format=S16LE ! filesink location=/audio/navidrome.fifo

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -88,6 +88,33 @@ spec:
             - name: audio-pipes
               mountPath: /audio
 
+        - name: init-navidrome-fifo
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              rm -f /audio/navidrome.fifo
+              mkfifo /audio/navidrome.fifo
+              chmod 666 /audio/navidrome.fifo
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: audio-pipes
+              mountPath: /audio
+
       containers:
         - name: snapserver
           image: gjcourt/snapcast:0.34.0-snapweb0.9.3
@@ -203,6 +230,70 @@ spec:
               cpu: 1000m
               memory: 512Mi
 
+        - name: mopidy
+          # gjcourt/mopidy:3.4.2-1 — first-party image built from images/mopidy/
+          # (Phase 1 of docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). After
+          # the first build, this should be digest-pinned per AGENTS.md image
+          # discipline; tag-only is acceptable while bootstrapping the image.
+          image: gjcourt/mopidy:3.4.2-1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: NAVIDROME_URL
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_URL
+            - name: NAVIDROME_USER
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_USER
+            - name: NAVIDROME_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_PASSWORD
+            - name: HOME
+              value: /mopidy-state
+          ports:
+            - name: mpd
+              containerPort: 6600
+          command:
+            - sh
+            - -c
+            - |
+              # Substitute env vars into the templated config before starting.
+              # gettext-base provides envsubst in the python:slim base image.
+              envsubst < /etc/mopidy/mopidy.conf > /tmp/mopidy.conf
+              exec mopidy --config /tmp/mopidy.conf
+          readinessProbe:
+            tcpSocket:
+              port: mpd
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 6
+          volumeMounts:
+            - name: mopidy-config
+              mountPath: /etc/mopidy/mopidy.conf
+              subPath: mopidy.conf
+              readOnly: true
+            - name: mopidy-state
+              mountPath: /mopidy-state
+            - name: audio-pipes
+              mountPath: /audio
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
       volumes:
         - name: snapserver-config
           configMap:
@@ -217,3 +308,9 @@ spec:
         - name: go-librespot-config
           configMap:
             name: go-librespot-config
+        - name: mopidy-config
+          configMap:
+            name: mopidy-config
+        - name: mopidy-state
+          persistentVolumeClaim:
+            claimName: snapcast-mopidy-state

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -231,11 +231,11 @@ spec:
               memory: 512Mi
 
         - name: mopidy
-          # gjcourt/mopidy:3.4.2-1 — first-party image built from images/mopidy/
-          # (Phase 1 of docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). After
-          # the first build, this should be digest-pinned per AGENTS.md image
-          # discipline; tag-only is acceptable while bootstrapping the image.
-          image: gjcourt/mopidy:3.4.2-1
+          # ghcr.io/gjcourt/mopidy:2026-05-04 — first-party image built by
+          # .github/workflows/build-mopidy.yml from images/mopidy/. Tag-only is
+          # acceptable per AGENTS.md (CI guarantees date-tag immutability for
+          # first-party gjcourt/* images).
+          image: ghcr.io/gjcourt/mopidy:2026-05-04
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - configmap-mopidy.yaml
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
   - pdb.yaml
+  # secret-navidrome-credentials.yaml is created from the .yaml.example template
+  # and SOPS-encrypted by the operator before this PR can land. See PR body and
+  # docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
+  - secret-navidrome-credentials.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/snapcast/secret-navidrome-credentials.yaml.example
+++ b/apps/base/snapcast/secret-navidrome-credentials.yaml.example
@@ -1,0 +1,32 @@
+# Template for the navidrome-credentials Secret consumed by the mopidy sidecar.
+#
+# The actual encrypted version lives at:
+#   apps/base/snapcast/secret-navidrome-credentials.yaml
+# and should NEVER be committed in plaintext.
+#
+# To create it for the first time:
+#
+#   cp apps/base/snapcast/secret-navidrome-credentials.yaml.example \
+#      apps/base/snapcast/secret-navidrome-credentials.yaml
+#   # Edit the .yaml file and replace the PLACEHOLDER values below with real
+#   # Navidrome Subsonic credentials.
+#   sops -e -i apps/base/snapcast/secret-navidrome-credentials.yaml
+#
+# Then add `secret-navidrome-credentials.yaml` to apps/base/snapcast/kustomization.yaml
+# and commit.
+#
+# .sops.yaml's fallback creation_rule already covers any `*secret*.yaml` under
+# apps/, so SOPS will encrypt with the homelab age key automatically.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: navidrome-credentials
+  namespace: snapcast
+  labels:
+    app: snapcast
+type: Opaque
+stringData:
+  NAVIDROME_URL: "https://music.burntbytes.com"
+  NAVIDROME_USER: "PLACEHOLDER_REPLACE_BEFORE_SOPS"
+  NAVIDROME_PASSWORD: "PLACEHOLDER_REPLACE_BEFORE_SOPS"

--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -36,3 +36,11 @@ spec:
       port: 57622
       targetPort: 57622
       protocol: TCP
+
+    # MPD protocol — mopidy sidecar exposes port 6600 for clients
+    # (Symfonium, MALP, ncmpcpp). Browse the Navidrome library, queue
+    # tracks; audio streams into the snapcast `navidrome` source.
+    - name: mpd
+      port: 6600
+      targetPort: 6600
+      protocol: TCP

--- a/apps/base/snapcast/storage.yaml
+++ b/apps/base/snapcast/storage.yaml
@@ -11,3 +11,19 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+# Mopidy sidecar state: Subsonic library cache (mopidy-subidy) and Mopidy
+# bookkeeping. ~10–50 MB in practice; 1Gi gives plenty of headroom.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapcast-mopidy-state
+  namespace: snapcast
+  labels:
+    app: snapcast
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
+++ b/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: in-progress
 last_modified: 2026-05-03
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -54,7 +54,7 @@ Sorted by filing date (newest first).
 | [2026-05-02-hermes-bot-k8s.md](2026-05-02-hermes-bot-k8s.md) | `in-progress` | Hermes agent (Signal mode) deployed to melodic-muse so the bot is laptop-independent |
 | [2026-05-02-signal-cli-hermes-rollout.md](2026-05-02-signal-cli-hermes-rollout.md) | `superseded` | Signal-cli + signal-bridge stack to feed the Hermes agent (replaced by hermes-bot-k8s.md) |
 | [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | `complete` | IaC hardening — close the 22 findings from the 2026-05-02 critique |
-| [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | `planned` | Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio |
+| [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | `in-progress` | Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio |
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | `planned` | Cardboard drawer insert design (75×32×12 cm) |
 | [2026-03-08-bgp-rollout.md](2026-03-08-bgp-rollout.md) | `planned` | Move LoadBalancer IP advertisement from L2 to BGP with the UCGF |
 | [2026-03-08-adguard-dns-rollout.md](2026-03-08-adguard-dns-rollout.md) | `in-progress` | Roll AdGuard Home as the homelab DNS resolver |


### PR DESCRIPTION
## ⚠️ DRAFT — gated on operator action

Stages Phases 2-7 of [\`docs/plans/2026-03-14-navidrome-snapcast-mopidy.md\`](docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). After merge, MPD clients (Symfonium, MALP, ncmpcpp) can connect to the snapcast LB IP on TCP 6600 and stream the Navidrome library to any HifiBerry via the new \`navidrome\` snapcast source.

**CI will fail on this PR** until the operator creates the SOPS-encrypted credentials Secret. That failure is the gate.

## Operator unblock checklist

1. **Build and push the Mopidy image** (Phase 1 — out of scope for this PR but required before merge):
   ```bash
   mkdir -p images/mopidy
   # populate images/mopidy/Dockerfile per the plan
   docker buildx build \
     --platform linux/amd64,linux/arm64 \
     -t gjcourt/mopidy:3.4.2-1 \
     --push \
     images/mopidy
   ```
2. **Create the credentials Secret** (Phase 8):
   ```bash
   cp apps/base/snapcast/secret-navidrome-credentials.yaml.example \
      apps/base/snapcast/secret-navidrome-credentials.yaml
   # Edit the .yaml file: replace PLACEHOLDER values with real Navidrome
   # Subsonic credentials. (You can create a dedicated low-privilege user
   # in Navidrome's UI for the bot rather than using your own login.)
   sops -e -i apps/base/snapcast/secret-navidrome-credentials.yaml
   git add apps/base/snapcast/secret-navidrome-credentials.yaml
   git commit -m "feat(snapcast): SOPS-encrypted navidrome credentials"
   git push
   ```
3. **Mark this PR ready for review** and merge.

## What this PR contains

| File | Phase | Change |
|---|---|---|
| \`apps/base/snapcast/configmap-mopidy.yaml\` (new) | 2 | Mopidy config (envsubst-templated for Subsonic creds) — uses the full GStreamer pipeline so the FIFO gets raw S16LE PCM, not a container format |
| \`apps/base/snapcast/configmap.yaml\` | 3 | Adds the \`navidrome\` source line to snapserver.conf |
| \`apps/base/snapcast/deployment.yaml\` | 4 + 5 | New \`init-navidrome-fifo\` busybox initContainer (mkfifo) + Mopidy sidecar with envsubst entrypoint, MPD probe, and PVC mount at \`/mopidy-state\` |
| \`apps/base/snapcast/storage.yaml\` | 6 | Adds \`snapcast-mopidy-state\` PVC (1Gi) |
| \`apps/base/snapcast/service.yaml\` | 7 | Exposes TCP 6600 (\`mpd\`) on the snapcast LoadBalancer |
| \`apps/base/snapcast/secret-navidrome-credentials.yaml.example\` (new) | 8 (template) | Plaintext template — operator copies + SOPS-encrypts |
| \`apps/base/snapcast/kustomization.yaml\` | wiring | References the new ConfigMap and the (operator-created) Secret |
| \`docs/plans/2026-03-14-navidrome-snapcast-mopidy.md\` | — | Status \`planned\` → \`in-progress\` |
| \`docs/plans/README.md\` | — | Index update |

## Known caveats

- **Image is tag-only** (\`gjcourt/mopidy:3.4.2-1\`) — should be digest-pinned per AGENTS.md image discipline. Tag-only is acceptable while bootstrapping the image; the first follow-up after merge should be a digest pin.
- **\`envsubst\` requires gettext-base** — the Phase 1 Dockerfile in the plan installs \`gettext\` via apt; verify before push or the sidecar entrypoint will fail (\`sh: envsubst: not found\`).
- **No NetworkPolicy** for the new sidecar — the snapcast namespace isn't yet opted into the cluster's NetworkPolicy framework (only excalidraw is). Snapcast can be onboarded as part of the deferred Phase 1 fan-out from the critique remediation plan.
- **\`readOnlyRootFilesystem: false\`** — Mopidy writes to \`/tmp/mopidy-cache\`. The existing snapcast containers also don't set readOnly root, for consistency. Hardening is a separate follow-up.

## Test plan

- [x] \`kustomize build apps/base/snapcast/\` (with the secret reference temporarily commented out) passes locally — the new ConfigMap, init container, sidecar, PVC, and service port all render cleanly.
- [x] \`kustomize build apps/staging/snapcast/\` and \`apps/production/snapcast/\` also pass.
- [ ] After operator unblocks: \`kustomize build apps/base/snapcast/\` passes with the encrypted Secret in place.
- [ ] Pod comes up clean in staging — all 4 containers (\`init-fifo\`, \`init-spotify-fifo\`, \`init-navidrome-fifo\`) pass; main containers (\`snapserver\`, \`go-librespot\`, \`mopidy\`) become Ready.
- [ ] \`ncmpcpp -h <staging-snapcast-LB-IP> -p 6600\` connects, lists Navidrome library, queues a track.
- [ ] Audio plays on a HifiBerry assigned to the \`navidrome\` snapcast stream.
- [ ] Promote to production.
- [ ] Update \`docs/operations/apps/snapcast.md\` to document the new MPD source (follow-up).
- [ ] Flip plan to \`complete\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)