### PR TITLE
fix(openwebui): use fromEntities:host for gateway ingress

### DIFF
--- a/apps/base/openwebui/networkpolicy.yaml
+++ b/apps/base/openwebui/networkpolicy.yaml
@@ -13,18 +13,11 @@ spec:
     matchLabels:
       app: openwebui
   ingress:
-    # Traffic from the Gateway API parent namespace (Cilium Envoy proxy in `default`)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: default
-      toPorts:
-        - ports:
-            - port: "8080"
-              protocol: TCP
-    # Kubelet-originated readiness/liveness probes
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
+    # Cilium Envoy (gateway) runs hostNetwork in kube-system, so its connections
+    # arrive with host entity identity — must use fromEntities: host, not fromEndpoints.
+    # Kubelet probes are auto-exempted by Cilium and don't need an explicit rule.
+    - fromEntities:
+        - host
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Summary

Fixes the CiliumNetworkPolicy ingress rule so the Cilium gateway can actually reach the Open WebUI pod.

## Root cause

Cilium Envoy runs with `hostNetwork: true`. Gateway connections to backend pods therefore arrive with the **host entity** identity — not as a pod in any namespace. The previous rules:

```yaml
# WRONG — both miss hostNetwork processes
- fromEndpoints:
    - matchLabels: {k8s:io.kubernetes.pod.namespace: default}
- fromEndpoints:
    - matchLabels: {k8s:io.kubernetes.pod.namespace: kube-system}
```

Silently dropped all gateway traffic. The readiness probe still passed because Cilium auto-exempts kubelet health probes from network policy evaluation.

**Symptom:** pod shows `1/1 Running/Ready`, HTTPRoute is `Accepted`, but every browser request gets `upstream connect error … reset reason: connection timeout` from Envoy.

## Fix

```yaml
- fromEntities:
    - host
```

## Note

`apps/base/adguard/networkpolicy.yaml` and `apps/base/excalidraw/networkpolicy.yaml` have the same wrong pattern — follow-up PRs needed.

## Test plan

- [ ] Merge and let Flux reconcile (`apps-production`, ~10 min)
- [ ] Confirm `chat.burntbytes.com` loads the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)