### PR TITLE
docs(ops): record StatefulSet immutable-field and HelmRelease timeout fixes

### DIFF
--- a/docs/operations/2026-05-02-flux-debugging.md
+++ b/docs/operations/2026-05-02-flux-debugging.md
@@ -2,7 +2,7 @@
 title: Flux debugging — common patterns
 status: Stable
 created: 2026-05-02
-updated: 2026-05-02
+updated: 2026-05-04
 updated_by: gjcourt
 tags: [operations, flux, debugging, runbook]
 ---
@@ -37,7 +37,9 @@ flux reconcile kustomization apps-staging -n flux-system
 | Symptom | Cause | Fix |
 |---|---|---|
 | `HelmRelease status: 'Failed'` blocking kustomization | Immutable StatefulSet field in chart upgrade | Delete the StatefulSet, `flux reconcile helmrelease --reset`. Add `upgrade.remediation.remediationStrategy: uninstall` to the HelmRelease. |
-| `dependency 'X' is not ready` | Upstream kustomization stalled | Fix the upstream kustomization first. |
+| `timeout waiting for: [StatefulSet/X status: 'InProgress']` | Helm install/upgrade timed out waiting for StatefulSet rollout | `flux reconcile helmrelease <name> -n <namespace> --reset` — clears the failure state and retries. |
+| `StatefulSet/X dry-run failed (Invalid): spec: Forbidden: updates to statefulset spec for fields other than…` | Immutable field changed on a Flux-managed StatefulSet — most commonly `volumeClaimTemplates` storage size | `kubectl delete statefulset <name> -n <ns> --cascade=orphan` (pods keep running), then `flux reconcile kustomization <name> -n flux-system`. Flux recreates the StatefulSet with the new spec; existing PVCs are unaffected and retain their original size. |
+| `dependency 'X' is not ready` | Upstream kustomization stalled | Fix the upstream kustomization first. Note: `infra-controllers` failure cascades to `infra-configs` → `apps-production` → `apps-staging`. |
 | HA enters recovery mode | 0-byte include file (`automations.yaml` etc.) | Init container must write `[]`, not `touch`. |
 | PR not appearing in staging | CI checks pending or failing | Fix CI failures; staging rebuilds automatically once CI is green. |
 | Staging has stale code | Staging workflow run failed | `gh workflow run staging-deploy.yaml`. |

--- a/docs/operations/apps/adguard.md
+++ b/docs/operations/apps/adguard.md
@@ -58,3 +58,13 @@ To verify AdGuard Home is working:
   - Check the logs of the `adguard-sync` CronJob: `kubectl logs -n adguard -l job-name=adguard-sync`
   - Verify the credentials in the `adguard-sync-credentials` secret are correct.
   - Ensure the replica pods are reachable from the sync job pod.
+- **Flux reconciliation blocked: `StatefulSet dry-run failed (Invalid): spec: Forbidden`**:
+  - Cause: `volumeClaimTemplates` storage size was changed in the manifest. This field is immutable on existing StatefulSets.
+  - Fix: delete the StatefulSet with `--cascade=orphan` so pods keep running, then let Flux recreate it.
+  ```bash
+  kubectl delete statefulset adguard -n adguard-prod --cascade=orphan
+  kubectl delete statefulset adguard -n adguard-stage --cascade=orphan
+  flux reconcile kustomization apps-production -n flux-system
+  flux reconcile kustomization apps-staging -n flux-system
+  ```
+  The existing PVCs (`config-adguard-0`, `work-adguard-0`) retain their original size; the new template size applies only to PVCs created for future replicas. To actually resize existing PVCs, patch them manually — see `docs/plans/2026-02-15-adguard-ha.md`.


### PR DESCRIPTION
## Summary

- Adds two new rows to the Flux debugging runbook covering failure patterns hit on 2026-05-04:
  - **Helm install/upgrade timeout** (`StatefulSet status: 'InProgress'`) → `flux reconcile helmrelease --reset`
  - **StatefulSet immutable field** (`volumeClaimTemplates` size bump) → `kubectl delete --cascade=orphan` + reconcile; expands the cascade note on `dependency 'X' is not ready`
- Adds a dedicated **Troubleshooting** entry to the adguard runbook with the exact recovery commands and an explanation of why the existing PVCs are unaffected

## Root cause (2026-05-04 incident)

`apps-production` and `apps-staging` were blocked because the `volumeClaimTemplates` storage size on the adguard StatefulSet was bumped from `1Gi` to `5Gi` — an immutable field. Separately, `infra-controllers` was blocked because the `loki` HelmRelease timed out on install. Both were fixed without pod downtime.

## Test plan
- [ ] No kustomize build changes — docs only
- [ ] Verify links and commands are accurate against the live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)