### PR TITLE
fix(netpol): use pod ports (80/443) not service ports (8080/8443) for adguard gateway ingress

### DIFF
--- a/apps/base/adguard/networkpolicy.yaml
+++ b/apps/base/adguard/networkpolicy.yaml
@@ -51,15 +51,17 @@ spec:
     # to a dedicated proxy IP (reserved identity 8, "ingress"). Same-node
     # connections arrive as "host"; cross-node VXLAN as "remote-node".
     # All three entities are required. Kubelet probes are auto-exempted.
+    # Ports are pod ports (80/443/3000), not service ports (8080/8443/3000) —
+    # Cilium evaluates ingress policy after DNAT.
     - fromEntities:
         - host
         - remote-node
         - ingress
       toPorts:
         - ports:
-            - port: "8080"
+            - port: "80"
               protocol: TCP
-            - port: "8443"
+            - port: "443"
               protocol: TCP
             - port: "3000"
               protocol: TCP


### PR DESCRIPTION
## Summary

- **Root cause**: `CiliumNetworkPolicy` ingress rules are evaluated **after DNAT**. The `adguard-admin` Service maps `8080→pod:80` and `8443→pod:443`, so Envoy's connection hits the adguard pod on port **80**, not 8080.
- **Previous fix** (PR #471) corrected the `fromEntities` (added `ingress`), but the `toPorts` still listed service ports `8080/8443` — those never match because the packet has already been DNAT'd.
- **This PR** changes the gateway ingress rule to pod ports `80/443/3000`.

The `adguard-sync` CronJob rule already listed port `80` (correct pod port) and is unchanged.

## Test plan

- [ ] `kustomize build apps/production/adguard` passes ✅
- [ ] `kustomize build apps/staging/adguard` passes ✅
- [ ] Merge → Flux reconcile → verify `adguard.burntbytes.com` loads in browser
- [ ] Confirm no regression on DNS (port 53 rules unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)