### PR TITLE
fix(external-services): add BackendTLSPolicy for hestia HTTPS upstream

### DIFF
--- a/apps/production/external-services/hestia.yaml
+++ b/apps/production/external-services/hestia.yaml
@@ -1,6 +1,8 @@
 # hestia — TrueNAS GPU server (10.42.2.10)
-# TrueNAS web UI runs HTTPS on 443 with a self-signed cert. We proxy to 443
-# and rely on the BackendTLSPolicy below to skip upstream cert verification.
+# TrueNAS web UI runs HTTPS on 443. BackendTLSPolicy (below) tells the gateway
+# to use TLS for the upstream connection and validate against system CAs.
+# Prereq: configure TrueNAS with a Let's Encrypt cert for hestia.burntbytes.com
+# via System → Certificates → ACME DNS Authenticator (Cloudflare).
 ---
 apiVersion: v1
 kind: Service
@@ -63,3 +65,19 @@ spec:
     - backendRefs:
         - name: hestia
           port: 443
+---
+# BackendTLSPolicy: gateway uses TLS to reach hestia:443 and validates the
+# cert against system (Let's Encrypt) CAs.
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: hestia-tls
+  namespace: external-services
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: hestia
+  validation:
+    wellKnownCACertificates: System
+    hostname: hestia.burntbytes.com


### PR DESCRIPTION
## Summary

- Adds `BackendTLSPolicy` for the `hestia` Service in `external-services`
- Without it, the Cilium gateway sends **plain HTTP** to `hestia:443` (a TLS port) — TrueNAS sees HTTP on an HTTPS port and drops the connection → 502 Bad Gateway on `hestia.burntbytes.com`
- The policy tells the gateway to use TLS upstream and validate the cert against system CAs (Let's Encrypt)

## Prerequisite

TrueNAS needs a publicly-trusted cert for `hestia.burntbytes.com`:
- TrueNAS System → Certificates → ACME DNS Authenticator → Cloudflare (same API token already used by cert-manager)

## Test plan

- [ ] Configure TrueNAS ACME cert for `hestia.burntbytes.com`
- [ ] Merge and let Flux reconcile (~10 min)
- [ ] Confirm `hestia.burntbytes.com` proxies to TrueNAS web UI without a 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)