### PR TITLE
feat(cilium): enable BGP control plane (Phase 2a — canary on one worker)

### DIFF
--- a/infra/configs/cilium/bgp-advertisement.yaml
+++ b/infra/configs/cilium/bgp-advertisement.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: lb-ip-advertisement
+  labels:
+    advertise: lb-ips
+spec:
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+      # Empty matchLabels = match all services with a LoadBalancer IP.
+      selector:
+        matchLabels: {}

--- a/infra/configs/cilium/bgp-cluster-config.yaml
+++ b/infra/configs/cilium/bgp-cluster-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPClusterConfig
+metadata:
+  name: homelab-bgp
+spec:
+  # Phase 2a: canary only (one worker labeled bgp-canary=true).
+  # Phase 2b will replace this with role-based exclusion of control-plane nodes.
+  nodeSelector:
+    matchLabels:
+      bgp-canary: "true"
+  bgpInstances:
+    - name: homelab
+      localASN: 65010
+      peers:
+        - name: ucgf
+          peerASN: 65100
+          peerAddress: 10.42.2.1
+          peerConfigRef:
+            name: ucgf-peer
+            group: cilium.io
+            kind: CiliumBGPPeerConfig

--- a/infra/configs/cilium/bgp-peer-config.yaml
+++ b/infra/configs/cilium/bgp-peer-config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: ucgf-peer
+spec:
+  timers:
+    holdTimeSeconds: 90
+    keepAliveTimeSeconds: 30
+    connectRetryTimeSeconds: 120
+  transport:
+    peerPort: 179
+  families:
+    - afi: ipv4
+      safi: unicast
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 120

--- a/infra/configs/cilium/kustomization.yaml
+++ b/infra/configs/cilium/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - l2-announcement-policy.yaml
+  - bgp-advertisement.yaml
+  - bgp-cluster-config.yaml
+  - bgp-peer-config.yaml
+  - l2-announcement-policy.yaml   # kept during transition; removed in Phase 4a
   - load-balancer-ip-pool.yaml

--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -93,6 +93,14 @@ l2announcements:
   # -- Enable L2 announcements
   enabled: true
 
+# -- Configure BGP control plane
+# Enabling this is cluster-wide; whether a node *peers* is determined by the
+# CiliumBGPClusterConfig nodeSelector. Phase 2a of the BGP rollout starts with
+# a canary worker (label `bgp-canary=true`); Phase 2b promotes to all workers.
+# See docs/plans/2026-03-08-bgp-rollout.md.
+bgpControlPlane:
+  enabled: true
+
 # -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
 k8sServiceHost: "10.42.2.20"
 # @schema


### PR DESCRIPTION
## Summary

Phase 2a of the BGP rollout ([docs/plans/2026-03-08-bgp-rollout.md](docs/plans/2026-03-08-bgp-rollout.md)). Canary one worker before promoting cluster-wide.

- Enable cluster-wide Cilium BGP control plane: `bgpControlPlane.enabled: true` in Helm values. Triggers a Cilium DaemonSet rollout (~30s per node, rolling).
- Three new `cilium.io/v2` CRs:
  - `CiliumBGPPeerConfig/ucgf-peer` — IPv4 unicast, timers (hold 90s / keepalive 30s / connect-retry 120s), graceful-restart 120s
  - `CiliumBGPAdvertisement/lb-ip-advertisement` — advertises all LoadBalancer IPs (empty selector)
  - `CiliumBGPClusterConfig/homelab-bgp` — selector `bgp-canary=true`, peers UCGF at `10.42.2.1` AS 65100 from local AS 65010
- `talos-lmh-kyf` already labeled `bgp-canary=true` (transient label; replaced by role-based exclusion in Phase 2b).

## Coexistence with L2

L2 policy is unchanged. Both protocols advertise the same /32s through Phases 2a → 4a. Phase 4a removes L2.

## Validation

- `kustomize build infra/configs/cilium` passes
- `kustomize build infra/controllers` shows `bgpControlPlane.enabled: true` in the cilium-helm-values ConfigMap

## Post-merge plan

1. `flux reconcile source git flux-system && flux reconcile kustomization infra-controllers -n flux-system --with-source`
2. Wait for DaemonSet rollout
3. `flux reconcile kustomization infra-configs -n flux-system --with-source`
4. Verify only the canary establishes BGP:
   - `cilium-dbg bgp peers` on `talos-lmh-kyf` → Established
   - Other 5 nodes → no BGP instance configured
   - `ssh root@10.42.2.1 'vtysh -c "show bgp summary"'` → 1 dynamic peer `*10.42.2.23` Established
   - `ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'` → all baseline /32s with single next-hop `10.42.2.23`
5. **Soak ≥1 hour** before Phase 2b promotes selector to all workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)