### PR TITLE
fix(homeassistant): use new lovelace dashboards format (deprecation fix)

### DIFF
--- a/apps/base/homeassistant/configmap.yaml
+++ b/apps/base/homeassistant/configmap.yaml
@@ -12,9 +12,14 @@ data:
     frontend:
       themes: !include_dir_merge_named themes
 
-    # Enable YAML dashboards (loads *.yaml from /config/dashboards/)
+    # Enable YAML dashboards (explicit dashboard registration)
     lovelace:
-      mode: yaml
+      dashboards:
+        control:
+          mode: yaml
+          filename: dashboards/control.yaml
+          title: Control
+          show_in_sidebar: true
 
     automation: !include automations.yaml
     script: !include scripts.yaml


### PR DESCRIPTION
## Problem

Home Assistant is showing a deprecation warning:
> Your YAML dashboard configuration uses the legacy mode: yaml option, which will be removed in Home Assistant 2026.8.0.

The dashboard content was also appearing empty because the old  format is being phased out.

## Fix

Replace the deprecated format:


With the new explicit dashboard registration:


This matches the format HA recommends and will continue working after 2026.8.0.

## Files Changed
-  — updated lovelace config