### PR TITLE
fix(netpol): add ingress entity to adguard and excalidraw CiliumNetworkPolicies

### DIFF
--- a/apps/base/adguard/networkpolicy.yaml
+++ b/apps/base/adguard/networkpolicy.yaml
@@ -47,11 +47,14 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-    # Admin UI from the Gateway namespace (`default` — Cilium Gateway API).
-    # Matches the HTTPRoute that exposes adguard-admin externally.
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: default
+    # Admin UI via Gateway API. Cilium's Envoy proxy binds upstream connections
+    # to a dedicated proxy IP (reserved identity 8, "ingress"). Same-node
+    # connections arrive as "host"; cross-node VXLAN as "remote-node".
+    # All three entities are required. Kubelet probes are auto-exempted.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
       toPorts:
         - ports:
             - port: "8080"
@@ -70,17 +73,6 @@ spec:
             - port: "80"
               protocol: TCP
             - port: "8080"
-              protocol: TCP
-    # Kubelet probes (readiness/liveness). Cilium tags node-local traffic
-    # with the kube-system namespace identity.
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
-      toPorts:
-        - ports:
-            - port: "80"
-              protocol: TCP
-            - port: "443"
               protocol: TCP
   egress:
     # kube-dns / CoreDNS for in-cluster Service resolution.

--- a/apps/base/excalidraw/networkpolicy.yaml
+++ b/apps/base/excalidraw/networkpolicy.yaml
@@ -29,21 +29,14 @@ spec:
     matchLabels:
       app: excalidraw
   ingress:
-    # Traffic from the Gateway API parent namespace (`default`).
-    # Cilium Gateway API translates external HTTPS into pod-to-pod traffic
-    # whose source identity is the Envoy proxy in the `default` namespace.
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: default
-      toPorts:
-        - ports:
-            - port: "80"
-              protocol: TCP
-    # Kubelet-originated probes (readiness/liveness/startup). On Cilium,
-    # node-local traffic carries the `kube-system` namespace identity.
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
+    # Gateway API traffic. Cilium's Envoy proxy binds upstream connections to a
+    # dedicated proxy IP (reserved identity 8, "ingress"). Same-node connections
+    # arrive as "host"; cross-node VXLAN connections as "remote-node". All three
+    # are required. Kubelet probes are auto-exempted by Cilium.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
       toPorts:
         - ports:
             - port: "80"


### PR DESCRIPTION
## Summary

Same fix as #469 (openwebui), applied to adguard and excalidraw.

- **adguard**: gateway admin UI rule changed from `fromEndpoints: {namespace: default}` to `fromEntities: [host, remote-node, ingress]`; redundant kubelet kube-system rule removed (Cilium auto-exempts probes)
- **excalidraw**: same — gateway ingress rule replaced, redundant kubelet rule removed

## Why

`fromEndpoints` with namespace selectors doesn't work for Cilium's Gateway API Envoy proxy, which binds upstream connections to a dedicated proxy IP classified as reserved identity 8 (`ingress`). Without the `ingress` entity, all gateway→pod connections are silently dropped.

See PR #469 for the full root-cause investigation.

## Test plan

- [x] `kustomize build apps/production/adguard` passes
- [x] `kustomize build apps/production/excalidraw` passes
- [x] `kustomize build apps/staging/adguard` passes
- [x] `kustomize build apps/staging/excalidraw` passes
- [ ] Merge and verify adguard admin UI and excalidraw remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)