### PR TITLE
feat(netpol): add CiliumNetworkPolicies for all apps missing network policies

### DIFF
--- a/apps/base/audiobookshelf/kustomization.yaml
+++ b/apps/base/audiobookshelf/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/audiobookshelf/networkpolicy.yaml
+++ b/apps/base/audiobookshelf/networkpolicy.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+  labels:
+    app.kubernetes.io/name: audiobookshelf
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on pod port 13378 (service maps 3005→13378); egress DNS only.
+  endpointSelector:
+    matchLabels:
+      app: audiobookshelf
+  ingress:
+    # Gateway API. Cilium's Envoy proxy source IP is identity 8 ("ingress").
+    # Same-node: "host", cross-node VXLAN: "remote-node". All three required.
+    # toPorts uses the pod port (13378), not the service port (3005).
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "13378"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/base/authelia/kustomization.yaml
+++ b/apps/base/authelia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml

--- a/apps/base/authelia/networkpolicy.yaml
+++ b/apps/base/authelia/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authelia
+  namespace: authelia
+  labels:
+    app.kubernetes.io/name: authelia
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 9091; egress DNS + SMTP (port 465) for email notifications.
+  endpointSelector:
+    matchLabels:
+      app: authelia
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # SMTP submissions to Gmail for email-based 2FA notifications.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "465"
+              protocol: TCP

--- a/apps/base/golinks/kustomization.yaml
+++ b/apps/base/golinks/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - secret-ghcr.yaml
   - service.yaml

--- a/apps/base/golinks/networkpolicy.yaml
+++ b/apps/base/golinks/networkpolicy.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: golinks
+  namespace: golinks
+  labels:
+    app.kubernetes.io/name: golinks
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8080; egress DNS + CNPG PostgreSQL.
+  endpointSelector:
+    matchLabels:
+      app: golinks
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # CNPG PostgreSQL cluster (primary + replicas).
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/apps/base/hermes/kustomization.yaml
+++ b/apps/base/hermes/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - networkpolicy.yaml
   - storage.yaml
   - configmap.yaml
   - serviceaccount.yaml

--- a/apps/base/hermes/networkpolicy.yaml
+++ b/apps/base/hermes/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hermes
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: No external ingress; egress DNS + signal-cli bridge + LAN LLM API.
+  endpointSelector:
+    matchLabels:
+      app: hermes
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # signal-cli bridge service for outbound Signal messages.
+    - toEndpoints:
+        - matchLabels:
+            app: signal-cli
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # LLM inference API on TrueNAS (10.42.2.10). Not in-cluster so Cilium
+    # treats it as world; toCIDR keeps it scoped to a single host.
+    - toCIDR:
+        - 10.42.2.10/32
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homeassistant
+  namespace: homeassistant
+  labels:
+    app.kubernetes.io/name: homeassistant
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8123; egress DNS + HTTPS for external integrations.
+  endpointSelector:
+    matchLabels:
+      app: homeassistant
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # External integrations: cloud APIs, weather services, device bridges.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/apps/base/homepage/kustomization.yaml
+++ b/apps/base/homepage/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
 labels:

--- a/apps/base/homepage/networkpolicy.yaml
+++ b/apps/base/homepage/networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 3000; egress DNS + Kubernetes API for cluster widgets.
+  endpointSelector:
+    matchLabels:
+      app: homepage
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Kubernetes API server for cluster widget data (pods, services, etc.).
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP

--- a/apps/base/immich/kustomization.yaml
+++ b/apps/base/immich/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - job-db-init.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/immich/networkpolicy.yaml
+++ b/apps/base/immich/networkpolicy.yaml
@@ -1,0 +1,147 @@
+---
+# Three policies for Immich's three pod components (server, machine-learning, redis).
+# Pod labels use app=immich + component=<name>, not app.kubernetes.io/name.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-server
+  namespace: immich
+  labels:
+    app.kubernetes.io/name: immich
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 2283; egress DNS + CNPG + Redis + ML service + HTTPS.
+  endpointSelector:
+    matchLabels:
+      app: immich
+      component: server
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "2283"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # CNPG PostgreSQL (pgvecto.rs variant).
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # In-namespace Redis for job queue.
+    - toEndpoints:
+        - matchLabels:
+            app: immich
+            component: redis
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # In-namespace machine-learning service for CLIP / face recognition.
+    - toEndpoints:
+        - matchLabels:
+            app: immich
+            component: machine-learning
+      toPorts:
+        - ports:
+            - port: "3003"
+              protocol: TCP
+    # External HTTPS for geocoding, map tiles, and metadata enrichment.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-machine-learning
+  namespace: immich
+  labels:
+    app.kubernetes.io/name: immich
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Ingress from server only; egress DNS + HTTPS for model downloads.
+  endpointSelector:
+    matchLabels:
+      app: immich
+      component: machine-learning
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: immich
+            component: server
+      toPorts:
+        - ports:
+            - port: "3003"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Hugging Face and other model registries for initial model download.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-redis
+  namespace: immich
+  labels:
+    app.kubernetes.io/name: immich
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Ingress from server only on 6379; egress DNS only.
+  endpointSelector:
+    matchLabels:
+      app: immich
+      component: redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: immich
+            component: server
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/base/jellyfin/kustomization.yaml
+++ b/apps/base/jellyfin/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/jellyfin/networkpolicy.yaml
+++ b/apps/base/jellyfin/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jellyfin
+  namespace: jellyfin
+  labels:
+    app.kubernetes.io/name: jellyfin
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8096; egress DNS + HTTPS for metadata (TMDB, fanart.tv).
+  endpointSelector:
+    matchLabels:
+      app: jellyfin
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # External metadata providers: TMDB, fanart.tv, MusicBrainz, etc.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/linkding/networkpolicy.yaml
+++ b/apps/base/linkding/networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: linkding
+  namespace: linkding
+  labels:
+    app.kubernetes.io/name: linkding
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 9090; egress DNS + HTTPS for bookmark title/favicon enrichment.
+  endpointSelector:
+    matchLabels:
+      app: linkding
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Fetches page titles and favicons for newly saved bookmarks.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/apps/base/mealie/kustomization.yaml
+++ b/apps/base/mealie/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/mealie/networkpolicy.yaml
+++ b/apps/base/mealie/networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mealie
+  namespace: mealie
+  labels:
+    app.kubernetes.io/name: mealie
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 9000; egress DNS + HTTPS for recipe scraping.
+  endpointSelector:
+    matchLabels:
+      app: mealie
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Scrapes recipes from external URLs on demand.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/apps/base/memos/kustomization.yaml
+++ b/apps/base/memos/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/memos/networkpolicy.yaml
+++ b/apps/base/memos/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: memos
+  namespace: memos
+  labels:
+    app.kubernetes.io/name: memos
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 5230; egress DNS + CNPG PostgreSQL.
+  endpointSelector:
+    matchLabels:
+      app: memos
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "5230"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/apps/base/navidrome/kustomization.yaml
+++ b/apps/base/navidrome/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - service.yaml
   - serviceaccount.yaml

