### PR TITLE
fix(cilium): wire CiliumBGPPeerConfig to advertisements (Phase 2a follow-up)

### DIFF
--- a/infra/configs/cilium/bgp-peer-config.yaml
+++ b/infra/configs/cilium/bgp-peer-config.yaml
@@ -13,6 +13,11 @@ spec:
   families:
     - afi: ipv4
       safi: unicast
+      # Select which CiliumBGPAdvertisements feed this address-family.
+      # Matches `lb-ip-advertisement` (label advertise: lb-ips).
+      advertisements:
+        matchLabels:
+          advertise: lb-ips
   gracefulRestart:
     enabled: true
     restartTimeSeconds: 120


### PR DESCRIPTION
## Summary

After the Phase 2a CRs landed, the canary peer reached Established but advertised 0 prefixes:

```
Local AS  Peer AS  Peer Address    Session       Family         Received  Advertised
65010     65100    10.42.2.1:179   established   ipv4/unicast   0         0
```

`cilium-dbg bgp routes available ipv4 unicast` was empty too. Root cause: the `CiliumBGPPeerConfig` had no `families[].advertisements` selector, so the peer had no advertisements attached.

## Fix

Add `families[0].advertisements.matchLabels{advertise: lb-ips}` to `CiliumBGPPeerConfig/ucgf-peer`. This matches the existing `CiliumBGPAdvertisement/lb-ip-advertisement` (which already carries `metadata.labels.advertise: lb-ips`) and attaches it to the IPv4 unicast family.

## Test plan

- [x] `kustomize build infra/configs/cilium` passes
- [ ] After merge + reconcile: `cilium-dbg bgp peers` on canary shows `Advertised: 7` (the count of LB IPs)
- [ ] `vtysh -c "show ip route bgp"` on UCGF shows all baseline /32s with next-hop `10.42.2.23`

🤖 Generated with [Claude Code](https://claude.com/claude-code)