### PR TITLE
feat(mopidy): image + build workflow (Phase 1 of navidrome-snapcast-mopidy)

### DIFF
--- a/.github/workflows/build-mopidy.yml
+++ b/.github/workflows/build-mopidy.yml
@@ -1,0 +1,66 @@
+name: Build mopidy
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/mopidy/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: gjcourt/mopidy
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: images/mopidy
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            docker.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            docker.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### mopidy published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`docker.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Update \`apps/base/snapcast/deployment.yaml\` mopidy container \`image:\` to this tag (or a digest pin), then rebase PR #426." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-mopidy.yml
+++ b/.github/workflows/build-mopidy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: docker.io
+  REGISTRY: ghcr.io
   IMAGE_NAME: gjcourt/mopidy
 
 jobs:
@@ -16,17 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -52,8 +53,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            docker.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-            docker.io/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -61,6 +62,6 @@ jobs:
         run: |
           echo "### mopidy published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`docker.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Update \`apps/base/snapcast/deployment.yaml\` mopidy container \`image:\` to this tag (or a digest pin), then rebase PR #426." >> $GITHUB_STEP_SUMMARY

--- a/images/mopidy/Dockerfile
+++ b/images/mopidy/Dockerfile
@@ -1,0 +1,45 @@
+# Multi-arch Mopidy image for the Snapcast pod's MPD/Subsonic sidecar.
+#
+# Mopidy bridges Navidrome (Subsonic API) into Snapcast: MPD clients connect on
+# 6600, Mopidy fetches the library via mopidy-subidy, and the GStreamer audio
+# pipeline writes raw S16LE PCM into a shared FIFO that snapserver reads as the
+# `navidrome` source. See docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
+
+FROM python:3.12-slim-bookworm
+
+# Runtime deps:
+#   - gstreamer1.0-plugins-{base,good} + tools — the audio pipeline (audioresample,
+#     audioconvert, filesink) and `gst-inspect-1.0` for debugging.
+#   - libcairo2 — pulled in by Mopidy's Pykka/dbus stack.
+#   - libgstreamer1.0-0 / libgstreamer-plugins-base1.0-0 — GStreamer core libs.
+#   - gettext-base — provides `envsubst`, which the snapcast pod's mopidy
+#     entrypoint runs to expand ${NAVIDROME_*} env vars from the Subsonic
+#     credentials Secret into /tmp/mopidy.conf before invoking mopidy. Without
+#     this the sidecar fails with `sh: envsubst: not found`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gettext-base \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-tools \
+        libcairo2 \
+        libgstreamer-plugins-base1.0-0 \
+        libgstreamer1.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        mopidy==3.4.2 \
+        mopidy-mpd==3.3.0 \
+        mopidy-subidy==0.9.1 \
+        mopidy-local==3.2.1
+
+# Match the snapcast pod's `runAsUser: 1000` / `fsGroup: 1000`. The sidecar
+# only writes to /tmp (cache) and the mopidy-state PVC mounted at /mopidy-state,
+# both writable by UID 1000 via fsGroup, so no extra chown is needed at build.
+RUN groupadd --system --gid 1000 mopidy \
+    && useradd --system --uid 1000 --gid 1000 --home-dir /mopidy-state --shell /usr/sbin/nologin mopidy
+
+USER 1000:1000
+
+EXPOSE 6600
+
+ENTRYPOINT ["/usr/local/bin/mopidy"]

