### PR TITLE
feat(homeassistant): allow egress to Mosquitto MQTT on port 1883

### DIFF
--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -51,3 +51,12 @@ spec:
         - ports:
             - port: "8083"
               protocol: TCP
+    # Mosquitto MQTT broker (in-cluster, mosquitto namespace).
+    - toEndpoints:
+        - matchLabels:
+            app: mosquitto
+            k8s:io.kubernetes.pod.namespace: mosquitto
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a `toEndpoints` egress rule to the Home Assistant `CiliumNetworkPolicy` allowing HA to reach the in-cluster Mosquitto MQTT broker at `mosquitto.mosquitto.svc.cluster.local:1883`
- Uses `toEndpoints` (not `toCIDR`) so Cilium can enforce the rule against the actual pod identity rather than IP

## After merge

1. Reconcile: `flux reconcile source git flux-system && flux reconcile kustomization apps-production -n flux-system`
2. In HA → Settings → Devices & Services → Add Integration → MQTT
   - Broker: `mosquitto.mosquitto.svc.cluster.local`
   - Port: `1883`
   - No username/password (broker runs with `allow_anonymous true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)