### PR TITLE
feat(snapcast): persist server state to PVC and document Spotify auth

### DIFF
--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -99,8 +99,12 @@ spec:
           env:
             - name: HOME
               value: /tmp
+            # State file (server.json: client MACs, group/stream assignments) is
+            # persisted to the spotify-state PVC so pod restarts don't lose stream
+            # assignments. go-librespot files live at the PVC root; snapserver
+            # writes to the snapserver/ subdirectory — no conflict.
             - name: XDG_CONFIG_HOME
-              value: /tmp/.config
+              value: /var/lib/snapserver
           ports:
             - name: stream
               containerPort: 1704
@@ -130,6 +134,8 @@ spec:
               mountPath: /tmp
             - name: audio-pipes
               mountPath: /audio
+            - name: spotify-state
+              mountPath: /var/lib/snapserver
           resources:
             requests:
               cpu: 10m

--- a/docs/operations/apps/snapcast.md
+++ b/docs/operations/apps/snapcast.md
@@ -9,8 +9,10 @@ Snapcast is deployed as a Kubernetes `Deployment` with a single replica in the `
   - `snapserver`: The main Snapcast server that reads audio streams and serves them to clients.
   - `go-librespot` (Sidecar): An open-source Spotify client that acts as a Spotify Connect receiver. It outputs raw PCM audio to a shared named pipe (FIFO) that `snapserver` reads.
 - **Storage**:
-  - **Spotify State**: Uses a PersistentVolumeClaim (`snapcast-spotify-state`) backed by the `synology-iscsi` storage class to store Spotify credentials and pairing state.
-  - **Shared Audio**: Uses an `emptyDir` volume (`shared-audio`) to share the named pipe (`/audio/spotify.fifo`) between the `go-librespot` sidecar and `snapserver`.
+  - **Spotify State / Server State**: Uses a PersistentVolumeClaim (`snapcast-spotify-state`) backed by the `synology-iscsi` storage class. Both containers share this PVC:
+    - `go-librespot` mounts it at `/config` — stores `state.json` (Spotify OAuth credentials and device ID).
+    - `snapserver` mounts it at `/var/lib/snapserver` (`XDG_CONFIG_HOME`) — stores `snapserver/server.json` (client MAC addresses and their group/stream assignments). This persistence means kitchen and living-room stay on the `spotify` stream across pod restarts.
+  - **Shared Audio**: Uses an `emptyDir` volume to share the named pipe (`/audio/spotify.fifo`) between the `go-librespot` sidecar and `snapserver`.
 - **Networking**:
   - The `snapcast` Service is a `LoadBalancer` (via Cilium IPAM) exposing:
     - `1704/TCP`: Snapcast audio stream
@@ -57,27 +59,90 @@ kubectl -n snapcast-prod exec deploy/snapcast -c snapserver -- sh -c 'cat /dev/u
   kubectl logs -n snapcast-prod deploy/snapcast -c go-librespot
   ```
 
