### PR TITLE
feat(bgp): UCGF BGP migration — phases 0–1 + tracking PR for 2–4

### DIFF
--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -796,19 +796,49 @@ If a future requirement demands BGP from CP nodes (e.g., advertising pod CIDRs f
 
 ## Baseline appendix
 
-> Filled in during Phase 0.3.
+> Filled in during Phase 0.3 — captured 2026-05-04.
+
+### Cluster topology
 
 ```
-# kubectl get svc -A -o jsonpath='...' (paste output here)
-default/cilium-gateway-app-gateway-production: 10.42.2.40
-default/cilium-gateway-app-gateway-staging: 10.42.2.42
-adguard-prod/adguard: 10.42.2.43
-adguard-stage/adguard: 10.42.2.42
-snapcast-prod/snapcast: 10.42.2.44
-snapcast-stage/snapcast: 10.42.2.41
+NAME            STATUS   ROLES           INTERNAL-IP
+talos-ykb-uir   Ready    control-plane   10.42.2.20
+talos-2mz-rfj   Ready    control-plane   10.42.2.21
+talos-v2l-hng   Ready    control-plane   10.42.2.22
+talos-lmh-kyf   Ready    <none>          10.42.2.23   # canary worker (Phase 2a)
+talos-18u-ski   Ready    <none>          10.42.2.24
+talos-kot-7x7   Ready    <none>          10.42.2.25
 ```
 
-Replace with the live output captured at Phase 0.3 time. Anyone reading this plan a year from now needs to know what was advertised at cutover.
+All 3 control-plane nodes carry `node.kubernetes.io/exclude-from-external-load-balancers` (verified at Phase 0.3).
+
+### LoadBalancer service IP map
+
+```
+adguard-prod/adguard:                            10.42.2.43
+adguard-prod/adguard-dns-secondary:              10.42.2.45
+adguard-stage/adguard:                           10.42.2.42
+default/cilium-gateway-app-gateway-production:   10.42.2.40
+default/cilium-gateway-app-gateway-staging:      10.42.2.42
+snapcast-prod/snapcast:                          10.42.2.37
+snapcast-stage/snapcast:                         10.42.2.41
+```
+
+> **Known anomaly:** `default/cilium-gateway-app-gateway-staging` and `adguard-stage/adguard` are both allocated `10.42.2.42`. BGP will advertise this /32 once. Cleanup tracked separately.
+
+### UCGF state at Phase 0.1
+
+| | |
+|:--|:--|
+| Firmware | 5.0.16 |
+| Kernel | 5.4.213-ui-ipq9574 |
+| FRR package | `frr 10.1.2-1+ubnt-35995+g695732fae09e` (arm64) |
+| FRR service before pre-flight | `disabled / inactive (dead)` |
+| Action taken | `bgpd=yes` in `/etc/frr/daemons` (backup at `/etc/frr/daemons.bak-pre-bgp`); `systemctl enable --now frr` |
+| Dry-run `router bgp 65100` / `no router bgp 65100` | accepted, no errors |
+| LAN segment | `br2 = 10.42.2.0/24`, gateway `10.42.2.1` |
+
+**Operator note:** UniFi firmware upgrades may revert `/etc/frr/daemons`. Re-apply `bgpd=yes` and re-enable FRR after any upgrade — the existing Phase 1.4 persistence note already covers `frr.conf`; extend it to `daemons` as well.
 
 ---
 

--- a/docs/reference/ucgf-bgp-frr.conf
+++ b/docs/reference/ucgf-bgp-frr.conf
@@ -1,8 +1,45 @@
 ! UniFi Cloud Gateway Fiber — FRR (vtysh) running config snapshot
 !
-! TODO: populate during Phase 1.2 of docs/plans/bgp-rollout.md
-! Capture with:
-!   ssh root@10.42.2.1 'vtysh -c "show running-config"' > docs/infra/ucgf-bgp-frr.conf
+! Captured 2026-05-04 during Phase 1.2 of docs/plans/2026-03-08-bgp-rollout.md.
+! Refresh with:
+!   ssh root@10.42.2.1 'vtysh -c "show running-config"' > docs/reference/ucgf-bgp-frr.conf
 !
 ! Treat this file as the canonical reference. Diff against the live config
-! after every UniFi firmware upgrade — firmware updates may wipe /etc/frr/frr.conf.
+! after every UniFi firmware upgrade — firmware updates may wipe /etc/frr/frr.conf
+! AND /etc/frr/daemons. If FRR comes back disabled, restore both:
+!   sed -i 's/^bgpd=no/bgpd=yes/' /etc/frr/daemons
+!   systemctl enable --now frr
+!   vtysh -f /path/to/this/file   (or paste the config below into vtysh)
+!
+frr version 10.1.2
+frr defaults traditional
+hostname Home
+domainname burntbytes.com
+log syslog informational
+service integrated-vtysh-config
+!
+ip prefix-list K8S-LB-IPS seq 10 permit 10.42.2.0/24 ge 32 le 32
+!
+router bgp 65100
+ bgp router-id 10.42.2.1
+ no bgp ebgp-requires-policy
+ neighbor K8S-NODES peer-group
+ neighbor K8S-NODES remote-as 65010
+ neighbor K8S-NODES description melodic-muse-worker
+ bgp listen range 10.42.2.0/24 peer-group K8S-NODES
+ !
+ address-family ipv4 unicast
+  neighbor K8S-NODES route-map K8S-LB-IN in
+  neighbor K8S-NODES route-map DENY-ALL out
+  maximum-paths 8
+ exit-address-family
+exit
+!
+route-map K8S-LB-IN permit 10
+ match ip address prefix-list K8S-LB-IPS
+exit
+!
+route-map DENY-ALL deny 10
+exit
+!
+end


### PR DESCRIPTION
Tracking PR for the BGP rollout in [docs/plans/2026-03-08-bgp-rollout.md](docs/plans/2026-03-08-bgp-rollout.md).

## What's in this commit (phases 0 + 1)

- **Phase 0**: Baseline appendix populated with the live cluster topology and LoadBalancer IP map captured 2026-05-04. Surfaces the `10.42.2.42` IP duplication anomaly between `gateway-staging` and `adguard-stage`.
- **Phase 1**: BGP configured on the UCGF (AS 65100). FRR was installed but disabled — `bgpd=yes` set in `/etc/frr/daemons` and the service enabled. The full running config snapshot is committed at `docs/reference/ucgf-bgp-frr.conf` with post-firmware-upgrade restoration steps.

## Subsequent phases will land as additional commits on this branch

- **Phase 2a** — Cilium `bgpControlPlane.enabled: true` + canary `CiliumBGPClusterConfig` selecting one worker
- **Phase 2b** — promote selector to all workers
- **Phase 3** — soak (no code changes)
- **Phase 4a** — delete `CiliumL2AnnouncementPolicy`
- **Phase 4b** — `l2announcements.enabled: false` in Helm values

Each phase has explicit GO/NO-GO operator approval per the plan.

## Verification (Phase 1)

- `show running-config bgpd` matches plan intent
- `show bgp summary` → `% No BGP neighbors found` (expected — cluster side not configured yet)
- LAN smoke tests on `.40`, `.43`, `.37` all return 200/resolved → L2 still carrying traffic, BGP did not disturb existing flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)