### PR TITLE
fix(probes): correct homeassistant and homepage health check endpoints

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - containerPort: 8123
           readinessProbe:
             httpGet:
-              path: /api/
+              path: /
               port: 8123
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -72,7 +72,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /api/
+              path: /
               port: 8123
             initialDelaySeconds: 30
             periodSeconds: 20

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -34,16 +34,14 @@ spec:
           ports:
             - containerPort: 3000
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /api/healthcheck
+            tcpSocket:
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 20


### PR DESCRIPTION
## Summary

Two health probe regressions introduced by PR #479 (health probes):

- **homeassistant** (`apps/base/homeassistant/deployment.yaml`): both readiness and liveness probes were hitting `/api/` which requires a Bearer auth token — returning HTTP 401. Kubelet treats any non-2xx as failure, so the liveness probe killed the container every ~7 minutes. Fixed by changing to GET `/` (the login page), which returns 200 for unauthenticated requests.

- **homepage** (`apps/base/homepage/deployment.yaml`): `HOMEPAGE_ALLOWED_HOSTS=gethomepage.dev` validates the HTTP Host header on every request. Kubelet's probe sends the pod IP as the Host header, which does not match `gethomepage.dev`, causing HTTP 400 on both probes. Fixed by switching both probes to `tcpSocket` on port 3000, which bypasses Host-header validation while still confirming the server is listening.

## Test plan

- [ ] `kustomize build apps/production/homeassistant` passes
- [ ] `kustomize build apps/production/homepage` passes
- [ ] After reconcile: `homeassistant-prod` pod enters `1/1 Running` without liveness-kill events
- [ ] After reconcile: `homepage-prod` pod enters `1/1 Running` without liveness-kill events

🤖 Generated with [Claude Code](https://claude.com/claude-code)