### PR TITLE
fix(golinks): add http-go gateway listener for bare 'go' hostname

### DIFF
--- a/apps/production/golinks/httproute.yaml
+++ b/apps/production/golinks/httproute.yaml
@@ -28,7 +28,7 @@ spec:
   parentRefs:
     - name: app-gateway-production
       namespace: default
-      sectionName: http
+      sectionName: http-go
   rules:
     - backendRefs:
         - name: golinks

--- a/infra/configs/gateway/gateway-production.yaml
+++ b/infra/configs/gateway/gateway-production.yaml
@@ -24,6 +24,17 @@ spec:
           selector:
             matchLabels:
               http-ingress: "true"
+    # Plain HTTP listener for bare 'go' intranet shortcut (go/link style)
+    - name: http-go
+      port: 80
+      protocol: HTTP
+      hostname: "go"
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              http-ingress: "true"
     # LAN HTTPS listener for production traffic
     - name: https
       port: 443


### PR DESCRIPTION
## Summary
- The production gateway's `http` listener only accepts `*.burntbytes.com`, which silently rejects single-label hostnames like `go`
- The `golinks-http-intranet` HTTPRoute (merged in #474) was pointing at `sectionName: http` and getting `NoMatchingListenerHostname`
- Add a dedicated `http-go` listener on port 80 with `hostname: "go"` and wire the HTTPRoute to it via `sectionName: http-go`

## Test plan
- [ ] CI: `kustomize build apps/production/golinks/` and `kustomize build infra/configs/` both pass
- [ ] After merge + Flux reconcile: `kubectl get httproute -n golinks-prod golinks-http-intranet` shows `Accepted: True`
- [ ] `http://go/chat` resolves and proxies to golinks from a LAN client

🤖 Generated with [Claude Code](https://claude.com/claude-code)