### PR TITLE
fix(reliability): add PodDisruptionBudgets to 12 apps

### DIFF
--- a/apps/base/audiobookshelf/kustomization.yaml
+++ b/apps/base/audiobookshelf/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/audiobookshelf/pdb.yaml
+++ b/apps/base/audiobookshelf/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: audiobookshelf

--- a/apps/base/authelia/kustomization.yaml
+++ b/apps/base/authelia/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml

--- a/apps/base/authelia/pdb.yaml
+++ b/apps/base/authelia/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: authelia
+  namespace: authelia
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: authelia

--- a/apps/base/excalidraw/kustomization.yaml
+++ b/apps/base/excalidraw/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
 labels:

--- a/apps/base/excalidraw/pdb.yaml
+++ b/apps/base/excalidraw/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: excalidraw
+  namespace: excalidraw
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: excalidraw

--- a/apps/base/hermes/kustomization.yaml
+++ b/apps/base/hermes/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - configmap.yaml
   - serviceaccount.yaml
   - deployment.yaml
+  - pdb.yaml
 labels:
   - includeSelectors: false
     pairs:

--- a/apps/base/hermes/pdb.yaml
+++ b/apps/base/hermes/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hermes
+  namespace: hermes
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: hermes

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/homeassistant/pdb.yaml
+++ b/apps/base/homeassistant/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homeassistant
+  namespace: homeassistant
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: homeassistant

--- a/apps/base/homepage/kustomization.yaml
+++ b/apps/base/homepage/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
 labels:

--- a/apps/base/homepage/pdb.yaml
+++ b/apps/base/homepage/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/linkding/pdb.yaml
+++ b/apps/base/linkding/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: linkding
+  namespace: linkding
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: linkding

--- a/apps/base/memos/kustomization.yaml
+++ b/apps/base/memos/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/memos/pdb.yaml
+++ b/apps/base/memos/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: memos
+  namespace: memos
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: memos

--- a/apps/base/overture/kustomization.yaml
+++ b/apps/base/overture/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - secret-ghcr.yaml
   - service.yaml
   - service-monitor.yaml

--- a/apps/base/overture/pdb.yaml
+++ b/apps/base/overture/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: overture
+  namespace: overture
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: overture

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml

--- a/apps/base/signal-cli/pdb.yaml
+++ b/apps/base/signal-cli/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: signal-cli
+  namespace: signal-cli
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: signal-cli

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - pdb.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/snapcast/pdb.yaml
+++ b/apps/base/snapcast/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: snapcast
+  namespace: snapcast
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: snapcast

--- a/apps/base/synology-iscsi-monitor/kustomization.yaml
+++ b/apps/base/synology-iscsi-monitor/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - namespace.yaml
+  - pdb.yaml
   - prometheus-rule.yaml
   - script-cm.yaml
   - service.yaml

--- a/apps/base/synology-iscsi-monitor/pdb.yaml
+++ b/apps/base/synology-iscsi-monitor/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: synology-iscsi-monitor
+  namespace: synology-iscsi-monitor
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: synology-iscsi-exporter


### PR DESCRIPTION
## Summary

- Adds `pdb.yaml` to 12 apps that were missing PodDisruptionBudgets: `audiobookshelf`, `authelia`, `excalidraw`, `hermes`, `homeassistant`, `homepage`, `linkding`, `memos`, `overture`, `signal-cli`, `snapcast`, `synology-iscsi-monitor`
- All single-replica apps get `maxUnavailable: 0` — node drains block until the pod reschedules rather than creating an availability gap
- `synology-iscsi-monitor` gets `maxUnavailable: 1` (infrastructure daemon, brief gap is acceptable)
- `homepage` PDB uses `app.kubernetes.io/name: homepage` to match its non-standard pod selector label
- `synology-iscsi-monitor` PDB uses `app: synology-iscsi-exporter` to match the actual pod selector label

## Test plan

- [x] `kustomize build apps/production/<app>` passes for all 12 affected apps
- [ ] After merge: verify Flux reconciles without errors (`flux get kustomizations -A`)
- [ ] After merge: verify PDBs are present in cluster (`kubectl get pdb -A`)

Closes Phase 2 / PR B of `docs/plans/2026-05-04-phase2-5-completion.md` (finding #13 from critique remediation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)