### PR TITLE
feat(adguard-stage): decouple from gateway-staging shared-IP

### DIFF
--- a/apps/staging/adguard/kustomization.yaml
+++ b/apps/staging/adguard/kustomization.yaml
@@ -19,9 +19,14 @@ patches:
       kind: Service
       name: adguard
     patch: |
-      - op: replace
+      # Drop sharing annotations inherited from base. The multi-node cluster
+      # removes any IP-scarcity reason to co-tenant; only staging was actually
+      # sharing (with gateway-staging on .42). IPAM allocates a standalone IP
+      # for adguard-stage from home-c-pool after this patch.
+      - op: remove
         path: /metadata/annotations/lbipam.cilium.io~1sharing-cross-namespace
-        value: default,adguard-stage,audiobookshelf-stage,linkding-stage,mealie-stage,memos-stage
+      - op: remove
+        path: /metadata/annotations/lbipam.cilium.io~1sharing-key
   - target:
       kind: Namespace
       name: adguard

--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -815,16 +815,29 @@ All 3 control-plane nodes carry `node.kubernetes.io/exclude-from-external-load-b
 ### LoadBalancer service IP map
 
 ```
-adguard-prod/adguard:                            10.42.2.43
-adguard-prod/adguard-dns-secondary:              10.42.2.45
-adguard-stage/adguard:                           10.42.2.42
+adguard-prod/adguard:                            10.42.2.43   # pinned (client DNS configs)
+adguard-prod/adguard-dns-secondary:              10.42.2.45   # pinned (client DNS configs)
+adguard-stage/adguard:                           10.42.2.42   # → standalone IP after this PR
 default/cilium-gateway-app-gateway-production:   10.42.2.40
-default/cilium-gateway-app-gateway-staging:      10.42.2.42
+default/cilium-gateway-app-gateway-staging:      10.42.2.42   # retains .42 alone after split
 snapcast-prod/snapcast:                          10.42.2.37
 snapcast-stage/snapcast:                         10.42.2.41
 ```
 
-> **Known anomaly:** `default/cilium-gateway-app-gateway-staging` and `adguard-stage/adguard` are both allocated `10.42.2.42`. BGP will advertise this /32 once. Cleanup tracked separately.
+> **Shared-IP cleanup (this PR):** Pre-PR, `gateway-staging` and `adguard-stage` co-tenanted `10.42.2.42` via `lbipam.cilium.io/sharing-key: homelab`, a single-node-era IP-compaction holdover. Multi-node cluster removes that scarcity. This PR strips the sharing annotations from `adguard-stage`'s overlay so IPAM allocates it a standalone IP from `home-c-pool`. `gateway-staging` retains `.42`. Production is unchanged: `adguard-prod` keeps `.43`/`.45` (pinned by client DNS configs) and `gateway-production` keeps `.40`.
+
+### LB IP pools
+
+Two pools are present (unchanged for BGP — the prefix-list `10.42.2.0/24 ge 32 le 32` covers both):
+
+| Pool | Range | Notes |
+|:-----|:------|:------|
+| `home-c-pool` | `10.42.2.40` – `10.42.2.254` | Legacy pool; covers all gateway and adguard IPs |
+| `home-compute-pool` | `10.42.2.30` – `10.42.2.37` | Added 2026-05-05 for snapcast/compute-tier services |
+
+### L2 announcement policy
+
+A single `CiliumL2AnnouncementPolicy` named `l2-announcement-policy-staging` is in effect. Despite the name, it has **no service selector** (`spec: {externalIPs: true, loadBalancerIPs: true}`) so it covers all LB IPs cluster-wide. Phase 4a removes this single resource.
 
 ### UCGF state at Phase 0.1
 


### PR DESCRIPTION
## Summary

- `adguard-stage` and `gateway-staging` previously co-tenanted `10.42.2.42` via `lbipam.cilium.io/sharing-key: homelab`. That was a single-node-era IP-compaction holdover that the multi-node cluster no longer needs.
- Strip the sharing annotations from `adguard-stage`'s overlay so IPAM allocates it a **standalone IP from `home-c-pool`** (likely `.44`).
- `gateway-staging` retains `.42` alone.
- Production is **unchanged**: `adguard-prod` keeps `.43`/`.45` (pinned by client DNS configs) and `gateway-production` keeps `.40`.
- Also folds in BGP-rollout plan amendments from the .42 investigation: documents both IP pools and clarifies the cluster-wide scope of `l2-announcement-policy-staging`.

## Why now

Captured during pre-flight for the BGP migration ([docs/plans/2026-03-08-bgp-rollout.md](docs/plans/2026-03-08-bgp-rollout.md)). Lands a clean baseline before Phase 2a.

## Risk

- Brief disruption to `adguard-stage` while IPAM reallocates and the kernel installs the new IP. App-level traffic via `adguard.stage.burntbytes.com` is unaffected (gateway routes by Host header).
- Anything pinning `10.42.2.42:53` directly for *staging* DNS would need to flip to the new IP. Operator confirmed nothing pins staging.
- Prod adguard at `.43` / `.45` is **not touched** (different overlay).

## Test plan

- [ ] `kustomize build apps/staging/adguard` passes (validated locally)
- [ ] After merge + Flux reconcile: `kubectl get svc -n adguard-stage adguard -o jsonpath='{.status.loadBalancer.ingress[0].ip}'` shows a new IP
- [ ] `kubectl get svc -n default cilium-gateway-app-gateway-staging` still shows `.42`
- [ ] `https://adguard.stage.burntbytes.com` resolves and loads
- [ ] `dig @<new-IP> example.com +short` succeeds
- [ ] No prod-side change

🤖 Generated with [Claude Code](https://claude.com/claude-code)