### PR TITLE
fix(mopidy): bump mopidy-subidy 0.9.1 → 1.1.0 (PyPI fix)

### DIFF
--- a/images/mopidy/Dockerfile
+++ b/images/mopidy/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
         mopidy==3.4.2 \
         mopidy-mpd==3.3.0 \
-        mopidy-subidy==0.9.1 \
+        mopidy-subidy==1.1.0 \
         mopidy-local==3.2.1
 
 # Match the snapcast pod's `runAsUser: 1000` / `fsGroup: 1000`. The sidecar

--- a/images/mopidy/README.md
+++ b/images/mopidy/README.md
@@ -27,7 +27,7 @@ MPD client ──TCP:6600──► mopidy sidecar ──Subsonic──► Navidr
 |------------------|----------|--------------------------------------------------|
 | `mopidy`         | `3.4.2`  | Music server core                                |
 | `mopidy-mpd`     | `3.3.0`  | MPD protocol frontend (port 6600)                |
-| `mopidy-subidy`  | `0.9.1`  | Subsonic backend — talks to Navidrome            |
+| `mopidy-subidy`  | `1.1.0`  | Subsonic backend — talks to Navidrome            |
 | `mopidy-local`   | `3.2.1`  | Local-library backend (disabled in snapcast use) |
 
 System packages (Debian bookworm):


### PR DESCRIPTION
## Summary

The Mopidy build workflow (#436) failed on first run because the plan's Dockerfile spec pinned \`mopidy-subidy==0.9.1\`, which doesn't exist on PyPI. Only \`1.0.0\` and \`1.1.0\` are published. Bumping to \`1.1.0\` (latest, supports Mopidy 3.x).

## Test plan

- [ ] Build workflow runs on merge and produces \`ghcr.io/gjcourt/mopidy:<date>\`
- [ ] Tag visible at https://github.com/gjcourt/homelab/pkgs/container/mopidy

🤖 Generated with [Claude Code](https://claude.com/claude-code)