### PR TITLE
fix(renovate-automerge): make email failure non-fatal

### DIFF
--- a/infra/controllers/renovate-automerge/script-configmap.yaml
+++ b/infra/controllers/renovate-automerge/script-configmap.yaml
@@ -214,8 +214,9 @@ data:
             try:
                 send_report(results)
             except Exception as exc:
-                print(f"Email failed: {exc}", file=sys.stderr, flush=True)
-                sys.exit(1)
+                # Email is best-effort notification; don't fail the job over it.
+                # The merge/hold decisions above already completed successfully.
+                print(f"Email failed (non-fatal): {exc}", file=sys.stderr, flush=True)
 
 
     if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Root cause of 2026-05-04 08:00 UTC failure: Gmail App Password rejected with SMTP 535 "Bad Credentials"
- The script called `sys.exit(1)` on any SMTP exception, causing the Kubernetes Job to retry 6 times — generating 7 Error pods for a notification failure, not an automerge failure
- Email is a best-effort notification; the merge/hold decisions already completed successfully before the `send_report()` call
- Fix: catch the SMTP exception, log it as non-fatal, and exit 0

## What changed

`infra/controllers/renovate-automerge/script-configmap.yaml`: removed `sys.exit(1)` from the SMTP exception handler

## Root cause of the credential failure

The Gmail App Password in `secret-renovate-automerge-env` was revoked/expired. It was already rotated at 16:44 UTC on 2026-05-04. The manual run at 17:10 UTC succeeded but had 0 Renovate PRs so email was never tested with the new credentials. This PR ensures future credential failures produce a warning log rather than a cascading retry storm.

## Test plan

- [ ] CI `yaml-lint` and `validate-kustomize` pass
- [ ] After merge: `flux reconcile kustomization infra-controllers` applies the new script configmap
- [ ] Next scheduled run (08:00 UTC tomorrow) should complete without Error pods even if SMTP fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)