### PR TITLE
fix: restore L2 announcements alongside BGP for same-subnet ARP

### DIFF
--- a/infra/configs/cilium/kustomization.yaml
+++ b/infra/configs/cilium/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - bgp-advertisement.yaml
   - bgp-cluster-config.yaml
   - bgp-peer-config.yaml
+  - l2-announcement-policy.yaml
   - load-balancer-ip-pool.yaml

--- a/infra/configs/cilium/l2-announcement-policy.yaml
+++ b/infra/configs/cilium/l2-announcement-policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: l2-announcement-policy-staging
+  namespace: kube-system
+spec:
+  externalIPs: true
+  loadBalancerIPs: true

--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -89,12 +89,11 @@ cgroup:
   hostRoot: /sys/fs/cgroup
 
 # -- Configure L2 announcements
-# Disabled at the Helm level after the BGP migration (Phase 4b of the BGP
-# rollout plan). The CiliumL2AnnouncementPolicy resource was removed in
-# Phase 4a; this flag was a no-op without it, but flipping it false keeps
-# config consistent and stops Cilium from initializing the L2 module.
+# Re-enabled alongside BGP: BGP handles cross-subnet routing (e.g. VLAN 4
+# clients via UCG-Fiber), but same-subnet clients (VLAN 2, 10.42.2.x) ARP
+# directly for LB IPs and need L2 announcements to get a response.
 l2announcements:
-  enabled: false
+  enabled: true
 
 # -- Configure BGP control plane
 # Enabling this is cluster-wide; whether a node *peers* is determined by the


### PR DESCRIPTION
## Summary

- Restores `infra/configs/cilium/l2-announcement-policy.yaml` (deleted in BGP Phase 4a)
- Re-adds it to `infra/configs/cilium/kustomization.yaml`
- Re-enables `l2announcements.enabled: true` in `infra/controllers/cilium/values.yaml`

## Why

BGP Phase 4a/4b removed L2 announcements under the assumption BGP was sufficient. It works for cross-subnet clients (VLAN 4, Mac) that route through UCG-Fiber. But **same-subnet clients** (VLAN 2, `10.42.2.x`, e.g. Apple TV at `10.42.2.19`) ARP directly for LB IPs like AdGuard DNS (`10.42.2.43`) and get no response without L2 announcements.

Both mechanisms are complementary and can run in parallel.

## Test plan

- [ ] `kustomize build infra/configs/cilium` passes ✅
- [ ] `kustomize build infra/controllers` passes ✅
- [ ] After merge + Flux reconcile: `arp -n 10.42.2.43` on a same-subnet host returns an entry
- [ ] Apple TV at `10.42.2.19` can reach cluster services again

🤖 Generated with [Claude Code](https://claude.com/claude-code)