### PR TITLE
fix(llama-cpp): enable vision with --mmproj for Qwen3.6-35B-A3B

### DIFF
--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -9,6 +9,7 @@ services:
       - "8000:8080"
     command: >
       -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf
+      --mmproj /models/mmproj-F16.gguf
       --alias Qwen3.6-35B-A3B
       --host 0.0.0.0
       --port 8080


### PR DESCRIPTION
## Summary

Enable multimodal vision support for the Qwen3.6-35B-A3B llama.cpp server by adding the  flag pointing to the F16 vision projector.

The Qwen3.6-35B-A3B model supports vision, but llama.cpp requires a separate mmproj file for image understanding. This PR adds:

-  to the llama.cpp command

**Before deploying:** Download the mmproj file to your TrueNAS at :
```bash
wget -O /mnt/main/ai/models/gguf/mmproj-F16.gguf \\
  "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf"
```

The F16 variant is ~899 MB (smallest of the three available: BF16, F16, F32).