### PR TITLE
fix(llama-cpp): revert --mmproj vision (CUDA OOM at 256K ctx)

### DIFF
--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -9,7 +9,6 @@ services:
       - "8000:8080"
     command: >
       -m /models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf
-      --mmproj /models/mmproj-F16.gguf
       --alias Qwen3.6-35B-A3B
       --host 0.0.0.0
       --port 8080


### PR DESCRIPTION
## Summary

- Reverts #512: drops `--mmproj /models/mmproj-F16.gguf` from the llama.cpp compose command.
- Vision-on + 256K ctx + q8_0 KV cache exhausts the 4090 (24071/24564 MiB used; ~493 MiB free). mmproj warmup hits `cudaMalloc failed: out of memory` allocating the 248 MiB compute graph at 1472×1472, and real vision requests stall at HTTP 503.
- Text inference was unaffected (LLM context allocated before warmup), so the symptom looked like a partial server outage.

## Path forward

Re-enable vision in a follow-up PR by combining:
- `--image-max-pixels 1048576` (cap vision graph at 1024×1024)
- `--ctx-size 131072` (halves KV cache footprint)

## Test plan

- [ ] Compose pulls the existing `2026-05-04` image (no tag change, no rollback)
- [ ] After `docker compose up -d`, `nvidia-smi` shows headroom and `docker logs llama` no longer prints the cudaMalloc OOM warmup line
- [ ] `curl http://10.42.2.10:8000/v1/chat/completions` text completion still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)