### PR TITLE
fix(staging): fix vitals namespace and add staging parity for openwebui/overture

### DIFF
--- a/apps/production/external-services/README.md
+++ b/apps/production/external-services/README.md
@@ -1,0 +1,27 @@
+# external-services
+
+Kubernetes `Service` + `Endpoints` objects that expose LAN appliances
+(Synology NAS, TrueNAS, router, go-librespot speakers) as in-cluster
+Services, plus `HTTPRoute` resources that route `*.burntbytes.com` hostnames
+to those endpoints via the production gateway.
+
+Manifests live directly under `apps/production/` because this app has no
+staging counterpart — see below.
+
+## No staging overlay
+
+This app intentionally has no `apps/staging/external-services/` overlay (and
+no `apps/base/external-services/` base; the manifests live directly under
+`apps/production/`).
+
+Reason: external-services reverse-proxies LAN appliances (Synology NAS,
+TrueNAS, router) that exist only on the production network and have no
+staging equivalent. The `Endpoints` objects carry hard-coded production IP
+addresses (`10.42.x.x`). There are no staging versions of these physical
+devices, and creating dummy staging endpoints would produce non-functional
+routes with no validation value.
+
+To validate changes safely, run
+`kustomize build apps/production/external-services` locally before pushing,
+then verify the target appliance is reachable at its IP from within the
+cluster after merge.

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
   - mealie
   - memos
   - navidrome
+  - openwebui
+  - overture
   - signal-cli
   - snapcast
   - vitals

--- a/apps/staging/openwebui/httproute.yaml
+++ b/apps/staging/openwebui/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: openwebui-http
+  namespace: openwebui-stage
+spec:
+  hostnames:
+    - chat.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: openwebui-https
+  namespace: openwebui-stage
+spec:
+  hostnames:
+    - chat.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: openwebui
+          port: 8080

--- a/apps/staging/openwebui/kustomization.yaml
+++ b/apps/staging/openwebui/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openwebui-stage
+resources:
+  - ../../base/openwebui/
+  - httproute.yaml
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: openwebui
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: openwebui-stage

--- a/apps/staging/overture/httproute.yaml
+++ b/apps/staging/overture/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: overture-http
+  namespace: overture-stage
+spec:
+  hostnames:
+    - overture.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: overture-https
+  namespace: overture-stage
+spec:
+  hostnames:
+    - overture.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: overture
+          port: 8080

--- a/apps/staging/overture/kustomization.yaml
+++ b/apps/staging/overture/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: overture-stage
+resources:
+  - ../../base/overture/
+  - httproute.yaml
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: overture
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: overture-stage

--- a/apps/staging/vitals/secret-aws-creds.yaml
+++ b/apps/staging/vitals/secret-aws-creds.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vitals-aws-creds-secret
-  namespace: vitals
+  namespace: vitals-stage
 type: Opaque
 stringData:
   ACCESS_KEY_ID: ENC[AES256_GCM,data:6HTb56RYtVEHflT9pf+DC5puo/4=,iv:/Yn9aCew9AwOcE3Ul4jmTF5r3X6oZtf+FYctWKDAHXg=,tag:BTUjcFQohWVJOmJ8Ru0AUg==,type:str]

--- a/apps/staging/vitals/secret-db-credentials.yaml
+++ b/apps/staging/vitals/secret-db-credentials.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vitals-db-credentials
-  namespace: vitals
+  namespace: vitals-stage
   labels:
     app: vitals
     env: staging


### PR DESCRIPTION
## Summary

- **vitals staging**: fixed 2 SOPS secret files (`secret-aws-creds.yaml`, `secret-db-credentials.yaml`) that hardcoded `namespace: vitals` instead of `namespace: vitals-stage`
- **openwebui**: added thin staging overlay (`apps/staging/openwebui/`) — was production-only; serves at `chat.stage.burntbytes.com`
- **overture**: added thin staging overlay (`apps/staging/overture/`) — was production-only; serves at `overture.stage.burntbytes.com`
- **external-services**: added `README.md` documenting intentional staging omission (LAN appliances with hard-coded production IPs have no staging equivalent)
- `cloudflare-tunnel` and `synology-iscsi-monitor` READMEs already exist from a prior PR

Closes findings #18 and #19 from `docs/plans/2026-05-02-critique-remediation.md` (Phase 4 / PRs 4.1+4.2).

## Test plan

- [x] `kustomize build apps/staging/vitals` — all namespaces show `vitals-stage`
- [x] `kustomize build apps/staging/openwebui` — builds cleanly, routes to `chat.stage.burntbytes.com`
- [x] `kustomize build apps/staging/overture` — builds cleanly, routes to `overture.stage.burntbytes.com`
- [x] `kustomize build apps/staging` — full staging overlay builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)