### PR TITLE
fix(homeassistant): fix exhaust fan automations and dashboard for Lutron Caseta switches

### DIFF
--- a/apps/base/homeassistant/configmap.yaml
+++ b/apps/base/homeassistant/configmap.yaml
@@ -53,30 +53,31 @@ data:
     # already has 'automation: !include automations.yaml', the included file
     # must be a bare list of automation objects.
     - alias: "Bathroom fan auto-off — start timer"
-      description: "When a bathroom fan turns on, start a timer. Turns fan off when timer expires."
+      description: "When a bathroom exhaust fan turns on, start a timer. Turns fan off when timer expires."
       trigger:
         - platform: state
           entity_id:
-            - fan.*
+            - switch.*_exhaust_fan
           from: "off"
           to: "on"
       condition:
-        # Only bathroom fans
+        # Only bathroom exhaust fans
         - condition: template
           value_template: >
             {{ "bathroom" in trigger.to_state.entity_id | lower or
-               "bath" in trigger.to_state.entity_id | lower }}
+               "bath" in trigger.to_state.entity_id | lower or
+               "powder" in trigger.to_state.entity_id | lower }}
       action:
         - variables:
             # Extract bathroom name from entity ID
-            # fan.bathroom_main_fan → bathroom_main
-            # fan.bath_guest_fan → bath_guest
+            # switch.master_bathroom_exhaust_fan → master_bathroom
+            # switch.hall_bathroom_exhaust_fan → hall_bathroom
+            # switch.powder_bathroom_exhaust_fan → powder_bathroom
             fan_name: >
               {{ trigger.to_state.object_id
-                 | replace("_fan", "")
-                 | replace("fan_", "") }}
+                 | replace("_exhaust_fan", "") }}
             helper_id: >
-              {{ "input_text." ~ fan_name ~ "_timer" }}
+              {{ "input_number." ~ fan_name ~ "_fan_minutes" }}
             timer_entity: >
               {{ "timer." ~ fan_name ~ "_fan_timer" }}
             delay_minutes: >
@@ -99,56 +100,59 @@ data:
         # Only bathroom fan timers (not other timers in the house)
         - condition: template
           value_template: >
-            {{ "timer.bathroom_" in trigger.event.data.entity_id | lower or
-               "timer.bath_" in trigger.event.data.entity_id | lower }}
+            {{ "timer.master_bathroom" in trigger.event.data.entity_id | lower or
+               "timer.hall_bathroom" in trigger.event.data.entity_id | lower or
+               "timer.powder_bathroom" in trigger.event.data.entity_id | lower }}
       action:
         - variables:
-            # Derive fan entity ID from timer entity ID
-            # timer.bathroom_main_fan_timer → fan.bathroom_main_fan
-            fan_entity: >
+            # Derive switch entity ID from timer entity ID
+            # timer.master_bathroom_fan_timer → switch.master_bathroom_exhaust_fan
+            # timer.hall_bathroom_fan_timer → switch.hall_bathroom_exhaust_fan
+            # timer.powder_bathroom_fan_timer → switch.powder_bathroom_exhaust_fan
+            switch_entity: >
               {{ trigger.event.data.entity_id
-                 | replace("timer.", "fan.")
-                 | replace("_fan_timer", "_fan") }}
+                 | replace("timer.", "switch.")
+                 | replace("_fan_timer", "_exhaust_fan") }}
         # Turn off the fan
-        - service: fan.turn_off
+        - service: switch.turn_off
           target:
-            entity_id: "{{ fan_entity }}"
+            entity_id: "{{ switch_entity }}"
           continue_on_error: true
   control.yaml: |
-    # Bathroom Fan Control Dashboard
+    # Exhaust Fan Control Dashboard
     #
-    # A controlplane dashboard for bathroom fan timers.
-    # Shows all bathroom fan timers, their state, and allows manual control.
+    # A controlplane dashboard for exhaust fan timers.
+    # Shows all exhaust fan timers, their state, and allows manual control.
     #
     # Setup per bathroom (after creating helpers via HA UI):
     #   1. Add a section below for the new bathroom
     #   2. Copy one of the existing <bathroom> sections
     #   3. Replace <bathroom> with the bathroom name
-    #   4. Replace the fan entity ID with the actual fan entity
+    #   4. Replace the fan entity ID with the actual switch entity
     #
-    # Example for a 4th bathroom:
+    # Example for a new bathroom:
     #   - type: vertical-stack
     #     cards:
     #       - type: entity
-    #         entity: timer.bathroom_4th_fan_timer
+    #         entity: timer.new_bathroom_fan_timer
     #       - type: button
