### PR TITLE
fix(signal-cli): bump heap + memory for second linked account

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -44,22 +44,30 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 10
+          env:
+            # Default JVM MaxRAMPercentage (~25%) caps the heap far below the
+            # cgroup limit, so the container shows free RAM while the JVM
+            # throws `OutOfMemoryError: Java heap space`. Pin -Xmx so the
+            # heap actually uses the headroom.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx2048m -XX:MaxRAMPercentage=75.0"
           volumeMounts:
             - name: signal-cli-config
               mountPath: /var/lib/signal-cli
           resources:
             requests:
               cpu: 50m
-              memory: 512Mi
+              memory: 1Gi
             limits:
               cpu: 500m
-              # signal-cli is a JVM app and OOMs the container on the
-              # 512Mi limit during sustained operation (observed 42 restarts
-              # over 6h with `java.lang.OutOfMemoryError: Java heap space`).
-              # 1.5Gi gives the JVM headroom for the heap + metaspace +
-              # native code with a single linked account; bump again if a
-              # second account is added.
-              memory: 1536Mi
+              # signal-cli is a JVM app and OOMs the heap during sustained
+              # operation. 1.5Gi worked for one account; with two linked
+              # accounts (+16179397251 and +14153089014) it throws
+              # `OutOfMemoryError: Java heap space`. 3Gi covers two accounts;
+              # JAVA_TOOL_OPTIONS above pins -Xmx so the JVM uses it (default
+              # MaxRAMPercentage is ~25%). Bump both if a third account is
+              # added.
+              memory: 3Gi
         - name: signal-bridge
           image: ghcr.io/gjcourt/signal-bridge:2026-05-03
           env:


### PR DESCRIPTION
## Summary

- Both `hermes-prod` and `hermes-callee-prod` are crashlooping (47 restarts in ~3.5h) because their dependency `signal-cli` is crashlooping with `java.lang.OutOfMemoryError: Java heap space` (218 restarts on the bridge sidecar over 28h).
- Two compounding causes — the deployment comment from the prior 1.5Gi bump explicitly warned *"bump again if a second account is added"*, and a second account (`+14153089014`, hermes-callee) was added in `ffb9807` without raising the limit. Even at 1.5Gi, the JVM's default `MaxRAMPercentage` (~25%) caps the heap at ~384Mi, so `kubectl top` shows free RAM (545Mi used) while the JVM is already heap-exhausted.
- Fix: pin `JAVA_TOOL_OPTIONS=-Xmx2048m` and raise the container memory limit 1.5Gi → 3Gi (requests 512Mi → 1Gi).

## RCA evidence

```
$ kubectl logs -n signal-cli deploy/signal-cli -c signal-cli --tail=80
... INFO  SocketHandler - Accepted new client connection 8095
WARN  SocketHandler - Connection handler failed, closing connection
java.lang.OutOfMemoryError: Java heap space
Exception in thread "daemon-listener" java.lang.OutOfMemoryError: Java heap space

$ kubectl top pod -n signal-cli --containers
POD                           NAME         CPU(cores)   MEMORY(bytes)
signal-cli-7f664c8946-2pr58   signal-cli   1m           545Mi      ← well below 1536Mi limit; JVM heap is the binding constraint
```

## Test plan

- [x] `kustomize build apps/production/signal-cli` passes
- [x] `kustomize build apps/staging/signal-cli` passes
- [x] Rendered manifest contains `JAVA_TOOL_OPTIONS=-Xmx2048m -XX:MaxRAMPercentage=75.0` and `memory: 3Gi`
- [ ] After merge + Flux reconcile: `kubectl get pod -n signal-cli` shows `Running 2/2`, restart count stops growing
- [ ] `kubectl logs -n signal-cli deploy/signal-cli -c signal-cli` no longer logs `OutOfMemoryError`
- [ ] `kubectl get pod -n hermes-prod` and `-n hermes-callee-prod` reach `Running 1/1`
- [ ] DM each bot from the operator number; reply lands within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)