### PR TITLE
docs(bgp-plan): record Cilium 1.19 / CRD v2 schema gotchas from Phase 2a

### DIFF
--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -308,6 +308,13 @@ spec:
   families:
     - afi: ipv4
       safi: unicast
+      # REQUIRED on Cilium 1.19 / CRD v2: select which CiliumBGPAdvertisement
+      # resources feed each address-family. Without this, the peer reaches
+      # Established but Advertised stays at 0 — no /32s are sent.
+      # The label must match the labels on bgp-advertisement.yaml below.
+      advertisements:
+        matchLabels:
+          advertise: lb-ips
   gracefulRestart:
     enabled: true
     restartTimeSeconds: 120
@@ -357,9 +364,10 @@ spec:
           peerASN: 65100
           peerAddress: 10.42.2.1
           peerConfigRef:
+            # CRD v2 only accepts `name`. The v2alpha1 fields `group` and
+            # `kind` are not in the v2 schema — including them causes
+            # `field not declared in schema` and Flux dry-run failure.
             name: ucgf-peer
-            group: cilium.io
-            kind: CiliumBGPPeerConfig
 ```
 
 ### 2a.7 Wire into kustomization
@@ -387,7 +395,16 @@ flux reconcile kustomization infra-controllers -n flux-system --with-source
 flux reconcile kustomization infra-configs -n flux-system --with-source
 ```
 
-Wait for the `cilium` DaemonSet rollout to complete (`bgpControlPlane: true` triggers an agent restart on every node).
+> **Cilium 1.19 gotcha:** flipping `bgpControlPlane.enabled` updates the `cilium-config` ConfigMap but **does not change the DaemonSet pod template hash**. The Helm upgrade reports success, the DaemonSet reports "successfully rolled out", but the existing agent pods keep running with the old config — `cilium-dbg bgp peers` returns "BGP Control Plane is disabled". The same applies to the `cilium-operator` Deployment, which is what auto-generates `CiliumBGPNodeConfig` per matched node. Both must be bounced manually:
+>
+> ```bash
+> kubectl rollout restart ds/cilium -n kube-system
+> kubectl rollout status ds/cilium -n kube-system
+> kubectl rollout restart deploy/cilium-operator -n kube-system
+> kubectl rollout status deploy/cilium-operator -n kube-system
+> ```
+>
+> Symptom of skipping the operator restart: `kubectl get ciliumbgpnodeconfig` returns `No resources found` even though the cluster config and node label both exist. After the operator restart, one `CiliumBGPNodeConfig` per matched node appears within seconds and the peer initiates BGP.
 
 ### 2a.9 Verify (one peer only)
 


### PR DESCRIPTION
## Summary

Three plan-vs-reality deviations surfaced on Cilium 1.19 (CRD storage v2) during the canary rollout. Fold them into Phase 2a so a future operator running this plan doesn't re-discover them.

## Gotchas documented

1. **`CiliumBGPPeerConfig.spec.families[].advertisements` is REQUIRED.** Without it the peer reaches `Established` but `Advertised` stays at `0` — no /32s are sent. (Discovered via PR #509.)

2. **`peerConfigRef` in v2 only accepts `name`.** The v2alpha1 fields `group` and `kind` cause `field not declared in schema` and Flux dry-run failure. (Discovered via PR #508.)

3. **Flipping `bgpControlPlane.enabled` in Helm values doesn't roll the agent DaemonSet or the operator Deployment.** Helm reports success, the DS rollout reports done, but pods keep running with the old config — `cilium-dbg bgp peers` reports "BGP Control Plane is disabled". The operator must also be bounced; without it `CiliumBGPNodeConfig` is never generated. Both `kubectl rollout restart` invocations are now spelled out in step 2a.8 with the symptom-of-skipping note.

## Scope

Doc-only — no manifest changes. The cluster-side fixes already shipped via PRs #508 / #509 and the two manual rollout restarts during the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)