### PR TITLE
fix(homeassistant): allow egress to Lutron bridge on port 8081 (LEAP)

### DIFF
--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -41,7 +41,14 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
-    # Lutron Caséta Smart Bridge at 10.42.2.16 — LEAP API (pylutron-caseta uses mTLS on 8083).
+    # Lutron Caséta Smart Bridge at 10.42.2.16. Two TLS ports are required:
+    #   8083 — LAP (Lutron Authentication Protocol): cert signing during the
+    #          pairing flow (CSR submission, button-press wait, signed-cert return).
+    #   8081 — LEAP (Lutron Extensible Application Protocol): post-pair
+    #          verification AND all normal device control/state communication.
+    # Earlier comment claimed pylutron-caseta uses 8083 alone — wrong; pairing
+    # uses 8083 then verification + steady-state ops use 8081. Without 8081 the
+    # bridge appears to "pair successfully" then immediately becomes unreachable.
     # toCIDR is required because Cilium classifies non-cluster LAN hosts as world,
     # but the world rule above only opens 443/80. The bridge is LAN-only so a CIDR
     # rule is more precise than widening the world ports.
@@ -50,6 +57,8 @@ spec:
       toPorts:
         - ports:
             - port: "8083"
+              protocol: TCP
+            - port: "8081"
               protocol: TCP
     # Mosquitto MQTT broker (in-cluster, mosquitto namespace).
     - toEndpoints:


### PR DESCRIPTION
## Root cause

The Lutron Caséta integration uses **two ports** on the bridge:

| Port | Protocol | Used for |
|---|---|---|
| 8083 | LAP (Lutron Authentication Protocol) | Cert-signing pairing flow only — CSR submission, button-press wait, signed-cert return |
| 8081 | LEAP (Lutron Extensible Application Protocol) | Post-pair verification AND **all normal device control / state communication** |

Our CNP only allowed 8083. Visible symptom during diagnostic pairing: bridge entered pairing mode (`Permissions: ["Public","PhysicalAccess"]`), signed our cert, returned the cert + Lutron RootCertificate. Then `pylutron_caseta._async_verify_certificate` timed out trying to open a TCP connection to `bridge:8081` (silently dropped by Cilium). The integration appeared to "pair successfully" but immediately became unreachable.

## Verification

Read on the running HA pod:
```
_async_generate_certificate → connects to 8083  (CSR + cert sign) ✓
_async_verify_certificate   → connects to 8081  (LEAP ping)        ✗ blocked
```

The earlier inline comment in `networkpolicy.yaml` claimed "pylutron-caseta uses mTLS on 8083" — that's only half the story. Updated to document both ports correctly.

## After merge

Once Flux reconciles `apps-production`, re-run the pairing flow. The post-pair verification step will now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)