### PR TITLE
fix(images): pin openwebui digest and add signal-cli imagePullSecret

### DIFF
--- a/apps/base/openwebui/deployment.yaml
+++ b/apps/base/openwebui/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: openwebui
-          image: ghcr.io/open-webui/open-webui:v0.9.2
+          image: ghcr.io/open-webui/open-webui:v0.9.2@sha256:a7e4796ae894d1e2a0c1824860ade472f35c507608a01c3581377b5c19b0ed49
           ports:
             - containerPort: 8080
           envFrom:

--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -20,6 +20,8 @@ spec:
     spec:
       serviceAccountName: signal-cli
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ghcr-secret
       containers:
         - name: signal-cli
           image: ghcr.io/asamk/signal-cli@sha256:23a808b97eaa65e15f09809e5644aedf33e838db833552dfe825ca52dcd0940e

--- a/apps/base/signal-cli/kustomization.yaml
+++ b/apps/base/signal-cli/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - networkpolicy.yaml
   - pdb.yaml
+  - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml
   - servicemonitor.yaml

--- a/apps/base/signal-cli/secret-ghcr.yaml
+++ b/apps/base/signal-cli/secret-ghcr.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:sLQhw86/zZPCJ7VwyX1174YdYqVfjAbR9FxuSqhN/SeT7QWeaU3DdTKpysmjW6SgSfx1j5Bglc+/GGSM1Un/9bv8Uy0WRoLnupgScyCtZoE8usF8MaFRhRzibd3jh5JZOqu+F++/3nf99+ENwT7bM+3Q3S5OzSyDPLT4sTOAzfM5W4+j/e1XvsA4x2j1h4u2yLWLCHBY7ACs0jj1h2GVpvHl6+4/r+Wy76oBwOM8rFkXtGqa9ajD8WRSIQq6ZBDCTXc4xgozWNYIKv0+z85KJUeYXiSbrYWebkaHIoQQH6vARmUh3JITFCVHcwxSyPBDcE0CR0GocuUFkcO2RuyWzWrgSR5YeMFXQMd1Z91r3xkyEnXN1tLfqw==,iv:MEMr8N4V49VuhoLKXcUgP6NfX3CZ/H+/5yZ/SIvw53Q=,tag:H0g+V+gZlZaJO8ebVvrYjA==,type:str]
+kind: Secret
+metadata:
+  name: ghcr-secret
+type: kubernetes.io/dockerconfigjson
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmbFg3c25IM0xOWDlhV0dM
+        OG43WUpHUjBhV254eXBPVzVFOW5qUk1UUlh3CkJvTkl0cytLaDE4d3RWdTFyRHZ4
+        R0E2VVJwL3A5QStRakRBdlgvUXA2M0UKLS0tIGtOcUhNNlRXQlJKUGtSOGhJTU9Q
+        WmlIdUFEejE2d2ZPSFIzRWdVc1V2ZUEK97vJuo8Hj86xhgj7ndiP1hJfovptQdJW
+        tYHAMvx61BFm5uBV2AB0QQRODKpdJcgGlLDOcz+RjHChHpUTuur0yA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-15T23:56:20Z"
+  mac: ENC[AES256_GCM,data:O5RnqsvsHV41Ru1+O0iFFQ1BRMr9hawCqvS18KghHMggeSCAXA+JDQpU8XCSvvHPNbpwaOnGpnG5oa6UBaveKwssscTqsrebFhRVdlRoOq+AZEaeba2qKA+YYp7YKLfrYBU6iQvp3AVJjhUulkPwD+2r9w01CURHvm+KR8ZYyUA=,iv:2MT+ocn5KZdTlrxm01OBF0PDm/l4ZhlzdJsjMeL2UgQ=,tag:lkUwEuLq4KwTwiaILkXDzQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.11.0


### PR DESCRIPTION
## Summary

- **openwebui**: append `@sha256` digest to the `v0.9.2` tag so the image reference is immutable and cannot be silently replaced if the tag is re-pushed
- **signal-cli**: add `secret-ghcr.yaml` (SOPS-encrypted dockerconfigjson) and wire `imagePullSecrets: [{name: ghcr-secret}]` into the deployment so the private `ghcr.io/gjcourt/signal-bridge` image can be pulled without auth failures

Closes findings #15 and #16 (partial) from `docs/plans/2026-05-02-critique-remediation.md`.

## Digest source

```
docker buildx imagetools inspect ghcr.io/open-webui/open-webui:v0.9.2
# Digest: sha256:a7e4796ae894d1e2a0c1824860ade472f35c507608a01c3581377b5c19b0ed49
```

## Test plan

- [x] `kustomize build apps/production/openwebui` passes and shows the pinned digest
- [x] `kustomize build apps/production/signal-cli` passes and shows `ghcr-secret` in both the Secret resource and `imagePullSecrets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)