### PR TITLE
fix: post-merge bugs — linkding CNPG egress, openwebui OOM, overture staging

### DIFF
--- a/apps/base/linkding/networkpolicy.yaml
+++ b/apps/base/linkding/networkpolicy.yaml
@@ -32,6 +32,13 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
     # Fetches page titles and favicons for newly saved bookmarks.
     - toEntities:
         - world

--- a/apps/base/openwebui/deployment.yaml
+++ b/apps/base/openwebui/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 1000m
-              memory: 1Gi
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -19,7 +19,6 @@ resources:
   - memos
   - navidrome
   - openwebui
-  - overture
   - signal-cli
   - snapcast
   - vitals


### PR DESCRIPTION
## Summary

Three regressions introduced by the phase 2–5 batch merges (#473, #479, #480):

- **linkding** (`apps/base/linkding/networkpolicy.yaml`): CNP was missing egress to CNPG pods on port 5432. The `migrate` init container timed out on every pod restart. All other CNPG-backed apps (golinks, memos, vitals, immich) already had this rule — linkding was the only one missed. Fix: add `toEndpoints: [{cnpg.io/podRole: instance}]` on port 5432.

- **openwebui** (`apps/base/openwebui/deployment.yaml`): Container OOMKilled during startup while fetching 30 HuggingFace model files. The 1 Gi limit was pre-existing but the rolling restart triggered by PR #479 (health probes) forced a fresh container start, exposing the OOM that had previously been hidden by a long-lived pod. Fix: raise memory limit 1 Gi → 2 Gi.

- **overture staging** (`apps/staging/kustomization.yaml`): PR #480 added an `apps/staging/overture/` overlay but the base Deployment references `overture-secrets` and `overture-container-env` that don't exist in staging, causing `CreateContainerConfigError` on every pod start. Fix: remove overture from the staging kustomization; it's production-only (requires real OAuth credentials).

## Unrelated pre-existing issues (not fixed here)

- `hermes-stage` / `hermes-callee-stage` CrashLoopBackOff — same signal-cli health-check error appears in `hermes-prod` too; this is a signal-cli flakiness issue predating our PRs.
- `overture-prod` CrashLoopBackOff (40h) — predates our PRs.

## Test plan

- [ ] `kustomize build apps/production/linkding` passes
- [ ] `kustomize build apps/staging/linkding` passes
- [ ] `kustomize build apps/production/openwebui` passes
- [ ] `kustomize build apps/staging` passes (no overture)
- [ ] After reconcile: `linkding-prod` pod enters `Running` (init container connects to DB)
- [ ] After reconcile: `openwebui-prod` pod enters `Running` (2 Gi budget clears OOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)