### PR TITLE
fix(overture): allow egress HTTPS for tempo-bridge external RPC

### DIFF
--- a/apps/base/overture/networkpolicy.yaml
+++ b/apps/base/overture/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: overture
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 8080; egress DNS + CNPG PostgreSQL.
+  description: Gateway ingress on 8080; egress DNS + CNPG PostgreSQL + external Ethereum RPC (tempo-bridge).
   endpointSelector:
     matchLabels:
       app: overture
@@ -38,4 +38,13 @@ spec:
       toPorts:
         - ports:
             - port: "5432"
+              protocol: TCP
+    # tempo-bridge makes HTTPS calls to the Moderato/Tempo Ethereum RPC
+    # (rpc.moderato.tempo.xyz) and ghcr.io at startup. Without this rule
+    # Cilium drops all outbound HTTPS and the container OOM-kills on retry storms.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
               protocol: TCP


### PR DESCRIPTION
## Summary

- The `tempo-bridge` sidecar in the overture deployment calls `rpc.moderato.tempo.xyz` (Moderato/Tempo Ethereum RPC) via HTTPS on startup
- The previous `CiliumNetworkPolicy` only allowed egress to DNS (port 53) and CNPG (port 5432) — no world-egress rule for HTTPS
- Cilium dropped all outbound 443 traffic, causing `fetch failed` errors in a tight retry loop that OOM-killed the container within ~2 minutes (exit code 137) on every restart
- Fix: add `toEntities: [world]` on TCP port 443 to the overture CNP egress rules

## Test plan

- [ ] PR #484 (CNP namespace fix + memory limit bump to 512Mi) already merged
- [ ] CI `yaml-lint` and `validate-kustomize` pass
- [ ] After merge: `flux reconcile kustomization apps-production`
- [ ] Verify `overture-prod` pod reaches `2/2 Running` with tempo-bridge no longer crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)