### PR TITLE
fix(external-services): use gateway.networking.k8s.io/v1 for BackendTLSPolicy

### DIFF
--- a/apps/production/external-services/hestia.yaml
+++ b/apps/production/external-services/hestia.yaml
@@ -68,7 +68,7 @@ spec:
 ---
 # BackendTLSPolicy: gateway uses TLS to reach hestia:443 and validates the
 # cert against system (Let's Encrypt) CAs.
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: hestia-tls


### PR DESCRIPTION
## Summary

One-line fix: `v1alpha3` → `v1` for the `BackendTLSPolicy` on `hestia`.

## Impact

This is a **Flux-blocker** — every reconciliation since #464 merged has been failing with:

```
BackendTLSPolicy/external-services/hestia-tls dry-run failed:
no matches for kind "BackendTLSPolicy" in version "gateway.networking.k8s.io/v1alpha3"
```

`v1alpha3` is installed in the CRD but `served=false`. Only `v1` is served. Nothing has applied to the cluster since this landed — including the openwebui `remote-node` fix (#466) and the AGENTS.md update (#467).

## Test plan

- [ ] Merge — Flux should immediately reconcile and apply all pending changes
- [ ] Confirm `chat.burntbytes.com` loads (picks up the #466 netpol fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)