### PR TITLE
feat(homeassistant): codify Switchboard dashboard as YAML

### DIFF
--- a/apps/base/homeassistant/configmap.yaml
+++ b/apps/base/homeassistant/configmap.yaml
@@ -20,6 +20,12 @@ data:
           filename: dashboards/control.yaml
           title: Control
           show_in_sidebar: true
+        switchboard:
+          mode: yaml
+          filename: dashboards/switchboard.yaml
+          title: Switchboard
+          icon: mdi:lightbulb-group
+          show_in_sidebar: true
 
     automation: !include automations.yaml
     script: !include scripts.yaml
@@ -311,3 +317,122 @@ data:
                   data:
                     entity_id: fan.bathroom_master_fan
                 show_name: true
+  switchboard.yaml: |
+    # Switchboard Dashboard
+    #
+    # A whole-house light-control dashboard. One masonry view ("Lights") with
+    # entity cards grouped by room, each card listing the room's light entities
+    # with toggle switches.
+    #
+    # Codified from the HA UI on 2026-05-04 (originally created via Settings →
+    # Dashboards → Add Dashboard, persisted at /config/.storage/lovelace.switchboard).
+    # Adding a new room or light:
+    #   1. Add an entity card under views[0].cards in the appropriate room block,
+    #      or copy an existing room block and rename.
+    #   2. Each entity must exist as a HA `light.*` entity (added via the Lutron
+    #      Caséta integration or another light platform).
+
+    title: Switchboard
+    views:
+      - title: Lights
+        path: lights
+        icon: mdi:lightbulb-group
+        type: masonry
+        cards:
+          - type: entities
+            title: Kitchen
+            entities:
+              - entity: light.kitchen_main_lights
+                toggle: true
+              - entity: light.kitchen_island_pendants
+                toggle: true
+              - entity: light.kitchen_under_cabinet
+                toggle: true
+          - type: entities
+            title: Living Room
+            entities:
+              - entity: light.living_room_sconces
+                toggle: true
+          - type: entities
+            title: Dining Room
+            entities:
+              - entity: light.dining_room_sconces
+                toggle: true
+          - type: entities
+            title: Foyer
+            entities:
+              - entity: light.front_foyer_spot_lights
+                toggle: true
+          - type: entities
+            title: Hallway
+            entities:
+              - entity: light.hallway_long
+                toggle: true
+              - entity: light.hallway_landing
+                toggle: true
+          - type: entities
+            title: Office
+            entities:
+              - entity: light.office_main_lights
+                toggle: true
+          - type: entities
+            title: Master Bedroom
+            entities:
+              - entity: light.master_bedroom_main_lights
+                toggle: true
+              - entity: light.master_bedroom_entry
+                toggle: true
+              - entity: light.master_bedroom_sconce_north
+                toggle: true
+              - entity: light.master_bedroom_sconce_south
+                toggle: true
+          - type: entities
+            title: Master Bathroom
+            entities:
+              - entity: light.master_bathroom_ceiling
+                toggle: true
+              - entity: light.master_bathroom_vanity
+                toggle: true
+          - type: entities
+            title: Niccolo Bedroom
+            entities:
+              - entity: light.niccolo_bedroom_main_lights
+                toggle: true
+          - type: entities
+            title: Nursery
+            entities:
+              - entity: light.nursery_bedroom_main_lights
+                toggle: true
+              - entity: light.nursery_bedroom_closet_light
+                toggle: true
+          - type: entities
+            title: Hall Bathroom
+            entities:
+              - entity: light.hall_bathroom_main_lights
+                toggle: true
+              - entity: light.hall_bathroom_vanity_lights
+                toggle: true
+          - type: entities
+            title: Powder Bathroom
+            entities:
+              - entity: light.powder_bathroom_chandelier
+                toggle: true
+          - type: entities
+            title: Butler Pantry
+            entities:
+              - entity: light.butler_pantry_main_lights
+                toggle: true
+          - type: entities
+            title: Laundry Room
+            entities:
+              - entity: light.laundry_room_main_lights
+                toggle: true
+              - entity: light.laundry_room_cove
+                toggle: true
+          - type: entities
+            title: Exterior
+            entities:
+              - entity: light.exterior_east
+                toggle: true
+              - entity: light.exterior_west
+                toggle: true

