### PR TITLE
fix(renovate-automerge): rotate Gmail App Password for SMTP

### DIFF
--- a/infra/controllers/renovate-automerge/secret.yaml
+++ b/infra/controllers/renovate-automerge/secret.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secret-renovate-automerge-env
-  namespace: renovate
+    name: secret-renovate-automerge-env
+    namespace: renovate
 stringData:
-  SMTP_USER: ENC[AES256_GCM,data:rlLiDva1JxxAFDIdCuQzZlk=,iv:682upu6YfdPRYDtczzPfIILPYKGt9WX9caMnbicH8Ic=,tag:iOQIT8HP2uaq3uK7NyRuVQ==,type:str]
-  SMTP_PASS: ENC[AES256_GCM,data:EXTSGAtAftOBGq4kmfq05vrQLAbLB2IVtClTc3nNUw==,iv:uPD+VD2ceDdedlqxyNz493qlCuqvRBLo3HZ50cfxyuI=,tag:cQ36t1CqCaswsfCy7H2ywQ==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:rlLiDva1JxxAFDIdCuQzZlk=,iv:682upu6YfdPRYDtczzPfIILPYKGt9WX9caMnbicH8Ic=,tag:iOQIT8HP2uaq3uK7NyRuVQ==,type:str]
+    SMTP_PASS: ENC[AES256_GCM,data:42R2YUSLb1EpJd5XY+LEwmIvWg==,iv:zzd4FEkMQKjiaOnjGfyyHQKesg+fE9VWrG83/QCcRQk=,tag:HrC7nas8bl86joz+vDmN2A==,type:str]
 sops:
-  age:
-    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVUxGMFo1MkZBT2Ztbkc5
-        Tm05R0xneGZhb2tYMnlRTnV4QVFoYTU5YnhZCndmelNUY0V1MzJxNzVZN0NNVFoy
-        NWJwQWFlK3ZKbDRtYzVKRnh4UzBqa00KLS0tIG1pVW5YNGhRRTQvUUVpWUZDblM3
-        Q2gzUVlkc2NOTUdyaXVnWWdCQUFrQVkKfLveOyNJPkd54yAsvsQZt51Xgrvj+92w
-        GporjYr+V2zWob/MpneZSb09A7msV/S1LRpmhvy4jBc8br5d76yy2g==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-01T18:46:31Z"
-  mac: ENC[AES256_GCM,data:CcRDfTyzYRriOhLESO1hH6JF0oe+lKxt4AUnGRPeuL9EU9xdqT3nd9/zuYcNEg/he+bu3E5npEU3SJOgU8trn0Y+6yxr3hDYBLgHJ+I87PMAs2OtfMdl4/Fg/taLP/OFobMh0CtJb76eDewGgH4HLxDF3y+HV9nDFADPmBacM9M=,iv:TjIj7wmywMaKZjzFBtexHP8/K6Z0F1anJLj06KO4IWQ=,tag:Q4ZYvimRWfo1Mium+Z1s7Q==,type:str]
-  encrypted_regex: ^(data|stringData)$
-  version: 3.12.1
+    age:
+        - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVUxGMFo1MkZBT2Ztbkc5
+            Tm05R0xneGZhb2tYMnlRTnV4QVFoYTU5YnhZCndmelNUY0V1MzJxNzVZN0NNVFoy
+            NWJwQWFlK3ZKbDRtYzVKRnh4UzBqa00KLS0tIG1pVW5YNGhRRTQvUUVpWUZDblM3
+            Q2gzUVlkc2NOTUdyaXVnWWdCQUFrQVkKfLveOyNJPkd54yAsvsQZt51Xgrvj+92w
+            GporjYr+V2zWob/MpneZSb09A7msV/S1LRpmhvy4jBc8br5d76yy2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-04T16:44:39Z"
+    mac: ENC[AES256_GCM,data:Vi1nRW38kRDzc+5mhFKSE5ISo4Zigcp6Xe13piEmWGpqSQ3VSYw9E8GRKsvssmo+lr4KiQRWQqiPIPzd776ImrFz3hLcpKJrpkOvjpXyoA/3DAk35GVFpq8a2Z6Hqj+KLqglZFk9E/rc5zYBgkkrwF1U+hFk0Vl0lUcq3UeFpXw=,iv:lYyuh/F2pDGvnlJwcQgpcRNefveLfPyLoisC1Aaczfw=,tag:eZgcgBlbE+8ZE2u5jjWyKw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
## Summary

- Replaces the expired/revoked Gmail App Password in `secret-renovate-automerge-env`
- Every automerge job since deployment has been failing at the email step with `535 5.7.8 Username and Password not accepted`, causing k8s to retry up to the backoff limit each day

## Test plan

- [ ] Verify `kustomize build infra/controllers/renovate-automerge` passes (CI gate)
- [ ] After merge + Flux reconcile, trigger a manual job run or wait for the 8 AM UTC cron — confirm email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)