### PR TITLE
fix(snapcast): move IP pin annotation to production overlay only

### DIFF
--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     app: snapcast
   annotations:
-    lbipam.cilium.io/ip-pool: home-compute-pool
-    lbipam.cilium.io/ips: 10.42.2.37
+    lbipam.cilium.io/ip-pool: home-c-pool
 spec:
   type: LoadBalancer
   selector:

--- a/apps/production/snapcast/kustomization.yaml
+++ b/apps/production/snapcast/kustomization.yaml
@@ -22,3 +22,7 @@ patches:
       - op: add
         path: /metadata/labels/http-ingress
         value: "true"
+  - path: service-patch.yaml
+    target:
+      kind: Service
+      name: snapcast

--- a/apps/production/snapcast/service-patch.yaml
+++ b/apps/production/snapcast/service-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snapcast
+  annotations:
+    lbipam.cilium.io/ip-pool: home-compute-pool
+    lbipam.cilium.io/ips: 10.42.2.37


### PR DESCRIPTION
## Summary
- PR #481 pinned `lbipam.cilium.io/ips: 10.42.2.37` in `apps/base/snapcast/service.yaml`, which affects both prod and staging
- `snapcast-stage` claimed 10.42.2.37 first, leaving `snapcast-prod` with `<pending>` IP
- Move the IP pin + `home-compute-pool` annotation to a production-only strategic merge patch; base reverts to `home-c-pool` with no IP pin

## Test plan
- [ ] `kustomize build apps/production/snapcast/` → Service has `lbipam.cilium.io/ips: 10.42.2.37` and `home-compute-pool`
- [ ] `kustomize build apps/staging/snapcast/` → Service has only `home-c-pool`, no `ips` annotation
- [ ] After merge + Flux reconcile: `kubectl get svc -n snapcast-prod snapcast` shows EXTERNAL-IP `10.42.2.37`
- [ ] `kubectl get svc -n snapcast-stage snapcast` gets a different IP from `home-c-pool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)