### PR TITLE
fix(snapcast): allow LAN client ingress on ports 1704/1705/1780

### DIFF
--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: snapcast
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 1780 (web UI); egress DNS + HTTPS for Spotify Connect.
+  description: Gateway ingress on 1780 (web UI); LAN snapclients on 1704/1705/1780; egress DNS + Spotify HTTPS.
   endpointSelector:
     matchLabels:
       app: snapcast
@@ -19,6 +19,18 @@ spec:
         - ingress
       toPorts:
         - ports:
+            - port: "1780"
+              protocol: TCP
+    # snapclient connections from LAN (HifiBerry devices at .38/.39 and any
+    # future client on the compute VLAN). 1704=audio, 1705=control, 1780=MPRIS JSON-RPC.
+    - fromCIDR:
+        - 10.42.2.0/24
+      toPorts:
+        - ports:
+            - port: "1704"
+              protocol: TCP
+            - port: "1705"
+              protocol: TCP
             - port: "1780"
               protocol: TCP
   egress:


### PR DESCRIPTION
## Summary

The snapcast CNP only allowed port 1780 ingress from the gateway (`host`/`remote-node`/`ingress` entities), blocking all direct snapclient connections from LAN devices.

HifiBerry snapclients at 10.42.2.38 (kitchen) and 10.42.2.39 (living-room) need:
- **1704/TCP** — audio stream (the core snapcast protocol)
- **1705/TCP** — control / RPC
- **1780/TCP** — JSON-RPC used by the `snapcastmpris` Python extension to send MPRIS commands back to the server

Fix: add `fromCIDR: 10.42.2.0/24` rule covering all three ports (scoped to the compute VLAN so it doesn't open to the internet).

## Test plan

- [ ] CI passes
- [ ] After merge + `flux reconcile kustomization apps-production`: `kubectl get ciliumnetworkpolicy snapcast -n snapcast-prod` shows the new ingress rules
- [ ] `docker logs snapcast` on 10.42.2.38 shows `snapclient now running in background` without connection errors
- [ ] Both `kitchen` and `living-room` appear in Snapweb at https://snapcast.burntbytes.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)