### PR TITLE
fix(homeassistant): remove invalid lovelace.dashboards YAML block (HA UI broken)

### DIFF
--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -5,20 +5,17 @@ default_config:
 frontend:
   themes: !include_dir_merge_named themes
 
-# Enable YAML dashboards (explicit dashboard registration)
-lovelace:
-  dashboards:
-    control:
-      mode: yaml
-      filename: dashboards/control.yaml
-      title: Control
-      show_in_sidebar: true
-    switchboard:
-      mode: yaml
-      filename: dashboards/switchboard.yaml
-      title: Switchboard
-      icon: mdi:lightbulb-group
-      show_in_sidebar: true
+# Lovelace runs in storage mode (the default). Dashboards are registered via
+# the storage registry in /config/.storage/lovelace_dashboards. YAML-mode
+# dashboards listed there reference files mounted from this ConfigMap at
+# /config/dashboards/<name>.yaml (control.yaml, switchboard.yaml).
+#
+# Note: HA's YAML-config `lovelace.dashboards` block requires slug keys to
+# contain a hyphen (`url path needs to contain a hyphen`), which `control`
+# and `switchboard` don't have. The storage registry has no such rule, so
+# we manage these via the registry instead. To convert a UI-created (mode:
+# storage) dashboard to YAML mode, edit the registry entry directly: set
+# mode: yaml and filename: dashboards/<file>.yaml.
 
 automation: !include automations.yaml
 script: !include scripts.yaml


### PR DESCRIPTION
## URGENT — fixes HA UI broken after PR #513

After PR #513's configMapGenerator refactor rolled out, the new HA pod tried to load the `lovelace.dashboards.{control, switchboard}` YAML block and **rejected it** because slug keys require a hyphen:

```
Invalid config for 'lovelace': Url path needs to contain a hyphen (-)
Setup failed for 'lovelace': Invalid config.
Setup failed for 'frontend': Could not setup dependencies: lovelace
```

Both `frontend` and `lovelace` failed → entire HA UI is broken right now.

## Why this only just surfaced

PR #513 was the **first time** HA actually loaded the `lovelace.dashboards` block. Before #513, the pod was running with stale subPath-mounted content that pre-dated the block. The earlier "add `dashboards.control` to configmap" PR was technically broken from day one but never actually applied at runtime.

## Fix

Drop the YAML `lovelace.dashboards` block entirely. Both Control and Switchboard are registered via the **storage registry** (`/config/.storage/lovelace_dashboards`), which has no hyphen requirement. The existing storage entry for Control is `mode: yaml` + `filename: dashboards/control.yaml` and points at the same file mounted from this ConfigMap.

Lovelace falls back to default `mode: storage` when the block is omitted; the storage registry processes normally.

## Follow-up (operator action, optional)

The Switchboard storage entry is currently `mode: storage` (UI-created data). To make the YAML version the source of truth without changing the URL:

1. Edit `/config/.storage/lovelace_dashboards` on the pod
2. Find the `switchboard` item; change `"mode": "storage"` → `"mode": "yaml"` and add `"filename": "dashboards/switchboard.yaml"`
3. Delete `/config/.storage/lovelace.switchboard`
4. Restart HA

🤖 Generated with [Claude Code](https://claude.com/claude-code)