### PR TITLE
fix(cnp): add namespace selectors for cross-namespace Cilium policies

### DIFF
--- a/apps/base/hermes/networkpolicy.yaml
+++ b/apps/base/hermes/networkpolicy.yaml
@@ -24,9 +24,12 @@ spec:
             - port: "53"
               protocol: TCP
     # signal-cli bridge service for outbound Signal messages.
+    # Cilium toEndpoints is namespace-scoped for namespaced CNPs — must include
+    # k8s:io.kubernetes.pod.namespace to reach signal-cli's own namespace.
     - toEndpoints:
         - matchLabels:
             app: signal-cli
+            k8s:io.kubernetes.pod.namespace: signal-cli
       toPorts:
         - ports:
             - port: "8080"

--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -89,7 +89,7 @@ spec:
               memory: 64Mi
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               path: /health

--- a/apps/base/signal-cli/networkpolicy.yaml
+++ b/apps/base/signal-cli/networkpolicy.yaml
@@ -13,10 +13,22 @@ spec:
     matchLabels:
       app: signal-cli
   ingress:
-    # hermes calls signal-bridge on port 8080 to send messages.
+    # hermes and hermes-callee call signal-bridge on port 8080. Cilium
+    # fromEndpoints is namespace-scoped for namespaced CNPs — each hermes
+    # namespace must be listed explicitly with k8s:io.kubernetes.pod.namespace.
     - fromEndpoints:
         - matchLabels:
             app: hermes
+            k8s:io.kubernetes.pod.namespace: hermes-prod
+        - matchLabels:
+            app: hermes
+            k8s:io.kubernetes.pod.namespace: hermes-stage
+        - matchLabels:
+            app: hermes
+            k8s:io.kubernetes.pod.namespace: hermes-callee-prod
+        - matchLabels:
+            app: hermes
+            k8s:io.kubernetes.pod.namespace: hermes-callee-stage
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Root cause

Cilium `fromEndpoints`/`toEndpoints` in a **namespaced** `CiliumNetworkPolicy` are implicitly scoped to the CNP's own namespace. Without an explicit `k8s:io.kubernetes.pod.namespace` label in the selector, traffic from other namespaces is silently dropped even if the pod labels match.

This was discovered when `hermes-stage` (and by extension all hermes bots on reconnect) couldn't reach `signal-cli` after PR #473 applied network policies.

**Experimental proof:** A pod with `app=hermes` in `hermes-stage` namespace got TCP timeout connecting to signal-cli:8080; the identical pod in `signal-cli` namespace connected immediately and got `{"status":"ok"}`. The existing `hermes-prod` connection survived because it was established before the CNP was applied — Cilium preserves established flows across policy changes.

## Changes

- **`apps/base/signal-cli/networkpolicy.yaml`**: `fromEndpoints` now lists all four hermes namespaces (`hermes-prod`, `hermes-stage`, `hermes-callee-prod`, `hermes-callee-stage`) with explicit namespace labels. Any hermes bot can now establish new connections to the signal-bridge.

- **`apps/base/hermes/networkpolicy.yaml`**: `toEndpoints` for signal-cli now includes `k8s:io.kubernetes.pod.namespace: signal-cli`, so hermes pods in their own namespaces can reach signal-cli's namespace.

- **`apps/base/overture/deployment.yaml`**: `tempo-bridge` memory limit raised 256 Mi → 512 Mi. The container loads an EVM contract ABI on startup and was OOMKilled (exit code 137) before it could pass the `/health` probe.

## Test plan

- [ ] `kustomize build apps/production/signal-cli` passes
- [ ] `kustomize build apps/production/hermes` passes
- [ ] `kustomize build apps/staging/hermes` passes
- [ ] After reconcile: `hermes-stage` enters `1/1 Running` (signal-bridge reachable)
- [ ] After reconcile: `hermes-callee-stage` enters `1/1 Running`
- [ ] After reconcile: `overture-prod` enters `2/2 Running` (tempo-bridge no longer OOMKilled)
- [ ] `hermes-prod` reconnects after its next restart (no longer grandfathered by pre-CNP connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)