### PR TITLE
feat(golinks): add bare 'go' intranet hostname

### DIFF
--- a/apps/production/golinks/httproute.yaml
+++ b/apps/production/golinks/httproute.yaml
@@ -20,6 +20,23 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
+  name: golinks-http-intranet
+  namespace: golinks-prod
+spec:
+  hostnames:
+    - go
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - backendRefs:
+        - name: golinks
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
   name: golinks-https
   namespace: golinks-prod
 spec:


### PR DESCRIPTION
## Summary

- Adds a new `golinks-http-intranet` HTTPRoute for the bare hostname `go` on the HTTP listener
- Routes `http://go/*` directly to the golinks service (no HTTPS redirect, since public CAs won't issue certs for single-label hostnames)
- Golinks itself issues 302s to the real destination URLs which are full HTTPS
- Pair with an AdGuard DNS rewrite: `go` → `10.42.2.40`

## Test plan

- [ ] Add AdGuard DNS rewrite: `go` → `10.42.2.40`
- [ ] After Flux reconcile, `curl -v http://go/chat` from home network resolves and redirects to target URL
- [ ] `go.burntbytes.com` HTTPS behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)