### PR TITLE
fix(openwebui): add ingress entity to CiliumNetworkPolicy

### DIFF
--- a/apps/base/openwebui/networkpolicy.yaml
+++ b/apps/base/openwebui/networkpolicy.yaml
@@ -13,13 +13,14 @@ spec:
     matchLabels:
       app: openwebui
   ingress:
-    # Cilium Envoy (gateway) is a hostNetwork DaemonSet. On a multi-node cluster
-    # with VXLAN tunneling, the Envoy pod and the app pod may be on different nodes.
-    # Same-node connections arrive as host; cross-node connections arrive as
-    # remote-node. Both are required. Kubelet probes are auto-exempted by Cilium.
+    # Cilium Envoy (Gateway API) binds upstream sockets to a dedicated proxy IP
+    # (e.g. 10.244.x.15) that Cilium marks as reserved identity 8 ("ingress").
+    # Same-node connections arrive as "host"; cross-node VXLAN connections arrive
+    # as "remote-node". All three are required. Kubelet probes are auto-exempted.
     - fromEntities:
         - host
         - remote-node
+        - ingress
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Summary

- **Root cause of chat.burntbytes.com timeout found**: Cilium's Gateway API proxy binds upstream connections to a dedicated proxy IP (e.g. `10.244.1.15`) classified as reserved identity 8 (`ingress`), not `host` or `remote-node`
- The previous policy only allowed `host` and `remote-node`, so all 38 Envoy upstream connection attempts timed out
- Add `ingress` to `fromEntities` in the openwebui CiliumNetworkPolicy

## How it was found

Envoy admin socket on `cilium-envoy-tl7jv` showed `cx_connect_fail=38`, `rq_total=0`. Direct `/dev/tcp` bash tests from the same pod to the openwebui pod succeeded (confirming the network path was fine), but Envoy's own connections all failed. Checking Cilium's ipcache on the destination node (`cilium-d5wh7`):

```
10.244.1.15/32  identity=8  tunnelendpoint=10.42.2.21  flags=hastunnel
```

Identity 8 = `reserved:ingress`. The Envoy proxy uses a dedicated proxy source IP (not the node IP) for upstream connections, and Cilium marks that IP as the `ingress` entity.

## Test plan

- [ ] kustomize build passes (validated locally)
- [ ] Merge and force Flux reconcile: `flux reconcile kustomization apps-production -n flux-system`
- [ ] `chat.burntbytes.com` loads without connection timeout
- [ ] Envoy stat `upstream_rq_total` for openwebui cluster increments on `cilium-envoy-tl7jv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)