### PR TITLE
chore(cilium): disable l2announcements helm flag (Phase 4b)

### DIFF
--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -89,9 +89,12 @@ cgroup:
   hostRoot: /sys/fs/cgroup
 
 # -- Configure L2 announcements
+# Disabled at the Helm level after the BGP migration (Phase 4b of the BGP
+# rollout plan). The CiliumL2AnnouncementPolicy resource was removed in
+# Phase 4a; this flag was a no-op without it, but flipping it false keeps
+# config consistent and stops Cilium from initializing the L2 module.
 l2announcements:
-  # -- Enable L2 announcements
-  enabled: true
+  enabled: false
 
 # -- Configure BGP control plane
 # Enabling this is cluster-wide; whether a node *peers* is determined by the


### PR DESCRIPTION
## Summary

Phase 4b of the BGP rollout — purely cosmetic. The `CiliumL2AnnouncementPolicy` resource was removed in Phase 4a (PR #519); the Helm flag has been a no-op since then. Flipping it `false` so Cilium stops initializing the L2 module and so future readers don't have to wonder why a feature labeled "enabled" has no associated policy.

## Effect

- Triggers a Cilium DaemonSet rollout (~30s per node, rolling).
- BGP graceful-restart (`restartTimeSeconds: 120` on `CiliumBGPPeerConfig/ucgf-peer`) keeps the advertised routes installed on the UCGF for up to 120s after the agent goes down on each node — sessions re-establish well within that window.
- Zero traffic impact expected.

## Note: config-only Helm changes don't auto-rollout

Per the lesson documented in PR #510 (Phase 2a gotchas), flipping a Helm value updates the `cilium-config` ConfigMap but doesn't change the DaemonSet pod-template hash. After Flux reconciles, I'll manually `kubectl rollout restart ds/cilium` to actually pick up the new config. (Operator restart not needed — this flag affects the agent only.)

## Verification

- [ ] After rollout: `cilium-dbg bgp peers` on each worker still Established (uptime resets to seconds, that's expected after agent restart)
- [ ] UCGF: 3 peers Established, all 7 /32s with 3 next-hops each (ECMP holds)
- [ ] LAN smoke: `gateway-prod`, `adguard-prod`, `adguard-stage` all 200 / DNS resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)