### PR TITLE
feat(images): add snapcast-hifiberry patched client image + docs

### DIFF
--- a/.github/workflows/build-snapcast-hifiberry.yml
+++ b/.github/workflows/build-snapcast-hifiberry.yml
@@ -1,0 +1,67 @@
+name: Build snapcast-hifiberry
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/snapcast-hifiberry/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/snapcast-hifiberry
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: images/snapcast-hifiberry
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### snapcast-hifiberry published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Update \`/data/extensions/snapcast/docker-compose.yaml\` on kitchen (10.42.2.38) and living-room (10.42.2.39) to this tag." >> $GITHUB_STEP_SUMMARY

--- a/docs/operations/apps/snapcast.md
+++ b/docs/operations/apps/snapcast.md
@@ -76,3 +76,44 @@ kubectl -n snapcast-prod exec deploy/snapcast -c snapserver -- sh -c 'cat /dev/u
 - **Audio Sync Issues**:
   - Ensure all clients and the server have accurate time synchronization (NTP).
   - Adjust the latency offset for specific clients in the Snapweb UI if necessary.
+
+## 10. HifiBerry Clients (kitchen / living-room)
+
+Two HifiBerry OS devices run snapclient as a Docker extension:
+- `kitchen` — `10.42.2.38`
+- `living-room` — `10.42.2.39`
+
+### Image
+
+The upstream HifiBerry extension image (`ghcr.io/hifiberry/extension_snapcast:0.28.0`) has two bugs that prevent snapclient from running. A patched image is maintained at `ghcr.io/gjcourt/snapcast-hifiberry` with a build pipeline in `images/snapcast-hifiberry/`. See `images/snapcast-hifiberry/README.md` for full details on the bugs and upgrade procedure.
+
+**Known upstream bugs fixed by the patch image:**
+1. Runtime audio libs missing from the final build stage — `libasound`, `libvorbis`, `libogg`, `libFLAC`, `libopus`, `libsoxr` are built in the compile stage but not installed in the runtime image.
+2. Wrong binary path — `snapcastmpris.py` hardcodes `/bin/snapclient` but the binary lands at `/usr/local/bin/snapclient`. The patch adds a symlink.
+
+### Device setup
+
+Each device has:
+- `/data/extensions/snapcast/docker-compose.yaml` — extension config; references `ghcr.io/gjcourt/snapcast-hifiberry:<tag>`
+- `/etc/snapcastmpris.conf` — INI file (no section header) with `server = 10.42.2.37` (the production LB VIP)
+
+To check status:
+```bash
+ssh root@10.42.2.38 "docker exec snapcast ps aux"
+# Should show: /usr/bin/python3 snapcastmpris.py AND /bin/snapclient -e -h 10.42.2.37
+```
+
+To pull and deploy a new image on both devices:
+```bash
+for ip in 10.42.2.38 10.42.2.39; do
+  ssh root@$ip "
+    docker pull ghcr.io/gjcourt/snapcast-hifiberry:<tag>
+    sed -i 's|image: ghcr.io/gjcourt/snapcast-hifiberry:.*|image: ghcr.io/gjcourt/snapcast-hifiberry:<tag>|' /data/extensions/snapcast/docker-compose.yaml
+    docker-compose -f /data/extensions/snapcast/docker-compose.yaml up -d
+  "
+done
+```
+
+### Network policy note
+
+The snapcast CNP uses `fromEntities: world` (not `fromCIDR: 10.42.2.0/24`) for ports 1704/1705/1780. This is intentional: Cilium SNATs LB traffic to a node IP before it reaches the pod, so a CIDR rule for the LAN subnet never matches. The security boundary is the LAN VLAN — `10.42.2.37` is unreachable from outside VLAN 2.

--- a/images/snapcast-hifiberry/Dockerfile
+++ b/images/snapcast-hifiberry/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/hifiberry/extension_snapcast:0.28.0
+
+USER root
+
+# The upstream image builds snapclient from source but omits the runtime
+# audio codec libraries from the final stage, so snapclient fails to start
+# with "Error loading shared library libasound.so.2" etc.
+#
+# Additionally, the Python MPRIS wrapper (snapcastmpris.py) hardcodes
+# /bin/snapclient but the binary lands at /usr/local/bin/snapclient.
+RUN apk update && apk add --no-cache \
+    alsa-lib \
+    libvorbis \
+    libogg \
+    flac \
+    opus \
+    soxr && \
+    ln -s /usr/local/bin/snapclient /bin/snapclient
+
+USER snapcast