--- a/apps/base/navidrome/networkpolicy.yaml
+++ b/apps/base/navidrome/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: navidrome
+  namespace: navidrome
+  labels:
+    app.kubernetes.io/name: navidrome
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 4533; egress DNS + HTTPS for Last.fm and Deezer scrobbling.
+  endpointSelector:
+    matchLabels:
+      app: navidrome
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "4533"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Last.fm scrobbling, Deezer cover art, artist bios.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/overture/kustomization.yaml
+++ b/apps/base/overture/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - secret-ghcr.yaml
   - service.yaml
   - service-monitor.yaml

--- a/apps/base/overture/networkpolicy.yaml
+++ b/apps/base/overture/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: overture
+  namespace: overture
+  labels:
+    app.kubernetes.io/name: overture
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8080; egress DNS + CNPG PostgreSQL.
+  endpointSelector:
+    matchLabels:
+      app: overture
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml

--- a/apps/base/signal-cli/networkpolicy.yaml
+++ b/apps/base/signal-cli/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: signal-cli
+  namespace: signal-cli
+  labels:
+    app.kubernetes.io/name: signal-cli
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Ingress from hermes only; egress DNS + HTTPS for Signal servers.
+  endpointSelector:
+    matchLabels:
+      app: signal-cli
+  ingress:
+    # hermes calls signal-bridge on port 8080 to send messages.
+    - fromEndpoints:
+        - matchLabels:
+            app: hermes
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Signal protocol servers (TLS websocket over 443).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - configmap-go-librespot.yaml
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: snapcast
+  namespace: snapcast
+  labels:
+    app.kubernetes.io/name: snapcast
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 1780 (web UI); egress DNS + HTTPS for Spotify Connect.
+  endpointSelector:
+    matchLabels:
+      app: snapcast
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "1780"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # go-librespot (Spotify Connect) connects to Spotify's servers over HTTPS.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/vitals/kustomization.yaml
+++ b/apps/base/vitals/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - networkpolicy.yaml
   - pdb.yaml
   - secret-ghcr.yaml
   - service.yaml

--- a/apps/base/vitals/networkpolicy.yaml
+++ b/apps/base/vitals/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vitals
+  namespace: vitals
+  labels:
+    app.kubernetes.io/name: vitals
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8080; egress DNS + CNPG PostgreSQL.
+  endpointSelector:
+    matchLabels:
+      app: vitals
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Closes finding #2 from [docs/plans/2026-05-02-critique-remediation.md](docs/plans/2026-05-02-critique-remediation.md) — *NetworkPolicies absent cluster-wide*.

Adds `networkpolicy.yaml` to every app that was missing one (16 apps). Each policy follows the established pattern from adguard/excalidraw/openwebui:

- **Gateway ingress**: `fromEntities: [host, remote-node, ingress]` on the **pod** port (not the service port — Cilium evaluates after DNAT)
- **DNS egress**: always allowed to kube-dns
- **External egress**: only where the app genuinely needs it (SMTP, world:443, specific CIDR)
- **CNPG egress**: `cnpg.io/podRole: instance` selector — matches primary + replica without hardcoding env-specific cluster names in base

Notable per-app decisions:
- **audiobookshelf**: pod port 13378 (service maps 3005→13378 — same DNAT trap as the adguard bug fixed in PR #472)
- **homepage**: egress to `kube-apiserver` entity for cluster widgets
- **immich**: 3 separate CNPs for server/machine-learning/redis components
- **hermes**: no gateway ingress; egress to signal-cli pods + `toCIDR: 10.42.2.10/32` for TrueNAS LLM API
- **signal-cli**: ingress from hermes only; egress to Signal servers

These policies are ready for the default-deny `CiliumClusterwideNetworkPolicy` to be applied per namespace (Phase 1.1 step 4).

## Test plan

- [x] `kustomize build apps/production/<app>` passes for all 16 apps
- [ ] After merge + Flux reconcile: verify each app still responds at its hostname
- [ ] Enable `network-policies: enforced` label on one namespace, confirm Hubble shows no unexpected drops before expanding
- [ ] Linked to Phase 1 / PR 1.1 of the critique remediation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)