### PR TITLE
revert: "feat(hestia): tune llama-cpp inference for 4090" (#434)

### DIFF
--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -12,17 +12,13 @@ services:
       --alias Qwen3.6-35B-A3B
       --host 0.0.0.0
       --port 8080
-      --ctx-size 32768
-      --flash-attn on
-      --cache-type-k f16
-      --cache-type-v f16
+      --ctx-size 409600
+      --cache-type-k q8_0
+      --cache-type-v q8_0
       --n-gpu-layers 99
-      --parallel 4
+      --parallel 1
       --cont-batching
-      --threads 16
-      --threads-batch 16
-      --batch-size 512
-      --ubatch-size 512
+      --threads 8
       --temp 0.6
       --top-k 20
       --top-p 0.95


### PR DESCRIPTION
## Summary

Revert PR #434. Operator reports the new flag set made inference on the 4090 \"nearly unusable\" — performance regression severe enough to need an immediate rollback. Restore the prior known-working configuration on \`hosts/hestia/llms/docker-compose-llama-cpp.yml\` while we systematically benchmark each change.

## What this restores

| Flag | #434 introduced | This PR restores |
|---|---|---|
| \`--ctx-size\` | \`32768\` | \`409600\` |
| \`--flash-attn\` | \`on\` | (unset) |
| \`--cache-type-k\`/\`-v\` | \`f16\` | \`q8_0\` |
| \`--parallel\` | \`4\` | \`1\` |
| \`--threads\` | \`16\` (+ \`--threads-batch 16\`) | \`8\` |
| \`--batch-size\` / \`--ubatch-size\` | \`512\` / \`512\` | (default) |

This is a vanilla \`git revert\` of \`8b66868\` — no other changes.

## Why \"systematically benchmark\" matters

PR #434 changed **six flags simultaneously**, so the regression's root cause isn't isolable from a single read. Likely contributors include:

- **\`f16\` KV cache vs. \`q8_0\`**: f16 doubles the per-token KV memory; with 4 parallel slots and even moderate context, total KV scales aggressively.
- **\`--parallel 4\`**: inflates effective batch + KV memory; Qwen3.6-35B-A3B's MoE expert routing under concurrency may also be the culprit.
- **\`--threads 16 / --threads-batch 16\`**: may oversubscribe physical cores; the original 8 was probably tuned for the host's actual core count.
- **\`--ctx-size\` reduction is generally good** for VRAM pressure — that one likely isn't the regression on its own.

A real fix changes one flag at a time and measures.

## Plan once this lands

I'll open a follow-up plan doc \`docs/plans/2026-05-04-llama-cpp-benchmarking.md\` proposing:

1. Baseline measurement on the reverted config: cold-start latency, first-token latency, tokens/sec (decode), tokens/sec (prefill), peak VRAM, all under a fixed prompt corpus.
2. \`llama-bench\` for synthetic perf (decoding + prefill across context lengths) — hermetic, no Hermes-shaped variability.
3. End-to-end measurement against Hermes / a curl harness for realistic prompt + tool-use shapes.
4. Then iterate one flag at a time on the values from #434, recording the before/after delta. Land the wins individually so future regressions can be bisected.

## Bootstrap order

1. Merge this PR.
2. Hestia GHA runner (if bootstrapped) auto-deploys the reverted compose. Otherwise the operator pastes manually into SCALE UI per \`hosts/hestia/README.md\`.
3. Verify inference responsive again — \`curl http://10.42.2.10:8000/v1/models\` returns and a small completion roundtrips at the previously-acceptable latency.
4. Open the benchmarking plan PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)