### PR TITLE
fix(snapcast): pin LB IP to 10.42.2.37 in compute static range

### DIFF
--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     app: snapcast
   annotations:
-    lbipam.cilium.io/ip-pool: home-c-pool
+    lbipam.cilium.io/ip-pool: home-compute-pool
+    lbipam.cilium.io/ips: 10.42.2.37
 spec:
   type: LoadBalancer
   selector:

--- a/infra/configs/cilium/load-balancer-ip-pool.yaml
+++ b/infra/configs/cilium/load-balancer-ip-pool.yaml
@@ -8,3 +8,14 @@ spec:
   blocks:
     - start: 10.42.2.40
       stop: 10.42.2.254
+---
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  # Static compute range (10.42.2.20-39, VLAN 2). Used for services that need
+  # a stable IP in the compute band rather than the DHCP pool above .40.
+  name: home-compute-pool
+spec:
+  blocks:
+    - start: 10.42.2.30
+      stop: 10.42.2.37


### PR DESCRIPTION
## Summary

- snapcast currently floats in the DHCP pool (`home-c-pool`, 10.42.2.40–254) and landed on 10.42.2.44
- The snapclients at 10.42.2.38 and 10.42.2.39 need a stable, predictable server address
- 10.42.2.20–39 is the VLAN 2 compute static range — the right home for a server

## Changes

- **`infra/configs/cilium/load-balancer-ip-pool.yaml`**: add `home-compute-pool` covering 10.42.2.30–37 (leaves .38/.39 for the RPi snapclients)
- **`apps/base/snapcast/service.yaml`**: switch to `home-compute-pool` and pin via `lbipam.cilium.io/ips: 10.42.2.37`

## After merge

Flux reconciles infra-configs first (pool appears), then apps-production (service re-annotated). Cilium will release 10.42.2.44 and assign 10.42.2.37. The existing L2 announcement policy already covers all LB IPs on VLAN 2 — no announcement policy change needed.

Snapclients at .38/.39 should be pointed at 10.42.2.37.

## Test plan

- [ ] `kubectl get svc -n snapcast-prod snapcast` shows `EXTERNAL-IP: 10.42.2.37`
- [ ] `ping 10.42.2.37` from home network responds
- [ ] Snapcast stream reachable on port 1704 from a snapclient

🤖 Generated with [Claude Code](https://claude.com/claude-code)