### PR TITLE
fix(snapcast): use world entity for snapclient ports, revert externalTrafficPolicy

### DIFF
--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -8,23 +8,19 @@ metadata:
     app.kubernetes.io/name: snapcast
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 1780 (web UI); LAN snapclients on 1704/1705/1780; egress DNS + Spotify HTTPS.
+  description: LAN snapclients (world entity; SNAT prevents CIDR match) on 1704/1705/1780; egress DNS + Spotify HTTPS.
   endpointSelector:
     matchLabels:
       app: snapcast
   ingress:
+    # Cilium SNATs external traffic to a node IP (10.244.x.x) before the pod sees
+    # it, so fromCIDR: 10.42.2.0/24 never matches. Use world to allow all external
+    # sources; the real boundary is the LAN VLAN which is the only path to this VIP.
     - fromEntities:
         - host
         - remote-node
         - ingress
-      toPorts:
-        - ports:
-            - port: "1780"
-              protocol: TCP
-    # snapclient connections from LAN (HifiBerry devices at .38/.39 and any
-    # future client on the compute VLAN). 1704=audio, 1705=control, 1780=MPRIS JSON-RPC.
-    - fromCIDR:
-        - 10.42.2.0/24
+        - world
       toPorts:
         - ports:
             - port: "1704"

--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -9,9 +9,6 @@ metadata:
     lbipam.cilium.io/ip-pool: home-c-pool
 spec:
   type: LoadBalancer
-  # Preserve source IPs from LAN clients so the CNP fromCIDR rule can match.
-  # Without this, Cilium SNATs traffic to a node IP before it reaches the pod.
-  externalTrafficPolicy: Local
   selector:
     app: snapcast
   ports:


### PR DESCRIPTION
## Summary

- Revert `externalTrafficPolicy: Local` from snapcast service (PR #493 broke L2 announcements)
- Update CNP to use `fromEntities: world` for ports 1704/1705/1780 instead of `fromCIDR: 10.42.2.0/24`
- Consolidate two ingress rules into one

## Problem chain

**PR #492** added `fromCIDR: 10.42.2.0/24` to allow HifiBerry snapclients from VLAN 2.

**Discovery**: with `externalTrafficPolicy: Cluster` (default), Cilium SNATs all external LB traffic to a node IP (`10.244.0.168`) before the pod sees it. Confirmed via `cilium monitor --type drop`:
```
drop (Policy denied) identity world->12962: 10.244.0.168:33114 -> 10.244.1.72:1704
```
The source IP is `10.244.0.168`, not `10.42.2.38`, so the `fromCIDR` rule never matched.

**PR #493** attempted to fix this with `externalTrafficPolicy: Local` to disable SNAT. That worked at the pod level, but Cilium's L2 announcement lease **did not transfer** to the node running the pod. The wrong node (`talos-ykb-uir`) kept renewing the lease even though the pod is on `talos-2mz-rfj`, resulting in `Connection refused` from clients.

**This PR**: revert to `externalTrafficPolicy: Cluster`, and instead use `fromEntities: world` for the snapcast ports. The security boundary is the LAN VLAN — `10.42.2.37` is only reachable from devices on VLAN 2, so permitting `world` at the CNP level is acceptable.

## Test plan

- [ ] CI passes
- [ ] Merge and confirm `externalTrafficPolicy` is removed from `kubectl get svc -n snapcast-prod snapcast`
- [ ] Confirm `cilium monitor --type drop` shows no drops from `10.42.2.38`/`10.42.2.39`
- [ ] Both HifiBerry snapclients appear in Snapweb at `https://snapcast.burntbytes.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)