### PR TITLE
docs/alerts(bgp): Phase 5 — monitoring rules + cilium reference rewrite + plan completion

### DIFF
--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -1,9 +1,12 @@
 ---
-status: planned
-last_modified: 2026-05-03
+status: completed
+last_modified: 2026-05-05
+completed: 2026-05-05
 ---
 
 # BGP Rollout Plan — UniFi Cloud Gateway Fiber + Cilium
+
+> **Completed 2026-05-05.** All 7 LoadBalancer IPs are now advertised via BGP from each of the 3 worker nodes (AS 65010 → UCGF AS 65100); the UCGF installs 3 ECMP next-hops per /32. L2 announcements (`CiliumL2AnnouncementPolicy`) deleted in Phase 4a, `l2announcements.enabled: false` in Helm values as of Phase 4b. Plan-vs-reality gotchas (CRD v2 schema differences, helm-config-only changes not auto-rolling, deprecated `lovelace.dashboards` slug-validator, port 8081 also needed for Lutron) folded into the Phase 2a/4b sections inline. Outstanding follow-up: enable `prometheus.enabled: true` in Cilium Helm values so the BGP alert rules in `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp`) actually fire.
 
 Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kubernetes node and the UniFi Cloud Gateway Fiber (UCGF). The router gets real routing-table entries for LoadBalancer IPs instead of relying on gratuitous ARP — better reliability, observability, and multi-node readiness.
 

--- a/docs/reference/cilium.md
+++ b/docs/reference/cilium.md
@@ -1,70 +1,139 @@
 # Cilium
 
-> **Migration in flight (2026-05-02):** LoadBalancer IP advertisement is moving from L2 Announcements to BGP peering with the UCGF. See [`docs/plans/2026-03-08-bgp-rollout.md`](../plans/2026-03-08-bgp-rollout.md). Update this doc when the migration completes.
-
 ## 1. Overview
-Cilium is the Container Network Interface (CNI) used in the homelab cluster. It provides high-performance networking, security, and observability using eBPF. It also serves as the LoadBalancer IPAM provider (replacing MetalLB) and the Gateway API controller.
+
+Cilium is the Container Network Interface (CNI) used in the homelab cluster. It provides high-performance networking, security, and observability via eBPF. It also serves as the LoadBalancer IPAM provider (replacing MetalLB) and the Gateway API controller.
 
 ## 2. Architecture
+
 Cilium is deployed via Flux using the official Helm chart. It runs as a DaemonSet (`cilium`) on all nodes and a Deployment (`cilium-operator`) for cluster-wide operations.
-- **Datapath**: Uses eBPF with `kubeProxyReplacement: true` (kube-proxy is completely removed).
-- **IPAM**: Uses Kubernetes IPAM mode.
-- **LoadBalancer**: Cilium L2 Announcements are enabled to announce LoadBalancer IPs to the local network.
+
+- **Datapath**: eBPF with `kubeProxyReplacement: true` (kube-proxy is completely removed).
+- **IPAM**: Kubernetes IPAM mode.
+- **LoadBalancer IP advertisement**: BGP peering with the UCGF (UniFi Cloud Gateway Fiber). Each worker establishes an eBGP session from AS 65010 to UCGF AS 65100 and advertises every LoadBalancer IP as a /32. The UCGF installs three ECMP next-hops per /32 (one per worker), so any single-worker BGP failure leaves traffic served by the other two. **L2 announcements are no longer used** — see [`docs/plans/2026-03-08-bgp-rollout.md`](../plans/2026-03-08-bgp-rollout.md) for the migration history. The canonical UCGF FRR config is snapshotted at [`docs/reference/ucgf-bgp-frr.conf`](ucgf-bgp-frr.conf).
 - **Gateway API**: Cilium acts as the Gateway API controller, provisioning Envoy proxies for routing ingress traffic.
 - **Observability**: Hubble, Hubble Relay, and Hubble UI are enabled for network visibility.
 
 ## 3. URLs
-- **Hubble UI**: (Internal port-forward only, or via specific ingress if configured)
+
+- **Hubble UI**: internal port-forward only (`cilium hubble port-forward`), or via Gateway API ingress if configured.
 
 ## 4. Configuration
