### PR TITLE
chore(renovate-automerge): add drift and python-nginx-signing to automerge repos

### DIFF
--- a/infra/controllers/renovate-automerge/configmap.yaml
+++ b/infra/controllers/renovate-automerge/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: renovate-automerge-env
   namespace: renovate
 data:
-  GITHUB_REPOS: gjcourt/homelab,gjcourt/golinks,gjcourt/llmux,gjcourt/Pingo,gjcourt/soundbyte,gjcourt/tempo-interview,gjcourt/vitals
+  GITHUB_REPOS: gjcourt/homelab,gjcourt/golinks,gjcourt/llmux,gjcourt/Pingo,gjcourt/soundbyte,gjcourt/tempo-interview,gjcourt/vitals,gjcourt/drift,gjcourt/python-nginx-signing
   EMAIL_TO: gjcourt@gmail.com
   SMTP_HOST: smtp.gmail.com
   SMTP_PORT: "587"


### PR DESCRIPTION
## Summary

- Adds `gjcourt/drift` and `gjcourt/python-nginx-signing` to `GITHUB_REPOS` in the automerge configmap
- Brings the automerge list in sync with the renovate scanner (which already covers all 9 repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)