-    #         entity: timer.bathroom_4th_fan_timer
+    #         entity: timer.new_bathroom_fan_timer
     #         name: Cancel Timer
     #         tap_action:
     #           action: call-service
     #           service: timer.cancel
     #           service_data:
-    #             entity_id: timer.bathroom_4th_fan_timer
+    #             entity_id: timer.new_bathroom_fan_timer
     #       - type: entity
-    #         entity: fan.bathroom_4th_fan
+    #         entity: switch.new_bathroom_exhaust_fan
     #       - type: button
-    #         entity: fan.bathroom_4th_fan
+    #         entity: switch.new_bathroom_exhaust_fan
     #         name: Turn Off
     #         tap_action:
     #           action: call-service
-    #           service: fan.turn_off
+    #           service: switch.turn_off
     #           service_data:
-    #             entity_id: fan.bathroom_4th_fan
+    #             entity_id: switch.new_bathroom_exhaust_fan
 
     title: Control
     views:
@@ -159,113 +163,17 @@ data:
           # Header
           # ========================================================================
           - type: heading
-            heading: Bathroom Fan Timers
+            heading: Exhaust Fan Timers
             heading_size: h2
 
           - type: markdown
             content: >
-              **How it works:** When a bathroom fan turns on, a timer starts.
+              **How it works:** When an exhaust fan turns on, a timer starts.
               When the timer expires, the fan turns off.
               Adjust the delay per bathroom using the input helper.
 
           # ========================================================================
-          # Bathroom Main
-          # ========================================================================
-          - type: vertical-stack
-            cards:
-              - type: heading
-                heading: Main Bathroom
-                heading_size: h3
-
-              - type: horizontal-stack
-                cards:
-                  - type: entity
-                    entity: timer.bathroom_main_fan_timer
-                    name: Timer
-                    state_color: true
-                  - type: entity
-                    entity: input_text.bathroom_main_timer
-                    name: Delay (min)
-                    state_color: false
-
-              - type: horizontal-stack
-                cards:
-                  - type: button
-                    entity: timer.bathroom_main_fan_timer
-                    name: Cancel Timer
-                    show_icon: false
-                    tap_action:
-                      action: call-service
-                      service: timer.cancel
-                      data:
-                        entity_id: timer.bathroom_main_fan_timer
-                    show_name: true
-                  - type: entity
-                    entity: fan.bathroom_main_fan
-                    name: Fan
-                    state_color: true
-
-              - type: button
-                entity: fan.bathroom_main_fan
-                name: Turn Off Fan
-                show_icon: false
-                tap_action:
-                  action: call-service
-                  service: fan.turn_off
-                  data:
-                    entity_id: fan.bathroom_main_fan
-                show_name: true
-
-          # ========================================================================
-          # Bathroom Guest
-          # ========================================================================
-          - type: vertical-stack
-            cards:
-              - type: heading
-                heading: Guest Bathroom
-                heading_size: h3
-
-              - type: horizontal-stack
-                cards:
-                  - type: entity
-                    entity: timer.bathroom_guest_fan_timer
-                    name: Timer
-                    state_color: true
-                  - type: entity
-                    entity: input_text.bathroom_guest_timer
-                    name: Delay (min)
-                    state_color: false
-
-              - type: horizontal-stack
-                cards:
-                  - type: button
-                    entity: timer.bathroom_guest_fan_timer
-                    name: Cancel Timer
-                    show_icon: false
-                    tap_action:
-                      action: call-service
-                      service: timer.cancel
-                      data:
-                        entity_id: timer.bathroom_guest_fan_timer
-                    show_name: true
-                  - type: entity
-                    entity: fan.bathroom_guest_fan
-                    name: Fan
-                    state_color: true
-
-              - type: button
-                entity: fan.bathroom_guest_fan
-                name: Turn Off Fan
-                show_icon: false
-                tap_action:
-                  action: call-service
-                  service: fan.turn_off
-                  data:
-                    entity_id: fan.bathroom_guest_fan
-                show_name: true
-
-          # ========================================================================
-          # Bathroom Master
+          # Master Bathroom
           # ========================================================================
           - type: vertical-stack
             cards:
@@ -276,38 +184,134 @@ data:
               - type: horizontal-stack
                 cards:
                   - type: entity
-                    entity: timer.bathroom_master_fan_timer
+                    entity: timer.master_bathroom_fan_timer
                     name: Timer
                     state_color: true
                   - type: entity
-                    entity: input_text.bathroom_master_timer
+                    entity: input_number.master_bathroom_fan_minutes
                     name: Delay (min)
                     state_color: false
 
               - type: horizontal-stack
                 cards:
                   - type: button
-                    entity: timer.bathroom_master_fan_timer
+                    entity: timer.master_bathroom_fan_timer
                     name: Cancel Timer
                     show_icon: false
                     tap_action:
                       action: call-service
                       service: timer.cancel
                       data:
-                        entity_id: timer.bathroom_master_fan_timer
+                        entity_id: timer.master_bathroom_fan_timer
                     show_name: true
                   - type: entity
-                    entity: fan.bathroom_master_fan
+                    entity: switch.master_bathroom_exhaust_fan
                     name: Fan
                     state_color: true
 
               - type: button
-                entity: fan.bathroom_master_fan
+                entity: switch.master_bathroom_exhaust_fan
                 name: Turn Off Fan
                 show_icon: false
                 tap_action:
                   action: call-service
-                  service: fan.turn_off
+                  service: switch.turn_off
                   data:
-                    entity_id: fan.bathroom_master_fan
+                    entity_id: switch.master_bathroom_exhaust_fan
+                show_name: true
+
+          # ========================================================================
+          # Hall Bathroom
+          # ========================================================================
+          - type: vertical-stack
+            cards:
+              - type: heading
+                heading: Hall Bathroom
+                heading_size: h3
+
+              - type: horizontal-stack
+                cards:
+                  - type: entity
+                    entity: timer.hall_bathroom_fan_timer
+                    name: Timer
+                    state_color: true
+                  - type: entity
+                    entity: input_number.hall_bathroom_fan_minutes
+                    name: Delay (min)
+                    state_color: false
+
+              - type: horizontal-stack
+                cards:
+                  - type: button
+                    entity: timer.hall_bathroom_fan_timer
+                    name: Cancel Timer
+                    show_icon: false
+                    tap_action:
+                      action: call-service
+                      service: timer.cancel
+                      data:
+                        entity_id: timer.hall_bathroom_fan_timer
+                    show_name: true
+                  - type: entity
+                    entity: switch.hall_bathroom_exhaust_fan
+                    name: Fan
+                    state_color: true
+
+              - type: button
+                entity: switch.hall_bathroom_exhaust_fan
+                name: Turn Off Fan
+                show_icon: false
+                tap_action:
+                  action: call-service
+                  service: switch.turn_off
+                  data:
+                    entity_id: switch.hall_bathroom_exhaust_fan
+                show_name: true
+
+          # ========================================================================
+          # Powder Bathroom
+          # ========================================================================
+          - type: vertical-stack
+            cards:
+              - type: heading
+                heading: Powder Bathroom
+                heading_size: h3
+
+              - type: horizontal-stack
+                cards:
+                  - type: entity
+                    entity: timer.powder_bathroom_fan_timer
+                    name: Timer
+                    state_color: true
+                  - type: entity
+                    entity: input_number.powder_bathroom_fan_minutes
+                    name: Delay (min)
+                    state_color: false
+
+              - type: horizontal-stack
+                cards:
+                  - type: button
+                    entity: timer.powder_bathroom_fan_timer
+                    name: Cancel Timer
+                    show_icon: false
+                    tap_action:
+                      action: call-service
+                      service: timer.cancel
+                      data:
+                        entity_id: timer.powder_bathroom_fan_timer
+                    show_name: true
+                  - type: entity
+                    entity: switch.powder_bathroom_exhaust_fan
+                    name: Fan
+                    state_color: true
+
+              - type: button
+                entity: switch.powder_bathroom_exhaust_fan
+                name: Turn Off Fan
+                show_icon: false
+                tap_action:
+                  action: call-service
+                  service: switch.turn_off
+                  data:
+                    entity_id: switch.powder_bathroom_exhaust_fan
                 show_name: true


### PR DESCRIPTION
## Changes

- **Automations**: Updated to use `switch.*_exhaust_fan` entities instead of non-existent `fan.*` entities
- **Entity ID derivation**: Fixed to correctly map timer entities to switch entities (e.g., `timer.master_bathroom_fan_timer` → `switch.master_bathroom_exhaust_fan`)
- **Input helpers**: Changed from `input_text.*_timer` to `input_number.*_fan_minutes` to match actual HA helpers
- **Control dashboard**: Rewrote to reference correct switch entities and timer/input entities
- **Bathroom naming**: Aligned view names with actual entity names (Master, Hall, Powder)

## Context

The exhaust fans are Lutron Caseta switches, not native Home Assistant fan entities:
- `switch.master_bathroom_exhaust_fan`
- `switch.hall_bathroom_exhaust_fan`
- `switch.powder_bathroom_exhaust_fan`

The previous config referenced `fan.bathroom_main_fan`, `fan.bathroom_guest_fan`, `fan.bathroom_master_fan` which don't exist.

## Also Applied

- Switchboard dashboard updated directly on the running HA instance to add an "Exhaust Fans" view with all 3 fans