-- **Helm Values**: Located in `infra/controllers/cilium/values.yaml`.
-  - `kubeProxyReplacement: true`
-  - `l2announcements.enabled: true`
-  - `gatewayAPI.enabled: true`
-  - `hubble.enabled: true`
-- **IP Pool**: Defined in `infra/configs/cilium/load-balancer-ip-pool.yaml`.
-  - Pool Name: `home-compute-pool`
-  - Range: `10.42.2.40` - `10.42.2.254`
-- **L2 Announcement Policy**: Defined in `infra/configs/cilium/l2-announcement-policy.yaml`.
 
-## 5. Usage Instructions
-Cilium operates transparently. When a `Service` of type `LoadBalancer` is created, Cilium automatically assigns an IP from the `home-compute-pool` and announces it via ARP (L2).
-When a `Gateway` or `HTTPRoute` is created, Cilium configures Envoy to route the traffic.
+### Helm values
 
-To interact with Cilium CLI:
+Located in `infra/controllers/cilium/values.yaml`:
+
+- `kubeProxyReplacement: true`
+- `bgpControlPlane.enabled: true` — enables the agent's BGP module
+- `l2announcements.enabled: false` — disabled after migration (Phase 4b)
+- `gatewayAPI.enabled: true`
+- `hubble.enabled: true`
+
+### LoadBalancer IP pools
+
+Defined in `infra/configs/cilium/load-balancer-ip-pool.yaml`. Two pools:
+
+| Pool | Range | Use |
+|---|---|---|
+| `home-c-pool` | `10.42.2.40` – `10.42.2.254` | Default — gateways, adguard, etc. |
+| `home-compute-pool` | `10.42.2.30` – `10.42.2.37` | Compute-tier services (snapcast etc.) |
+
+The BGP advertisement permits any /32 in `10.42.2.0/24` (covers both pools without needing pool-specific rules).
+
+### BGP resources
+
+In `infra/configs/cilium/`:
+
+| File | Resource | Notes |
+|---|---|---|
+| `bgp-cluster-config.yaml` | `CiliumBGPClusterConfig` | nodeSelector: every non-control-plane node peers (auto picks up new workers) |
+| `bgp-peer-config.yaml` | `CiliumBGPPeerConfig` | timers, IPv4 unicast family, attaches the LB-IP advertisement via `families[].advertisements.matchLabels{advertise: lb-ips}` |
+| `bgp-advertisement.yaml` | `CiliumBGPAdvertisement` | matchLabels {} → advertise every LoadBalancer IP cluster-wide |
+
+### UCGF (router) side
+
+The UCGF runs FRRouting (FRR) 10.x. BGP is configured via `vtysh`; the UniFi controller UI does not expose BGP. Authoritative config snapshot in [`docs/reference/ucgf-bgp-frr.conf`](ucgf-bgp-frr.conf). Re-apply this snapshot after every UniFi firmware upgrade — firmware updates may revert both `/etc/frr/frr.conf` AND `/etc/frr/daemons` (re-set `bgpd=yes` in daemons and `systemctl enable --now frr` if the service comes back disabled).
+
+## 5. Usage
+
+Cilium operates transparently. When a `Service` of type `LoadBalancer` is created:
+1. Cilium IPAM allocates an IP from the appropriate pool.
+2. The agent on each worker advertises the IP as a /32 to the UCGF via BGP.
+3. The UCGF installs three ECMP next-hops in its FIB.
+4. Traffic from anywhere on the LAN routes through the UCGF to one of the three workers; Cilium then routes to the backing pod.
+
+### CLI
+
 ```bash
-# Install cilium CLI locally if not present
+# Cluster status
 cilium status
+
+# Connectivity test
 cilium connectivity test
+
+# BGP peers (per node — query each agent)
+kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium \
+  --field-selector spec.nodeName=<NODE> -o jsonpath='{.items[0].metadata.name}')" \
+  -- cilium-dbg bgp peers
+
+# BGP routes advertised by a node
+kubectl exec -n kube-system "$(kubectl get pod -n kube-system -l k8s-app=cilium \
+  --field-selector spec.nodeName=<NODE> -o jsonpath='{.items[0].metadata.name}')" \
+  -- cilium-dbg bgp routes available ipv4 unicast
+```
+
+### Router side (read-only)
+
+```bash
+ssh root@10.42.2.1 'vtysh -c "show bgp summary"'        # peer state
+ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'       # ECMP path count per /32
+ssh root@10.42.2.1 'vtysh -c "show running-config"'     # full FRR config
 ```
 
 ## 6. Testing
