### PR TITLE
fix(hermes-stage): point staging at prod signal-cli, scale down signal-cli-stage

### DIFF
--- a/apps/staging/hermes-callee/kustomization.yaml
+++ b/apps/staging/hermes-callee/kustomization.yaml
@@ -18,13 +18,11 @@ patches:
       - op: replace
         path: /metadata/name
         value: hermes-callee-stage
-  # Mirror the staging-only overrides applied to the primary hermes bot:
-  # repoint at signal-cli-stage and bump verbosity. This keeps the two staging
-  # bots symmetric.
+  # Staging shares the production signal-cli (staging has no registered accounts)
   - target:
       kind: ConfigMap
       name: hermes-config
     patch: |
       - op: replace
         path: /data/SIGNAL_HTTP_URL
-        value: http://signal-cli-bridge.signal-cli-stage.svc.cluster.local:8080
+        value: http://signal-cli-bridge.signal-cli.svc.cluster.local:8080

--- a/apps/staging/hermes/kustomization.yaml
+++ b/apps/staging/hermes/kustomization.yaml
@@ -18,14 +18,14 @@ patches:
       - op: replace
         path: /metadata/name
         value: hermes-stage
-  # Staging targets signal-cli-stage namespace
+  # Staging shares the production signal-cli (staging has no registered accounts)
   - target:
       kind: ConfigMap
       name: hermes-config
     patch: |
       - op: replace
         path: /data/SIGNAL_HTTP_URL
-        value: http://signal-cli-bridge.signal-cli-stage.svc.cluster.local:8080
+        value: http://signal-cli-bridge.signal-cli.svc.cluster.local:8080
   # Tighter checkpoint retention to keep the smaller staging PVC in check
   - target:
       kind: ConfigMap

--- a/apps/staging/signal-cli/kustomization.yaml
+++ b/apps/staging/signal-cli/kustomization.yaml
@@ -18,3 +18,12 @@ patches:
       - op: replace
         path: /metadata/name
         value: signal-cli-stage
+  # No registered Signal accounts in staging — scale to zero to avoid
+  # CrashLoopBackOff from missing account data.
+  - target:
+      kind: Deployment
+      name: signal-cli
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 0


### PR DESCRIPTION
## Summary

- `signal-cli-stage` has been CrashLoopBackOff (44+ restarts) since its PVC was provisioned 3 days ago — no Signal accounts were ever registered in it, so signal-cli exits with code 3 ("Failed to read local accounts list")
- This cascades to `hermes-stage` and `hermes-callee-stage` failing to connect to Signal and crash-looping themselves
- Fix: repoint both staging hermes bots at the **production** `signal-cli` service via cross-namespace DNS, and scale `signal-cli-stage` to 0 replicas to stop the crash loop

## Changes

| File | Change |
|------|--------|
| `apps/staging/hermes/kustomization.yaml` | `SIGNAL_HTTP_URL` → prod signal-cli |
| `apps/staging/hermes-callee/kustomization.yaml` | `SIGNAL_HTTP_URL` → prod signal-cli |
| `apps/staging/signal-cli/kustomization.yaml` | `replicas: 0` patch added |

## Test plan

- [ ] After Flux reconcile: `signal-cli-stage` pod count drops to 0
- [ ] `hermes-stage` and `hermes-callee-stage` pods reach `1/1 Running`
- [ ] Production signal-cli unaffected (`hermes-prod` and `hermes-callee-prod` still healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)