### PR TITLE
fix(overture): allow Prometheus to scrape metrics on port 8080

### DIFF
--- a/apps/base/overture/networkpolicy.yaml
+++ b/apps/base/overture/networkpolicy.yaml
@@ -21,6 +21,14 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary

- Prometheus scrape target for overture was `down` with `context deadline exceeded` — Cilium was blocking the connection
- Root cause: `CiliumNetworkPolicy/overture` only allowed ingress on port 8080 from `host`, `remote-node`, and `ingress` entities; no rule permitted the Prometheus pod in the `monitoring` namespace
- Fix: add a `fromEndpoints` ingress rule matching `k8s:io.kubernetes.pod.namespace: monitoring` + `app.kubernetes.io/name: prometheus` → port 8080

## Test plan

- [ ] Flux reconciles `apps-production` after merge
- [ ] `kubectl get ciliumnetworkpolicy overture -n overture-prod -o yaml` shows new ingress rule
- [ ] Prometheus target at `/graph#` shows overture target `up`
- [ ] Grafana `overture-acmeusd` dashboard shows data

🤖 Generated with [Claude Code](https://claude.com/claude-code)