--- a/images/snapcast-hifiberry/README.md
+++ b/images/snapcast-hifiberry/README.md
@@ -1,0 +1,53 @@
+# snapcast-hifiberry image
+
+Patched version of `ghcr.io/hifiberry/extension_snapcast` for use on HifiBerry OS devices (kitchen at `10.42.2.38`, living-room at `10.42.2.39`).
+
+## Why this exists
+
+The upstream HifiBerry extension image (`ghcr.io/hifiberry/extension_snapcast:0.28.0`) has two bugs that prevent snapclient from running:
+
+1. **Missing runtime audio libraries** — the multi-stage Dockerfile compiles snapclient with `alsa-lib`, `libvorbis`, `libogg`, `flac`, `opus`, and `soxr` in the builder stage but does not install their runtime counterparts in the final stage. snapclient fails at startup with `Error loading shared library libasound.so.2` (and similar for the others).
+
+2. **Wrong binary path** — `snapcastmpris.py` (the Python MPRIS wrapper that manages snapclient) hardcodes `/bin/snapclient`, but the binary is installed at `/usr/local/bin/snapclient`. The subprocess call silently fails and snapclient never starts.
+
+## What this image does
+
+Layers on top of the upstream image (same `snapclient` binary, same Python wrapper, same entrypoint) and:
+- Installs the six missing runtime codec/audio libraries via `apk`
+- Creates a symlink `/bin/snapclient → /usr/local/bin/snapclient`
+
+## Upstream reference
+
+`ghcr.io/hifiberry/extension_snapcast:0.28.0`  
+GitHub: https://github.com/hifiberry/extension_snapcast
+
+## Build (local, arm64)
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  -t ghcr.io/gjcourt/snapcast-hifiberry:latest \
+  --load \
+  images/snapcast-hifiberry
+```
+
+## Deploying to HifiBerry devices
+
+The docker-compose on each device (`/data/extensions/snapcast/docker-compose.yaml`) references this image. After a new image is published, update the tag and restart:
+
+```bash
+ssh root@10.42.2.38 "
+  docker pull ghcr.io/gjcourt/snapcast-hifiberry:<tag>
+  sed -i 's|image: ghcr.io/gjcourt/snapcast-hifiberry:.*|image: ghcr.io/gjcourt/snapcast-hifiberry:<tag>|' /data/extensions/snapcast/docker-compose.yaml
+  docker-compose -f /data/extensions/snapcast/docker-compose.yaml up -d
+"
+```
+
+Repeat for `10.42.2.39` (living-room).
+
+## Upgrading the upstream image
+
+When upgrading from `0.28.0` to a newer HifiBerry extension tag:
+1. Update the `FROM` line in the Dockerfile
+2. Verify the two bugs are still present (check with `docker run --rm <new-tag> ldd /usr/local/bin/snapclient` for missing libs, and `docker run --rm <new-tag> ls /bin/snapclient` for the symlink)
+3. If upstream has fixed both issues, this image can be retired and the `docker-compose.yaml` on each device reverted to point at the upstream image directly


### PR DESCRIPTION
## Summary

- Adds `images/snapcast-hifiberry/` — patched Docker image for HifiBerry OS snapclient devices
- Adds `.github/workflows/build-snapcast-hifiberry.yml` — builds arm64 image to ghcr.io on merge
- Updates `docs/operations/apps/snapcast.md` — documents HifiBerry client setup, known upstream bugs, and the CNP world-entity rationale

## Background

The two HifiBerry devices (kitchen `10.42.2.38`, living-room `10.42.2.39`) run `ghcr.io/hifiberry/extension_snapcast:0.28.0` as a Docker extension. That image has two bugs:

1. **Missing runtime audio libs** — `alsa-lib`, `libvorbis`, `libogg`, `flac`, `opus`, `soxr` are compiled in the builder stage but not installed in the final Alpine stage. snapclient exits immediately with `Error loading shared library libasound.so.2`.

2. **Wrong binary path** — `snapcastmpris.py` calls `/bin/snapclient` but the binary is at `/usr/local/bin/snapclient`. The subprocess silently does nothing.

The patch image layers both fixes on top of upstream (no recompilation needed). CI builds arm64-only since the HifiBerry devices are aarch64.

## After merge

The workflow will build and push `ghcr.io/gjcourt/snapcast-hifiberry:<date>`. Update the docker-compose on both devices to pull the new tag (see `images/snapcast-hifiberry/README.md` for the one-liner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)