### PR TITLE
feat(cilium): expose agent + operator metrics so BGP alerts fire

### DIFF
--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -140,6 +140,14 @@ operator:
   replicas: 2
   # Cluster-critical: the operator manages identities and IP pools.
   priorityClassName: system-node-critical
+  # Expose operator metrics + ServiceMonitor scraped by kube-prometheus-stack
+  # (selector: release=kube-prometheus-stack on the ServiceMonitor).
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: kube-prometheus-stack
 
 hubble:
   # -- Enable Hubble (true by default).
@@ -150,3 +158,15 @@ hubble:
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: true
+
+# -- Expose Cilium agent metrics on :9962. Required for the cilium-bgp
+# alert rules in infra/configs/alerts/prometheus-rules.yaml to fire
+# (cilium_bgp_session_state lives on this endpoint). The ServiceMonitor
+# carries `release: kube-prometheus-stack` so it matches our Prometheus
+# instance's serviceMonitorSelector.
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack


### PR DESCRIPTION
## Summary

The `cilium-bgp` PrometheusRule group landed in PR #523 references `cilium_bgp_session_state`, exported by the agent on `:9962`. Until now that endpoint wasn't enabled in our Helm values — `enable-metrics: "true"` was set in cilium-config but the agent's Prometheus listener itself wasn't started, so the alerts evaluated against an empty result set and were silent.

This PR enables agent + operator Prometheus exporters and creates ServiceMonitors that kube-prometheus-stack can scrape (the Prometheus instance's `serviceMonitorSelector` is `release=kube-prometheus-stack`).

## Effect

- Triggers a Cilium DaemonSet rollout (~30s per node, rolling). BGP graceful-restart keeps the routes installed on UCGF through the agent restart — same risk profile as Phase 4b, which held cleanly.
- Per the Phase 2a lesson: **config-only Helm changes don't auto-roll the DS**. After Flux reconciles the new values, manual `kubectl rollout restart ds/cilium` is needed.
- ServiceMonitors auto-discovered on the next reconcile; metrics start flowing within a minute.

## Verification

- [ ] `cilium-dbg bgp peers` on each worker still Established post-rollout
- [ ] `kubectl get servicemonitor -n kube-system` shows `cilium-agent` and `cilium-operator` with `release=kube-prometheus-stack` label
- [ ] Prometheus targets list includes both `cilium-agent` and `cilium-operator`, all up
- [ ] `cilium_bgp_session_state` returns a value from a Prometheus query

🤖 Generated with [Claude Code](https://claude.com/claude-code)