### PR TITLE
fix(homeassistant): allow egress to Lutron Caséta bridge (port 8083)

### DIFF
--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -41,3 +41,13 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
+    # Lutron Caséta Smart Bridge at 10.42.2.16 — LEAP API (pylutron-caseta uses mTLS on 8083).
+    # toCIDR is required because Cilium classifies non-cluster LAN hosts as world,
+    # but the world rule above only opens 443/80. The bridge is LAN-only so a CIDR
+    # rule is more precise than widening the world ports.
+    - toCIDR:
+        - 10.42.2.16/32
+      toPorts:
+        - ports:
+            - port: "8083"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a `toCIDR: 10.42.2.16/32` egress rule on port 8083 to the Home Assistant `CiliumNetworkPolicy`.
- The Lutron Caséta integration (`pylutron-caseta`) uses the LEAP API over mTLS on port 8083. The existing policy only allowed world egress on 443/80, causing the integration to time out on every connection attempt ("Failed setup, will retry: Timed out on connect for 10.42.2.16").
- Uses a narrow CIDR rule rather than widening the `world` ports — the bridge is LAN-only and Cilium classifies it as `world` regardless of subnet.

## Test plan

- [ ] Merge and `flux reconcile kustomization apps-production -n flux-system` to apply immediately
- [ ] Verify Lutron integration shows as healthy in HA Settings → Integrations
- [ ] Confirm `kubectl exec -n homeassistant-prod deploy/homeassistant -- nc -zv 10.42.2.16 8083` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)