### PR TITLE
fix(alerts): use actual Cilium 1.19 BGP metric name + values

### DIFF
--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -167,30 +167,26 @@ spec:
     # (Phase 4 of docs/plans/2026-03-08-bgp-rollout.md). With ECMP across 3
     # worker peers, a single peer down still serves traffic via the other 2 —
     # but two down means traffic capacity is halved and a third loss is total
-    # outage. Alert on each transition.
+    # outage.
     #
-    # cilium_bgp_session_state values per Cilium 1.19:
-    #   1 = Idle, 2 = Connect, 3 = Active, 4 = OpenSent,
-    #   5 = OpenConfirm, 6 = Established
-    #
-    # NOTE: these expressions reference the Cilium agent metrics endpoint.
-    # That endpoint requires `prometheus.enabled: true` in the cilium Helm
-    # values. The flag is currently OFF; alerts will be silent until it's
-    # enabled (tracked separately).
+    # Cilium 1.19 exports a binary up/down gauge:
+    #   cilium_bgp_control_plane_session_state{neighbor=...,vrouter=...}
+    #     1 = session is Established (up)
+    #     0 = anything else (idle/connect/active/etc.)
     # -------------------------------------------------------------------------
     - name: cilium-bgp
       rules:
         - alert: CiliumBGPSessionDown
-          expr: cilium_bgp_session_state != 6
+          expr: cilium_bgp_control_plane_session_state == 0
           for: 2m
           labels:
             severity: warning
           annotations:
-            summary: "Cilium BGP peer not Established on {{ $labels.node }}"
+            summary: "Cilium BGP peer down to {{ $labels.neighbor }}"
             description: >
-              BGP peer {{ $labels.peer }} on node {{ $labels.node }} is in state {{ $value }} (expected 6 = Established) for ≥2m. LB IPs advertised by this node are no longer reaching the UCGF; ECMP path count drops by one. Check the agent log: kubectl logs -n kube-system -l k8s-app=cilium --field-selector spec.nodeName={{ $labels.node }} #magic___^_^___line
+              BGP peer {{ $labels.neighbor }} (AS {{ $labels.neighbor_asn }}, vrouter {{ $labels.vrouter }}) on pod {{ $labels.pod }} is not Established for ≥2m. LB IPs advertised by this node are no longer reaching the UCGF; ECMP path count drops by one. Check the agent log: kubectl logs -n kube-system {{ $labels.pod }} #magic___^_^___line
         - alert: CiliumBGPNoPeers
-          expr: absent(cilium_bgp_session_state) or sum(cilium_bgp_session_state == 6) < 1
+          expr: absent(cilium_bgp_control_plane_session_state) or sum(cilium_bgp_control_plane_session_state == 1) < 1
           for: 5m
           labels:
             severity: critical
@@ -199,7 +195,7 @@ spec:
             description: >
               No Cilium worker has a BGP session in Established state with the UCGF for ≥5m. All LoadBalancer IPs are unreachable from outside the node hosting their backing pod. This is a total LB IP outage. Check UCGF: ssh root@10.42.2.1 'vtysh -c "show bgp summary"' #magic___^_^___line
         - alert: CiliumBGPMultipleSessionsDown
-          expr: sum(cilium_bgp_session_state != 6) >= 2
+          expr: sum(cilium_bgp_control_plane_session_state == 0) >= 2
           for: 2m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary

PR #523 introduced alerts referencing `cilium_bgp_session_state != 6`, assuming the GoBGP-style 1-6 enum (1=Idle..6=Established). Cilium 1.19 actually exports a **binary gauge**:

\`\`\`
# HELP cilium_bgp_control_plane_session_state Current state of the BGP session with the peer, Up = 1 or Down = 0
# TYPE cilium_bgp_control_plane_session_state gauge
cilium_bgp_control_plane_session_state{neighbor="10.42.2.1:179",neighbor_asn="65100",vrouter="65010"} 1
\`\`\`

Confirmed by directly querying `:9962/metrics` on a worker after PR #524 enabled the agent prometheus endpoint.

## Fix

- Metric name: `cilium_bgp_session_state` → `cilium_bgp_control_plane_session_state`
- Down predicate: `!= 6` → `== 0`
- Up predicate: `== 6` → `== 1`
- Annotations now reference the actual labels Cilium emits (`neighbor`, `neighbor_asn`, `vrouter`, `pod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)