### PR TITLE
feat(security): pod security baseline batch 2 (Phase 1 PR 1.2 fan-out)

### DIFF
--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -85,10 +86,22 @@ spec:
               subPath: proxmox.yaml
             - mountPath: /app/config/logs
               name: logs
+            # Next.js standalone server writes its image-optimization cache
+            # under /app/.next/cache; required when readOnlyRootFilesystem
+            # is enabled.
+            - mountPath: /app/.next/cache
+              name: next-cache
+            # Generic /tmp for any tempfile writes during render.
+            - mountPath: /tmp
+              name: tmp
 
       volumes:
         - name: homepage-config
           configMap:
             name: homepage
         - name: logs
+          emptyDir: {}
+        - name: next-cache
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -18,10 +18,15 @@ spec:
     spec:
       serviceAccountName: synology-iscsi-monitor
       automountServiceAccountToken: false
+      # The python:3.14-slim base image has no USER directive and runs as
+      # root by default; pinning the pod to UID 1000 with fsGroup is
+      # intentional. The exporter only ever talks to the Synology over SSH
+      # and serves Prometheus metrics — it has no on-disk state.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -33,6 +38,10 @@ spec:
             - |
               pip install --user paramiko prometheus_client && python /app/exporter.py
           env:
+            # HOME=/tmp lets `pip install --user` and paramiko (which writes
+            # ~/.ssh/known_hosts via AutoAddPolicy) work under
+            # readOnlyRootFilesystem — the /tmp emptyDir below is the
+            # writable target for both.
             - name: HOME
               value: "/tmp"
             - name: PYTHONUNBUFFERED
@@ -68,13 +77,21 @@ spec:
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
           volumeMounts:
             - name: script-volume
               mountPath: /app
+            # `pip install --user` writes to $HOME/.local and paramiko writes
+            # ~/.ssh/known_hosts; both resolve under HOME=/tmp. Required when
+            # readOnlyRootFilesystem is enabled.
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: script-volume
           configMap:
             name: synology-iscsi-exporter-script
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary

Continues the Phase 1 / PR 1.2 pod-security baseline fan-out from
[`docs/plans/2026-05-02-critique-remediation.md`](docs/plans/2026-05-02-critique-remediation.md),
picking up where canary PR #398 (mealie/memos/audiobookshelf) and PR #404
(hermes parity) left off. Pattern is identical to PR #398: pod-level
`runAsNonRoot` + `fsGroup` + seccomp; container-level
`allowPrivilegeEscalation: false` + `readOnlyRootFilesystem: true` +
`drop: [ALL]`; emptyDir mounts for any path the app must write to.

Two apps brought to full baseline this round:

- **homepage** — UID 1000 (already set). Adds `readOnlyRootFilesystem: true`
  plus two emptyDir mounts: `/app/.next/cache` (Next.js standalone image
  cache) and `/tmp`. The upstream entrypoint's chown calls already tolerate
  failure and `/app/config` was built `--chown=1000:1000`, so they're
  no-ops in practice. The v1.10 `proxmox.yaml` EACCES bug is already
  worked around by mounting that file from the configmap (see commit
  9c49ed9).
- **synology-iscsi-monitor** — UID 1000 (already set). Adds `fsGroup: 1000`
  and `readOnlyRootFilesystem: true` with a `/tmp` emptyDir. The pod's
  startup `pip install --user` and paramiko's `AutoAddPolicy`
  `~/.ssh/known_hosts` both resolve under `HOME=/tmp` (already set in env).

### Audit table — current state of `apps/base/<app>` security context

| App | runAsNonRoot | seccomp | allowPrivEsc:false | drop:[ALL] | readOnlyRootFs | Notes |
|---|---|---|---|---|---|---|
| adguard | no | yes | yes | yes | no | DNS:53 + first-boot writes; **skip** |
| audiobookshelf | yes | yes | yes | yes | yes | done in #398 |
| authelia | yes | yes | yes | yes | **false (documented)** | writes /app/.healthcheck.env; **skip** |
| excalidraw | no | yes | no | no | no | nginx master needs root to bind :80; **skip** |
| golinks | yes | yes | yes | yes | yes | already fully baselined |
| hermes / hermes-callee | yes | yes | yes | yes | no | done in #404; uv venv conflicts with rOFs; **defer** |
| homeassistant | no | yes | yes | yes | no | image runs as root; **skip** |
| **homepage** | yes | yes | yes | yes | **no → yes (this PR)** | + /app/.next/cache + /tmp emptyDirs |
| immich | partial | yes | partial | partial | partial | GPU/ML; **skip** |
| jellyfin | no | yes | no | no | no | GPU passthrough; **skip** |
| linkding | yes | yes | yes | yes | no | supervisord conflict (documented in PR #398 body); **skip** |
| mealie | yes | yes | yes | yes | yes | done in #398 |
| memos | yes | yes | yes | yes | yes | done in #398 |
| navidrome | yes | yes | yes | yes | **false (explicit)** | deferred until writable paths mapped |
| overture | yes | yes | yes (both) | yes (both) | partial (tempo-bridge:false) | **defer** tempo-bridge until image-source review |
| signal-cli | none | none | no | no | no | no securityContext at all — needs full research, not a baseline patch; **skip** |
| snapcast | yes | yes | yes (4 ctrs) | yes (4 ctrs) | no | multi-container audio + /dev; **skip** |
| **synology-iscsi-monitor** | yes | yes | yes | yes | **no → yes (this PR)** | + /tmp emptyDir, + fsGroup=1000 |
| vitals | yes | yes | yes | yes | yes | already fully baselined |

### Apps baselined in this PR

| App | UID/GID/fsGroup | New emptyDir mounts |
|---|---|---|
| homepage | 1000 (unchanged) | `/app/.next/cache`, `/tmp` |
| synology-iscsi-monitor | 1000 + new `fsGroup: 1000` | `/tmp` |

### Apps explicitly skipped

See the audit table's Notes column. Briefly: adguard, authelia, excalidraw,
hermes, hermes-callee, homeassistant, immich, jellyfin, linkding, navidrome,
overture (tempo-bridge), signal-cli, snapcast — each has a known constraint
documented above. Subsequent batches can address them individually with
app-specific research (e.g., nginx-unprivileged for excalidraw, supervisord
config redirects for linkding).

## Test plan

- [x] `kustomize build apps/base/homepage` passes
- [x] `kustomize build apps/staging/homepage` passes
- [x] `kustomize build apps/production/homepage` passes
- [x] `kustomize build apps/base/synology-iscsi-monitor` passes
- [x] `kustomize build apps/production/synology-iscsi-monitor` passes (no staging variant)
- [x] `kustomize build apps/staging` passes
- [x] `kustomize build apps/production` passes
- [x] No plaintext secrets in diff
- [ ] Post-merge: `kubectl -n homepage-stage get pods` — pod stays Running, no CrashLoopBackOff from EROFS
- [ ] Post-merge: homepage UI still serves at the staging URL (image optimization works)
- [ ] Post-merge: `kubectl -n synology-iscsi-monitor get pods` — pod stays Running
- [ ] Post-merge: `synology_iscsi_lun_size_bytes` still scraped by Prometheus (verify in Grafana / `kubectl logs deploy/synology-iscsi-exporter`)
- [ ] If any regression: revert this PR; the canary pattern from PR #398 is unaffected.

Refs: `docs/plans/2026-05-02-critique-remediation.md` (Phase 1 / PR 1.2);
canary pattern PR #398; hermes parity PR #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)