### PR TITLE
fix(alcatraz): correct IP typo and use DSM port 5000

### DIFF
--- a/apps/production/external-services/alcatraz.yaml
+++ b/apps/production/external-services/alcatraz.yaml
@@ -1,5 +1,6 @@
-# alcatraz — NAS (10.4.2.11)
-# Adjust port to match the device's actual web UI port.
+# alcatraz — Synology NAS (10.42.2.11)
+# Synology DSM serves its UI on port 5000 (HTTP). Gateway terminates TLS
+# at the edge and proxies plaintext to alcatraz:5000.
 ---
 apiVersion: v1
 kind: Service
@@ -10,9 +11,9 @@ spec:
   type: ClusterIP
   ports:
     - name: http
-      port: 80
+      port: 5000
       protocol: TCP
-      targetPort: 80
+      targetPort: 5000
 ---
 apiVersion: v1
 kind: Endpoints
@@ -21,10 +22,10 @@ metadata:
   namespace: external-services
 subsets:
   - addresses:
-      - ip: 10.4.2.11
+      - ip: 10.42.2.11
     ports:
       - name: http
-        port: 80
+        port: 5000
         protocol: TCP
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -61,4 +62,4 @@ spec:
   rules:
     - backendRefs:
         - name: alcatraz
-          port: 80
+          port: 5000


### PR DESCRIPTION
## What changed

- Fixed Endpoint IP: `10.4.2.11` → `10.42.2.11` (missing digit)
- Changed all ports from 80 → 5000 (Synology DSM HTTP UI port)

## Why

`alcatraz.burntbytes.com` was broken for two reasons:
1. Typo in the Endpoint IP — the route was pointing at a non-existent host
2. Port 80 on the Synology serves a static page, not DSM; the actual UI is on port 5000

## Type of change

- [x] `fix` — bug fix

## Checklist

- [x] Branch fetched from latest `origin/master`
- [x] `kustomize build apps/production/external-services` passes
- [x] No unrelated changes in this PR