### PR TITLE
feat(hestia): tune llama-cpp inference for RTX 4090

### DIFF
--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -12,13 +12,17 @@ services:
       --alias Qwen3.6-35B-A3B
       --host 0.0.0.0
       --port 8080
-      --ctx-size 409600
-      --cache-type-k q8_0
-      --cache-type-v q8_0
+      --ctx-size 32768
+      --flash-attn on
+      --cache-type-k f16
+      --cache-type-v f16
       --n-gpu-layers 99
-      --parallel 1
+      --parallel 4
       --cont-batching
-      --threads 8
+      --threads 16
+      --threads-batch 16
+      --batch-size 512
+      --ubatch-size 512
       --temp 0.6
       --top-k 20
       --top-p 0.95


### PR DESCRIPTION
## Changes

- `--ctx-size 409600` → `32768`: 400K context was consuming 23GB of 24GB VRAM just for KV cache, causing constant CPU↔GPU transfers
- `--flash-attn on`: Enable FlashAttention2 for faster, more VRAM-efficient attention
- `--cache-type-k/v q8_0` → `f16`: KV cache fits comfortably now, no need for quantization
- `--parallel 1` → `4`: Allow concurrent requests
- `--threads 8` → `16` + `--threads-batch 16`: Faster prompt processing
- `--batch-size 512` + `--ubatch-size 512`: Better throughput

## Expected Impact

- **VRAM usage**: Should drop from ~23GB to ~8-10GB (model weights only, minimal KV cache)
- **Inference speed**: Expected 2-5x improvement in tokens/sec due to reduced CPU↔GPU transfers and FlashAttention2
- **TTFB**: Should drop significantly (currently ~1.6s for 200 tokens)

## Notes

- Model unchanged — still Qwen3.6-35B-A3B-UD-IQ4_NL.gguf
- 32K context is more than sufficient for any realistic conversation
- GHA runner will auto-deploy to TrueNAS on merge