### PR TITLE
feat(homepage): add chat.burntbytes.com to Tools column

### DIFF
--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -29,6 +29,10 @@
         description: Audiobook and podcast server
 
 - Tools:
+    - Chat:
+        icon: mdi-chat
+        href: https://chat.burntbytes.com
+        description: AI chat interface
     - Vitals:
         icon: mdi-heart-pulse
         href: https://vitals.burntbytes.com


### PR DESCRIPTION
## Summary

- Adds Chat (`https://chat.burntbytes.com`) as the first entry in the Tools column on the production Homepage dashboard.

## Test plan

- [ ] Merge and verify Chat tile appears at the top of Tools on https://homepage.burntbytes.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)