### PR TITLE
feat(images): llama-cpp-bench image with llama-bench binary

### DIFF
--- a/.github/workflows/build-llama-cpp-bench.yml
+++ b/.github/workflows/build-llama-cpp-bench.yml
@@ -1,0 +1,64 @@
+name: Build llama-cpp-bench
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/llama-cpp-bench/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/llama-cpp-bench
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: images/llama-cpp-bench
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### llama-cpp-bench published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Update \`hosts/hestia/llms/docker-compose-llama-cpp.yml\` to reference \`llama-cpp-bench\` image with the \`llama-bench\` command, then paste into SCALE UI." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-llama-cpp-bench.yml
+++ b/.github/workflows/build-llama-cpp-bench.yml
@@ -51,7 +51,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-            ghcr.io/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -1,6 +1,6 @@
 services:
   llama:
-    image: ghcr.io/gjcourt/llama-cpp-bench:latest
+    image: ghcr.io/gjcourt/llama-cpp-bench:2026-05-04
     container_name: llama
     restart: unless-stopped
     volumes:

--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -1,6 +1,6 @@
 services:
   llama:
-    image: ghcr.io/ggml-org/llama.cpp@sha256:a8c56356fbfde209910b8098d0a060f4b84997f23b65491df3f2b61fae91dd7b
+    image: ghcr.io/gjcourt/llama-cpp-bench:latest
     container_name: llama
     restart: unless-stopped
     volumes:

--- a/images/llama-cpp-bench/Dockerfile
+++ b/images/llama-cpp-bench/Dockerfile
@@ -1,0 +1,49 @@
+# llama.cpp image extended with llama-bench for kernel-level benchmarking.
+#
+# Base: official ggml-org/llama.cpp image (digest-pinned, CUDA-enabled).
+# Adds: llama-bench binary from the Ubuntu x64 release.
+#
+# Usage:
+#   docker run --rm --gpus all -v /models:/models \
+#     ghcr.io/gjcourt/llama-cpp-bench:2026-05-04 \
+#     llama-bench -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf --n-gpu-layers 99 -p 256,1024 -n 128 -r 5 -o md
+
+# Stage 1: pull the base image and give it a name we can COPY from
+ARG BASE_IMAGE=ghcr.io/ggml-org/llama.cpp@sha256:a8c56356fbfde209910b8098d0a060f4b84997f23b65491df3f2b61fae91dd7b
+FROM ${BASE_IMAGE} AS ggml-base
+
+# Stage 2: build on top of the base, adding llama-bench
+FROM ${BASE_IMAGE}
+
+ARG LLAMA_CPP_RELEASE=b9012
+ARG UBUNTU_TARBALL_URL="https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_RELEASE}/llama-${LLAMA_CPP_RELEASE}-bin-ubuntu-x64.tar.gz"
+
+# Download the Ubuntu release tarball and extract only llama-bench
+RUN set -eu; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL -o "${tmp}/llama.tar.gz" "${UBUNTU_TARBALL_URL}"; \
+    tar xzf "${tmp}/llama.tar.gz" -C "${tmp}"; \
+    cp "${tmp}/llama-${LLAMA_CPP_RELEASE}/llama-bench" /usr/local/bin/llama-bench; \
+    chmod 755 /usr/local/bin/llama-bench; \
+    rm -rf "${tmp}"
+
+# Copy the base image's shared libraries into /usr/local/lib/ so llama-bench
+# can find them at runtime. We copy everything from /app/ to be safe.
+COPY --from=ggml-base /app/ /usr/local/lib/
+
+# Create symlinks for the versioned library files so the dynamic linker
+# can resolve SONAMEs. Only process concrete versioned files (not symlinks).
+RUN set -eu; \
+    cd /usr/local/lib; \
+    for f in libggml-base.so.* libggml.so.* libllama-common.so.* libllama.so.* libmtmd.so.*; do \
+        [ -f "$f" ] || continue; \
+        [ -L "$f" ] && continue; \
+        base="${f%%.*}"; \
+        mid="${f%.*}"; \
+        ln -sf "$f" "$mid"; \
+        ln -sf "$mid" "$base"; \
+    done; \
+    ldconfig
+
+# Verify the binary loads correctly
+RUN llama-bench --help | head -1

--- a/images/llama-cpp-bench/README.md
+++ b/images/llama-cpp-bench/README.md
@@ -1,0 +1,35 @@
+# llama-cpp-bench
+
+llama.cpp image extended with `llama-bench` for kernel-level benchmarking.
+
+## Base image
+
+Digest-pinned from `ghcr.io/ggml-org/llama.cpp` (CUDA-enabled).
+
+## What's added
+
+- `llama-bench` binary from the official Ubuntu x64 release tarball
+- Required shared libraries (`libllama*.so*`, `libggml*.so*`, `libmtmd*.so*`)
+- `ldconfig` run so the dynamic linker finds the libs
+
+## Building
+
+```bash
+docker buildx build -t llama-cpp-bench:latest -f images/llama-cpp-bench/Dockerfile .
+```
+
+## CI
+
+Built automatically on push to `master` (triggered by changes to `images/llama-cpp-bench/**`).
+Also available via `workflow_dispatch` from the GitHub Actions tab.
+
+Tags: `YYYY-MM-DD` (first build) / `YYYY-MM-DD-N` (retries).
+
+## Usage
+
+```bash
+docker run --rm --gpus all -v /models:/models \
+  ghcr.io/gjcourt/llama-cpp-bench:2026-05-04 \
+  llama-bench -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf \
+    --n-gpu-layers 99 -p 256,1024 -n 128 -r 5 -o md
+```


### PR DESCRIPTION
## Summary

Adds a custom Docker image that layers `llama-bench` onto the official llama.cpp image, enabling kernel-level synthetic benchmarking on the RTX 4090. Also switches the llama.cpp service to use the new image.

## What's in this PR

| File | Purpose |
|---|---|
| `images/llama-cpp-bench/Dockerfile` | Multi-stage build: pulls the official image as `ggml-base`, downloads `llama-bench` from the Ubuntu x64 release tarball, copies base image libs into `/usr/local/lib/` with SONAME symlink resolution |
| `.github/workflows/build-llama-cpp-bench.yml` | CI workflow: builds on push to master (triggered by changes to `images/llama-cpp-bench/**`), pushes to `ghcr.io/gjcourt/llama-cpp-bench` with date tags only |
| `images/llama-cpp-bench/README.md` | Usage docs |
| `hosts/hestia/llms/docker-compose-llama-cpp.yml` | Switches image from `ghcr.io/ggml-org/llama.cpp` to `ghcr.io/gjcourt/llama-cpp-bench:2026-05-04` |

## Why a custom image

The official `ghcr.io/ggml-org/llama.cpp` image only ships `llama-server` — no `llama-bench`. The Ubuntu x64 release tarball includes `llama-bench` but was built against different library SONAME versions than the official image, so we copy the base image's libraries and create proper symlinks.

## Usage

```bash
docker run --rm --gpus all -v /models:/models \
  ghcr.io/gjcourt/llama-cpp-bench:2026-05-04 \
  llama-bench -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf \
    --n-gpu-layers 99 -p 256,1024 -n 128 -r 5 -o md
```

## Tagging

- `YYYY-MM-DD` (first build of day) — idempotent, date-pinned
- `YYYY-MM-DD-N` (retry attempts on the same day)
- No `:latest` tag — always use the specific date tag for reproducibility

The docker-compose references `2026-05-04`. On subsequent days, update the tag in the docker-compose to the current date after CI builds.
