### PR TITLE
feat(cilium): promote BGP from canary to all workers (Phase 2b)

### DIFF
--- a/infra/configs/cilium/bgp-cluster-config.yaml
+++ b/infra/configs/cilium/bgp-cluster-config.yaml
@@ -4,11 +4,15 @@ kind: CiliumBGPClusterConfig
 metadata:
   name: homelab-bgp
 spec:
-  # Phase 2a: canary only (one worker labeled bgp-canary=true).
-  # Phase 2b will replace this with role-based exclusion of control-plane nodes.
+  # Phase 2b: every node EXCEPT control-plane peers. Workers establish BGP;
+  # CP nodes are excluded — they wouldn't advertise LB IPs anyway because of
+  # node.kubernetes.io/exclude-from-external-load-balancers, so a BGP session
+  # from them would just be noise. New workers are picked up automatically as
+  # soon as they join the cluster.
   nodeSelector:
-    matchLabels:
-      bgp-canary: "true"
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
   bgpInstances:
     - name: homelab
       localASN: 65010


### PR DESCRIPTION
## Summary

Phase 2b of the BGP rollout ([docs/plans/2026-03-08-bgp-rollout.md](docs/plans/2026-03-08-bgp-rollout.md)). Canary on `talos-lmh-kyf` has been Established and serving 7 prefixes for **2h21m** with no flap; promoting now to all 3 workers.

## Change

`infra/configs/cilium/bgp-cluster-config.yaml` — replace canary selector:
```yaml
nodeSelector:
  matchLabels:
    bgp-canary: "true"
```
with role-based exclusion of control-plane nodes:
```yaml
nodeSelector:
  matchExpressions:
    - key: node-role.kubernetes.io/control-plane
      operator: DoesNotExist
```

CP nodes already carry `node.kubernetes.io/exclude-from-external-load-balancers` so they'd never advertise LB IPs anyway — running BGP from them would just be noise. New workers picked up automatically as soon as they join the cluster.

## Hot-applied

Changing `CiliumBGPClusterConfig.nodeSelector` does **not** require a Cilium agent or operator restart. The cilium-operator watches the resource and reconciles `CiliumBGPNodeConfig` per matching node; the agents pick those up within seconds. Expected timeline:

1. Flux applies the change → operator sees new selector → generates `CiliumBGPNodeConfig` for the 2 new workers (talos-18u-ski, talos-kot-7x7).
2. Within ~30s, those agents initiate BGP to UCGF.
3. UCGF sees 3 dynamic peers; ECMP installs 3 next-hops per LB IP.

## Verification (post-merge + reconcile)

- [ ] All 3 workers `Established` on UCGF: `vtysh -c "show bgp summary"` → `*10.42.2.{23,24,25}` all up
- [ ] `vtysh -c "show ip route bgp"` shows 3 next-hops per /32 (ECMP holds)
- [ ] Each Cilium agent on workers shows `cilium-dbg bgp peers` Established
- [ ] CP nodes show no BGP activity
- [ ] LAN smoke tests still pass (gateway, adguard, snapcast)

## Cleanup

After verification, remove the now-redundant `bgp-canary=true` label from `talos-lmh-kyf` — the canary worker keeps peering because it now matches the role-based selector, the label has no further effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)