-To verify Cilium is working correctly:
+
 ```bash
+# Pods up
 kubectl -n kube-system get pods -l k8s-app=cilium
-kubectl -n kube-system logs ds/cilium
-```
-Run the Cilium connectivity test suite:
-```bash
+
+# Recent agent logs
+kubectl -n kube-system logs ds/cilium --tail=100
+
+# End-to-end connectivity probe
 cilium connectivity test
 ```
 
+LB-IP-specific smoke (from any LAN client):
+
+```bash
+curl -sk -o /dev/null -w "%{http_code}\n" https://home.burntbytes.com   # gateway-prod (.40)
+dig @10.42.2.43 example.com +short                                       # adguard-prod
+```
+
 ## 7. Monitoring & Alerting
-- **Hubble**: Use Hubble CLI or UI to observe network flows.
+
+- **Hubble** for flow observability:
   ```bash
   cilium hubble port-forward
   hubble observe
   ```
-- **Metrics**: Cilium exposes Prometheus metrics (if configured in values).
+- **BGP alerts** (in `infra/configs/alerts/prometheus-rules.yaml` group `cilium-bgp`): `CiliumBGPSessionDown` / `CiliumBGPNoPeers` / `CiliumBGPMultipleSessionsDown`.
+  > **Currently silent.** The agent metrics endpoint requires `prometheus.enabled: true` in the Helm values, which is not yet set. Tracked as a separate follow-up — flipping it triggers another Cilium DaemonSet rollout.
 
 ## 8. Disaster Recovery
-- **Backup Strategy**: Cilium configuration is stored in Git. No persistent state needs to be backed up.
-- **Restore Procedure**: Re-apply the Flux Kustomization. If nodes are recreated, Cilium will automatically rebuild the eBPF maps.
+
+- **Configuration**: All cluster-side state is in Git (Helm values, BGP CRs, LB IP pools). No persistent state to back up on the cluster side.
+- **UCGF FRR config**: Snapshotted at `docs/reference/ucgf-bgp-frr.conf`. Re-apply after a firmware upgrade if FRR comes back disabled or with a wiped config.
+- **Restore procedure**: Re-apply the Flux Kustomization. If nodes are recreated, Cilium rebuilds eBPF maps automatically; BGP sessions re-establish within ~30s of agent startup.
 
 ## 9. Troubleshooting
-- **Pods stuck in ContainerCreating**: Often a CNI issue. Check Cilium agent logs on the specific node.
-- **LoadBalancer IP not reachable**:
-  - Verify the IP is assigned: `kubectl get svc <name>`
-  - Check L2 announcements: `kubectl get ciliuml2announcementpolicies`
-  - Ensure no IP conflicts on the local network.
-- **Gateway API routing issues**: Check the status of the `Gateway` and `HTTPRoute` resources. Look at the Envoy logs in the Cilium agent pods.
+
+- **Pods stuck in ContainerCreating** — usually a CNI issue. Check the Cilium agent log on the affected node.
+- **LoadBalancer IP not reachable from LAN**:
+  1. Confirm the IP is assigned: `kubectl get svc <name>`.
+  2. Confirm the workers are advertising it: `cilium-dbg bgp routes available ipv4 unicast` on each worker — should list the /32.
+  3. Confirm the UCGF received it: `ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'` — expect 3 next-hops.
+  4. If steps 1-2 are good but 3 is missing, the worker→UCGF BGP session is down. Check `cilium-dbg bgp peers`.
+- **Gateway API routing**: check `Gateway` / `HTTPRoute` status; Envoy logs are inside the Cilium agent pods.
+- **Helm-value-only config change didn't take effect** — Cilium config-only Helm changes update the `cilium-config` ConfigMap but **don't change the DaemonSet pod template hash**, so the rollout is a no-op and pods keep the old config. Manually `kubectl rollout restart ds/cilium -n kube-system` and (if the change affects operator-managed CRs) `kubectl rollout restart deploy/cilium-operator -n kube-system`.

--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -159,3 +159,51 @@ spec:
             summary: "Container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} CPU > 90% of limit"
             description: >
               Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) has been using more than 90% of its CPU limit for 10+ minutes (current: {{ $value | humanizePercentage }}). Consider increasing the CPU limit or investigating a busy loop.
