### PR TITLE
fix(openwebui): add remote-node to gateway ingress entities

### DIFF
--- a/apps/base/openwebui/networkpolicy.yaml
+++ b/apps/base/openwebui/networkpolicy.yaml
@@ -13,11 +13,13 @@ spec:
     matchLabels:
       app: openwebui
   ingress:
-    # Cilium Envoy (gateway) runs hostNetwork in kube-system, so its connections
-    # arrive with host entity identity — must use fromEntities: host, not fromEndpoints.
-    # Kubelet probes are auto-exempted by Cilium and don't need an explicit rule.
+    # Cilium Envoy (gateway) is a hostNetwork DaemonSet. On a multi-node cluster
+    # with VXLAN tunneling, the Envoy pod and the app pod may be on different nodes.
+    # Same-node connections arrive as host; cross-node connections arrive as
+    # remote-node. Both are required. Kubelet probes are auto-exempted by Cilium.
     - fromEntities:
         - host
+        - remote-node
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Summary

Adds `remote-node` to the `fromEntities` ingress rule so the Cilium gateway can reach the Open WebUI pod from any node in the cluster.

## Root cause

Previous fix (#465) used only `fromEntities: host`, which covers same-node Envoy→pod connections. On this **6-node VXLAN cluster**, the Cilium Envoy DaemonSet pod handling a request and the app pod can be on **different nodes**. Cross-node connections in VXLAN tunnel mode arrive at the destination with `remote-node` identity, not `host` — so gateway traffic from another node was still silently dropped.

```yaml
# Before (still broken for cross-node)
- fromEntities: [host]

# After
- fromEntities: [host, remote-node]
```

## Test plan

- [ ] Merge and let Flux reconcile (~10 min)
- [ ] Confirm `chat.burntbytes.com` loads

**Note:** `adguard` and `excalidraw` network policies have the same wrong pattern and need the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)