--- a/images/mopidy/README.md
+++ b/images/mopidy/README.md
@@ -1,0 +1,94 @@
+# mopidy
+
+Custom multi-arch [Mopidy](https://mopidy.com) image for the Snapcast pod's MPD
+sidecar. Bridges Navidrome's Subsonic API into Snapcast so MPD clients
+(Symfonium, MALP, ncmpcpp) can browse the Navidrome library and stream PCM
+into the `navidrome` Snapcast source.
+
+See `docs/plans/2026-03-14-navidrome-snapcast-mopidy.md` for the full design.
+
+## Architecture
+
+```
+MPD client ──TCP:6600──► mopidy sidecar ──Subsonic──► Navidrome
+                              │
+                              ▼  GStreamer pipeline
+                              audioresample ! audioconvert
+                              ! audio/x-raw,rate=44100,channels=2,format=S16LE
+                              ! filesink location=/audio/navidrome.fifo
+                              │
+                              ▼
+                      snapserver (snapcast pod) ──► HifiBerry clients
+```
+
+## What's installed
+
+| Package          | Version  | Purpose                                          |
+|------------------|----------|--------------------------------------------------|
+| `mopidy`         | `3.4.2`  | Music server core                                |
+| `mopidy-mpd`     | `3.3.0`  | MPD protocol frontend (port 6600)                |
+| `mopidy-subidy`  | `0.9.1`  | Subsonic backend — talks to Navidrome            |
+| `mopidy-local`   | `3.2.1`  | Local-library backend (disabled in snapcast use) |
+
+System packages (Debian bookworm):
+- `gstreamer1.0-plugins-base`, `gstreamer1.0-plugins-good`, `gstreamer1.0-tools`
+  — audio pipeline elements + `gst-inspect-1.0` for debugging.
+- `libcairo2`, `libgstreamer1.0-0`, `libgstreamer-plugins-base1.0-0` — runtime
+  libs.
+- `gettext-base` — provides `envsubst`, used by the snapcast pod's mopidy
+  sidecar entrypoint to expand `${NAVIDROME_*}` env vars from the
+  `navidrome-credentials` Secret into the Mopidy config at startup. Not
+  installed in upstream Mopidy images; required for the sidecar's entrypoint.
+
+## Runtime contract
+
+| Convention | Value | Notes |
+|---|---|---|
+| User | `1000:1000` | Matches snapcast pod's `runAsUser: 1000` / `fsGroup: 1000` |
+| MPD port | `6600/tcp` | Exposed for clients via the snapcast Service |
+| Config path | `/etc/mopidy/mopidy.conf` (mounted from `mopidy-config` ConfigMap) | The pod's entrypoint runs `envsubst` and writes the resolved file to `/tmp/mopidy.conf` before invoking `mopidy --config /tmp/mopidy.conf`. |
+| State dir | `/mopidy-state` (PVC `snapcast-mopidy-state`, 1Gi) | Subsonic library cache + Mopidy bookkeeping. |
+| Cache dir | `/tmp/mopidy-cache` (emptyDir / tmpfs via container `/tmp`) | |
+| Audio sink | `/audio/navidrome.fifo` (shared `audio-pipes` emptyDir) | Created by the `init-navidrome-fifo` initContainer; snapserver reads as a `pipe://` source. |
+| Subsonic creds | `NAVIDROME_URL`, `NAVIDROME_USER`, `NAVIDROME_PASSWORD` env vars | Sourced from the SOPS-encrypted `navidrome-credentials` Secret. |
+
+## Image build
+
+Images are published to `docker.io/gjcourt/mopidy` by the GHA workflow
+`.github/workflows/build-mopidy.yml` on every push to `master` that touches
+`images/mopidy/**`, plus `workflow_dispatch` for manual runs.
+
+Tag format: `YYYY-MM-DD` (first build of the day) or `YYYY-MM-DD-N` (reruns of
+the same workflow). Multi-arch: `linux/amd64` and `linux/arm64`. The `latest`
+tag is also moved to the most recent build.
+
+The snapcast pod's deployment manifest (`apps/base/snapcast/deployment.yaml`)
+should be retagged to point at the date tag produced by the first CI build of
+this image. Subsequent updates should digest-pin per AGENTS.md image
+discipline.
+
+## Local build
+
+```bash
+docker build -t gjcourt/mopidy:dev images/mopidy
+```
+
+For a multi-arch local build (matches CI):
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t gjcourt/mopidy:dev \
+  --load \
+  images/mopidy
+```
+
+## Smoke test
+
+```bash
+# Confirm mopidy + plugins all load
+docker run --rm --entrypoint mopidy gjcourt/mopidy:dev --version
+
+# Confirm envsubst is present (sidecar entrypoint requirement)
+docker run --rm --entrypoint envsubst gjcourt/mopidy:dev --help
+```

--- a/images/mopidy/README.md
+++ b/images/mopidy/README.md
@@ -54,9 +54,10 @@ System packages (Debian bookworm):
 
 ## Image build
 
-Images are published to `docker.io/gjcourt/mopidy` by the GHA workflow
+Images are published to `ghcr.io/gjcourt/mopidy` by the GHA workflow
 `.github/workflows/build-mopidy.yml` on every push to `master` that touches
-`images/mopidy/**`, plus `workflow_dispatch` for manual runs.
+`images/mopidy/**`, plus `workflow_dispatch` for manual runs. Authentication
+uses the auto-provisioned `GITHUB_TOKEN` — no operator-set secrets required.
 
 Tag format: `YYYY-MM-DD` (first build of the day) or `YYYY-MM-DD-N` (reruns of
 the same workflow). Multi-arch: `linux/amd64` and `linux/arm64`. The `latest`


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/plans/2026-03-14-navidrome-snapcast-mopidy.md`](docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). Adds a custom Mopidy image + CI build workflow so the snapcast pod's MPD/Subsonic sidecar (PR #426) has an image to pull. Removes the manual `docker buildx ... --push` step the plan originally called for.

PR #426 (Phases 2-7) is gated on this PR landing first — once a date-tagged image exists in `docker.io/gjcourt/mopidy`, PR #426's `image:` reference is retagged off the placeholder `gjcourt/mopidy:3.4.2-1`.

## What's in this PR

| File | Purpose |
|---|---|
| `images/mopidy/Dockerfile` | `python:3.12-slim-bookworm` + mopidy 3.4.2, mopidy-mpd 3.3.0, mopidy-subidy 0.9.1, mopidy-local 3.2.1; full GStreamer stack; runs as UID 1000 to match the snapcast pod's `runAsUser`. |
| `images/mopidy/README.md` | Image purpose, runtime contract, smoke-test steps. Mirrors `images/signal-bridge/README.md`. |
| `.github/workflows/build-mopidy.yml` | Push to `master` (path-filtered on `images/mopidy/**`) + `workflow_dispatch`. Multi-arch (`linux/amd64`, `linux/arm64`) via QEMU + buildx. Pushes to `docker.io/gjcourt/mopidy:<YYYY-MM-DD>[-N]` and `:latest`. |

## Notable additions vs the plan

- **`gettext-base` is installed** — not in the plan's Dockerfile sketch, but required because the snapcast pod's mopidy sidecar entrypoint runs `envsubst < /etc/mopidy/mopidy.conf > /tmp/mopidy.conf` to expand `${NAVIDROME_*}` env vars from the `navidrome-credentials` Secret before invoking mopidy. Without `gettext-base`, the sidecar fails immediately with `sh: envsubst: not found`. The PR #426 description already calls this out as a Phase 1 prerequisite.
- **Non-root `USER 1000:1000`** — Mopidy upstream runs as root by default. Setting UID 1000 in the image matches the snapcast pod's `securityContext.runAsUser: 1000` / `fsGroup: 1000`.

## Tag scheme

Matches `build-signal-bridge.yml`: `YYYY-MM-DD` for the first build of a UTC day, `YYYY-MM-DD-N` for reruns of the same workflow attempt. Multi-arch manifest list at each tag plus a `:latest` mover. Per AGENTS.md: tags are strictly increasing.

## Registry choice

Sibling images in `apps/base/snapcast/deployment.yaml` (`gjcourt/snapcast:0.34.0-snapweb0.9.3`, `gjcourt/go-librespot:v0.6.2-1`) have no registry prefix and resolve to `docker.io`, so this image targets `docker.io/gjcourt/mopidy` as well. This is the **first Docker Hub workflow in this repo** — `build-signal-bridge.yml` publishes to `ghcr.io` using the auto-provisioned `GITHUB_TOKEN`. This workflow needs `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to be added to the repository's Actions secrets before the first run will succeed.

## Test plan

- [x] `yamllint -c .yamllint .github/workflows/build-mopidy.yml` passes (clean).
- [ ] Operator sets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` repo secrets.
- [ ] After merge, `Build mopidy` workflow runs and publishes `docker.io/gjcourt/mopidy:<YYYY-MM-DD>` (multi-arch manifest list, amd64 + arm64).
- [ ] `docker run --rm --entrypoint mopidy docker.io/gjcourt/mopidy:<tag> --version` lists mopidy 3.4.2 + the three plugins.
- [ ] `docker run --rm --entrypoint envsubst docker.io/gjcourt/mopidy:<tag> --help` succeeds (proves `gettext-base` is in the layer).
- [ ] Retag PR #426's mopidy container `image:` to the published date tag (or digest-pin), encrypt the `secret-navidrome-credentials.yaml` Secret, mark PR #426 ready for review, merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)