### PR TITLE
fix(cilium): CiliumBGPClusterConfig peerConfigRef schema (v2)

### DIFF
--- a/infra/configs/cilium/bgp-cluster-config.yaml
+++ b/infra/configs/cilium/bgp-cluster-config.yaml
@@ -18,5 +18,3 @@ spec:
           peerAddress: 10.42.2.1
           peerConfigRef:
             name: ucgf-peer
-            group: cilium.io
-            kind: CiliumBGPPeerConfig


### PR DESCRIPTION
## Summary

Phase 2a follow-up. Flux dry-run rejected the new `CiliumBGPClusterConfig` because the resource included `peerConfigRef.{group, kind}` — those fields exist in the **v2alpha1** schema (which the plan's example used) but were dropped in **v2** (storage version). v2 only accepts `peerConfigRef.name`.

```
infra-configs Kustomization status:
  CiliumBGPClusterConfig/homelab-bgp dry-run failed:
    .spec.bgpInstances[name="homelab"].peers[name="ucgf"].peerConfigRef.group:
    field not declared in schema
```

This commit removes the two unsupported keys; `name: ucgf-peer` is sufficient.

## Test plan

- [x] `kustomize build infra/configs/cilium` passes
- [ ] After merge + reconcile: `kubectl get ciliumbgpclusterconfig homelab-bgp -o yaml` shows the resource applied
- [ ] BGP peer Established on canary (talos-lmh-kyf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)