### PR TITLE
feat(adguard): bump volumeClaimTemplate sizes 1Gi → 5Gi

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -98,6 +98,12 @@ spec:
             - mountPath: /opt/adguardhome/work
               name: work
 
+  # NOTE: volumeClaimTemplates are immutable for already-existing PVCs.
+  # Bumping these values affects only PVCs created for *new* pod ordinals
+  # (e.g., a third replica). To resize existing PVCs, run the manual
+  # `kubectl patch pvc` step documented in
+  # docs/plans/2026-02-15-adguard-ha.md (or just patch on the cluster).
+  # Synology CSI supports online volume expansion.
   volumeClaimTemplates:
     - metadata:
         name: config
@@ -106,7 +112,7 @@ spec:
         storageClassName: synology-iscsi
         resources:
           requests:
-            storage: 1Gi
+            storage: 5Gi
     - metadata:
         name: work
       spec:
@@ -114,4 +120,4 @@ spec:
         storageClassName: synology-iscsi
         resources:
           requests:
-            storage: 1Gi
+            storage: 5Gi


### PR DESCRIPTION
## Summary

Bring the StatefulSet's \`volumeClaimTemplates\` in line with how production was manually expanded. The original 1Gi default filled with query logs (logged in [the AdGuard HA plan](docs/plans/2026-02-15-adguard-ha.md)). \`work-adguard-0\` was manually grown to 5Gi at the time; the other three PVCs stayed at 1Gi.

## What this PR does (and doesn't)

| | Effect |
|---|---|
| ✅ Update \`config\` and \`work\` templates 1Gi → 5Gi | Future replicas (e.g. \`replicas: 3\`) get correctly-sized PVCs |
| ✅ Add inline comment on the volumeClaimTemplate block | Reminds the next operator of the immutability caveat |
| ❌ Resize *existing* PVCs | Kustomize / kubectl apply can't change a volumeClaimTemplate that's already bound. Need manual \`kubectl patch\` (below). |

## Post-merge ops (run on cluster — Synology CSI supports online expansion)

\`\`\`bash
kubectl patch pvc config-adguard-0 -n adguard-prod \\
  -p '{"spec":{"resources":{"requests":{"storage":"5Gi"}}}}'
kubectl patch pvc config-adguard-1 -n adguard-prod \\
  -p '{"spec":{"resources":{"requests":{"storage":"5Gi"}}}}'
kubectl patch pvc work-adguard-1 -n adguard-prod \\
  -p '{"spec":{"resources":{"requests":{"storage":"5Gi"}}}}'
\`\`\`

\`work-adguard-0\` is already at 5Gi from the prior manual expansion. Staging only has \`-0\` ordinals (single replica) so consider whether you want to patch them too — they're inert at 1Gi but technically out of spec.

\`\`\`bash
# Verify after patching
kubectl get pvc -n adguard-prod
\`\`\`

Each PVC should report \`Capacity: 5Gi\` once the Synology CSI driver propagates the resize (usually within seconds).

## Verification

\`\`\`
kustomize build apps/production/adguard/  → 611 lines, both PVCs show storage: 5Gi
kustomize build apps/staging/adguard/     → OK
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)