### PR TITLE
fix(snapcast): set externalTrafficPolicy: Local to preserve LAN client source IPs

### DIFF
--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -10,6 +10,9 @@ metadata:
     lbipam.cilium.io/ips: 10.42.2.37
 spec:
   type: LoadBalancer
+  # Preserve source IPs from LAN clients so the CNP fromCIDR rule can match.
+  # Without this, Cilium SNATs traffic to a node IP before it reaches the pod.
+  externalTrafficPolicy: Local
   selector:
     app: snapcast
   ports:


### PR DESCRIPTION
## Summary

- Add `externalTrafficPolicy: Local` to the snapcast LoadBalancer service

## Problem

HifiBerry snapclient devices (`10.42.2.38`, `10.42.2.39`) could not connect to the snapserver even after the CNP fix in #492 added `fromCIDR: 10.42.2.0/24` for ports 1704/1705/1780.

Root cause: Cilium SNATs external traffic to a node-local pod IP (`10.244.0.168`) before it reaches the snapcast pod. The pod sees `10.244.0.168` (classified as `world` identity), not `10.42.2.38`, so the `fromCIDR` rule never matches and every snapclient SYN is dropped.

Confirmed via `cilium monitor --type drop`:
```
xx drop (Policy denied) identity world->12962: 10.244.0.168:33114 -> 10.244.1.72:1704 tcp SYN
```

## Fix

`externalTrafficPolicy: Local` disables the SNAT for external traffic. The pod now sees the real `10.42.2.x` source IP, which matches the CNP `fromCIDR: 10.42.2.0/24` rule and the connection is permitted.

## Test plan

- [ ] Staging reconciles cleanly
- [ ] Merge to master and confirm `kubectl get svc -n snapcast-prod snapcast` shows `externalTrafficPolicy: Local`
- [ ] Verify `cilium monitor --type drop` no longer shows drops from `10.42.2.38`/`10.42.2.39`
- [ ] Confirm both HifiBerry snapclients appear in Snapweb at `https://snapcast.burntbytes.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)