+
+    # -------------------------------------------------------------------------
+    # Cilium BGP session health
+    #
+    # LoadBalancer IPs are advertised to the UCGF via BGP from each worker
+    # (Phase 4 of docs/plans/2026-03-08-bgp-rollout.md). With ECMP across 3
+    # worker peers, a single peer down still serves traffic via the other 2 —
+    # but two down means traffic capacity is halved and a third loss is total
+    # outage. Alert on each transition.
+    #
+    # cilium_bgp_session_state values per Cilium 1.19:
+    #   1 = Idle, 2 = Connect, 3 = Active, 4 = OpenSent,
+    #   5 = OpenConfirm, 6 = Established
+    #
+    # NOTE: these expressions reference the Cilium agent metrics endpoint.
+    # That endpoint requires `prometheus.enabled: true` in the cilium Helm
+    # values. The flag is currently OFF; alerts will be silent until it's
+    # enabled (tracked separately).
+    # -------------------------------------------------------------------------
+    - name: cilium-bgp
+      rules:
+        - alert: CiliumBGPSessionDown
+          expr: cilium_bgp_session_state != 6
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cilium BGP peer not Established on {{ $labels.node }}"
+            description: >
+              BGP peer {{ $labels.peer }} on node {{ $labels.node }} is in state {{ $value }} (expected 6 = Established) for ≥2m. LB IPs advertised by this node are no longer reaching the UCGF; ECMP path count drops by one. Check the agent log: kubectl logs -n kube-system -l k8s-app=cilium --field-selector spec.nodeName={{ $labels.node }} #magic___^_^___line
+        - alert: CiliumBGPNoPeers
+          expr: absent(cilium_bgp_session_state) or sum(cilium_bgp_session_state == 6) < 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cilium has zero BGP peers Established cluster-wide"
+            description: >
+              No Cilium worker has a BGP session in Established state with the UCGF for ≥5m. All LoadBalancer IPs are unreachable from outside the node hosting their backing pod. This is a total LB IP outage. Check UCGF: ssh root@10.42.2.1 'vtysh -c "show bgp summary"' #magic___^_^___line
+        - alert: CiliumBGPMultipleSessionsDown
+          expr: sum(cilium_bgp_session_state != 6) >= 2
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cilium has {{ $value }} BGP peers down — ECMP halved or worse"
+            description: >
+              {{ $value }} BGP peers are not Established. ECMP path count per LB IP has dropped from 3 to ≤1; one more failure is a total outage. Investigate before traffic is affected.


### PR DESCRIPTION
## Summary

Phase 5 of the BGP rollout — three small, tightly-related changes closing out [docs/plans/2026-03-08-bgp-rollout.md](docs/plans/2026-03-08-bgp-rollout.md).

## 1. PrometheusRule group `cilium-bgp` (3 alerts)

Added to `infra/configs/alerts/prometheus-rules.yaml`:

| Alert | Severity | For | Trigger |
|---|---|---|---|
| `CiliumBGPSessionDown` | warning | 2m | Any peer not in state 6 (Established) |
| `CiliumBGPNoPeers` | critical | 5m | Zero established peers cluster-wide (total LB IP outage) |
| `CiliumBGPMultipleSessionsDown` | critical | 2m | ≥2 peers down (ECMP halved or worse) |

**Currently silent** — Cilium agent metrics (port 9962) aren't exposed by our Helm config (`prometheus.enabled` is unset). The rules are syntactically valid and ready to fire as soon as the metrics flip on. Tracked inline in `docs/reference/cilium.md` and in the plan completion banner as the one remaining follow-up.

## 2. Rewrite of `docs/reference/cilium.md`

Replace the L2-announcement architecture description with the BGP-only reality. Highlights:

- AS 65010 ↔ 65100 with ECMP 3 next-hops per /32
- Document **both** LB IP pools (`home-c-pool` `.40-.254`, `home-compute-pool` `.30-.37`) — the previous doc had only one with the wrong range
- CLI snippets for `cilium-dbg bgp peers` / `cilium-dbg bgp routes` per node
- UCGF `vtysh` commands
- Reference [`docs/reference/ucgf-bgp-frr.conf`](docs/reference/ucgf-bgp-frr.conf) for restore-after-firmware-upgrade
- New troubleshooting note: Cilium Helm-config-only changes don't auto-roll the DS (lesson learned in Phase 2a)

## 3. Mark plan completed

- Frontmatter: `status: planned` → `completed`, add `completed: 2026-05-05`
- Add a completion banner at the top of the plan summarizing the outcome and surfacing the outstanding `prometheus.enabled` follow-up

## Validation

- [x] `kustomize build infra/configs` includes the new `cilium-bgp` group
- [x] `kubectl apply --dry-run=client` accepts the updated PrometheusRule

🤖 Generated with [Claude Code](https://claude.com/claude-code)