### PR TITLE
fix(probes): add missing liveness and readiness probes to 10 apps

### DIFF
--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 13378
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 10m

--- a/apps/base/excalidraw/deployment.yaml
+++ b/apps/base/excalidraw/deployment.yaml
@@ -34,6 +34,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 5m

--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -62,6 +62,22 @@ spec:
           name: homeassistant
           ports:
             - containerPort: 8123
+          readinessProbe:
+            httpGet:
+              path: /api/
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 10m

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -41,6 +41,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/healthcheck
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 5m

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -61,15 +61,29 @@ spec:
           securityContext:
             privileged: true # Required for GPU access
 
-          # Readiness only — Jellyfin's startup time is highly variable on
-          # first-run library scans; a startupProbe + tight livenessProbe is
-          # tracked separately (#22, deferred).
+          # startupProbe gates liveness/readiness until Jellyfin is up.
+          # Allows up to 5 minutes for first-run library scans.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 0
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 6
 

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -63,6 +63,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
 
           resources:
             requests:

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -47,6 +47,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/app/about
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 10m

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -62,6 +62,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5230
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
 
           resources:
             requests:

--- a/apps/base/openwebui/deployment.yaml
+++ b/apps/base/openwebui/deployment.yaml
@@ -35,12 +35,29 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/backend/data
+          # startupProbe gates liveness/readiness while Open WebUI initializes.
+          # Allows up to 5 minutes for first-run model loading.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 0
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 6
           resources:

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -115,6 +115,13 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           volumeMounts:
             - name: snapserver-config
               mountPath: /etc/snapserver.conf
@@ -161,6 +168,17 @@ spec:
             initialDelaySeconds: 2
             periodSeconds: 5
             timeoutSeconds: 2
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  test -p /audio/spotify.fifo
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
             failureThreshold: 6
           volumeMounts:
             - name: spotify-state

--- a/apps/base/synology-iscsi-monitor/deployment.yaml
+++ b/apps/base/synology-iscsi-monitor/deployment.yaml
@@ -68,6 +68,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

Adds missing `livenessProbe` to 10 apps and `readinessProbe` to 1 app. Closes findings #8, #10, #22 from `docs/plans/2026-05-02-critique-remediation.md` (Phase 2 / PR 2.2).

## Changes per app

| App | What was added | Probe path/method |
|-----|---------------|-------------------|
| **audiobookshelf** | `livenessProbe` | `httpGet /healthcheck:13378` — mirrors existing readiness |
| **excalidraw** | `livenessProbe` | `tcpSocket:80` — static frontend, no reliable health path |
| **homepage** | `livenessProbe` | `httpGet /api/healthcheck:3000` — Next.js healthcheck endpoint |
| **jellyfin** | `startupProbe` + `livenessProbe` | `httpGet /health:http` — startupProbe allows up to 5 min for library scans; liveness uses `initialDelaySeconds: 0` (gated by startup) |
| **linkding** | `livenessProbe` | `httpGet /health:9090` — mirrors existing readiness |
| **mealie** | `livenessProbe` | `httpGet /api/app/about:9000` — mirrors existing readiness |
| **memos** | `livenessProbe` | `httpGet /healthz:5230` — mirrors existing readiness |
| **openwebui** | `startupProbe` + `livenessProbe` | `httpGet /health:8080` — startupProbe allows up to 5 min for model initialization; liveness uses `initialDelaySeconds: 0` |
| **snapcast** | `livenessProbe` (both containers) | snapserver: `tcpSocket:http (1780)`; go-librespot: `exec test -p /audio/spotify.fifo` — mirrors each container's readiness |
| **synology-iscsi-monitor** | `livenessProbe` | `httpGet /metrics:8000` — mirrors existing readiness (generous `initialDelaySeconds: 60` for pip install startup) |
| **homeassistant** | `readinessProbe` + `livenessProbe` | `httpGet /api/:8123` — HA REST API health indicator |

## Probe timing

- **livenessProbe**: `initialDelaySeconds: 30`, `periodSeconds: 20`, `timeoutSeconds: 5`, `failureThreshold: 6` (tolerant — false liveness kills the pod)
- **readinessProbe**: `initialDelaySeconds: 10`, `periodSeconds: 10`, `timeoutSeconds: 3`, `failureThreshold: 3` (tighter — gates traffic)
- **startupProbe** (jellyfin, openwebui): `failureThreshold: 30`, `periodSeconds: 10` — allows up to 5 minutes before first liveness check

## Test plan

- [x] `kustomize build apps/production/<app>` passes for all 11 affected apps (audiobookshelf, excalidraw, homepage, jellyfin, linkding, mealie, memos, openwebui, snapcast, synology-iscsi-monitor, homeassistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)