--- a/apps/base/homeassistant/dashboards/switchboard.yaml
+++ b/apps/base/homeassistant/dashboards/switchboard.yaml
@@ -1,0 +1,118 @@
+# Switchboard Dashboard
+#
+# A whole-house light-control dashboard. One masonry view ("Lights") with
+# entity cards grouped by room, each card listing the room's light entities
+# with toggle switches.
+#
+# Codified from the HA UI on 2026-05-04 (originally created via Settings →
+# Dashboards → Add Dashboard, persisted at /config/.storage/lovelace.switchboard).
+# Adding a new room or light:
+#   1. Add an entity card under views[0].cards in the appropriate room block,
+#      or copy an existing room block and rename.
+#   2. Each entity must exist as a HA `light.*` entity (added via the Lutron
+#      Caséta integration or another light platform).
+
+title: Switchboard
+views:
+  - title: Lights
+    path: lights
+    icon: mdi:lightbulb-group
+    type: masonry
+    cards:
+      - type: entities
+        title: Kitchen
+        entities:
+          - entity: light.kitchen_main_lights
+            toggle: true
+          - entity: light.kitchen_island_pendants
+            toggle: true
+          - entity: light.kitchen_under_cabinet
+            toggle: true
+      - type: entities
+        title: Living Room
+        entities:
+          - entity: light.living_room_sconces
+            toggle: true
+      - type: entities
+        title: Dining Room
+        entities:
+          - entity: light.dining_room_sconces
+            toggle: true
+      - type: entities
+        title: Foyer
+        entities:
+          - entity: light.front_foyer_spot_lights
+            toggle: true
+      - type: entities
+        title: Hallway
+        entities:
+          - entity: light.hallway_long
+            toggle: true
+          - entity: light.hallway_landing
+            toggle: true
+      - type: entities
+        title: Office
+        entities:
+          - entity: light.office_main_lights
+            toggle: true
+      - type: entities
+        title: Master Bedroom
+        entities:
+          - entity: light.master_bedroom_main_lights
+            toggle: true
+          - entity: light.master_bedroom_entry
+            toggle: true
+          - entity: light.master_bedroom_sconce_north
+            toggle: true
+          - entity: light.master_bedroom_sconce_south
+            toggle: true
+      - type: entities
+        title: Master Bathroom
+        entities:
+          - entity: light.master_bathroom_ceiling
+            toggle: true
+          - entity: light.master_bathroom_vanity
+            toggle: true
+      - type: entities
+        title: Niccolo Bedroom
+        entities:
+          - entity: light.niccolo_bedroom_main_lights
+            toggle: true
+      - type: entities
+        title: Nursery
+        entities:
+          - entity: light.nursery_bedroom_main_lights
+            toggle: true
+          - entity: light.nursery_bedroom_closet_light
+            toggle: true
+      - type: entities
+        title: Hall Bathroom
+        entities:
+          - entity: light.hall_bathroom_main_lights
+            toggle: true
+          - entity: light.hall_bathroom_vanity_lights
+            toggle: true
+      - type: entities
+        title: Powder Bathroom
+        entities:
+          - entity: light.powder_bathroom_chandelier
+            toggle: true
+      - type: entities
+        title: Butler Pantry
+        entities:
+          - entity: light.butler_pantry_main_lights
+            toggle: true
+      - type: entities
+        title: Laundry Room
+        entities:
+          - entity: light.laundry_room_main_lights
+            toggle: true
+          - entity: light.laundry_room_cove
+            toggle: true
+      - type: entities
+        title: Exterior
+        entities:
+          - entity: light.exterior_east
+            toggle: true
+          - entity: light.exterior_west
+            toggle: true

--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -106,6 +106,9 @@ spec:
             - name: config-file
               mountPath: /config/dashboards/control.yaml
               subPath: control.yaml
+            - name: config-file
+              mountPath: /config/dashboards/switchboard.yaml
+              subPath: switchboard.yaml
       volumes:
         - name: config
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Pulls the Switchboard light-control dashboard out of the storage-mode `/config/.storage/lovelace.switchboard` PVC file and into Git, mirroring the existing Control dashboard pattern.

The Switchboard is a single-view masonry layout with one entity-card per room (Kitchen, Living Room, Dining Room, Foyer, Hallway, Office, Master Bedroom, Master Bathroom, Niccolo Bedroom, Nursery, Hall Bathroom, Powder Bathroom, Butler Pantry, Laundry Room, Exterior), each card listing the room's light entities with toggle switches.

Captured 2026-05-04 from the live HA pod via `kubectl exec`.

## Tradeoff

After this lands, the dashboard is editable via PR only — the HA UI's Lovelace editor will refuse changes for YAML-mode dashboards. Same constraint already applies to Control.

## Required follow-up after merge (operator action on live pod)

The current storage-mode entry in `/config/.storage/lovelace.switchboard` and the registry entry in `/config/.storage/lovelace_dashboards` would coexist with the new YAML entry, producing **two "Switchboard" sidebar entries**. To clean up:

```bash
POD=$(kubectl get pod -n homeassistant-prod -l app=homeassistant -o jsonpath='{.items[0].metadata.name}')

# 1. Remove the storage-mode dashboard data file
kubectl exec -n homeassistant-prod "$POD" -c homeassistant -- rm /config/.storage/lovelace.switchboard

# 2. Remove the registry entry (drop the `switchboard` item from items[])
#    Use HA UI: Settings → Dashboards → Switchboard (storage one) → Delete
#    OR edit /config/.storage/lovelace_dashboards directly and bounce the pod
kubectl rollout restart deploy/homeassistant -n homeassistant-prod
```

## Test plan

- [x] `kustomize build apps/production/homeassistant` shows `switchboard.yaml` ConfigMap entry, deployment subPath mount at `/config/dashboards/switchboard.yaml`, and `lovelace.dashboards.switchboard` block in `configuration.yaml`
- [ ] After merge + Flux reconcile + operator cleanup of storage-mode dupe: only one "Switchboard" appears in sidebar
- [ ] Dashboard renders identically to before (rooms, entities, toggles)
- [ ] Lovelace UI editor refuses to edit Switchboard ("YAML dashboard cannot be edited")

🤖 Generated with [Claude Code](https://claude.com/claude-code)