-## 8. Disaster Recovery
+## 8. Spotify Connect: Initial Auth and Re-auth
+
+go-librespot uses interactive OAuth (Spotify's PKCE flow). The one-time auth must be performed manually; credentials persist in the PVC afterwards and survive pod restarts.
+
+### Initial authentication (or after PVC loss)
+
+1. Port-forward the OAuth callback port from your Mac to the pod:
+   ```bash
+   kubectl port-forward -n snapcast-prod deploy/snapcast 57622:57622 &
+   ```
+
+2. Capture the auth URL from the go-librespot log:
+   ```bash
+   kubectl logs -n snapcast-prod deploy/snapcast -c go-librespot | grep "accounts.spotify.com"
+   ```
+
+3. Open the URL in your browser. Spotify will redirect to `http://127.0.0.1:57622/login?code=...` — the port-forward catches this callback.
+
+4. Verify success:
+   ```bash
+   kubectl logs -n snapcast-prod deploy/snapcast -c go-librespot | grep "authenticated"
+   kubectl exec -n snapcast-prod deploy/snapcast -c go-librespot -- cat /config/state.json
+   ```
+   `state.json` should have a non-empty `credentials.username` and `credentials.data`.
+
+5. Kill the port-forward once done: `pkill -f "port-forward.*57622"`
+
+**Notes:**
+- The URL expires if the pod restarts. If the pod crashes during auth (it can happen if the callback arrives malformed), delete the pod to get a fresh URL: `kubectl delete pod -n snapcast-prod -l app=snapcast`
+- `zeroconf_enabled: false` in the go-librespot config means the device registers via Spotify cloud, not mDNS. "Snapcast" appears in the Spotify "Devices Available" list without needing mDNS propagation.
+
+## 9. Disaster Recovery
 - **Backup Strategy**:
-  - **Spotify State**: The `snapcast-spotify-state` PVC contains the Spotify pairing credentials. This is backed up via Synology Snapshot Replication.
-  - **Config**: The `snapserver.conf` is stored in Git.
+  - **Spotify State + Server State**: The `snapcast-spotify-state` PVC stores both go-librespot credentials (`state.json`) and snapserver's client/stream assignments (`snapserver/server.json`). Backed up via Synology Snapshot Replication.
+  - **Config**: `snapserver.conf` and `go-librespot` config are in Git (ConfigMaps).
 - **Restore Procedure**:
   1. Restore the `snapcast-spotify-state` LUN via Synology DSM if necessary.
-  2. Re-deploy the Snapcast manifests. If the Spotify state is lost, you will simply need to re-pair the device in the Spotify app.
+  2. Re-deploy the Snapcast manifests. If the Spotify credentials are lost, redo the auth flow in Section 8. Client stream assignments will also be lost — clients reconnect to the `default` stream; use Snapweb or the JSON-RPC one-liner below to move them back to `spotify`:
+     ```bash
+     # Move a group to the spotify stream (get group IDs from Server.GetStatus first)
+     curl -s http://10.42.2.37:1780/jsonrpc -H "Content-Type: application/json" \
+       -d '{"id":1,"jsonrpc":"2.0","method":"Group.SetStream","params":{"id":"<group-id>","stream_id":"spotify"}}'
+     ```
 
-## 9. Troubleshooting
-- **Spotify Connect Device Not Showing Up**:
-  - Verify the `go-librespot` sidecar is running and hasn't crashed.
-  - Check the `go-librespot` logs for authentication or mDNS discovery errors. Note that mDNS discovery across VLANs/subnets may require an mDNS repeater (e.g., Avahi) on your router.
-- **No Audio on Clients**:
-  - Verify the client is connected to the correct stream in the Snapweb UI.
-  - Check the `snapserver` logs for errors reading from the FIFO (`/audio/spotify.fifo`).
-  - Ensure the client is not muted in Snapweb.
-- **Audio Sync Issues**:
-  - Ensure all clients and the server have accurate time synchronization (NTP).
-  - Adjust the latency offset for specific clients in the Snapweb UI if necessary.
+## 10. Troubleshooting
 
-## 10. HifiBerry Clients (kitchen / living-room)
+### Spotify Connect device "Snapcast" not showing up
+- Verify go-librespot is running and not crash-looping: `kubectl get pods -n snapcast-prod`
+- Check go-librespot logs for auth errors. If you see `"to complete authentication visit the following link"` on every startup, credentials were lost — redo the auth flow in Section 8.
+- `zeroconf_enabled: false` means the device uses cloud registration, not mDNS. It should appear in Spotify's device list on any device logged into the same account without needing mDNS.
+
+### No audio on clients (spotify stream is idle)
+- Check which stream clients are assigned to:
+  ```bash
+  curl -s http://10.42.2.37:1780/jsonrpc -H "Content-Type: application/json" \
+    -d '{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}' | python3 -m json.tool
+  ```
+  Clients should have `"stream_id": "spotify"`. If they show `"stream_id": "default"`, the server state was lost (PVC issue or first boot after PVC wipe). Use Snapweb or the `Group.SetStream` RPC call from Section 9 to reassign them.
+- Verify the spotify stream status is `"playing"` (not `"idle"`) in the same output. If it's idle, go-librespot is not writing audio — check its logs.
+
+### Playback keeps transferring away from "Snapcast" to "Kitchen" or "Living Room"
+The HifiBerry OS devices (kitchen/living-room) ship with a native Spotify Connect implementation (Vollibrespot / HifiBerry's built-in service) that registers separate Spotify Connect devices named after the hostname. These compete with "Snapcast" for the active playback session.
+
+When this happens, go-librespot logs: `"playback was transferred to Kitchen"`. Audio on the snapcast stream stops because go-librespot stops writing to the FIFO.
+
+**Workaround**: Disable native Spotify on the HifiBerry devices. SSH in and check for a Vollibrespot or HifiBerry Spotify service:
+```bash
+ssh root@10.42.2.38 "systemctl list-units | grep -i spotify"
+ssh root@10.42.2.38 "ps aux | grep -i librespot"
+```
+Stop/disable any conflicting service and verify only "Snapcast" appears in Spotify's device list.
+
+If the native Spotify service cannot be cleanly disabled, as a workaround you can unregister it by deleting its credentials file (location varies by HifiBerry OS version — look in `/data/` or `/etc/`).
+
+### No audio despite spotify stream showing "playing"
+- Check client volumes — they default to ~28-30% after first connection. Use Snapweb to raise them.
+- Verify the client is not muted in Snapweb.
+- Check snapserver logs for FIFO read errors: `kubectl logs -n snapcast-prod deploy/snapcast -c snapserver`
+
+### Audio sync issues
+- Ensure all clients and the server have accurate NTP time synchronization.
+- Adjust the latency offset for specific clients in the Snapweb UI if necessary.
+
+## 11. HifiBerry Clients (kitchen / living-room)
 
 Two HifiBerry OS devices run snapclient as a Docker extension:
 - `kitchen` — `10.42.2.38`


### PR DESCRIPTION
## Summary

- **Persist snapserver state**: `snapserver` stores client/group/stream assignments in `server.json`. It was on an `emptyDir` (`/tmp`), so every pod restart lost kitchen and living-room's `spotify` stream assignments, requiring manual reassignment via Snapweb each time. Fix: mount the existing `snapcast-spotify-state` PVC into the `snapserver` container at `/var/lib/snapserver` and set `XDG_CONFIG_HOME` to that path. `go-librespot` continues to own the PVC root (`state.json`); `snapserver` writes to the `snapserver/` subdirectory — no conflict, no new PVC needed.
- **Docs**: Add Spotify OAuth auth/re-auth procedure (Section 8) with exact port-forward commands. Expand troubleshooting to cover wrong-stream assignment, HifiBerry native Spotify interference ("playback was transferred to Kitchen"), and low-volume first-connect behaviour.

## Test plan

- [ ] kustomize build passes for both overlays (validated before push)
- [ ] After merge and Flux reconcile, verify `kubectl exec -n snapcast-prod deploy/snapcast -c snapserver -- ls /var/lib/snapserver/snapserver/` shows `server.json`
- [ ] Delete the pod and let it restart; confirm kitchen and living-room reconnect on `spotify` stream without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)