### PR TITLE
docs: BGP Phase 4 incident postmortem + revised L2 removal gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ The historical `docs/apps/`, `docs/guides/`, `docs/incidents/`, and `docs/infra/
 
 ### Architecture
 
+- [Networking](architecture/networking/README.md) — physical topology, VLANs, L2+BGP load balancing, traffic flows
 - [Overlays and structure](architecture/overlays-and-structure.md) — base vs staging vs production
 - [DNS strategy](architecture/dns-strategy.md) — split-horizon DNS with wildcard records
 - [Gateway authentication](architecture/gateway-auth.md) — Global Forward Auth and Envoy filters

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,6 +5,7 @@ How the cluster is built **today** — the present shape of overlays, networking
 **Put here:**
 - System-level architecture overviews (DNS strategy, gateway authentication, base/staging/production overlay structure).
 - Cross-cutting infrastructure decisions that aren't tied to a single component.
+- Multi-doc topical bundles as subfolders (e.g. `networking/` for the LAN + cluster network architecture).
 
 **Do not put here:**
 - Proposals for future architecture — `design/` (or open-issue convention here today: `plans/` for in-flight decision + execution).
@@ -12,6 +13,10 @@ How the cluster is built **today** — the present shape of overlays, networking
 - Component-level reference (Cilium quirks, cert-manager config) — `reference/` (or the historical `infra/` while migration completes).
 - Runbooks — `operations/` (or the historical `apps/` and `guides/` while migration completes).
 
-**Naming convention:** `<topic>.md` for the existing inventory (DNS strategy, gateway-auth, overlays-and-structure); new docs added under this folder going forward should use `<yyyy-mm-dd>-<topic>.md`.
+**Index of topical bundles:**
+
+- [`networking/`](networking/README.md) — physical topology, VLANs/IP map, L2+BGP load balancing, traffic flows, glossary.
+
+**Naming convention:** `<topic>.md` for the existing inventory (DNS strategy, gateway-auth, overlays-and-structure); new docs added under this folder going forward should use `<yyyy-mm-dd>-<topic>.md`. Multi-doc bundles use a subfolder named `<topic>/` containing a `README.md` entry point and topic-specific siblings.
 
 **Allowed `status:` values:** `Stable`, `Superseded`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,4 +19,6 @@ How the cluster is built **today** — the present shape of overlays, networking
 
 **Naming convention:** `<topic>.md` for the existing inventory (DNS strategy, gateway-auth, overlays-and-structure); new docs added under this folder going forward should use `<yyyy-mm-dd>-<topic>.md`. Multi-doc bundles use a subfolder named `<topic>/` containing a `README.md` entry point and topic-specific siblings.
 
+**Today vs planned.** Architecture docs describe present state. When a planned change is relevant (because a current arrangement only makes sense alongside the plan that fixes it), reference the plan in a clearly-labeled "Forward links" section at the end of the doc — never inline in the main tables. The plan itself lives in `docs/plans/`.
+
 **Allowed `status:` values:** `Stable`, `Superseded`.

--- a/docs/architecture/networking/README.md
+++ b/docs/architecture/networking/README.md
@@ -18,18 +18,24 @@ last_modified: 2026-05-06
 > dependent on chain-loading. As-of dates appear in every frontmatter so a
 > reader knows when a fact was last verified.
 
-## One-paragraph mental model
+## Mental model
 
 The house has a single physical LAN segment terminating at a UniFi Cloud
-Gateway Fiber (UCGF) at `10.42.2.1`. The UCGF tags traffic into VLANs at the
-edge: cluster + wired devices share VLAN 2 (`10.42.2.0/24`), wireless clients
-sit on a separate VLAN (`10.42.4.0/24`), and the LB IP pool currently overlaps
-VLAN 2. Inside the cluster, Cilium runs as the CNI with VXLAN tunneling for
-pod-to-pod traffic, BGP for advertising LoadBalancer IPs to the UCGF, and L2
-announcements for same-subnet ARP fallback. External traffic enters via
+Gateway Fiber (UCGF) at `10.42.2.1`. The UCGF terminates 6 VLANs (Core,
+Lab, Security, Family, Guest, IoT), each on its own bridge interface and
+`/24`: Lab (`br2`, `10.42.2.0/24`) hosts the cluster, storage, and most
+wired devices; Family (`br4`, `10.42.4.0/24`) hosts wireless; the others
+serve their named purposes. The LoadBalancer IP pool currently overlaps
+the Lab VLAN — the source of the 2026-05-05 wired-device incident.
+
+Inside the cluster, Cilium runs as the CNI with VXLAN tunneling for
+pod-to-pod traffic, BGP for advertising LoadBalancer IPs to the UCGF, and
+L2 announcements for same-subnet ARP fallback. External traffic enters via
 Cloudflare Tunnel (no port-forwarding); internal traffic resolves through
-AdGuard split-horizon DNS to internal LB IPs and terminates TLS at a Cilium
-Gateway running Envoy.
+AdGuard (distributed via DHCP option 6 to every VLAN as
+`[10.42.2.43, 10.42.2.45]`), gets a wildcard-rewritten LB IP for
+`*.burntbytes.com`, and terminates TLS at a Cilium Gateway running Envoy
+on a worker node.
 
 ## Quick map
 
@@ -52,8 +58,9 @@ bug or incomplete migration.
 
 1. **Single physical LAN, segmented by VLAN.** All wired ports terminate on
    the UCGF or a UCGF-managed switch. VLAN tagging is the only network
-   isolation mechanism at L2.
-2. **The cluster is on one /24 (VLAN 2).** All 6 Talos nodes have IPs in
+   isolation mechanism at L2. Six VLANs are configured (Core, Lab, Security,
+   Family, Guest, IoT) — see [addressing.md](addressing.md).
+2. **The cluster is on the Lab VLAN.** All 6 Talos nodes have IPs in
    `10.42.2.20–.25`. The UCGF gateway is `10.42.2.1`.
 3. **External traffic enters via Cloudflare Tunnel only.** No port-forwarding
    on the UCGF; no router-side NAT for inbound. The tunnel

--- a/docs/architecture/networking/README.md
+++ b/docs/architecture/networking/README.md
@@ -1,0 +1,86 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Networking Architecture
+
+> **Audience.** This folder is the canonical home for networking architecture
+> docs covering the homelab cluster (`melodic-muse`) and the broader house
+> network it runs on. It is written for two consumers:
+>
+> - **LLMs** building context for cluster work — load `README.md` first, then
+>   the topic file relevant to the question.
+> - **Human operators** debugging or planning network changes — start at
+>   `README.md` for the mental model, then drill into the specific doc.
+>
+> Each file is self-contained: cross-referenced where useful, but not
+> dependent on chain-loading. As-of dates appear in every frontmatter so a
+> reader knows when a fact was last verified.
+
+## One-paragraph mental model
+
+The house has a single physical LAN segment terminating at a UniFi Cloud
+Gateway Fiber (UCGF) at `10.42.2.1`. The UCGF tags traffic into VLANs at the
+edge: cluster + wired devices share VLAN 2 (`10.42.2.0/24`), wireless clients
+sit on a separate VLAN (`10.42.4.0/24`), and the LB IP pool currently overlaps
+VLAN 2. Inside the cluster, Cilium runs as the CNI with VXLAN tunneling for
+pod-to-pod traffic, BGP for advertising LoadBalancer IPs to the UCGF, and L2
+announcements for same-subnet ARP fallback. External traffic enters via
+Cloudflare Tunnel (no port-forwarding); internal traffic resolves through
+AdGuard split-horizon DNS to internal LB IPs and terminates TLS at a Cilium
+Gateway running Envoy.
+
+## Quick map
+
+| Question | Doc |
+|---|---|
+| What does the physical network look like? Which switches, APs, cables? | [physical-topology.md](physical-topology.md) |
+| What VLANs exist? What IP ranges? Where do specific devices live? | [addressing.md](addressing.md) |
+| How do LoadBalancer IPs get advertised? L2 vs BGP, why both? | [cluster-load-balancing.md](cluster-load-balancing.md) |
+| How does a packet from device X reach service Y? | [traffic-flows.md](traffic-flows.md) |
+| What does <term> mean? | [glossary.md](glossary.md) |
+| How does DNS resolution work (split-horizon)? | [../dns-strategy.md](../dns-strategy.md) |
+| How is ingress authentication wired (Authelia + Envoy ext_authz)? | [../gateway-auth.md](../gateway-auth.md) |
+| Detailed Cilium config reference (Helm values, BGP CRDs)? | [../../reference/cilium.md](../../reference/cilium.md) |
+| Why does the current state look like this — what migrations happened? | [../../plans/](../../plans/) (search for `network`, `bgp`, `migration`) |
+
+## Top-level invariants (as of 2026-05-06)
+
+These are facts that should hold true in steady state. Violations indicate a
+bug or incomplete migration.
+
+1. **Single physical LAN, segmented by VLAN.** All wired ports terminate on
+   the UCGF or a UCGF-managed switch. VLAN tagging is the only network
+   isolation mechanism at L2.
+2. **The cluster is on one /24 (VLAN 2).** All 6 Talos nodes have IPs in
+   `10.42.2.20–.25`. The UCGF gateway is `10.42.2.1`.
+3. **External traffic enters via Cloudflare Tunnel only.** No port-forwarding
+   on the UCGF; no router-side NAT for inbound. The tunnel
+   (`apps/base/cloudflare-tunnel/`) terminates inside the cluster and routes
+   to the production gateway.
+4. **Internal hostnames resolve to LAN IPs via AdGuard split-horizon DNS.**
+   `*.burntbytes.com` rewrites to a LB IP on the LAN; public Cloudflare DNS
+   exists for some hosts but is overridden internally.
+5. **TLS terminates at the Cilium Gateway.** All `*.burntbytes.com` requests
+   land at an Envoy proxy on a worker node, which terminates TLS using
+   cert-manager-issued certificates and forwards plaintext or re-encrypted
+   traffic to backend pods.
+6. **LB IPs are advertised by both L2 and BGP simultaneously.** Cilium
+   announces every LoadBalancer IP via L2 (ARP) for same-subnet clients and
+   via BGP (3 worker peers, ECMP) to the UCGF for cross-subnet clients. See
+   [cluster-load-balancing.md](cluster-load-balancing.md) for why both are
+   currently required.
+7. **GitOps-driven cluster network state.** Every Cilium resource lives in
+   `infra/configs/cilium/` and `infra/controllers/cilium/`. Out-of-band
+   changes drift back on the next Flux reconcile.
+
+## Out of scope for this folder
+
+- **Per-app HTTPRoute and Service definitions** — see `apps/base/<app>/`.
+- **Cilium internals beyond architecture** (BPF maps, eBPF programs) — see
+  `docs/reference/cilium.md`.
+- **Authentication flow** — see [../gateway-auth.md](../gateway-auth.md).
+- **Storage networking (iSCSI/NFS)** — see `docs/reference/storage.md`.
+- **Incident postmortems** — see `docs/operations/incidents/`.
+- **Forward plans** — see `docs/plans/`.

--- a/docs/architecture/networking/README.md
+++ b/docs/architecture/networking/README.md
@@ -82,6 +82,51 @@ bug or incomplete migration.
    `infra/configs/cilium/` and `infra/controllers/cilium/`. Out-of-band
    changes drift back on the next Flux reconcile.
 
+## Threat model — what this folder intentionally exposes
+
+This is a public GitHub repo. The networking docs publish concrete IPs,
+VLAN layout, service-to-IP mappings, cluster node hostnames, and storage
+backend addresses. That is intentional: the threat model assumes
+**perimeter defenses hold**, and internal network reconnaissance is not
+something we expect to defend by topology obscurity.
+
+What is in scope (i.e. what defends the network):
+
+- **Perimeter:** Cloudflare Tunnel handles all inbound (no port-forwarding,
+  no public LAN exposure). The UCGF firewall blocks unsolicited inbound.
+- **Public services:** Authelia SSO + per-service authentication; TLS
+  terminates at the Cilium gateway with cert-manager-issued certificates.
+- **Internal segmentation:** CiliumNetworkPolicy gates pod-to-pod traffic
+  (~45 active policies); Kubernetes RBAC gates API access; SOPS encrypts
+  secrets at rest in the repo.
+- **Auditability:** GitOps means every change is in the commit history;
+  Hubble logs every flow.
+
+What is **not** defended by these docs:
+
+- Internal network recon by an attacker already on the LAN. Anyone with a
+  foothold can `nmap` the same map in seconds, browse mDNS, or read the
+  Cilium API for the full service inventory. Topology obscurity adds no
+  meaningful defense here.
+- Subdomain enumeration. Every Let's Encrypt cert issued by cert-manager
+  goes into Certificate Transparency logs (publicly searchable via
+  `crt.sh`), so listing service hostnames in docs reveals nothing new.
+
+What we deliberately keep **out** of the public repo:
+
+- Credentials, API keys, tokens, private keys, certificates.
+- SOPS-decrypted secrets (the `.sops.yaml` key reference is committed; the
+  decrypted contents never are).
+- MAC addresses, DHCP reservation tables, and any per-device identifiers
+  that would aid hardware-targeted attacks.
+- Specific firmware versions of network gear.
+
+If you're forking this repo or borrowing the architecture, the published
+detail level is appropriate **only** if your security model also leans on
+auth/perimeter rather than topology secrecy. If you need topology
+secrecy, move addressing.md and the per-device inventory into a private
+repo.
+
 ## Out of scope for this folder
 
 - **Per-app HTTPRoute and Service definitions** — see `apps/base/<app>/`.

--- a/docs/architecture/networking/addressing.md
+++ b/docs/architecture/networking/addressing.md
@@ -5,43 +5,76 @@ last_modified: 2026-05-06
 
 # Addressing: VLANs, Subnets, IP Allocation
 
-> **Scope.** Authoritative IP/VLAN map. For physical equipment see
-> [physical-topology.md](physical-topology.md). For LB IP advertisement
-> mechanics see [cluster-load-balancing.md](cluster-load-balancing.md).
+> **Scope.** Authoritative IP/VLAN map for the present-day network. For
+> physical equipment see [physical-topology.md](physical-topology.md). For
+> LB IP advertisement mechanics see
+> [cluster-load-balancing.md](cluster-load-balancing.md). Forward state
+> (planned subnets, planned VLAN moves) lives in `docs/plans/` — see
+> [Forward links](#forward-links) at the end of this doc.
 
 ## VLAN reference
 
-| VLAN ID | Subnet | Purpose | Tag boundary |
-|---|---|---|---|
-| 2 | `10.42.2.0/24` | **Cluster + storage + wired clients.** Talos nodes, hestia, Synology, Apple TV, HifiBerry, RPi, etc. Also currently the LB pool. | UCGF wired access ports |
-| 4 | `10.42.4.0/24` | Wireless clients (laptops, phones) | WAP SSIDs |
+The UCGF terminates 6 VLANs, each on its own bridge interface. Every VLAN
+has its own `/24`. UniFi's display name is shown in the "Name" column.
 
-> **As-of caveat.** This table reflects the VLAN structure I have direct
-> evidence for. Other VLANs may exist on the UCGF (guest WiFi, IoT, work) —
-> verify with the UniFi UI (Settings → Networks). When confirmed, add rows
-> here and update the `homelab.io/<x>` lookups in the plan docs.
+| Bridge | VLAN name | Subnet | Purpose | DHCP range |
+|---|---|---|---|---|
+| `br0` | Core | `10.42.1.0/24` | UniFi infrastructure (switches, APs, gateway mgmt) | `.100–.199` |
+| `br2` | Lab | `10.42.2.0/24` | Cluster nodes, storage, wired clients, **and currently the LB pool** | `.6–.254` |
+| `br3` | Security | `10.42.3.0/24` | Cameras and security devices | `.6–.254` |
+| `br4` | Family | `10.42.4.0/24` | Wireless clients (laptops, phones, tablets) | `.6–.254` |
+| `br6` | Guest | `10.42.6.0/24` | Guest WiFi | `.6–.254` |
+| `br7` | IoT | `10.42.7.0/24` | IoT devices (existing — currently lightly populated) | `.6–.254` |
+
+Refresh the live VLAN list:
+
+```bash
+ssh root@10.42.2.1 'ip -br addr show | grep "br[0-9]"'
+```
 
 ## Subnet allocation map
 
 | Subnet | Use | Notes |
 |---|---|---|
-| `10.42.2.0/24` | VLAN 2 — physical hosts + LB pool overlap | Sharing this `/24` with the LB pool is the root cause of the 2026-05-05 incident. Migration target: `10.42.3.0/24` for LB. |
-| `10.42.4.0/24` | VLAN 4 — wireless clients | |
-| `10.42.3.0/24` | (planned) dedicated LB pool | Plan `2026-05-06-network-resilience-and-bgp-completion.md` Phase D |
-| `10.42.20.0/24` | (planned) IoT VLAN | Plan Phase F.1 |
-| `10.244.0.0/16` | Cluster pod CIDR | Cilium IPAM (kubernetes mode); each node gets a `/24` slice (`.0/24`, `.1/24`, … `.5/24` for the 6 nodes) |
+| `10.42.1.0/24` | Core VLAN — UniFi infrastructure | Switches, APs; locked-down management plane |
+| `10.42.2.0/24` | Lab VLAN — cluster + storage + LB pool | Sharing the `/24` between cluster mgmt and LB pool is the root cause of the 2026-05-05 wired-device incident |
+| `10.42.3.0/24` | Security VLAN — cameras | |
+| `10.42.4.0/24` | Family VLAN — wireless clients | Cross-subnet to LB IPs; routes via UCGF/BGP |
+| `10.42.5.0/24` | (unallocated; reserved for future LB pool migration) | Plan: `2026-05-06-network-resilience-and-bgp-completion.md` Phase D |
+| `10.42.6.0/24` | Guest VLAN | Guest WiFi |
+| `10.42.7.0/24` | IoT VLAN | Currently lightly populated; the migration target for client devices currently on the Lab VLAN |
+| `10.244.0.0/16` | Cluster pod CIDR | Cilium IPAM (Kubernetes mode); each node gets a `/24` slice |
 | `10.96.0.0/12` | Kubernetes service CIDR | ClusterIP allocation; not visible outside the cluster |
 
-## Static IP allocation on `10.42.2.0/24`
+## DNS resolution by VLAN
+
+Verified from `/run/dnsmasq.dhcp.conf.d/*.conf` on the UCGF — every VLAN's
+DHCP option 6 (DNS server) distributes AdGuard directly:
+
+| VLAN | DHCP-distributed resolvers |
+|---|---|
+| All 6 LAN VLANs (Core, Lab, Security, Family, Guest, IoT) | `[10.42.2.43, 10.42.2.45]` |
+
+This means **every DHCP-managed client on the LAN points at AdGuard
+directly.** The UCGF is not in the DNS-forwarding path for client queries;
+clients send DNS queries to AdGuard and reach it via L2 (if same-subnet
+with the LB IP) or via BGP-installed routes through the UCGF (if
+cross-subnet). See `traffic-flows.md` Flow 1 and Flow 2 for the two paths.
+
+## Static IP allocation on `10.42.2.0/24` (Lab VLAN)
 
 Sorted numerically. Numbers below are mgmt IPs (the device itself), not
-service VIPs.
+service VIPs. Refresh from the UCGF's DHCP reservations:
+
+```bash
+ssh root@10.42.2.1 'cat /run/dnsmasq.dhcp.conf.d/* 2>/dev/null | grep "dhcp-host=set:net_Lab" | awk -F"," "{print \$5}" | sort -V'
+```
 
 | IP | Device / Role | Notes |
 |---|---|---|
-| `10.42.2.1` | UCGF (router/gateway) | DHCP server, DNS forwarder upstream, BGP AS 65100 |
-| `10.42.2.10` | hestia (TrueNAS GPU server) | LLM inference + iSCSI provider |
-| `10.42.2.11` | Synology NAS | iSCSI block storage |
+| `10.42.2.1` | UCGF (router/gateway) | DHCP server, FRR for BGP (AS 65100), bridge `br2` |
+| `10.42.2.10` | hestia (TrueNAS GPU server) | LLM inference, Signal-CLI, iSCSI provider via `democratic-csi` |
+| `10.42.2.11` | Synology NAS | iSCSI target backing CNPG PVCs (`csi.san.synology.com`) |
 | `10.42.2.19` | Apple TV | Wired |
 | `10.42.2.20` | `talos-ykb-uir` (CP) | `k8sServiceHost` SPOF |
 | `10.42.2.21` | `talos-2mz-rfj` (CP) | |
@@ -52,15 +85,15 @@ service VIPs.
 | `10.42.2.30–37` | LB pool: `home-compute-pool` | Currently used by snapcast-prod (`.37`) |
 | `10.42.2.38` | HifiBerry kitchen | |
 | `10.42.2.39` | HifiBerry living-room | |
-| `10.42.2.40–254` | LB pool: `home-c-pool` | Default gateways and AdGuard |
+| `10.42.2.40–254` | LB pool: `home-c-pool` | Default — gateways and AdGuard |
 | `10.42.2.143` | `kitchen-pi` (RPi 4) | EEE disabled (see incident `2026-03-10`) |
 
 > **Note on overlap.** `home-compute-pool` (`.30–.37`) and `home-c-pool`
-> (`.40–.254`) sandwich the static range `.38–.39` (HifiBerry devices) and
-> overlap conceptually with mgmt range `.20–.25`. The `kitchen-pi` at `.143`
-> sits inside the LB pool range — Cilium's LBIPAM avoids it because it
-> tracks allocations, but a static device that conflicts with a future LB IP
-> would silently break.
+> (`.40–.254`) sandwich the static range `.38–.39` (HifiBerry devices).
+> The `kitchen-pi` at `.143` sits inside the `home-c-pool` range — Cilium's
+> LBIPAM avoids it because it tracks DHCP-reserved IPs as unavailable, but
+> a hand-allocated IP that conflicts with a future LB IP would silently
+> break.
 
 ## Active LoadBalancer service IPs (as of 2026-05-06)
 
@@ -100,18 +133,16 @@ Private 2-byte ASN range: `64512–65534`.
 | Upstream from AdGuard | Cloudflare DNS, Quad9, etc. | AdGuard's configured upstream resolvers |
 
 The split-horizon — same hostname resolves to different IPs from inside vs
-outside the LAN — is implemented entirely by AdGuard's wildcard rewrite. Per
+outside the LAN — is implemented entirely by AdGuard's wildcard rewrite. See
 [../dns-strategy.md](../dns-strategy.md) for the full mechanism.
 
-## DHCP
+## Forward links
 
-UCGF runs the DHCP server. The lease range and reservations are configured
-via the UniFi UI; verify with:
+The following subnet/VLAN allocations are **not yet live** but are
+referenced by active plans. Tracking them here so the plan and the
+addressing map don't drift apart.
 
-```bash
-ssh root@10.42.2.1 'cat /run/dnsmasq.leases 2>/dev/null'
-```
-
-DHCP-distributed DNS is currently `[10.42.2.43, 10.42.2.45]`. Plan
-`2026-05-06-network-resilience-and-bgp-completion.md` Phase C adds `1.1.1.1`
-as a fallback resolver.
+| Allocation | Status | Plan |
+|---|---|---|
+| `10.42.5.0/24` reserved as dedicated LB-only subnet | Planned | [Phase D](../../plans/2026-05-06-network-resilience-and-bgp-completion.md) |
+| Lab-VLAN client devices (Apple TV, HifiBerry, kitchen-pi) migrate to existing IoT VLAN `10.42.7.0/24` | Planned | [Phase F.1](../../plans/2026-05-06-network-resilience-and-bgp-completion.md) |

--- a/docs/architecture/networking/addressing.md
+++ b/docs/architecture/networking/addressing.md
@@ -1,0 +1,117 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Addressing: VLANs, Subnets, IP Allocation
+
+> **Scope.** Authoritative IP/VLAN map. For physical equipment see
+> [physical-topology.md](physical-topology.md). For LB IP advertisement
+> mechanics see [cluster-load-balancing.md](cluster-load-balancing.md).
+
+## VLAN reference
+
+| VLAN ID | Subnet | Purpose | Tag boundary |
+|---|---|---|---|
+| 2 | `10.42.2.0/24` | **Cluster + storage + wired clients.** Talos nodes, hestia, Synology, Apple TV, HifiBerry, RPi, etc. Also currently the LB pool. | UCGF wired access ports |
+| 4 | `10.42.4.0/24` | Wireless clients (laptops, phones) | WAP SSIDs |
+
+> **As-of caveat.** This table reflects the VLAN structure I have direct
+> evidence for. Other VLANs may exist on the UCGF (guest WiFi, IoT, work) —
+> verify with the UniFi UI (Settings → Networks). When confirmed, add rows
+> here and update the `homelab.io/<x>` lookups in the plan docs.
+
+## Subnet allocation map
+
+| Subnet | Use | Notes |
+|---|---|---|
+| `10.42.2.0/24` | VLAN 2 — physical hosts + LB pool overlap | Sharing this `/24` with the LB pool is the root cause of the 2026-05-05 incident. Migration target: `10.42.3.0/24` for LB. |
+| `10.42.4.0/24` | VLAN 4 — wireless clients | |
+| `10.42.3.0/24` | (planned) dedicated LB pool | Plan `2026-05-06-network-resilience-and-bgp-completion.md` Phase D |
+| `10.42.20.0/24` | (planned) IoT VLAN | Plan Phase F.1 |
+| `10.244.0.0/16` | Cluster pod CIDR | Cilium IPAM (kubernetes mode); each node gets a `/24` slice (`.0/24`, `.1/24`, … `.5/24` for the 6 nodes) |
+| `10.96.0.0/12` | Kubernetes service CIDR | ClusterIP allocation; not visible outside the cluster |
+
+## Static IP allocation on `10.42.2.0/24`
+
+Sorted numerically. Numbers below are mgmt IPs (the device itself), not
+service VIPs.
+
+| IP | Device / Role | Notes |
+|---|---|---|
+| `10.42.2.1` | UCGF (router/gateway) | DHCP server, DNS forwarder upstream, BGP AS 65100 |
+| `10.42.2.10` | hestia (TrueNAS GPU server) | LLM inference + iSCSI provider |
+| `10.42.2.11` | Synology NAS | iSCSI block storage |
+| `10.42.2.19` | Apple TV | Wired |
+| `10.42.2.20` | `talos-ykb-uir` (CP) | `k8sServiceHost` SPOF |
+| `10.42.2.21` | `talos-2mz-rfj` (CP) | |
+| `10.42.2.22` | `talos-v2l-hng` (CP) | |
+| `10.42.2.23` | `talos-lmh-kyf` (worker) | BGP peer |
+| `10.42.2.24` | `talos-18u-ski` (worker) | BGP peer |
+| `10.42.2.25` | `talos-kot-7x7` (worker) | BGP peer |
+| `10.42.2.30–37` | LB pool: `home-compute-pool` | Currently used by snapcast-prod (`.37`) |
+| `10.42.2.38` | HifiBerry kitchen | |
+| `10.42.2.39` | HifiBerry living-room | |
+| `10.42.2.40–254` | LB pool: `home-c-pool` | Default gateways and AdGuard |
+| `10.42.2.143` | `kitchen-pi` (RPi 4) | EEE disabled (see incident `2026-03-10`) |
+
+> **Note on overlap.** `home-compute-pool` (`.30–.37`) and `home-c-pool`
+> (`.40–.254`) sandwich the static range `.38–.39` (HifiBerry devices) and
+> overlap conceptually with mgmt range `.20–.25`. The `kitchen-pi` at `.143`
+> sits inside the LB pool range — Cilium's LBIPAM avoids it because it
+> tracks allocations, but a static device that conflicts with a future LB IP
+> would silently break.
+
+## Active LoadBalancer service IPs (as of 2026-05-06)
+
+These are the IPs **announced to the LAN** via BGP and L2:
+
+| Service | IP | Pool |
+|---|---|---|
+| `default/cilium-gateway-app-gateway-production` | `10.42.2.40` | `home-c-pool` |
+| `default/cilium-gateway-app-gateway-staging` | `10.42.2.42` | `home-c-pool` |
+| `adguard-prod/adguard` | `10.42.2.43` | `home-c-pool` (pinned via `lbipam.cilium.io/sharing-key`) |
+| `adguard-stage/adguard` | `10.42.2.44` | `home-c-pool` |
+| `adguard-prod/adguard-dns-secondary` | `10.42.2.45` | `home-c-pool` (pinned) |
+| `snapcast-stage/snapcast` | `10.42.2.41` | `home-c-pool` |
+| `snapcast-prod/snapcast` | `10.42.2.37` | `home-compute-pool` |
+
+Refresh:
+
+```bash
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}{"/"}{.metadata.name}{": "}{.status.loadBalancer.ingress[*].ip}{"\n"}{end}' | sort
+```
+
+## ASN reference
+
+| Entity | AS | Notes |
+|---|---|---|
+| UCGF | 65100 | Private 2-byte AS |
+| Cluster | 65010 | Private 2-byte AS; advertised from each worker node |
+
+Private 2-byte ASN range: `64512–65534`.
+
+## DNS authority chain
+
+| Layer | Resolver | Use |
+|---|---|---|
+| House-internal | AdGuard at `10.42.2.43` (primary), `10.42.2.45` (secondary) | Wildcard rewrites for `*.burntbytes.com`; ad/tracker filtering |
+| Public authority | Cloudflare (manages `burntbytes.com`) | Authoritative for the public zone (mostly Cloudflare Tunnel CNAMEs) |
+| Upstream from AdGuard | Cloudflare DNS, Quad9, etc. | AdGuard's configured upstream resolvers |
+
+The split-horizon — same hostname resolves to different IPs from inside vs
+outside the LAN — is implemented entirely by AdGuard's wildcard rewrite. Per
+[../dns-strategy.md](../dns-strategy.md) for the full mechanism.
+
+## DHCP
+
+UCGF runs the DHCP server. The lease range and reservations are configured
+via the UniFi UI; verify with:
+
+```bash
+ssh root@10.42.2.1 'cat /run/dnsmasq.leases 2>/dev/null'
+```
+
+DHCP-distributed DNS is currently `[10.42.2.43, 10.42.2.45]`. Plan
+`2026-05-06-network-resilience-and-bgp-completion.md` Phase C adds `1.1.1.1`
+as a fallback resolver.

--- a/docs/architecture/networking/cluster-load-balancing.md
+++ b/docs/architecture/networking/cluster-load-balancing.md
@@ -60,16 +60,40 @@ LB IP is unchanged.
    does service load balancing to a backend pod (which may live on any
    node).
 
+### Stable speaker-pool labels
+
+Lease elections by default use the cilium-operator's hashing across all
+nodes matched by the policy's `nodeSelector`. Pinning a service to a
+specific node by hostname is brittle — Talos auto-generates hostnames per
+install, so a node re-image yields a new hostname and the selector stops
+matching.
+
+The pattern used (or planned, depending on the migration phase) here is
+custom labels:
+
+```bash
+# Bootstrap-time, applied per worker
+kubectl label node <node> homelab.io/l2-speaker-pool=<a|b>
+```
+
+L2 policies select on `homelab.io/l2-speaker-pool` instead of hostname.
+Re-imaged nodes pick up the same pool by reapplying the label as part of
+the bootstrap runbook.
+
 ### Current state (verify)
 
 ```bash
-# All L2 leases
+# All L2 leases — note the holder (this changes on speaker re-election)
 kubectl -n kube-system get leases | grep cilium-l2announce
 
 # Module health on a cilium-agent
 CILIUM_POD=$(kubectl -n kube-system get pod -l app.kubernetes.io/name=cilium-agent -o name | head -1 | sed 's|pod/||')
 kubectl -n kube-system exec $CILIUM_POD -- cilium-dbg status --all-health 2>&1 | grep -A 2 "l2-announcer\|l2-responder"
 ```
+
+> The lease holder is whichever node won the most recent election. **Don't
+> hard-code the current speaker name into runbooks** — verify with the
+> command above whenever it matters.
 
 ### Failure modes
 
@@ -199,6 +223,82 @@ Because of the above, the HA story is asymmetric for the two client types:
 Practical implication: when the elected L2 speaker reboots, wired VLAN-2
 clients lose access for ~5–15s. Wireless clients are unaffected. When a
 worker reboots, no one notices.
+
+## Observability — Hubble
+
+Cilium ships a flow-observability layer called Hubble. It captures every
+packet seen by the BPF datapath at L3/L4 (and optionally L7) and exposes it
+via CLI, gRPC API, and web UI. **This is the primary tool for debugging
+"why didn't this packet reach that pod" questions.**
+
+Enabled in `infra/controllers/cilium/values.yaml`:
+
+```yaml
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+```
+
+### Common usages
+
+```bash
+# Tail every flow on a specific node
+kubectl -n kube-system exec ds/cilium -- hubble observe --follow
+
+# Filter by namespace
+hubble observe --namespace adguard-prod
+
+# Filter to drops only
+hubble observe --verdict DROPPED
+
+# Visualize in the UI (port-forward)
+cilium hubble ui
+# then open http://localhost:12000
+```
+
+### What Hubble can / can't see
+
+- ✅ Pod-to-pod traffic (every packet, both directions, with verdict).
+- ✅ Pod-to-LB and LB-to-pod (the BPF rewrite is visible).
+- ✅ External-to-LB after the packet enters a worker node.
+- ✅ DNS lookups when L7 visibility is enabled for the namespace.
+- ❌ Traffic between two LAN devices that doesn't traverse a cluster node
+  (e.g. Apple TV to UCGF). That stays on the wire and never hits BPF.
+- ❌ Traffic before BPF (raw frames on the host NIC). Use `tcpdump` on the
+  node for that.
+
+## Cilium Network Policies
+
+The cluster uses `CiliumNetworkPolicy` (Cilium's superset of Kubernetes
+`NetworkPolicy`) to gate east-west pod traffic. As of 2026-05-06: ~45
+`CiliumNetworkPolicy` resources and 3 `NetworkPolicy` resources active.
+
+```bash
+# Enumerate
+kubectl get ciliumnetworkpolicy -A
+kubectl get networkpolicy -A
+```
+
+Per-app policies live in `apps/base/<app>/networkpolicy.yaml` and are
+overlaid into staging/production. The default posture is "default-deny
+where a policy exists; default-allow where one doesn't" — which is the
+Kubernetes NetworkPolicy semantic, not a true zero-trust default.
+
+### What's typically locked down
+
+- Application pods: ingress restricted to gateway envoy + same-namespace.
+- AdGuard: ingress allowed from any LAN client (it's a DNS resolver), egress to upstream resolvers.
+- Storage-adjacent pods: egress allowed to the iSCSI targets (Synology, hestia).
+
+### Debugging a denied packet
+
+`hubble observe --verdict DROPPED` shows the policy that dropped the
+packet (look for `policy-verdict` reason). If the packet should have been
+allowed, identify the relevant `CiliumNetworkPolicy` and verify the
+`endpointSelector` + ingress/egress rules.
 
 ## Configuration files index
 

--- a/docs/architecture/networking/cluster-load-balancing.md
+++ b/docs/architecture/networking/cluster-load-balancing.md
@@ -1,0 +1,213 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Cluster Load Balancing: L2 + BGP
+
+> **Scope.** How LoadBalancer service IPs become reachable from the LAN.
+> Covers Cilium's BGP control plane, L2 announcements, ECMP behavior, and
+> the rationale for running both simultaneously. For the IP map see
+> [addressing.md](addressing.md). For per-client packet flow see
+> [traffic-flows.md](traffic-flows.md).
+
+## Why both L2 and BGP
+
+The cluster runs **two parallel mechanisms** for advertising LoadBalancer
+IPs to the LAN. They are not redundant alternatives — they cover **different
+client populations**, and each is required for its respective set:
+
+| Client type | Subnet relative to LB IP | Resolution mechanism |
+|---|---|---|
+| Wired client on VLAN 2 (Apple TV, HifiBerry, etc.) | Same `/24` as LB IP | **L2 ARP** — Cilium agent on an elected node responds with its own MAC |
+| Wireless client on VLAN 4 | Different subnet | **BGP routing** — UCGF has a `/32` route, picks an ECMP next-hop |
+| Cross-subnet wired (Mac on VLAN 4) | Different subnet | **BGP routing** (same as wireless) |
+| In-cluster pod | Special — uses Cilium's BPF kube-proxy replacement | Neither L2 nor BGP — direct socket-level rewrite |
+
+The mechanisms operate at different layers and don't conflict:
+
+- **L2 (ARP) operates at Layer 2.** It only matters when the source and
+  destination are in the same broadcast domain. The kernel's IP forwarding
+  rule sends an ARP request directly onto the wire instead of forwarding to
+  a gateway.
+- **BGP advertises Layer 3 routes.** It only matters when the destination is
+  outside the source's subnet, requiring routing-table lookup.
+
+A client running through both paths (e.g. moving from wired VLAN 2 to
+wireless VLAN 4 mid-session) silently transitions between mechanisms — the
+LB IP is unchanged.
+
+> **History.** The 2026-05-05 BGP rollout (Phase 4) tried to remove L2 on
+> the assumption that BGP was sufficient for everything. It is not — same-
+> subnet wired clients still need ARP. See
+> `docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`.
+
+## L2 announcements (Cilium L2 announcer)
+
+### Mechanism
+
+1. A `CiliumL2AnnouncementPolicy` resource declares which services should be
+   announced and from which nodes. Current policy: `l2-announcement-policy-staging`
+   (cluster-wide, no `nodeSelector`) — to be replaced per the active plan.
+2. The **cilium-operator** watches matching services and creates a
+   Kubernetes `Lease` per service IP in `kube-system`, named
+   `cilium-l2announce-<namespace>-<service>`.
+3. Lease leader election picks one node per IP. That node's **cilium-agent**
+   responds to ARP requests for the IP with its own NIC MAC and sends
+   periodic gratuitous ARPs.
+4. Same-subnet clients receive the ARP reply and send frames directly to
+   the elected node. From there, Cilium's in-kernel kube-proxy replacement
+   does service load balancing to a backend pod (which may live on any
+   node).
+
+### Current state (verify)
+
+```bash
+# All L2 leases
+kubectl -n kube-system get leases | grep cilium-l2announce
+
+# Module health on a cilium-agent
+CILIUM_POD=$(kubectl -n kube-system get pod -l app.kubernetes.io/name=cilium-agent -o name | head -1 | sed 's|pod/||')
+kubectl -n kube-system exec $CILIUM_POD -- cilium-dbg status --all-health 2>&1 | grep -A 2 "l2-announcer\|l2-responder"
+```
+
+### Failure modes
+
+| Failure | Behavior | Recovery |
+|---|---|---|
+| Speaker node reboots | Lease expires; another node wins re-election | ~15s ARP outage on default timing (5s with the proposed lease tuning) |
+| All eligible nodes drained | No speaker; ARP for LB IP fails | Same-subnet clients lose access until at least one node is back |
+| Cilium agent crash on speaker | Lease GC removes the lease; another node wins | ~lease-duration outage (15s default) |
+| Helm config change without DaemonSet restart | Configmap updates but agents keep old runtime config; L2 announcer module stays in stopped state | `kubectl rollout restart ds/cilium -n kube-system` |
+
+### Operator gotcha
+
+Cilium reads feature flags (`enable-l2-announcements`) at startup, not on
+configmap hot-reload. After any Helm value change to the `l2announcements:`
+block, **manually restart the DaemonSet:**
+
+```bash
+kubectl rollout restart ds/cilium -n kube-system
+kubectl rollout status ds/cilium -n kube-system
+```
+
+Without this step, the configmap shows the new value but the agents
+continue running with the old config — L2 silently doesn't work.
+
+## BGP (Cilium BGP control plane)
+
+### Mechanism
+
+1. The Cilium BGP control plane is enabled cluster-wide via Helm:
+   `bgpControlPlane.enabled: true`. This makes every cilium-agent capable
+   of running BGP.
+2. `CiliumBGPClusterConfig` (`infra/configs/cilium/bgp-cluster-config.yaml`)
+   selects which nodes actually peer. Current selector: every node **except
+   control-plane**, which selects all 3 workers.
+3. `CiliumBGPPeerConfig` defines timers, address families, and which
+   `CiliumBGPAdvertisement` resources feed each family.
+4. `CiliumBGPAdvertisement` declares what to advertise. Current advertisement
+   matches every LoadBalancer service (`matchLabels: {}`), advertising each
+   service's LB IP as a `/32`.
+5. Each worker initiates a TCP connection to UCGF `10.42.2.1:179`,
+   negotiates an eBGP session (AS 65010 ↔ AS 65100), and announces its `/32`s
+   with itself as the next-hop.
+
+### UCGF side
+
+The UCGF runs FRRouting (FRR). Authoritative config snapshot in
+[`docs/reference/ucgf-bgp-frr.conf`](../../reference/ucgf-bgp-frr.conf).
+Key elements:
+
+- **`bgp listen range 10.42.2.0/24 peer-group K8S-NODES`** — accepts BGP
+  from any LAN host asserting AS 65010. Lets new workers join automatically.
+- **`maximum-paths 8`** — installs all 3 worker next-hops in the routing
+  table for ECMP. Without this, FRR keeps only one path per prefix.
+- **`ip prefix-list K8S-LB-IPS`** — restricts inbound to `/32`s in the LB
+  pool subnet. A misconfigured cluster cannot push arbitrary routes
+  (e.g. a default route).
+- **`route-map DENY-ALL` outbound** — gateway never advertises its own
+  routes back to the cluster.
+
+### Result on the UCGF
+
+```bash
+ssh root@10.42.2.1 'vtysh -c "show ip route bgp"'
+# Each LB IP /32 with 3 next-hops (one per worker), ECMP weighted equally:
+# B>* 10.42.2.40/32 [20/0] via 10.42.2.23, eth0, weight 1
+#                       via 10.42.2.24, eth0, weight 1
+#                       via 10.42.2.25, eth0, weight 1
+```
+
+### Failure modes
+
+| Failure | Behavior | Recovery |
+|---|---|---|
+| One worker's BGP session drops | UCGF removes that next-hop after hold-time (90s); ECMP collapses to 2 paths | Automatic on session re-establishment |
+| Two workers' BGP sessions drop | One next-hop remains; no traffic loss but no HA | Automatic on session re-establishment |
+| All 3 worker BGP sessions drop | UCGF has no route; cross-subnet clients lose access | Automatic on first session re-establishment |
+| UCGF FRR daemon crashes | All BGP routes removed; cross-subnet access fails | `ssh root@10.42.2.1 systemctl restart frr` |
+| UCGF firmware upgrade reverts `/etc/frr/frr.conf` and `/etc/frr/daemons` | BGP not running at all | Re-apply `docs/reference/ucgf-bgp-frr.conf`; re-set `bgpd=yes` in `/etc/frr/daemons`; `systemctl enable --now frr` |
+
+### Graceful restart
+
+The peer config sets `gracefulRestart.enabled: true` with `restartTimeSeconds: 120`.
+This lets a Cilium agent restart without the UCGF dropping its routes
+immediately — the UCGF holds the routes until either the BGP session
+re-establishes or the 120s timer expires. End-to-end effect: a Cilium
+DaemonSet rolling restart causes ~zero LB outage as long as each agent's
+restart completes inside 120s.
+
+## ECMP behavior
+
+The UCGF installs 3 next-hops per LB IP. For each new flow, FRR picks one
+next-hop (typically by 5-tuple hash). Existing flows are sticky to their
+chosen next-hop until expiration.
+
+### Once a packet reaches a worker
+
+Both L2 and BGP paths converge on the same in-cluster behavior:
+
+1. Frame arrives on the worker's NIC (via L2 ARP for same-subnet, via UCGF
+   forwarding for routed).
+2. Cilium's BPF kube-proxy replacement looks up the destination IP+port in
+   the BPF service map.
+3. It rewrites the packet's destination to a backend pod IP (which may be
+   on any node) and forwards via VXLAN tunnel.
+4. The backend pod responds; reply traverses the same VXLAN back to the
+   ingress worker, which un-rewrites and sends the frame back to the LAN.
+
+`externalTrafficPolicy: Cluster` (the current default for all LB services)
+means **the ingress worker may not host the backend pod** — there's a
+second hop. `Local` would skip the second hop but reduce ECMP path count
+to "workers running the backing pod." The plan
+`2026-05-06-network-resilience-and-bgp-completion.md` Phase F.3 covers
+per-service review of this.
+
+## L2-vs-BGP HA asymmetry
+
+Because of the above, the HA story is asymmetric for the two client types:
+
+| | L2 (wired VLAN 2) | BGP (cross-subnet) |
+|---|---|---|
+| Active speakers per IP | 1 (lease holder) | 3 (all workers) |
+| Failover trigger | Lease expiry on speaker death | BGP hold-time on worker death |
+| Failover time | ~5–15s (depends on lease tuning) | ~90s (hold-time) |
+| Concurrent path count | 1 (no aggregate bandwidth across nodes) | 3 (ECMP) |
+| Single point of failure | The elected speaker node | Any single worker (other 2 cover) |
+
+Practical implication: when the elected L2 speaker reboots, wired VLAN-2
+clients lose access for ~5–15s. Wireless clients are unaffected. When a
+worker reboots, no one notices.
+
+## Configuration files index
+
+| File | Resource | Purpose |
+|---|---|---|
+| `infra/configs/cilium/load-balancer-ip-pool.yaml` | `CiliumLoadBalancerIPPool` × 2 | LB IP pools (`home-c-pool`, `home-compute-pool`) |
+| `infra/configs/cilium/l2-announcement-policy.yaml` | `CiliumL2AnnouncementPolicy` | L2 announcement policy (cluster-wide, no selector currently) |
+| `infra/configs/cilium/bgp-cluster-config.yaml` | `CiliumBGPClusterConfig` | Worker-only nodeSelector; AS 65010; peers with UCGF |
+| `infra/configs/cilium/bgp-peer-config.yaml` | `CiliumBGPPeerConfig` | Timers; IPv4 family; advertisement matchLabels |
+| `infra/configs/cilium/bgp-advertisement.yaml` | `CiliumBGPAdvertisement` | matchLabels {} → all LB IPs |
+| `infra/controllers/cilium/values.yaml` | Helm values | `bgpControlPlane.enabled: true`, `l2announcements.enabled: true`, `kubeProxyReplacement: true` |
+| `docs/reference/ucgf-bgp-frr.conf` | (snapshot) | UCGF FRR config; canonical reference |

--- a/docs/architecture/networking/glossary.md
+++ b/docs/architecture/networking/glossary.md
@@ -1,0 +1,208 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Networking Glossary
+
+> **Scope.** Quick definitions of terms used across the networking docs.
+> Definitions are written for the homelab's specific context — so e.g.
+> "BGP" reads in terms of Cilium ↔ UCGF, not general internet routing.
+
+## Concepts
+
+**ARP (Address Resolution Protocol).** L2 mechanism for finding the MAC
+address corresponding to an IP address. A host sends a broadcast frame
+"Who has 10.42.2.43?" and waits for a reply with the target's MAC. Only
+works **within a single broadcast domain** (same VLAN/subnet).
+
+**Broadcast domain.** The set of devices that receive an L2 broadcast frame.
+Bounded by router/L3 boundaries and VLAN tags. In this network, each VLAN
+is one broadcast domain.
+
+**BGP (Border Gateway Protocol).** A routing protocol used here for the
+cluster to advertise LoadBalancer IP `/32` routes to the UCGF. Each worker
+node speaks eBGP from AS 65010 to UCGF AS 65100. BGP is L3 only — it does
+not help with same-subnet ARP.
+
+**eBGP / iBGP.** External vs internal BGP. eBGP is between different ASNs
+(our case: cluster AS 65010 → UCGF AS 65100). iBGP is within one ASN.
+
+**ECMP (Equal-Cost Multi-Path).** When multiple equally-good routes exist
+for a destination, the router installs all of them and picks one per flow
+(usually 5-tuple hashed). On the UCGF, each LB IP `/32` has 3 ECMP next-hops
+(one per worker).
+
+**Edge port (PortFast).** STP setting that skips the listening/learning
+states on link-up and **does not generate TCNs on link-down/up.** Should be
+enabled on every port connected to an end device. See incident
+`2026-03-10` for why this matters.
+
+**EEE (Energy Efficient Ethernet, 802.3az).** PHY-level power saving where
+the NIC enters Low Power Idle during traffic gaps. Can interact badly with
+some switch firmwares (interpreted as link-down events). Disabled on RPi 4
+hosts in this network — see incident `2026-03-10`.
+
+**Gateway API.** Kubernetes API for advanced ingress (Gateway, HTTPRoute,
+GRPCRoute, etc.). Cilium implements it; provisions Envoy proxies as the
+data plane. See `docs/architecture/gateway-auth.md`.
+
+**Gratuitous ARP.** An unsolicited ARP announcement: "I am at IP X, here's
+my MAC." Sent by the L2 announcer when a service comes up or a lease
+changes hands, so other hosts update their ARP caches without waiting for
+their existing entries to expire.
+
+**Hold time (BGP).** Negotiated session timer; if the peer doesn't send
+keepalives or updates within this window, the session is considered dead.
+Set to 90s on this network's BGP sessions.
+
+**HTTPRoute.** Gateway API resource defining how requests to a hostname/path
+are routed to backend services. Each `*.burntbytes.com` app has one.
+
+**ICMP redirect.** Router message saying "you should send packets directly
+to <other-router>." Not used here; routing is BGP-installed and stable.
+
+**iSCSI (SCSI over TCP).** Block storage protocol. Cluster nodes connect to
+hestia (TrueNAS) and Synology iSCSI targets to back PersistentVolumes.
+Default port 3260.
+
+**Kube-proxy replacement.** Cilium's eBPF data path that replaces the
+`kube-proxy` component. Implements ClusterIP/NodePort/LoadBalancer service
+load balancing in eBPF, bypassing iptables and conntrack overhead.
+
+**LBIPAM.** Cilium's LoadBalancer IPAM — allocates LB IPs from
+`CiliumLoadBalancerIPPool` resources and assigns them to Service objects.
+
+**Lease (Kubernetes).** A resource type used for leader election. Cilium
+creates one per L2-announced service IP (`cilium-l2announce-<ns>-<svc>`)
+in `kube-system`; the holder is the elected speaker.
+
+**listen range (BGP).** FRR config that accepts BGP from any host within
+the given CIDR asserting the configured peer-group's AS. Used here so new
+worker nodes can BGP-peer without explicit per-node config on the UCGF.
+
+**Multicast / mDNS.** Multicast DNS (`*.local`) for service discovery —
+AirPlay, Bonjour, HomeKit, Snapcast. Doesn't cross VLAN boundaries unless
+explicitly reflected by the router (UniFi mDNS reflector). Relevant for
+the Phase F.1 IoT VLAN segmentation plan.
+
+**Next-hop.** The intermediate router/host a packet should be sent to in
+order to reach its destination. BGP advertisements include the originating
+peer's IP as the next-hop.
+
+**NodePort.** A Kubernetes Service type that exposes a service on a
+randomly-allocated port (default range 30000–32767) on every node. Not
+used as primary ingress here; the gateway uses LoadBalancer instead.
+
+**Pod CIDR.** The IP range from which Cilium allocates pod IPs. Set to
+`10.244.0.0/16`, sliced into `/24` per node.
+
+**Prefix-list.** FRR/BGP filter resource that matches a set of prefixes.
+Used here to restrict inbound BGP announcements to `/32`s within the LB
+pool subnet.
+
+**Route-map.** FRR/BGP filter resource that combines prefix-lists and
+attribute manipulations. Used here for inbound (`K8S-LB-IN` permits valid
+LB `/32`s) and outbound (`DENY-ALL` denies everything — UCGF advertises
+nothing back to the cluster).
+
+**SNAT (Source NAT).** Rewriting the source IP of an outbound packet to
+the egress interface's IP. Cilium does this for pod → external traffic
+(masquerading) so external services see the node IP, not the pod IP.
+
+**Split-horizon DNS.** Same hostname resolves to different IPs depending on
+who's asking. Implemented here by AdGuard's wildcard rewrite intercepting
+public Cloudflare DNS for LAN clients. See
+`docs/architecture/dns-strategy.md`.
+
+**STP (Spanning Tree Protocol).** L2 loop prevention. The Pro XG 48 PoE is
+the configured root bridge. STP TCNs (Topology Change Notifications) cause
+MAC table flushes — when emitted spuriously by a faulty switch, they cause
+subnet-wide blackouts. See incident `2026-03-10`.
+
+**TCN (Topology Change Notification).** STP message indicating "the
+forwarding topology changed; flush MAC tables." Should be rare in steady
+state.
+
+**TLS termination.** Decrypting TLS at an intermediate proxy (here: the
+Cilium gateway running Envoy) so the proxy can inspect the request. After
+termination, the proxy may re-encrypt to the backend or send plaintext.
+
+**Trunk port.** A switch port carrying frames for multiple VLANs, with
+802.1Q tags identifying which VLAN each frame belongs to. Inter-switch
+uplinks are typically trunks.
+
+**Untagged port (access port).** A switch port assigned to one VLAN; frames
+arrive without 802.1Q tags. End-device ports are typically untagged.
+
+**VLAN (Virtual LAN).** L2 segmentation. Each VLAN is its own broadcast
+domain with its own subnet. Tags are 12 bits (VLAN IDs 1–4094).
+
+**VXLAN.** L2-over-UDP encapsulation. Cilium uses it for pod-to-pod traffic
+between nodes — pod IPs are encapsulated and tunneled over the LAN, so the
+underlying network never sees pod CIDRs.
+
+## Homelab-specific terms
+
+**`burntbytes.com`.** The public domain. Cloudflare-authoritative. AdGuard
+intercepts `*.burntbytes.com` for LAN clients.
+
+**Cilium.** The CNI. Provides networking, BGP, L2 announcements, Gateway
+API, and observability via Hubble.
+
+**Cloudflare Tunnel (`cloudflared`).** Persistent outbound QUIC tunnel
+from a pod inside the cluster to Cloudflare's edge. Provides public
+ingress without port-forwarding. Config in `apps/base/cloudflare-tunnel/`.
+
+**hestia.** TrueNAS GPU server at `10.42.2.10`. Hosts vLLM/llama.cpp for
+local LLM inference, signal-cli-rest-api for the Hermes Signal bot, and
+serves iSCSI for non-Synology PVCs.
+
+**`melodic-muse`.** The Talos cluster name.
+
+**Synology.** NAS at `10.42.2.11`. iSCSI target backing CNPG PVCs.
+
+**UCGF (UniFi Cloud Gateway Fiber).** The router at `10.42.2.1`. Runs
+UniFi OS, FRRouting (FRR) for BGP, dnsmasq for DHCP. Single point of
+failure for cross-subnet traffic.
+
+**VLAN 2.** `10.42.2.0/24`. Cluster nodes, hestia, Synology, wired client
+devices, and the LB IP pool all share this VLAN currently.
+
+**VLAN 4.** `10.42.4.0/24`. Wireless clients.
+
+**`10.42.2.40` / `home-c-pool`.** The default LB IP pool for production
+gateway and AdGuard (`.43`/`.45`).
+
+## Acronyms quick-reference
+
+| Term | Expansion |
+|---|---|
+| AS | Autonomous System (BGP) |
+| ASN | AS Number |
+| BGP | Border Gateway Protocol |
+| BPF / eBPF | (extended) Berkeley Packet Filter |
+| CIDR | Classless Inter-Domain Routing (IP prefix notation) |
+| CNI | Container Network Interface |
+| CRD | Custom Resource Definition (Kubernetes) |
+| ECMP | Equal-Cost Multi-Path |
+| FRR | FRRouting |
+| iSCSI | Internet Small Computer Systems Interface |
+| L2 / L3 / L4 | OSI layers 2, 3, 4 |
+| LAG / LACP | Link Aggregation / LACP |
+| LB | LoadBalancer |
+| mDNS | Multicast DNS |
+| NIC | Network Interface Controller |
+| OIDC | OpenID Connect |
+| PHY | Physical layer (NIC) |
+| PVC | PersistentVolumeClaim |
+| RSTP | Rapid Spanning Tree Protocol |
+| SNI | Server Name Indication (TLS) |
+| SPOF | Single Point of Failure |
+| STP | Spanning Tree Protocol |
+| TCN | Topology Change Notification |
+| UCGF | UniFi Cloud Gateway Fiber |
+| VIP | Virtual IP |
+| VLAN | Virtual LAN |
+| VXLAN | Virtual Extensible LAN |
+| WAP | Wireless Access Point |

--- a/docs/architecture/networking/glossary.md
+++ b/docs/architecture/networking/glossary.md
@@ -59,12 +59,10 @@ Set to 90s on this network's BGP sessions.
 **HTTPRoute.** Gateway API resource defining how requests to a hostname/path
 are routed to backend services. Each `*.burntbytes.com` app has one.
 
-**ICMP redirect.** Router message saying "you should send packets directly
-to <other-router>." Not used here; routing is BGP-installed and stable.
-
 **iSCSI (SCSI over TCP).** Block storage protocol. Cluster nodes connect to
 hestia (TrueNAS) and Synology iSCSI targets to back PersistentVolumes.
-Default port 3260.
+Default port 3260. Both targets sit on the Lab VLAN with the cluster, so
+delivery is single-hop L2.
 
 **Kube-proxy replacement.** Cilium's eBPF data path that replaces the
 `kube-proxy` component. Implements ClusterIP/NodePort/LoadBalancer service
@@ -136,7 +134,9 @@ uplinks are typically trunks.
 arrive without 802.1Q tags. End-device ports are typically untagged.
 
 **VLAN (Virtual LAN).** L2 segmentation. Each VLAN is its own broadcast
-domain with its own subnet. Tags are 12 bits (VLAN IDs 1–4094).
+domain with its own subnet. Tags are 12 bits (VLAN IDs 1–4094). The home
+network has 6 VLANs (Core, Lab, Security, Family, Guest, IoT) — see
+[addressing.md](addressing.md) for the full table.
 
 **VXLAN.** L2-over-UDP encapsulation. Cilium uses it for pod-to-pod traffic
 between nodes — pod IPs are encapsulated and tunneled over the LAN, so the
@@ -144,11 +144,17 @@ underlying network never sees pod CIDRs.
 
 ## Homelab-specific terms
 
+**AdGuard (AdGuard Home).** The cluster's DNS server + ad/tracker filter.
+Runs in the `adguard-prod` namespace as a 2-replica StatefulSet behind two
+LoadBalancer service IPs: `10.42.2.43` (primary) and `10.42.2.45`
+(secondary). Distinct sharing-key annotations force the two services onto
+distinct IPs. UCGF distributes both as DHCP DNS option 6 to every LAN VLAN.
+
 **`burntbytes.com`.** The public domain. Cloudflare-authoritative. AdGuard
-intercepts `*.burntbytes.com` for LAN clients.
+intercepts `*.burntbytes.com` for LAN clients via wildcard rewrite.
 
 **Cilium.** The CNI. Provides networking, BGP, L2 announcements, Gateway
-API, and observability via Hubble.
+API, NetworkPolicy enforcement, and observability via Hubble.
 
 **Cloudflare Tunnel (`cloudflared`).** Persistent outbound QUIC tunnel
 from a pod inside the cluster to Cloudflare's edge. Provides public
@@ -166,10 +172,13 @@ serves iSCSI for non-Synology PVCs.
 UniFi OS, FRRouting (FRR) for BGP, dnsmasq for DHCP. Single point of
 failure for cross-subnet traffic.
 
-**VLAN 2.** `10.42.2.0/24`. Cluster nodes, hestia, Synology, wired client
-devices, and the LB IP pool all share this VLAN currently.
+**Lab VLAN (`br2`).** `10.42.2.0/24`. Cluster nodes, hestia, Synology,
+wired client devices, and the LB IP pool all share this VLAN currently.
 
-**VLAN 4.** `10.42.4.0/24`. Wireless clients.
+**Family VLAN (`br4`).** `10.42.4.0/24`. Wireless clients.
+
+**Other VLANs.** Core (`br0`, `10.42.1.0/24` UniFi mgmt), Security (`br3`,
+`10.42.3.0/24` cameras), Guest (`br6`), IoT (`br7`, `10.42.7.0/24`).
 
 **`10.42.2.40` / `home-c-pool`.** The default LB IP pool for production
 gateway and AdGuard (`.43`/`.45`).

--- a/docs/architecture/networking/physical-topology.md
+++ b/docs/architecture/networking/physical-topology.md
@@ -1,0 +1,111 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Physical Topology
+
+> **Scope.** Physical equipment, port-level cabling concepts, VLAN tagging
+> boundaries. For IP allocation see [addressing.md](addressing.md). For LB
+> traffic flow see [cluster-load-balancing.md](cluster-load-balancing.md).
+
+## Equipment inventory
+
+| Role | Device | IP (mgmt) | Notes |
+|---|---|---|---|
+| Router / L3 gateway | UniFi Cloud Gateway Fiber (UCGF) | `10.42.2.1` | Runs UniFi OS, FRRouting (FRR) for BGP, dnsmasq for DHCP |
+| Core switch | UniFi Pro XG 48 PoE | (UniFi-managed) | STP root bridge (priority 4096); uplink to UCGF; downlinks to access switches and end devices |
+| Access switch | UniFi Switch (various) | (UniFi-managed) | Distribution to wired endpoints |
+| Wireless | UniFi WAPs | (UniFi-managed) | Tag wireless SSIDs onto wireless VLAN(s) |
+| Removed | UniFi Flex 2.5G PoE | n/a | Removed 2026-03-10 — caused STP TCN storms; see `docs/operations/incidents/2026-03-10-rpi-stp-tcn-blackouts.md` |
+
+> The full UniFi device tree is the source of truth — `ssh root@10.42.2.1`
+> then UniFi UI for live device inventory. This table tracks the
+> roles/relationships, not transient device counts.
+
+## Cluster nodes
+
+6-node Talos cluster (`melodic-muse`). All on VLAN 2 (`10.42.2.0/24`):
+
+| Node | Role | Mgmt IP | Hardware notes |
+|---|---|---|---|
+| `talos-ykb-uir` | control-plane | `10.42.2.20` | Hardcoded as `k8sServiceHost` in Cilium values (SPOF — see plan `2026-05-06`) |
+| `talos-2mz-rfj` | control-plane | `10.42.2.21` | |
+| `talos-v2l-hng` | control-plane | `10.42.2.22` | |
+| `talos-lmh-kyf` | worker | `10.42.2.23` | BGP peer |
+| `talos-18u-ski` | worker | `10.42.2.24` | BGP peer |
+| `talos-kot-7x7` | worker | `10.42.2.25` | BGP peer |
+
+Talos hostnames are auto-generated with random suffixes. **A node re-image
+yields a new hostname** — any selector that references hostnames must be
+updated post-reimage. Plan `2026-05-06-network-resilience-and-bgp-completion.md`
+introduces stable `homelab.io/l2-speaker-pool=<a|b>` labels to insulate L2
+policies from this fragility.
+
+## Other infrastructure devices
+
+| Device | IP | VLAN | Role |
+|---|---|---|---|
+| hestia (TrueNAS GPU server) | `10.42.2.10` | 2 | LLM inference (vLLM/llama.cpp), Signal-CLI bridge, iSCSI provider for non-Synology PVCs |
+| Synology NAS | `10.42.2.11` | 2 | iSCSI block storage backing CNPG PVCs; DSM at port 5000 |
+
+Both are kept on VLAN 2 with the cluster because they participate in iSCSI
+sessions terminated by the cluster's Synology CSI driver. Moving them to a
+separate VLAN would route iSCSI through the UCGF, adding latency and a hop
+for every SCSI op.
+
+## Wired client devices
+
+These are user/service devices on VLAN 2 that share L2 with the cluster.
+Listed in the BGP plan as the gating constraint for ever removing L2
+announcements.
+
+| Device | IP | Notes |
+|---|---|---|
+| Apple TV | `10.42.2.19` | Wired via switch; DNS configured manually in tvOS UI |
+| HifiBerry kitchen | `10.42.2.38` | Snapcast client; static IP via OS config |
+| HifiBerry living-room | `10.42.2.39` | Snapcast client |
+| `kitchen-pi` | `10.42.2.143` | Raspberry Pi 4; `bcmgenet` NIC with EEE disabled (see incident `2026-03-10`) |
+
+Plan `2026-05-06-network-resilience-and-bgp-completion.md` Phase F.1 proposes
+moving these to a new VLAN 20 (`10.42.20.0/24`) once mDNS reflector
+prerequisites are confirmed.
+
+## Wireless
+
+Wireless clients (Macs, phones, tablets) sit on a separate VLAN
+(`10.42.4.0/24`). They route to cluster services through the UCGF — see
+[traffic-flows.md](traffic-flows.md) for the path.
+
+## VLAN tagging boundaries
+
+VLAN tagging is applied at:
+
+1. **UCGF LAN ports** — assign each port to a VLAN (untagged) or trunk multiple VLANs (tagged).
+2. **WAP SSIDs** — each SSID maps to a VLAN tag; wireless clients are placed on the configured VLAN.
+3. **Switch ports** — typically untagged on the configured VLAN; trunk uplinks tag everything.
+
+The cluster nodes do not use 802.1Q on their NICs — Talos sees VLAN-untagged
+frames on whichever access port the UCGF puts them on.
+
+## Spanning tree
+
+- Pro XG 48 PoE has bridge priority 4096 (root bridge).
+- Edge ports on end-device switch ports (recommended; partial — see incident `2026-03-10` Fix 2).
+- TC Guard on inter-switch uplinks is a future hardening item.
+
+## Cabling philosophy
+
+- **Star topology** — every endpoint terminates at a switch port, no daisy-chained access switches.
+- **No long copper runs over 90m.** Beyond that, use fiber.
+- **Cluster nodes home-run to the core switch.** Each Talos node has a single 2.5GbE link.
+- **No physical redundancy in current build.** Single uplink per access switch; single NIC per node. Network HA depends on protocol-layer redundancy (ECMP in BGP, lease re-election in L2), not redundant cabling.
+
+## Things that intentionally don't exist (yet)
+
+- **No dedicated storage VLAN.** iSCSI shares VLAN 2 with everything else.
+  Acceptable for current load (~1 Gbps peak); revisit if storage saturates the LAN.
+- **No dedicated mgmt VLAN for switches/APs.** Their mgmt IPs sit on VLAN 2.
+- **No physical link aggregation (LAG/LACP).** Single 2.5GbE per node is sufficient
+  for current per-node throughput.
+- **No second WAN.** UCGF has one fiber uplink. ISP outage = full Internet outage.

--- a/docs/architecture/networking/physical-topology.md
+++ b/docs/architecture/networking/physical-topology.md
@@ -25,22 +25,23 @@ last_modified: 2026-05-06
 
 ## Cluster nodes
 
-6-node Talos cluster (`melodic-muse`). All on VLAN 2 (`10.42.2.0/24`):
+6-node Talos cluster (`melodic-muse`). All on the Lab VLAN (`br2`,
+`10.42.2.0/24`):
 
 | Node | Role | Mgmt IP | Hardware notes |
 |---|---|---|---|
-| `talos-ykb-uir` | control-plane | `10.42.2.20` | Hardcoded as `k8sServiceHost` in Cilium values (SPOF — see plan `2026-05-06`) |
+| `talos-ykb-uir` | control-plane | `10.42.2.20` | Hardcoded as `k8sServiceHost` in Cilium values (SPOF) |
 | `talos-2mz-rfj` | control-plane | `10.42.2.21` | |
 | `talos-v2l-hng` | control-plane | `10.42.2.22` | |
 | `talos-lmh-kyf` | worker | `10.42.2.23` | BGP peer |
 | `talos-18u-ski` | worker | `10.42.2.24` | BGP peer |
 | `talos-kot-7x7` | worker | `10.42.2.25` | BGP peer |
 
-Talos hostnames are auto-generated with random suffixes. **A node re-image
-yields a new hostname** — any selector that references hostnames must be
-updated post-reimage. Plan `2026-05-06-network-resilience-and-bgp-completion.md`
-introduces stable `homelab.io/l2-speaker-pool=<a|b>` labels to insulate L2
-policies from this fragility.
+> Talos hostnames are auto-generated with random suffixes; a node re-image
+> produces a new hostname. Any Kubernetes selector that references hostnames
+> must be reapplied post-reimage. The L2 announcer's speaker-pool labels
+> ([cluster-load-balancing.md](cluster-load-balancing.md#stable-speaker-pool-labels))
+> avoid this trap by selecting on a custom label instead.
 
 ## Other infrastructure devices
 
@@ -56,9 +57,9 @@ for every SCSI op.
 
 ## Wired client devices
 
-These are user/service devices on VLAN 2 that share L2 with the cluster.
-Listed in the BGP plan as the gating constraint for ever removing L2
-announcements.
+These are user/service devices on the Lab VLAN that share L2 with the
+cluster. Listed in the BGP plan as the gating constraint for ever removing
+L2 announcements (`docs/plans/2026-05-06-network-resilience-and-bgp-completion.md`).
 
 | Device | IP | Notes |
 |---|---|---|
@@ -67,26 +68,36 @@ announcements.
 | HifiBerry living-room | `10.42.2.39` | Snapcast client |
 | `kitchen-pi` | `10.42.2.143` | Raspberry Pi 4; `bcmgenet` NIC with EEE disabled (see incident `2026-03-10`) |
 
-Plan `2026-05-06-network-resilience-and-bgp-completion.md` Phase F.1 proposes
-moving these to a new VLAN 20 (`10.42.20.0/24`) once mDNS reflector
-prerequisites are confirmed.
-
 ## Wireless
 
-Wireless clients (Macs, phones, tablets) sit on a separate VLAN
-(`10.42.4.0/24`). They route to cluster services through the UCGF — see
-[traffic-flows.md](traffic-flows.md) for the path.
+Wireless clients (Macs, phones, tablets) sit on the Family VLAN
+(`br4`, `10.42.4.0/24`). They route to cluster services through the UCGF —
+see [traffic-flows.md](traffic-flows.md) for the path.
+
+## Other VLANs
+
+The UCGF terminates four additional VLANs that don't participate in the
+cluster's data plane but are part of the broader house network:
+
+| VLAN | Subnet | Purpose |
+|---|---|---|
+| Core (`br0`) | `10.42.1.0/24` | UniFi infrastructure mgmt — switches, APs, gateway control plane |
+| Security (`br3`) | `10.42.3.0/24` | Cameras and security devices |
+| Guest (`br6`) | `10.42.6.0/24` | Guest WiFi |
+| IoT (`br7`) | `10.42.7.0/24` | IoT devices (currently lightly populated; migration target for the wired client devices above) |
+
+See [addressing.md](addressing.md) for the full VLAN/subnet map.
 
 ## VLAN tagging boundaries
 
 VLAN tagging is applied at:
 
-1. **UCGF LAN ports** — assign each port to a VLAN (untagged) or trunk multiple VLANs (tagged).
+1. **UCGF LAN ports / bridges** — each VLAN is its own bridge (`br0`, `br2`, `br3`, `br4`, `br6`, `br7`) with the UCGF holding `.1` of each `/24`.
 2. **WAP SSIDs** — each SSID maps to a VLAN tag; wireless clients are placed on the configured VLAN.
 3. **Switch ports** — typically untagged on the configured VLAN; trunk uplinks tag everything.
 
 The cluster nodes do not use 802.1Q on their NICs — Talos sees VLAN-untagged
-frames on whichever access port the UCGF puts them on.
+frames on whichever access port the UCGF puts them on (the Lab VLAN).
 
 ## Spanning tree
 

--- a/docs/architecture/networking/traffic-flows.md
+++ b/docs/architecture/networking/traffic-flows.md
@@ -28,27 +28,41 @@ forwarder, or LB doing the work.
 
 ## Flow 1: Wireless client → internal HTTPS service
 
-**Scenario.** Mac on VLAN 4 (wireless, `10.42.4.x`) opens
+**Scenario.** Mac on the Family VLAN (`br4`, `10.42.4.x`) opens
 `https://grafana.burntbytes.com`.
+
+The UCGF's DHCP server distributes AdGuard `[10.42.2.43, 10.42.2.45]`
+directly as the resolvers for **every** LAN VLAN (verified from
+`/run/dnsmasq.dhcp.conf.d/*.conf`). The UCGF is **not** in the DNS
+forwarding path — clients send DNS queries directly to AdGuard via
+routed delivery.
 
 ```
 [Mac, 10.42.4.50]
-  ↓ DNS query: "grafana.burntbytes.com" → 10.42.2.1 (DHCP-distributed resolver)
-[UCGF dnsmasq]
-  ↓ forwards to AdGuard at 10.42.2.43
-[AdGuard]
-  ↓ wildcard rewrite *.burntbytes.com → 10.42.2.40
-  ↓ returns 10.42.2.40
+  ↓ DNS query for grafana.burntbytes.com → 10.42.2.43 (DHCP-distributed)
+  ↓ "10.42.2.43 is not on my /24 (10.42.4.0/24); send to default gateway"
+  ↓ ARP for 10.42.4.1 (UCGF Family-VLAN interface br4)
+  ↓ Frame to UCGF
+[UCGF]
+  ↓ Routing-table lookup for 10.42.2.43/32 → BGP next-hop on talos-X (worker)
+  ↓ forwards frame to talos-X
+[talos-X cilium-agent BPF]
+  ↓ kube-proxy replacement: 10.42.2.43:53 → adguard-0 or adguard-1 pod
+  ↓ (VXLAN if the pod is on another node)
+[adguard pod]
+  ↓ Wildcard rewrite *.burntbytes.com → 10.42.2.40 (see ../dns-strategy.md)
+  ↓ DNS reply: 10.42.2.40
+  → reverse path back to Mac
 [Mac]
-  ↓ "10.42.2.40 is not on my /24 (10.42.4.0/24); send to default gateway"
-  ↓ ARP for 10.42.4.1 (UCGF VLAN-4 interface)
-  ↓ TCP SYN to 10.42.2.40:443
+  ↓ Now opens TCP to 10.42.2.40:443
+  ↓ "10.42.2.40 is not on my /24; send to default gateway"
+  ↓ TCP SYN frame to UCGF
 [UCGF]
   ↓ BGP route lookup: 10.42.2.40/32 → next-hops [.23, .24, .25] ECMP, picks one
-  ↓ forwards frame to talos-lmh-kyf (.23), arriving on its eno1
+  ↓ forwards frame to (e.g.) talos-lmh-kyf (.23), arriving on eno1
 [talos-lmh-kyf cilium-agent BPF]
-  ↓ kube-proxy replacement: dest 10.42.2.40:443 → cilium-envoy pod (any worker)
-  ↓ tunnels via VXLAN if pod is on another node
+  ↓ kube-proxy replacement: dest 10.42.2.40:443 → cilium-envoy pod (any node)
+  ↓ tunnels via VXLAN if envoy is on another node
 [cilium-envoy on talos-X]
   ↓ TLS handshake (SNI = grafana.burntbytes.com)
   ↓ cert-manager certificate served (Let's Encrypt)
@@ -58,6 +72,11 @@ forwarder, or LB doing the work.
   ↓ HTTP response
   → reverse path: VXLAN → cilium-envoy → BPF → eno1 → UCGF → Mac
 ```
+
+> **Note on DNS path.** The DNS query and the HTTPS connection follow
+> independent paths: both end at the cluster, but they hit different
+> services (AdGuard vs gateway), and each has its own ECMP next-hop choice
+> on the UCGF.
 
 ### What can break
 
@@ -81,11 +100,11 @@ forwarder, or LB doing the work.
   ↓ Configured DNS: 10.42.2.43 (manually set in tvOS)
   ↓ "10.42.2.43 is on my /24 (10.42.2.0/24); ARP directly"
   ↓ ARP broadcast: "Who has 10.42.2.43?"
-[Cilium L2 speaker — currently talos-2mz-rfj, .21]
+[Cilium L2 speaker — the elected node for this LB IP, e.g. talos-X]
   ↓ Cilium L2 announcer responds: "10.42.2.43 is at <my MAC>"
 [Apple TV]
-  ↓ Sends DNS query frame to .21's MAC
-[talos-2mz-rfj BPF]
+  ↓ Sends DNS query frame to talos-X's MAC
+[talos-X BPF — the L2 speaker for this IP]
   ↓ kube-proxy replacement: 10.42.2.43:53 → adguard-0 or adguard-1 pod
   ↓ forwards (possibly via VXLAN if adguard pod is on another node)
 [adguard pod]
@@ -209,30 +228,57 @@ service `grafana.monitoring.svc.cluster.local:80` whose backing pod is on
 
 ---
 
-## Flow 6: iSCSI from cluster to NAS
+## Flow 6: iSCSI from cluster to storage
 
-**Scenario.** A CNPG pod's PVC is backed by Synology iSCSI. Pod is on
-`talos-lmh-kyf` (`.23`).
+The cluster has **two** iSCSI providers, each via its own CSI driver and
+StorageClass. Both targets sit on the Lab VLAN (`br2`, `10.42.2.0/24`)
+alongside the cluster nodes, so the iSCSI path is single-hop L2 in both
+cases — no UCGF, no BGP, no Cilium service IPs involved.
+
+### 6a — Synology iSCSI (CNPG PVCs and most stateful workloads)
 
 ```
 [CNPG pod on .23]
   ↓ block I/O → kernel iSCSI initiator on the node
 [talos-lmh-kyf kernel]
-  ↓ TCP to Synology at 10.42.2.11:3260 (iSCSI target port)
-[switch L2 forwarding — same VLAN 2]
+  ↓ TCP to Synology at 10.42.2.11:3260
+[switch L2 forwarding — same VLAN]
 [Synology]
+  ↓ serves block; btrfs-backed
+```
+
+CSI driver: `csi.san.synology.com` (Synology official CSI). StorageClasses:
+`synology-iscsi`, `synology-iscsi-ephemeral`, `synology-nfs`.
+
+### 6b — hestia (TrueNAS) iSCSI via democratic-csi
+
+```
+[Pod on .24]
+  ↓ block I/O → kernel iSCSI initiator
+[talos-18u-ski kernel]
+  ↓ TCP to hestia at 10.42.2.10:3260
+[switch L2 forwarding — same VLAN]
+[hestia (TrueNAS)]
   ↓ serves block; ZFS-backed
 ```
 
-### Properties
+CSI driver: `org.democratic-csi.truenas-iscsi`. StorageClasses:
+`truenas-iscsi`, `truenas-iscsi-ephemeral`, `truenas-iscsi-ssd` (the SSD
+variant uses a separate ZFS pool).
 
-- **iSCSI traffic stays on VLAN 2.** Cluster nodes and Synology share the
-  broadcast domain — single-hop L2 delivery.
-- **No Cilium service IP involved.** The Synology CSI driver targets the
-  Synology directly via its mgmt IP; Cilium doesn't proxy.
-- **PVC churn = iSCSI session churn.** Mass PVC re-attach (e.g., after a
-  node reboot) creates many concurrent sessions; the Synology iSCSI manager
-  handles up to ~32 sessions cleanly.
+### Properties (both)
+
+- **L2-direct delivery.** Cluster nodes and storage targets share the Lab
+  VLAN broadcast domain. Single-hop frame from the node to the target.
+- **No Cilium service IP.** CSI drivers target the storage device's mgmt
+  IP directly; Cilium doesn't proxy iSCSI traffic.
+- **PVC churn = iSCSI session churn.** Mass PVC re-attach (e.g. after a
+  node reboot) creates many concurrent sessions on the target. Both
+  Synology and TrueNAS handle ~32 concurrent sessions cleanly; beyond that,
+  expect login retries.
+- **Storage outage = pod outage.** No multi-target failover; if the
+  Synology or hestia is offline, every PVC backed by it goes read-only or
+  fails. See `docs/operations/incidents/2026-02-28-iscsi-mass-readonly-cnpg-loki-immich.md`.
 
 ---
 

--- a/docs/architecture/networking/traffic-flows.md
+++ b/docs/architecture/networking/traffic-flows.md
@@ -1,0 +1,253 @@
+---
+status: Stable
+last_modified: 2026-05-06
+---
+
+# Traffic Flows
+
+> **Scope.** Annotated walkthroughs of the most common request paths through
+> the network. Each flow names the protocol-layer transitions, the
+> infrastructure component handling each step, and the failure mode if that
+> step breaks. For mechanism details see
+> [cluster-load-balancing.md](cluster-load-balancing.md). For IP map see
+> [addressing.md](addressing.md).
+
+## Conventions used in the diagrams
+
+```
+[Component]              — a host or service
+  ↓ (action / protocol)  — operation taking place
+[Component]              — next host
+```
+
+Solid arrows: actual traffic. Side-comments: what's being decided at each
+hop. "Path of least mystery" — every transition names the resolver,
+forwarder, or LB doing the work.
+
+---
+
+## Flow 1: Wireless client → internal HTTPS service
+
+**Scenario.** Mac on VLAN 4 (wireless, `10.42.4.x`) opens
+`https://grafana.burntbytes.com`.
+
+```
+[Mac, 10.42.4.50]
+  ↓ DNS query: "grafana.burntbytes.com" → 10.42.2.1 (DHCP-distributed resolver)
+[UCGF dnsmasq]
+  ↓ forwards to AdGuard at 10.42.2.43
+[AdGuard]
+  ↓ wildcard rewrite *.burntbytes.com → 10.42.2.40
+  ↓ returns 10.42.2.40
+[Mac]
+  ↓ "10.42.2.40 is not on my /24 (10.42.4.0/24); send to default gateway"
+  ↓ ARP for 10.42.4.1 (UCGF VLAN-4 interface)
+  ↓ TCP SYN to 10.42.2.40:443
+[UCGF]
+  ↓ BGP route lookup: 10.42.2.40/32 → next-hops [.23, .24, .25] ECMP, picks one
+  ↓ forwards frame to talos-lmh-kyf (.23), arriving on its eno1
+[talos-lmh-kyf cilium-agent BPF]
+  ↓ kube-proxy replacement: dest 10.42.2.40:443 → cilium-envoy pod (any worker)
+  ↓ tunnels via VXLAN if pod is on another node
+[cilium-envoy on talos-X]
+  ↓ TLS handshake (SNI = grafana.burntbytes.com)
+  ↓ cert-manager certificate served (Let's Encrypt)
+  ↓ HTTPRoute match: hostname grafana.burntbytes.com → grafana.monitoring.svc
+  ↓ forwards plaintext (or re-encrypted) to grafana pod
+[grafana pod]
+  ↓ HTTP response
+  → reverse path: VXLAN → cilium-envoy → BPF → eno1 → UCGF → Mac
+```
+
+### What can break
+
+| Step | Failure | Symptom |
+|---|---|---|
+| Mac → AdGuard | AdGuard pod not running or unreachable | DNS resolution fails; depending on fallback config (Phase C of the active plan), client may use 1.1.1.1 |
+| UCGF → BGP route | All 3 worker BGP sessions down | UCGF has no route; SYN times out |
+| UCGF → worker | One worker BGP session down | UCGF removes from ECMP set after hold-time; remaining workers handle traffic |
+| Worker → cilium-envoy | No envoy pod ready | 503 from gateway |
+| Envoy → backend | HTTPRoute misconfigured | 404 / 502 from envoy |
+
+---
+
+## Flow 2: Wired VLAN-2 client → DNS query
+
+**Scenario.** Apple TV on VLAN 2 (`10.42.2.19`) needs to resolve
+`example.com`.
+
+```
+[Apple TV, 10.42.2.19]
+  ↓ Configured DNS: 10.42.2.43 (manually set in tvOS)
+  ↓ "10.42.2.43 is on my /24 (10.42.2.0/24); ARP directly"
+  ↓ ARP broadcast: "Who has 10.42.2.43?"
+[Cilium L2 speaker — currently talos-2mz-rfj, .21]
+  ↓ Cilium L2 announcer responds: "10.42.2.43 is at <my MAC>"
+[Apple TV]
+  ↓ Sends DNS query frame to .21's MAC
+[talos-2mz-rfj BPF]
+  ↓ kube-proxy replacement: 10.42.2.43:53 → adguard-0 or adguard-1 pod
+  ↓ forwards (possibly via VXLAN if adguard pod is on another node)
+[adguard pod]
+  ↓ resolves example.com (via configured upstreams)
+  → reverse path
+```
+
+### What can break
+
+| Step | Failure | Symptom |
+|---|---|---|
+| Apple TV → ARP | L2 announcer disabled or speaker absent | ARP times out; Apple TV cannot reach cluster — this is exactly the 2026-05-05 incident |
+| Speaker death | Lease re-elected to another worker | ~5–15s outage during failover (lease tuning dependent) |
+| BPF lookup | adguard service has no ready endpoints | Connection refused |
+
+### Why BGP doesn't help here
+
+The Apple TV's kernel sees `10.42.2.43` as same-subnet and never consults
+the routing table. The UCGF's BGP route for `10.42.2.43/32` is irrelevant —
+the frame never reaches the UCGF. **L2 is the only mechanism that works for
+this path.**
+
+---
+
+## Flow 3: External Internet client → public HTTPS service (Cloudflare Tunnel)
+
+**Scenario.** Friend on the open Internet visits
+`https://home.burntbytes.com`.
+
+```
+[Internet client]
+  ↓ DNS lookup → Cloudflare authoritative for burntbytes.com
+  ↓ returns CNAME to <tunnel-id>.cfargotunnel.com → Cloudflare edge IP
+  ↓ TCP SYN to Cloudflare edge:443
+[Cloudflare edge]
+  ↓ TLS termination (Cloudflare-issued cert)
+  ↓ matches tunnel routing rule for hostname
+  ↓ sends request through persistent QUIC tunnel
+[cloudflared pod inside cluster]
+  ↓ originates request to internal service (config: ingress to local URL)
+  ↓ may target the production gateway directly: http://10.42.2.40
+[Cilium gateway path]
+  → same as Flow 1 from "TCP SYN to 10.42.2.40:443" onward, except
+    cloudflared talks to it from inside the pod network
+[backend pod]
+  ↓ response → reverse tunnel → Cloudflare edge → Internet client
+```
+
+### Key properties
+
+- **No port-forward on UCGF.** Inbound from Internet is impossible at the
+  router; only the persistent outbound tunnel exists.
+- **Public DNS is Cloudflare-managed.** `burntbytes.com` zone records live
+  in Cloudflare, mostly as CNAMEs to the tunnel.
+- **Internal split-horizon overrides public DNS for LAN clients.** AdGuard
+  intercepts `*.burntbytes.com` and returns the internal LB IP, keeping
+  traffic on-LAN and avoiding the tunnel hop for internal access.
+- **Authentication can layer at Cloudflare (Access) or at the cluster
+  (Authelia).** See [../gateway-auth.md](../gateway-auth.md) for how
+  Authelia integrates as an `ext_authz` filter on the Cilium gateway.
+
+---
+
+## Flow 4: Pod-to-pod communication
+
+**Scenario.** A pod running on `talos-lmh-kyf` (`.23`) needs to call a
+service `grafana.monitoring.svc.cluster.local:80` whose backing pod is on
+`talos-kot-7x7` (`.25`).
+
+```
+[Pod on .23, 10.244.3.42]
+  ↓ DNS query: grafana.monitoring.svc.cluster.local (CoreDNS in-cluster)
+  ↓ returns ClusterIP, e.g. 10.96.55.10
+  ↓ TCP SYN to 10.96.55.10:80
+[Cilium BPF on .23]
+  ↓ kube-proxy replacement: ClusterIP → backend pod IP (10.244.5.7 on .25)
+  ↓ direct socket-level rewrite (no DNAT in iptables — eBPF replaces it)
+  ↓ encapsulate in VXLAN to peer node .25
+[VXLAN tunnel: .23 → .25]
+[Cilium BPF on .25]
+  ↓ decapsulate; deliver to local pod 10.244.5.7
+[grafana pod]
+  ↓ response → reverse VXLAN → BPF → originating pod
+```
+
+### Properties
+
+- **VXLAN is internal-only.** The encap/decap happens between Cilium agents
+  on the cluster nodes' `cilium_vxlan` interface; nothing on the LAN sees
+  VXLAN.
+- **No L2 or BGP involved.** This path bypasses both. LB IP advertisement
+  is irrelevant for in-cluster traffic.
+- **Pod CIDR is `10.244.0.0/16`**, sliced into `/24` per node.
+
+---
+
+## Flow 5: Cluster pod → external Internet
+
+**Scenario.** A pod on `talos-18u-ski` (`.24`) calls
+`https://api.openai.com`.
+
+```
+[Pod on .24, 10.244.4.55]
+  ↓ TCP SYN to <openai IP>:443
+[Cilium BPF on .24]
+  ↓ no service IP match; egress rule
+  ↓ Masquerading IPTables: SNAT source to .24 (the node's IP)
+[Node eno1 → switch → UCGF]
+  ↓ UCGF default route → ISP
+[Internet]
+```
+
+### Properties
+
+- **Egress source IP is the node's IP** (Masquerading enabled in Cilium
+  values: `Masquerading: IPTables [IPv4: Enabled]`).
+- **No special egress gateway.** Pods leave from whichever node they're
+  scheduled on. Egress IP rotation = node selection.
+- **Reverse DNS will not resolve to a pod hostname.** External services
+  see one of `10.42.2.20–.25`, mapped (if at all) to nothing meaningful.
+
+---
+
+## Flow 6: iSCSI from cluster to NAS
+
+**Scenario.** A CNPG pod's PVC is backed by Synology iSCSI. Pod is on
+`talos-lmh-kyf` (`.23`).
+
+```
+[CNPG pod on .23]
+  ↓ block I/O → kernel iSCSI initiator on the node
+[talos-lmh-kyf kernel]
+  ↓ TCP to Synology at 10.42.2.11:3260 (iSCSI target port)
+[switch L2 forwarding — same VLAN 2]
+[Synology]
+  ↓ serves block; ZFS-backed
+```
+
+### Properties
+
+- **iSCSI traffic stays on VLAN 2.** Cluster nodes and Synology share the
+  broadcast domain — single-hop L2 delivery.
+- **No Cilium service IP involved.** The Synology CSI driver targets the
+  Synology directly via its mgmt IP; Cilium doesn't proxy.
+- **PVC churn = iSCSI session churn.** Mass PVC re-attach (e.g., after a
+  node reboot) creates many concurrent sessions; the Synology iSCSI manager
+  handles up to ~32 sessions cleanly.
+
+---
+
+## Quick "where am I in the path" lookup
+
+When debugging "X can't reach Y," start by asking:
+
+1. **What's the source's subnet?** Check `ip a` on the client.
+2. **What's the destination IP?** Resolve via the actual resolver the
+   client uses, not your own.
+3. **Are source and destination on the same `/24`?**
+   - **Same** → L2 ARP path (Flow 2). Test: `arp -n <dest>` should resolve;
+     if not, L2 announcer is broken.
+   - **Different** → BGP routing path (Flow 1). Test: traceroute the path;
+     UCGF should be hop 1; cluster worker should be hop 2.
+4. **Does the client use AdGuard?** Test: `dig @<adguard-ip> example.com`.
+5. **Does the gateway terminate TLS for the requested hostname?** Test:
+   `curl -kv https://<lb-ip>` and check the cert SAN.

--- a/docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md
+++ b/docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md
@@ -1,0 +1,180 @@
+# Incident: Wired Devices Lose Cluster Service Connectivity After BGP Migration
+
+**Date:** 2026-05-05
+**Status:** Resolved
+**Severity:** High — all wired devices on `10.42.2.0/24` unable to reach cluster LoadBalancer IPs
+**Duration:** ~1 day (BGP rollout completed 2026-05-05; regression detected same evening)
+**Environments affected:** Physical LAN (`10.42.2.0/24`), wired hosts only
+**Authors:** George Courtois
+
+---
+
+## Summary
+
+Following the BGP rollout (Phase 4a/4b in `docs/plans/2026-03-08-bgp-rollout.md`),
+wired devices on the `10.42.2.0/24` subnet lost the ability to reach cluster
+LoadBalancer IPs (AdGuard DNS at `10.42.2.43`, production gateway at `10.42.2.40`,
+etc.). The Apple TV at `10.42.2.19` was the trigger: it stopped working entirely
+because it could no longer resolve DNS.
+
+Wireless devices connected via UniFi WAPs were **unaffected** throughout.
+
+**Root cause:** Cilium's L2 announcement subsystem (gratuitous ARP / ARP reply) was
+removed as part of the BGP cutover (Phase 4a deleted the `CiliumL2AnnouncementPolicy`;
+Phase 4b set `l2announcements.enabled: false`). This is correct for routed clients but
+fatally wrong for any device on the **same `/24`** as the LB IP pool, which must resolve
+LB IPs via ARP — not via routing table lookups. BGP only helps the UCGF's routing table;
+it cannot answer ARP requests on behalf of a `/32` that is not locally resident on any
+host.
+
+**Fix:** Restored the `CiliumL2AnnouncementPolicy` and re-enabled
+`l2announcements.enabled: true` (PR #536). L2 and BGP now run simultaneously, which is
+the correct steady state for a topology where wired clients share a `/24` with LB IPs.
+
+---
+
+## Affected Services
+
+| Service / Host | Impact |
+|---|---|
+| Apple TV (`10.42.2.19`) | No DNS → no connectivity to any cluster service |
+| Any wired device on `10.42.2.0/24` | Unable to ARP for `10.42.2.40`–`10.42.2.254` |
+| AdGuard DNS (`10.42.2.43`, `10.42.2.45`) | Unreachable via ARP from same-subnet clients |
+| Production gateway (`10.42.2.40`) | Unreachable via ARP from same-subnet clients |
+| Wireless (WAP) clients | **Not affected** (see explanation below) |
+
+---
+
+## Timeline
+
+| Time | Event |
+|------|-------|
+| 2026-05-05 daytime | BGP rollout Phase 4a/4b completed; L2 removed; cluster traffic appeared normal |
+| 2026-05-05 evening | Apple TV (`10.42.2.19`) stops working; DNS and cluster services unreachable |
+| 2026-05-05 evening | Wireless devices (Mac, phones) confirmed working throughout the day |
+| 2026-05-05 evening | Diagnosed: wired VLAN-2 hosts cannot ARP for LB IPs; BGP-only is insufficient |
+| 2026-05-05 late | PR #536 opened: restore `CiliumL2AnnouncementPolicy` + `l2announcements.enabled: true` |
+| 2026-05-06 ~04:00 UTC | PR #536 merged; `flux reconcile` run on `infra-configs` + `infra-controllers` |
+| 2026-05-06 ~04:01 UTC | Cilium HelmRelease reconciled; configmap updated; agent pods NOT restarted (config hot-reload does not trigger DaemonSet rollout) |
+| 2026-05-06 ~04:02 UTC | Diagnosed: `l2-announcer` module STOPPED; Cilium reads feature flags at startup, not on configmap change |
+| 2026-05-06 ~04:05 UTC | `kubectl rollout restart ds/cilium -n kube-system` — 6-node rolling restart |
+| 2026-05-06 ~04:06 UTC | L2 leases appear: `cilium-l2announce-*` in `kube-system` with elected speaker `talos-2mz-rfj` |
+| 2026-05-06 ~04:06 UTC | Apple TV pingable and AirPlay port (7000) responding — incident resolved |
+
+---
+
+## Root Cause Analysis
+
+### Why BGP alone cannot serve same-subnet clients
+
+BGP advertises routes — it tells the UCGF "to reach `10.42.2.43/32`, forward traffic to
+worker node `10.42.2.23`." The UCGF installs this in its routing table and uses it for
+traffic that arrives from a **different subnet** and must be routed.
+
+However, a device on the **same `/24`** (`10.42.2.19`) applying the standard IP
+forwarding rule computes `10.42.2.43 & /24 == 10.42.2.0/24 == its own subnet` and sends
+an ARP request directly onto the wire:
+
+```
+Apple TV: "Who has 10.42.2.43? Tell 10.42.2.19"
+<silence — no Cilium agent responding>
+Apple TV: ARP timeout → cannot build Ethernet frame → TCP/IP fails
+```
+
+The UCGF routing table entry is never consulted, because the host never sends the frame
+to the gateway; it's trying to deliver it locally. Without a Cilium agent responding to
+ARP for the LB IP, the address is unreachable to any same-subnet client, regardless of
+BGP health.
+
+### Why wireless clients were unaffected
+
+UniFi WAPs place wireless clients on a separate VLAN/subnet from the wired management
+and compute network:
+
+```
+Wireless client (e.g. 10.10.0.50/24, VLAN 10)
+  │  "10.42.2.43 is NOT in my subnet (10.10.0.0/24)"
+  └→ sends frame to default gateway (UCGF at 10.10.0.1)
+       └→ UCGF routing table: BGP route 10.42.2.43/32 → next-hop 10.42.2.23
+            └→ forwarded to cluster worker → reaches AdGuard
+```
+
+Wireless clients see `10.42.2.43` as a **remote** address, route through the UCGF, and
+benefit from BGP routes. They never send an ARP for `10.42.2.43`. BGP alone is
+sufficient for them.
+
+The Apple TV (and any other wired device on `10.42.2.0/24`) has a different view:
+
+```
+Apple TV (10.42.2.19/24, VLAN 2)
+  │  "10.42.2.43 IS in my subnet (10.42.2.0/24)"
+  └→ sends ARP broadcast: "Who has 10.42.2.43?"
+       └→ <nobody answers after L2 removal>
+            └→ ARP fails → connectivity fails
+```
+
+### Why the Phase 4a test plan missed this
+
+The test plan in `docs/plans/2026-03-08-bgp-rollout.md` specified running the "LAN client
+`arp -d <ip>; curl …`" smoke test, but the test was executed from a Mac on VLAN 4 (or
+any cross-subnet host). That device routes through the UCGF and gets a BGP-installed
+route — the test passes trivially even with L2 removed. The test plan lacked coverage
+for wired devices on the **same `/24`** as the LB pool.
+
+There is also a secondary issue with the Phase 4b Helm change: setting
+`l2announcements.enabled: false` updated the `cilium-config` ConfigMap but did **not**
+trigger a Cilium DaemonSet rollout. This is a documented Cilium 1.19 gotcha (noted in
+the plan's Phase 2a section for `bgpControlPlane.enabled`), but it was not applied to
+Phase 4b. The DaemonSet continued running with the old runtime config, meaning when the
+L2 policy was restored, agents still had the feature disabled and needed a manual
+`kubectl rollout restart ds/cilium`.
+
+---
+
+## Resolution
+
+**PR #536** — `fix: restore L2 announcements alongside BGP for same-subnet ARP`
+
+1. Restored `infra/configs/cilium/l2-announcement-policy.yaml`
+2. Re-added it to `infra/configs/cilium/kustomization.yaml`
+3. Set `l2announcements.enabled: true` in `infra/controllers/cilium/values.yaml`
+4. Merged, force-reconciled `infra-configs` + `infra-controllers` + `helmrelease/cilium`
+5. `kubectl rollout restart ds/cilium` to pick up the runtime config change
+6. Verified `cilium-l2announce-*` Leases appeared and `l2-announcer` module showed `[OK]`
+
+---
+
+## Action Items
+
+| # | Action | Owner | Priority |
+|---|--------|-------|----------|
+| 1 | Update BGP rollout plan: Phase 4 is **invalid for the current topology** — see new plan doc | George | High |
+| 2 | Add wired same-subnet device to the Phase 4a test matrix | George | High |
+| 3 | Add a pre-Phase-4 gate: enumerate all devices sharing `/24` with the LB pool; get them off it first OR explicitly accept L2+BGP permanently | George | High |
+| 4 | Document the Cilium config hot-reload gotcha in the rollout plan | George | Medium |
+| 5 | Consider moving LB IP pool to a dedicated `/24` (e.g. `10.42.3.0/24`) that no client host shares — this is the only clean path to ever removing L2 | George | Low |
+
+---
+
+## Why L2 + BGP Together Is the Correct Steady State
+
+Until the LB IP pool is on a subnet that no wired client shares, **both mechanisms must
+run simultaneously**. They serve different traffic paths and do not conflict:
+
+| Traffic type | Resolution mechanism |
+|---|---|
+| Wireless clients (different VLAN/subnet) | BGP routes on UCGF → routed delivery |
+| Wired clients on `10.42.2.0/24` | L2 ARP → same-subnet direct delivery |
+| Cross-cluster traffic (pod-to-LB) | Cilium in-kernel LB (neither BGP nor L2) |
+
+Running both has no operational downside. BGP provides the ECMP, multi-path failover,
+and observability benefits it was designed for. L2 covers same-subnet ARP without
+interfering with BGP routes on the UCGF.
+
+---
+
+## Related
+
+- `docs/plans/2026-03-08-bgp-rollout.md` — original rollout plan (Phase 4 needs correction)
+- `docs/plans/2026-05-05-bgp-phase4-revision.md` — revised Phase 4 with safe L2 removal gate
+- PR #536 — fix commit

--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -11,9 +11,9 @@ completed: 2026-05-05
 > on `10.42.2.0/24` that ARP directly for LB IPs — see incident postmortem
 > `docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`. L2
 > announcements are restored. The correct steady state is **L2 + BGP together** until
-> the LB pool is moved to a dedicated subnet. See
-> `docs/plans/2026-05-05-bgp-phase4-revision.md` for the revised Phase 4 gate and
-> topology change path.
+> the LB pool is moved to a dedicated subnet. Forward execution is consolidated in
+> `docs/plans/2026-05-06-network-resilience-and-bgp-completion.md` (Phase D = LB pool
+> migration, Phase E = pure BGP).
 >
 > Plan-vs-reality gotchas (CRD v2 schema differences, helm-config-only changes not
 > auto-rolling, deprecated `lovelace.dashboards` slug-validator, port 8081 also needed

--- a/docs/plans/2026-03-08-bgp-rollout.md
+++ b/docs/plans/2026-03-08-bgp-rollout.md
@@ -1,12 +1,25 @@
 ---
-status: completed
+status: partially-reverted
 last_modified: 2026-05-05
 completed: 2026-05-05
 ---
 
 # BGP Rollout Plan — UniFi Cloud Gateway Fiber + Cilium
 
-> **Completed 2026-05-05.** All 7 LoadBalancer IPs are now advertised via BGP from each of the 3 worker nodes (AS 65010 → UCGF AS 65100); the UCGF installs 3 ECMP next-hops per /32. L2 announcements (`CiliumL2AnnouncementPolicy`) deleted in Phase 4a, `l2announcements.enabled: false` in Helm values as of Phase 4b. Plan-vs-reality gotchas (CRD v2 schema differences, helm-config-only changes not auto-rolling, deprecated `lovelace.dashboards` slug-validator, port 8081 also needed for Lutron) folded into the Phase 2a/4b sections inline. Outstanding follow-up: enable `prometheus.enabled: true` in Cilium Helm values so the BGP alert rules in `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp`) actually fire.
+> **Phases 1–3 complete. Phase 4 reverted 2026-05-05.** BGP is active and healthy (3
+> worker peers, ECMP). Phase 4a/4b (L2 removal) caused a regression for wired devices
+> on `10.42.2.0/24` that ARP directly for LB IPs — see incident postmortem
+> `docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`. L2
+> announcements are restored. The correct steady state is **L2 + BGP together** until
+> the LB pool is moved to a dedicated subnet. See
+> `docs/plans/2026-05-05-bgp-phase4-revision.md` for the revised Phase 4 gate and
+> topology change path.
+>
+> Plan-vs-reality gotchas (CRD v2 schema differences, helm-config-only changes not
+> auto-rolling, deprecated `lovelace.dashboards` slug-validator, port 8081 also needed
+> for Lutron) folded into the Phase 2a/4b sections inline. Outstanding follow-up: enable
+> `prometheus.enabled: true` in Cilium Helm values so the BGP alert rules in
+> `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp`) actually fire.
 
 Replace Cilium L2 announcements (ARP-based) with BGP peering between the Kubernetes node and the UniFi Cloud Gateway Fiber (UCGF). The router gets real routing-table entries for LoadBalancer IPs instead of relying on gratuitous ARP — better reliability, observability, and multi-node readiness.
 

--- a/docs/plans/2026-05-05-bgp-phase4-revision.md
+++ b/docs/plans/2026-05-05-bgp-phase4-revision.md
@@ -1,10 +1,17 @@
 ---
-status: active
-last_modified: 2026-05-05
+status: superseded
+last_modified: 2026-05-06
+superseded_by: docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
 ---
 
 # BGP Phase 4 Revision — Safe L2 Removal Gate
 
+> **Superseded 2026-05-06 by `docs/plans/2026-05-06-network-resilience-and-bgp-completion.md`.**
+> The unified plan folds this revision into its Phase D (LB pool migration) and
+> Phase E (pure BGP), and adds Phases A–C/F for the broader resilience and security
+> findings surfaced in the 2026-05-06 critique. Read this doc for historical context;
+> follow the unified plan for execution.
+>
 > **Context:** The original BGP rollout plan (`docs/plans/2026-03-08-bgp-rollout.md`)
 > completed Phases 1–4b on 2026-05-05 and removed L2 announcements entirely. This
 > caused a regression for wired devices on `10.42.2.0/24` that share a subnet with the

--- a/docs/plans/2026-05-05-bgp-phase4-revision.md
+++ b/docs/plans/2026-05-05-bgp-phase4-revision.md
@@ -1,0 +1,204 @@
+---
+status: active
+last_modified: 2026-05-05
+---
+
+# BGP Phase 4 Revision — Safe L2 Removal Gate
+
+> **Context:** The original BGP rollout plan (`docs/plans/2026-03-08-bgp-rollout.md`)
+> completed Phases 1–4b on 2026-05-05 and removed L2 announcements entirely. This
+> caused a regression for wired devices on `10.42.2.0/24` that share a subnet with the
+> LB IP pool and rely on ARP. See incident postmortem:
+> `docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`.
+>
+> **Current state (post-fix):** L2 announcements are restored. BGP + L2 run together.
+> This document defines the correct conditions and procedure for safely removing L2 in
+> the future, and explains why that is not yet possible.
+
+---
+
+## The Problem with Phase 4 As Executed
+
+Phase 4 of the BGP rollout assumed that once BGP was established, L2 announcements were
+redundant. This assumption is **false** when any client device shares a `/24` with the
+LB IP pool.
+
+```
+LB IP pool: 10.42.2.40 – 10.42.2.254
+Wired clients on same subnet: 10.42.2.0/24
+
+Apple TV (10.42.2.19) → ARP for 10.42.2.43
+                       ↑
+               NO BGP ROUTE HELPS HERE
+             ARP operates at L2, below routing
+```
+
+BGP installs routes in the UCGF's forwarding table. Those routes are consulted only for
+**inter-subnet** traffic. A device on `10.42.2.x` will always ARP directly for any
+destination in `10.42.2.0/24`, including LB IPs — the routing table is bypassed.
+
+The test plan executed after Phase 4a used a Mac on VLAN 4, which routes through the
+UCGF and benefits from BGP routes. It passed. The Apple TV on VLAN 2 was never tested.
+
+---
+
+## L2 + BGP Together Is Correct Steady State (Until Topology Changes)
+
+Run both mechanisms permanently until the preconditions for safe L2 removal (below) are
+met. They do not conflict:
+
+| Traffic path | Mechanism |
+|---|---|
+| Wireless clients (separate VLAN) | BGP → routed by UCGF |
+| Wired clients on `10.42.2.0/24` | L2 ARP → Cilium l2-announcer |
+| Pod-to-LB (in-cluster) | Cilium kube-proxy replacement |
+
+There is no operational cost to running both. The L2 announcer adds negligible overhead
+(a few Leases and periodic gratuitous ARPs).
+
+---
+
+## Preconditions for Safe L2 Removal
+
+L2 announcements can only be safely removed when **all** of the following are true:
+
+### Gate 1 — No client host shares a `/24` with any LB IP
+
+Verify:
+
+```bash
+# List all LB IPs
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' | sort -u
+
+# For each LB IP, determine its /24: 10.42.2.x → subnet 10.42.2.0/24
+# Then enumerate all wired client hosts on that /24 (DHCP leases, static assignments)
+# from the UCGF:
+ssh root@10.42.2.1 'cat /etc/dhcp/dhcpd.leases 2>/dev/null || ip neighbor show'
+```
+
+**Action required if gate fails:** Move the LB pool to a dedicated `/24` with no client
+hosts (see "Topology change path" below) before proceeding.
+
+### Gate 2 — LB IP pool is on a subnet that can be moved
+
+The current pool (`10.42.2.40`–`10.42.2.254`) shares `/24` with all cluster nodes
+(`10.42.2.20`–`10.42.2.25`), the UCGF (`10.42.2.1`), and wired client devices. This
+subnet cannot be vacated of clients without a full network migration.
+
+**Status:** Gate 2 **fails** with the current topology. Do not proceed to Phase 4 until
+resolved.
+
+### Gate 3 — Wired client device inventory is complete
+
+Before executing Phase 4a, enumerate every wired device connected to the network and
+confirm none are on the LB pool's `/24`:
+
+| Device category | VLAN | Shares /24 with LB pool? |
+|---|---|---|
+| Cluster nodes (`.20`–`.25`) | VLAN 2 | Yes — but they are the speakers, not clients |
+| Wireless clients | VLAN 10+ | No — routed via UCGF |
+| Apple TV (`.19`) | VLAN 2 | **Yes** |
+| HifiBerry nodes (`.38`, `.39`) | VLAN 2 | **Yes** |
+| `kitchen-pi` (`.143`) | VLAN 2 | **Yes** |
+| hestia/TrueNAS (`.10`) | VLAN 2 | **Yes** |
+| Synology (`10.42.2.11`) | VLAN 2 | **Yes** |
+
+**Status:** Gate 3 **fails**. Multiple wired devices on `10.42.2.0/24`.
+
+---
+
+## Topology Change Path (If You Want Pure BGP Someday)
+
+Move the LB IP pool to a dedicated `/24` with no client or infrastructure hosts. The
+recommended candidate is `10.42.3.0/24` (currently unused).
+
+### Steps
+
+1. **Add a new LB pool** for `10.42.3.0/24` in `infra/configs/cilium/load-balancer-ip-pool.yaml`.
+2. **Migrate pinned services** (AdGuard `.43`/`.45`, gateway `.40`) to new IPs in the
+   new pool. Update all client DNS configs (devices, AdGuard upstream forwards, etc.)
+   to use the new IPs.
+3. **Update UCGF prefix-list** to accept `/32`s from the new pool:
+   ```
+   ip prefix-list K8S-LB-IPS seq 20 permit 10.42.3.0/24 ge 32 le 32
+   ```
+4. **Soak** with both pools active. Confirm BGP announces new pool IPs and all clients
+   resolve correctly.
+5. **Remove old pool** (the `10.42.2.40`–`10.42.2.254` range).
+6. **Now execute Phase 4a/4b** — gates 1–3 are satisfied for the new pool.
+
+> **Note:** Step 2 requires updating DNS configs on every wired device that has
+> `10.42.2.43` hardcoded. The AdGuard AdGuard HA failover config, network DHCP DNS
+> option, and any static device configs all need updating. Budget a maintenance window.
+
+---
+
+## Revised Phase 4 Checklist
+
+When the topology change above is complete, re-execute Phase 4 with these additional
+checks:
+
+### Pre-Phase-4a gates (new)
+
+```bash
+# Gate 1: confirm no wired client shares /24 with the LB pool
+# Expected output: no 10.42.3.x addresses appear in DHCP client list
+ssh root@10.42.2.1 'vtysh -c "show ip bgp neighbors"'  # BGP still healthy
+
+# Gate 3: manual verification of wired device inventory
+# Walk through each device in the table above and confirm subnet assignment
+```
+
+### Phase 4a test matrix (updated)
+
+The original test matrix only tested from VLAN-4 clients (cross-subnet). Add:
+
+| Test | Expected |
+|---|---|
+| `arp -d 10.42.3.43; dig @10.42.3.43 example.com` from Apple TV | DNS resolves via BGP route |
+| `arp -d 10.42.3.43; ping 10.42.3.43` from wired device on VLAN 2 | Reachable (BGP route via UCGF) |
+| `arp -n 10.42.3.43` on a VLAN-2 host | No ARP entry — traffic goes through gateway |
+
+> Interpreting the last test: `arp -n` returning no entry for a **remote-subnet** LB IP
+> is **correct** — the host's kernel routes to the gateway, not directly. The prior test
+> (`arp -d <same-subnet-ip>; curl …`) was misleading because a cross-subnet host caches
+> the gateway's MAC, not the LB IP's MAC.
+
+### Phase 4b additional note
+
+When running `l2announcements.enabled: false`, the Cilium configmap updates but the
+DaemonSet pods **do not restart**. Cilium reads feature flags at startup, not on
+configmap hot-reload. After Phase 4b Helm reconcile, manually verify the agents see
+the change:
+
+```bash
+kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.enable-l2-announcements}'
+# Expected: false
+
+# Confirm l2-announcer module is stopped (expected once policy is removed)
+CILIUM_POD=$(kubectl -n kube-system get pod -l app.kubernetes.io/name=cilium-agent -o name | head -1 | sed 's|pod/||')
+kubectl -n kube-system exec $CILIUM_POD -- cilium-dbg status --all-health 2>&1 | grep l2-announcer
+```
+
+If the configmap shows `false` but agents still show `l2-announcer [OK]`, rolling restart
+is required:
+
+```bash
+kubectl rollout restart ds/cilium -n kube-system
+kubectl rollout status ds/cilium -n kube-system
+```
+
+---
+
+## Current State Summary
+
+| Component | State | Correct? |
+|---|---|---|
+| `CiliumL2AnnouncementPolicy` | Present (`l2-announcement-policy-staging`) | Yes |
+| `l2announcements.enabled` | `true` | Yes |
+| `bgpControlPlane.enabled` | `true` | Yes |
+| BGP peers | 3 workers Established | Yes |
+| L2 leases | All LB IPs leased to `talos-2mz-rfj` | Yes |
+| Phase 4 gate status | **BLOCKED** — wired clients on same /24 as LB pool | N/A |
+
+**Do not re-execute Phase 4 without clearing the topology gates above.**

--- a/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
+++ b/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
@@ -1,0 +1,500 @@
+---
+status: planned
+last_modified: 2026-05-06
+supersedes: docs/plans/2026-05-05-bgp-phase4-revision.md
+---
+
+# Network Resilience and BGP Completion Plan
+
+> **Context:** The 2026-05-05 wired-device incident
+> (`docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`)
+> exposed several latent issues in the LAN/cluster networking design. This plan
+> consolidates the fixes — from quick wins requiring no topology change through
+> the full LB-pool migration that finally enables pure-BGP — into a single
+> phased rollout. It supersedes `docs/plans/2026-05-05-bgp-phase4-revision.md`
+> (which becomes Phase D below).
+
+## Problems being solved
+
+From the 2026-05-06 architecture critique:
+
+| # | Problem | Severity | Phase |
+|---|---------|----------|-------|
+| 1 | All L2 leases concentrated on a single CP node | Major | A |
+| 2 | AdGuard primary/secondary HA undermined by co-located L2 leases | Major | A |
+| 3 | L2 lease failover takes ~15s on default timing | Moderate | A |
+| 4 | Helm-flag changes silently skip Cilium DaemonSet rollout | Moderate | A |
+| 5 | L2 policy still named `*-staging` (cluster-wide scope) | Minor | A |
+| 6 | No alerting on L2 lease churn | Minor | A |
+| 7 | Test plans don't cover wired same-subnet devices | Major | B |
+| 8 | DNS dependency loop — wired clients lose name resolution if cluster DNS fails | Moderate | C |
+| 9 | LB pool shares `/24` with cluster nodes and wired clients | Major | D |
+| 10 | IoT/AV devices share L2 broadcast domain with the kube-apiserver | Major | E |
+| 11 | BGP `listen range 10.42.2.0/24` accepts AS 65010 from any LAN host | Moderate | F |
+| 12 | All LB services blanket-default to `externalTrafficPolicy: Cluster` | Moderate | F |
+| 13 | `k8sServiceHost: 10.42.2.20` is a SPOF | Moderate | out-of-scope |
+
+## Constraints
+
+1. **Reversible per phase** — each phase ships its own rollback procedure.
+2. **No simultaneous changes** — phases serialize except where explicitly parallel.
+3. **Wired-VLAN-2 test device required** — every L2/BGP test matrix includes a real ARP-direct host (Apple TV, kitchen-pi, or a HifiBerry).
+4. **Pre-flight gate before destructive phases** — Phases D and E require explicit operator GO/NO-GO; Phases A–C are low-risk.
+
+---
+
+## Phase A — Same-day L2 hygiene (no topology change)
+
+Risk: low. Recoverable by reverting a single PR. No client-visible disruption expected.
+
+### A.1 Restrict L2 announcements to worker nodes
+
+**Problem #1.** Edit `infra/configs/cilium/l2-announcement-policy.yaml` to add a worker-only `nodeSelector` mirroring `bgp-cluster-config.yaml:9-14`:
+
+```yaml
+spec:
+  externalIPs: true
+  loadBalancerIPs: true
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+```
+
+Effect: lease leader election restricts to `talos-lmh-kyf` / `-18u-ski` / `-kot-7x7`. CP nodes (`-2mz-rfj` / `-v2l-hng` / `-ykb-uir`) drop out.
+
+### A.2 Split AdGuard primary/secondary onto different L2 speakers
+
+**Problem #2.** Add per-service `CiliumL2AnnouncementPolicy` resources with `serviceSelector` to force lease distribution. Two policies, one per service, each pinning to a disjoint node subset:
+
+```yaml
+# infra/configs/cilium/l2-announcement-policy-adguard-primary.yaml
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: l2-adguard-primary
+  namespace: kube-system
+spec:
+  loadBalancerIPs: true
+  serviceSelector:
+    matchLabels:
+      app.kubernetes.io/name: adguard
+      cilium.io/lb-pool: primary
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: In
+        values: ["talos-lmh-kyf", "talos-18u-ski"]
+```
+
+```yaml
+# infra/configs/cilium/l2-announcement-policy-adguard-secondary.yaml
+# pins to talos-kot-7x7 only — different node from primary
+```
+
+Add a label `cilium.io/lb-pool: primary` / `secondary` to the matching services in `apps/base/adguard/service.yaml` and `apps/production/adguard/service-dns-secondary.yaml`.
+
+Then narrow the cluster-wide policy from A.1 to **exclude** AdGuard services (add a `serviceSelector` matchExpression `NotIn: [adguard]`), or split it into a default-deny + per-service-allow model.
+
+> **Trade-off:** more YAML, but per-service ownership means a node failure breaks at most one DNS IP.
+
+### A.3 Tune L2 lease timing
+
+**Problem #3.** Edit `infra/controllers/cilium/values.yaml` (after the existing `l2announcements:` block):
+
+```yaml
+l2announcements:
+  enabled: true
+  leaseDuration: "5s"
+  leaseRenewDeadline: "3s"
+  leaseRetryPeriod: "1s"
+```
+
+Cuts speaker-failover ARP outage from ~15s to ~5s.
+
+> **Operator gotcha (Problem #4):** Helm-flag changes don't roll the Cilium DaemonSet automatically. After this phase merges and Flux reconciles, run:
+> ```bash
+> kubectl rollout restart ds/cilium -n kube-system
+> kubectl rollout status ds/cilium -n kube-system
+> ```
+
+### A.4 Rename and document
+
+**Problems #5 and #4.**
+
+- Rename `l2-announcement-policy-staging` → `l2-announcement-policy-default` in `infra/configs/cilium/l2-announcement-policy.yaml:4`. (Cluster-wide scope; "staging" is misleading.)
+- Add a header comment to `infra/controllers/cilium/values.yaml` listing values that require an explicit DaemonSet rollout: `l2announcements.*`, `bgpControlPlane.enabled`, `kubeProxyReplacement`, `routingMode`, anything mapping to `enable-*` configmap keys.
+
+### A.5 Add L2 churn alert
+
+**Problem #6.** Add a rule to `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp` or new `cilium-l2`):
+
+```yaml
+- alert: CiliumL2LeaseChurn
+  expr: |
+    rate(cilium_operator_lb_l2_acquired_leases_total[5m])
+      + rate(cilium_operator_lb_l2_released_leases_total[5m]) > 0.1
+  for: 10m
+  labels: { severity: warning }
+  annotations:
+    summary: "Cilium L2 leases churning"
+    description: "More than 0.1 lease handovers/sec over 10min — speaker is flapping."
+```
+
+### A.6 Verify
+
+```bash
+# Lease distribution should span at least 2 worker nodes, not 1 CP node
+kubectl -n kube-system get leases | grep cilium-l2announce | awk '{print $2}' | sort | uniq -c
+
+# Both AdGuard IPs reachable from a wired VLAN-2 device
+sudo arp -d 10.42.2.43; sudo arp -d 10.42.2.45
+dig @10.42.2.43 example.com +short
+dig @10.42.2.45 example.com +short
+```
+
+### Phase A GO criteria
+- All `cilium-l2announce-*` leases held by worker nodes only.
+- AdGuard `.43` and `.45` leased to **different** workers.
+- Wired VLAN-2 client (Apple TV ping, or kitchen-pi `dig`) reaches both AdGuard IPs.
+- L2 churn alert is loaded in Prometheus (`promtool` or UI verifies).
+
+### Phase A rollback
+```bash
+git revert <commit-sha>
+git push
+flux reconcile kustomization infra-configs -n flux-system --with-source
+flux reconcile kustomization infra-controllers -n flux-system --with-source
+kubectl rollout restart ds/cilium -n kube-system
+```
+
+---
+
+## Phase B — Test plan hardening (procedural)
+
+**Problem #7.** Before any subsequent network change, the test matrix must include a wired same-subnet device. This is procedural, not code, but documented as a phase to make it gate-blocking.
+
+### B.1 Designate test devices
+
+Add to `docs/operations/network-test-devices.md` (new):
+
+| Device | IP | VLAN | Why |
+|---|---|---|---|
+| Apple TV | 10.42.2.19 | 2 | Same-subnet wired ARP test |
+| `kitchen-pi` | 10.42.2.143 | 2 | SSH-able ARP test |
+| `living-room` HifiBerry | 10.42.2.39 | 2 | SSH-able ARP test |
+| Mac (george) | 10.42.4.x | 4 | Cross-subnet routing test |
+
+### B.2 Update existing test plans
+
+Edit `docs/plans/2026-03-08-bgp-rollout.md` test matrix and add a "wired VLAN-2 ARP" row:
+
+| Test | Pre | Post-2a | Post-2b | Post-4a | Post-4b |
+|---|---|---|---|---|---|
+| `ssh kitchen-pi 'arp -d 10.42.2.43; dig @10.42.2.43 …'` | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+This test must pass for every L2/BGP-impacting change going forward.
+
+### Phase B GO criteria
+- `docs/operations/network-test-devices.md` exists and documents the test devices.
+- Procedural sign-off: every L2/BGP PR template includes a checklist item "wired VLAN-2 ARP test executed and passed".
+
+### Phase B rollback
+N/A (procedural).
+
+---
+
+## Phase C — DNS resilience (parallel with B)
+
+**Problem #8.** Wired devices on VLAN 2 currently use `[10.42.2.43, 10.42.2.45]` (cluster AdGuard) as their resolver. Cluster outage → no DNS → no troubleshooting.
+
+### C.1 Update UCGF DHCP DNS option
+
+Add a third resolver as fallback. Choose either:
+
+- **Option 1 (preserves filtering during cluster health):** `[10.42.2.43, 10.42.2.45, 1.1.1.1]`. Clients use AdGuard normally; fall through to Cloudflare on dual-DNS failure. Trade-off: bypasses ad/tracker filtering during cluster outages.
+- **Option 2 (preserves filtering always):** Add a UCGF-local `dnsmasq` or `unbound` instance bound to `10.42.2.1` as third resolver, configured to forward to public resolvers but **not** AdGuard. Trade-off: more moving parts on the UCGF.
+
+Recommended: Option 1. The window is rare and short-lived.
+
+### C.2 Apply
+
+```bash
+ssh root@10.42.2.1
+# UniFi Network UI: Settings → Networks → LAN → Advanced → DHCP Service Management → DNS Server
+# Set: 10.42.2.43, 10.42.2.45, 1.1.1.1
+# Or via CLI if exposed by the UCGF firmware version.
+```
+
+### C.3 Verify
+
+```bash
+# After client renews lease (or `sudo dhclient -r eth0; sudo dhclient eth0`):
+ssh kitchen-pi 'cat /etc/resolv.conf'
+# nameserver 10.42.2.43
+# nameserver 10.42.2.45
+# nameserver 1.1.1.1
+```
+
+### Phase C GO criteria
+- Test wired client receives 3-entry DNS list on lease renewal.
+- Simulating cluster DNS failure (`kubectl scale sts/adguard --replicas=0` in a maintenance window) — wired clients fall through to public resolver within ~5s.
+
+### Phase C rollback
+Revert UCGF DHCP option to `[10.42.2.43, 10.42.2.45]`. Clients pick up on next lease renewal.
+
+---
+
+## Phase D — LB pool migration to dedicated `/24`
+
+**Problem #9.** This is the core topology change that unblocks Problem #10 below (Phase E) and finally enables pure BGP. Adapted from the prior `2026-05-05-bgp-phase4-revision.md`.
+
+> **Pre-flight gate:** Phase A must be complete and stable for ≥48h. Phase B's procedural test must be in effect.
+
+### D.1 Allocate dedicated subnet
+
+`10.42.3.0/24` is currently unused on the LAN. Reserve it as the LB-only subnet — **no client host will live here.**
+
+### D.2 Add new Cilium IP pool (additive)
+
+Create `infra/configs/cilium/load-balancer-ip-pool-v2.yaml`:
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: home-c-pool-v2
+spec:
+  blocks:
+    - start: 10.42.3.40
+      stop: 10.42.3.254
+---
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: home-compute-pool-v2
+spec:
+  blocks:
+    - start: 10.42.3.30
+      stop: 10.42.3.37
+```
+
+Add to `infra/configs/cilium/kustomization.yaml`. Both old and new pools coexist; services keep their existing IPs until explicitly migrated.
+
+### D.3 Update UCGF prefix-list
+
+```bash
+ssh root@10.42.2.1
+vtysh
+configure terminal
+ip prefix-list K8S-LB-IPS seq 20 permit 10.42.3.0/24 ge 32 le 32
+end
+write memory
+```
+
+### D.4 Migrate gateway IP
+
+The gateway services (`gateway-production`, `gateway-staging`) are referenced only by HTTPRoute hostnames + DNS, so the actual IP is largely transparent.
+
+1. Allocate `10.42.3.40` to `gateway-production` via overlay annotation `lbipam.cilium.io/ip-pool: home-c-pool-v2`.
+2. Update split-horizon DNS (AdGuard internal zone) to point `*.burntbytes.com` → `10.42.3.40`.
+3. Remove the old `.40` IP allocation.
+
+### D.5 Migrate AdGuard pinned IPs (the hard one)
+
+AdGuard `.43` and `.45` are baked into wired-client DNS configs (DHCP option from Phase C, plus any manual configs).
+
+Procedure:
+1. Allocate new IPs (`10.42.3.43`, `10.42.3.45`) via per-service overlay.
+2. Update UCGF DHCP DNS option from Phase C to advertise BOTH old and new: `[10.42.3.43, 10.42.3.45, 10.42.2.43, 10.42.2.45, 1.1.1.1]`.
+3. Wait 24h for clients to pick up new leases (or force renew on critical devices).
+4. Remove old `.43` / `.45` assignments. Update DHCP option to drop them.
+5. Sweep manual DNS configs (HomeKit/Home Assistant config, anything hand-rolled) for hardcoded `10.42.2.43`.
+
+### D.6 Migrate remaining LB services
+
+Less-pinned services (snapcast, etc.) migrate via overlay annotation change. Soak each for 24h before moving on.
+
+### D.7 Soak and verify pre-pure-BGP
+
+```bash
+# All LB IPs now in 10.42.3.x range
+kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' | sort -u
+# Expected: only 10.42.3.x, no 10.42.2.x
+
+# UCGF has BGP routes for new range
+ssh root@10.42.2.1 'vtysh -c "show ip route 10.42.3.0/24"'
+
+# Wired VLAN-2 device reaches new IPs via routing (NOT ARP — they're cross-subnet now)
+ssh kitchen-pi 'arp -n 10.42.3.43'   # Expected: no entry (gateway routes it)
+ssh kitchen-pi 'dig @10.42.3.43 example.com +short'   # Works via UCGF
+```
+
+### D.8 Remove old pools
+
+After ≥48h of clean operation:
+
+```bash
+# Delete old pool resources from infra/configs/cilium/load-balancer-ip-pool.yaml
+# (keep file but empty the blocks, or delete file and remove from kustomization.yaml)
+```
+
+### Phase D GO criteria
+- Zero LB services on `10.42.2.x`.
+- All wired clients have updated DNS configs (DHCP-distributed first; manual configs verified).
+- BGP routes for `10.42.3.0/24` installed on UCGF.
+- Wired VLAN-2 test device reaches every service via routed delivery (not ARP).
+
+### Phase D rollback per sub-step
+- D.2: delete the new pool resources. Existing services keep their `10.42.2.x` IPs.
+- D.4: revert HTTPRoute / DNS to point at old IP; revert overlay; service falls back to old pool.
+- D.5: re-add old IPs to the pinned services; update DHCP DNS option to put old IPs back first; let clients re-learn.
+- D.6: per-service revert.
+- D.8: re-add the pool blocks; existing services aren't affected because they already have the IPs in the new range.
+
+---
+
+## Phase E — Pure BGP (executes the original Phase 4)
+
+**Problem #10 (partial).** Once Phase D completes, the LB pool is on a subnet with no client hosts. L2 announcements become genuinely unnecessary.
+
+> **Pre-flight gate:** Phase D complete for ≥48h. No host on `10.42.3.0/24` (verify via UCGF ARP table and DHCP leases).
+
+### E.1 Delete L2 policy resources
+
+```bash
+# Remove every CiliumL2AnnouncementPolicy created in Phase A
+rm infra/configs/cilium/l2-announcement-policy.yaml
+rm infra/configs/cilium/l2-announcement-policy-adguard-primary.yaml
+rm infra/configs/cilium/l2-announcement-policy-adguard-secondary.yaml
+# Update kustomization.yaml accordingly
+```
+
+### E.2 Disable L2 in Helm + roll DaemonSet
+
+Edit `infra/controllers/cilium/values.yaml`:
+
+```yaml
+l2announcements:
+  enabled: false
+```
+
+After Flux reconcile:
+
+```bash
+# Required — does NOT auto-roll (Problem #4)
+kubectl rollout restart ds/cilium -n kube-system
+kubectl rollout status ds/cilium -n kube-system
+```
+
+### E.3 Verify
+
+```bash
+# No L2 policies, no L2 leases
+kubectl get ciliuml2announcementpolicy
+# No resources found
+
+kubectl -n kube-system get leases | grep -c cilium-l2announce
+# 0
+
+# All BGP peers still established with ≥48h uptime
+ssh root@10.42.2.1 'vtysh -c "show bgp summary"'
+
+# Wired VLAN-2 device still reaches services (via routing now)
+ssh kitchen-pi 'dig @10.42.3.43 example.com +short'
+```
+
+### Phase E GO criteria
+- Zero L2 policies and zero L2 leases.
+- All 3 BGP peers `Established`.
+- Wired VLAN-2 + cross-subnet test devices both reach every LB service.
+- 24h soak with no flap.
+
+### Phase E rollback
+Revert the deletion commits and run a DaemonSet rollout. ARP resumes within ~5s of L2 policies re-applying.
+
+---
+
+## Phase F — Defense-in-depth (parallelizable, post-E)
+
+These can run in any order after Phase E. Each is independent.
+
+### F.1 IoT VLAN segmentation (Problem #10 cont.)
+
+Move pure client devices off VLAN 2 onto a new VLAN 20 (`10.42.20.0/24`):
+
+| Device | Current | Target |
+|---|---|---|
+| Apple TV | 10.42.2.19 | 10.42.20.x |
+| HifiBerry kitchen | 10.42.2.38 | 10.42.20.x |
+| HifiBerry living-room | 10.42.2.39 | 10.42.20.x |
+| `kitchen-pi` | 10.42.2.143 | 10.42.20.x |
+
+Keep on VLAN 2 (mgmt/storage):
+- Cluster nodes (`.20-.25`)
+- hestia / TrueNAS GPU server (`.10`) — iSCSI peer to cluster
+- Synology (`.11`) — iSCSI peer to cluster
+- UCGF (`.1`)
+
+Procedure (per device): change UCGF port-VLAN assignment for the wired port, force DHCP renew, verify routed connectivity. Snapcast multicast (Bonjour) needs UCGF mDNS reflector enabled across VLAN 2 ↔ 20 to keep auto-discovery working.
+
+### F.2 Narrow BGP listen-range (Problem #11)
+
+After F.1, only cluster nodes remain on VLAN 2. Narrow the FRR `listen range`:
+
+```bash
+ssh root@10.42.2.1
+vtysh
+configure terminal
+router bgp 65100
+  no bgp listen range 10.42.2.0/24
+  bgp listen range 10.42.2.20/29 peer-group K8S-NODES
+end
+write memory
+```
+
+`/29` covers `.16-.23` (3 CP + 3 worker + spare) — much smaller attack surface.
+
+### F.3 Per-service externalTrafficPolicy review (Problem #12)
+
+For each LoadBalancer service in `apps/`, classify:
+
+- **`Cluster` (current default):** keep when source IP is irrelevant (gateway, snapcast).
+- **`Local`:** switch when source IP matters (auth logs, blackbox-probed services). Trade-off: ECMP path count drops to "nodes hosting the backing pod."
+
+Document the decision per-service in a comment next to the service definition.
+
+### F.4 Optional: BGP MD5 authentication
+
+If F.1/F.2 are deemed insufficient, add BGP password auth on both UCGF and Cilium peer-config. Out of scope unless an actual untrusted-LAN risk emerges.
+
+### Phase F GO criteria
+Per sub-phase. F.1: all listed devices on new VLAN, all services still reachable. F.2: BGP peers re-establish on the narrower range. F.3: per-service migration verified.
+
+---
+
+## Out of scope (separate plans)
+
+- **`k8sServiceHost` SPOF (Problem #13).** `infra/controllers/cilium/values.yaml:108` hardcodes `10.42.2.20`. Fix is independent: switch to `auto` or set up a CP VIP via Talos's built-in VIP feature. File as separate plan.
+
+---
+
+## Sequencing summary
+
+```
+Week 1  ─ Phase A (L2 hygiene + tuning)
+        └ Phase B (test plan hardening, parallel)
+        └ Phase C (DNS fallback, parallel)
+
+Week 2  ─ Phase D start (allocate new pool, migrate gateway)
+Week 3  ─ Phase D continue (migrate AdGuard, then long-tail services)
+Week 4  ─ Phase D soak (48h+) → Phase E (pure BGP)
+
+Week 5+ ─ Phase F sub-phases (IoT VLAN, listen-range, eTP review)
+```
+
+Each gate explicit. No phase auto-fires from the previous one.
+
+## Backout to current state
+
+If at any point the rollout proves more disruptive than expected: revert the latest phase, return to the post-Phase-A steady state (L2 distributed across workers + BGP both running), and re-evaluate. The current state is a defensible long-term posture; only the security finding (Problem #10) genuinely requires phase E+F to resolve.

--- a/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
+++ b/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
@@ -285,7 +285,19 @@ Revert UCGF DHCP option to `[10.42.2.43, 10.42.2.45]`. Clients pick up on next l
 
 ### D.1 Allocate dedicated subnet
 
-`10.42.3.0/24` is currently unused on the LAN. Reserve it as the LB-only subnet — **no client host will live here.**
+> **2026-05-06 correction:** an earlier draft of this plan named `10.42.3.0/24`
+> as the target, but on UCGF inspection that subnet is already in use as the
+> **Security VLAN** (`br3`, `10.42.3.0/24`). `10.42.5.0/24` is currently
+> unallocated — UCGF has interfaces for `br0/2/3/4/6/7` only, and `br5` is
+> free. Reserve `10.42.5.0/24` as the LB-only subnet — **no client host will
+> live here.**
+
+Verify before reserving (firmware drift could change available bridges):
+
+```bash
+ssh root@10.42.2.1 'ip -br addr show | grep "br[0-9]"'
+# Confirm no br5 / 10.42.5.x interface; if present, pick the next free /24.
+```
 
 ### D.2 Add new Cilium IP pool (additive)
 
@@ -298,8 +310,8 @@ metadata:
   name: home-c-pool-v2
 spec:
   blocks:
-    - start: 10.42.3.40
-      stop: 10.42.3.254
+    - start: 10.42.5.40
+      stop: 10.42.5.254
 ---
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
@@ -307,8 +319,8 @@ metadata:
   name: home-compute-pool-v2
 spec:
   blocks:
-    - start: 10.42.3.30
-      stop: 10.42.3.37
+    - start: 10.42.5.30
+      stop: 10.42.5.37
 ```
 
 Add to `infra/configs/cilium/kustomization.yaml`. Both old and new pools coexist; services keep their existing IPs until explicitly migrated.
@@ -319,7 +331,7 @@ Add to `infra/configs/cilium/kustomization.yaml`. Both old and new pools coexist
 ssh root@10.42.2.1
 vtysh
 configure terminal
-ip prefix-list K8S-LB-IPS seq 20 permit 10.42.3.0/24 ge 32 le 32
+ip prefix-list K8S-LB-IPS seq 20 permit 10.42.5.0/24 ge 32 le 32
 end
 write memory
 ```
@@ -350,7 +362,7 @@ Specific places to verify (not exhaustive):
 
 #### D.4.1 Apply
 
-1. Allocate `10.42.3.40` to `gateway-production` via overlay annotation `lbipam.cilium.io/ip-pool: home-c-pool-v2`.
+1. Allocate `10.42.5.40` to `gateway-production` via overlay annotation `lbipam.cilium.io/ip-pool: home-c-pool-v2`.
 2. Update every location from D.4.0's inventory atomically (a single PR for repo changes; a coordinated UI/AdGuard/Cloudflare change for non-repo).
 3. Remove the old `.40` IP allocation.
 
@@ -388,8 +400,8 @@ ssh root@10.42.2.1 'cat /run/dnsmasq.leases 2>/dev/null || ip neighbor show | gr
 #### D.5.1 Apply
 
 Procedure:
-1. Allocate new IPs (`10.42.3.43`, `10.42.3.45`) via per-service overlay.
-2. Update UCGF DHCP DNS option from Phase C to advertise BOTH old and new: `[10.42.3.43, 10.42.3.45, 10.42.2.43, 10.42.2.45, 1.1.1.1]`.
+1. Allocate new IPs (`10.42.5.43`, `10.42.5.45`) via per-service overlay.
+2. Update UCGF DHCP DNS option from Phase C to advertise BOTH old and new: `[10.42.5.43, 10.42.5.45, 10.42.2.43, 10.42.2.45, 1.1.1.1]`.
 3. **Force-update every static device from D.5.0** in parallel with the DHCP change.
 4. Wait through the UCGF DHCP lease half-life (verify lease duration in the UCGF UI; default is often 24h, so renewal kicks in at ~12h). Force renew on critical devices: `sudo dhclient -r && sudo dhclient` (Linux) or toggle Wi-Fi (macOS/iOS).
 5. Verify each test device's `/etc/resolv.conf` (or equivalent) shows the new IPs.
@@ -405,22 +417,22 @@ Less-pinned services (snapcast, etc.) migrate via overlay annotation change. Soa
 Routing-layer checks (necessary but not sufficient):
 
 ```bash
-# All LB IPs now in 10.42.3.x range
+# All LB IPs now in 10.42.5.x range
 kubectl get svc -A -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' | sort -u
-# Expected: only 10.42.3.x, no 10.42.2.x
+# Expected: only 10.42.5.x, no 10.42.2.x
 
 # UCGF has BGP routes for new range
-ssh root@10.42.2.1 'vtysh -c "show ip route 10.42.3.0/24"'
+ssh root@10.42.2.1 'vtysh -c "show ip route 10.42.5.0/24"'
 
 # Wired VLAN-2 device reaches new IPs via routing (NOT ARP — they're cross-subnet now)
-ssh kitchen-pi 'arp -n 10.42.3.43'   # Expected: no entry (gateway routes it)
+ssh kitchen-pi 'arp -n 10.42.5.43'   # Expected: no entry (gateway routes it)
 ```
 
 **Application-layer checks (required — catches HTTPRoute / cert-binding regressions):**
 
 ```bash
 # DNS resolution
-ssh kitchen-pi 'dig @10.42.3.43 example.com +short'
+ssh kitchen-pi 'dig @10.42.5.43 example.com +short'
 
 # Full HTTPS stack against the gateway (SNI + cert + HTTPRoute match)
 ssh kitchen-pi 'curl -sk --max-time 5 -o /dev/null -w "%{http_code}\n" https://home.burntbytes.com'
@@ -445,7 +457,7 @@ After ≥48h of clean operation:
 ### Phase D GO criteria
 - Zero LB services on `10.42.2.x`.
 - All wired clients have updated DNS configs (DHCP-distributed first; manual configs verified).
-- BGP routes for `10.42.3.0/24` installed on UCGF.
+- BGP routes for `10.42.5.0/24` installed on UCGF.
 - Wired VLAN-2 test device reaches every service via routed delivery (not ARP).
 
 ### Phase D rollback per sub-step
@@ -461,7 +473,7 @@ After ≥48h of clean operation:
 
 **Problem #10 (partial).** Once Phase D completes, the LB pool is on a subnet with no client hosts. L2 announcements become genuinely unnecessary.
 
-> **Pre-flight gate:** Phase D complete for ≥48h. No host on `10.42.3.0/24` (verify via UCGF ARP table and DHCP leases).
+> **Pre-flight gate:** Phase D complete for ≥48h. No host on `10.42.5.0/24` (verify via UCGF ARP table and DHCP leases).
 
 ### E.1 Delete L2 policy resources
 
@@ -522,7 +534,7 @@ kubectl -n kube-system get leases | grep -c cilium-l2announce
 ssh root@10.42.2.1 'vtysh -c "show bgp summary"'
 
 # Wired VLAN-2 device still reaches services (via routing now)
-ssh kitchen-pi 'dig @10.42.3.43 example.com +short'
+ssh kitchen-pi 'dig @10.42.5.43 example.com +short'
 ```
 
 ### Phase E GO criteria
@@ -542,14 +554,20 @@ These can run in any order after Phase E. Each is independent.
 
 ### F.1 IoT VLAN segmentation (Problem #10 cont.)
 
-Move pure client devices off VLAN 2 onto a new VLAN 20 (`10.42.20.0/24`):
+> **2026-05-06 correction:** an earlier draft proposed creating a new VLAN 20.
+> UCGF inspection shows an **IoT VLAN already exists** at `10.42.7.0/24`
+> (`br7`, configured as "IoT" in UniFi). Migrate to the existing VLAN rather
+> than provisioning a parallel one.
+
+Move pure client devices off the Lab VLAN (`br2`, `10.42.2.0/24`) onto the
+existing IoT VLAN (`br7`, `10.42.7.0/24`):
 
 | Device | Current | Target |
 |---|---|---|
-| Apple TV | 10.42.2.19 | 10.42.20.x |
-| HifiBerry kitchen | 10.42.2.38 | 10.42.20.x |
-| HifiBerry living-room | 10.42.2.39 | 10.42.20.x |
-| `kitchen-pi` | 10.42.2.143 | 10.42.20.x |
+| Apple TV | 10.42.2.19 | 10.42.7.x |
+| HifiBerry kitchen | 10.42.2.38 | 10.42.7.x |
+| HifiBerry living-room | 10.42.2.39 | 10.42.7.x |
+| `kitchen-pi` | 10.42.2.143 | 10.42.7.x |
 
 Keep on VLAN 2 (mgmt/storage):
 - Cluster nodes (`.20-.25`)
@@ -559,7 +577,7 @@ Keep on VLAN 2 (mgmt/storage):
 
 #### F.1.0 mDNS reflector pre-flight (BLOCKING)
 
-AirPlay (Apple TV ↔ Mac/iPhone), Snapcast/Bonjour, HomeKit pairing, and Spotify Connect all rely on mDNS discovery. Without cross-VLAN mDNS reflection, splitting Apple TV onto VLAN 20 breaks AirPlay from VLAN 4 wireless devices.
+AirPlay (Apple TV ↔ Mac/iPhone), Snapcast/Bonjour, HomeKit pairing, and Spotify Connect all rely on mDNS discovery. Without cross-VLAN mDNS reflection, splitting Apple TV onto the IoT VLAN breaks AirPlay from VLAN 4 (Family) wireless devices.
 
 **Verify before any device moves:**
 
@@ -568,7 +586,9 @@ AirPlay (Apple TV ↔ Mac/iPhone), Snapcast/Bonjour, HomeKit pairing, and Spotif
 # UniFi Network UI: Settings → Networks → <network> → Advanced → "Multicast DNS"
 # (Path varies by firmware version; "mDNS Repeater" or "Multicast DNS" both apply.)
 
-# 2. If supported, enable on BOTH VLAN 2 and VLAN 20 (and the wireless VLAN that needs to discover).
+# 2. If supported, enable mDNS reflector on the Lab VLAN (br2), IoT VLAN (br7),
+#    and Family/wireless VLAN (br4) — every VLAN that needs to discover or
+#    advertise services should be in the reflector group.
 
 # 3. Test cross-VLAN discovery BEFORE moving the Apple TV.
 #    From a Mac on the wireless VLAN: should see Apple TV and HifiBerry advertisements.

--- a/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
+++ b/docs/plans/2026-05-06-network-resilience-and-bgp-completion.md
@@ -47,25 +47,47 @@ From the 2026-05-06 architecture critique:
 
 Risk: low. Recoverable by reverting a single PR. No client-visible disruption expected.
 
-### A.1 Restrict L2 announcements to worker nodes
+> **Atomicity requirement:** A.1 through A.5 must ship as a single PR. Splitting A.1 and A.2 across two merges creates a transient window where AdGuard services are matched by both the cluster-wide policy and the per-service policies, causing ambiguous lease ownership.
 
-**Problem #1.** Edit `infra/configs/cilium/l2-announcement-policy.yaml` to add a worker-only `nodeSelector` mirroring `bgp-cluster-config.yaml:9-14`:
+### A.0 Apply stable speaker-pool labels to workers
+
+**Pre-step for A.1 and A.2.** Hostname-based pinning is brittle — Talos nodes get a new auto-generated hostname after a re-image. Apply a durable custom label to each worker, then select on that label everywhere downstream:
+
+```bash
+# Pool A — speakers for AdGuard primary and the cluster-wide default
+kubectl label node talos-lmh-kyf homelab.io/l2-speaker-pool=a
+kubectl label node talos-18u-ski homelab.io/l2-speaker-pool=a
+
+# Pool B — speakers for AdGuard secondary (forced different from primary)
+kubectl label node talos-kot-7x7 homelab.io/l2-speaker-pool=b
+```
+
+Document this step in `docs/operations/talos-node-bootstrap.md` so a future node-replacement run reapplies the label. If the runbook doesn't yet exist, create it with this section.
+
+### A.1 Restrict L2 announcements to worker nodes (default policy)
+
+**Problem #1.** Edit `infra/configs/cilium/l2-announcement-policy.yaml` to add a worker-only `nodeSelector` and exclude AdGuard services (deferred to A.2's per-service policies):
 
 ```yaml
 spec:
   externalIPs: true
   loadBalancerIPs: true
+  serviceSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values: ["adguard"]
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
         operator: DoesNotExist
 ```
 
-Effect: lease leader election restricts to `talos-lmh-kyf` / `-18u-ski` / `-kot-7x7`. CP nodes (`-2mz-rfj` / `-v2l-hng` / `-ykb-uir`) drop out.
+Effect: cluster-wide policy covers everything **except** AdGuard, restricted to worker nodes. AdGuard is owned by per-service policies in A.2.
 
 ### A.2 Split AdGuard primary/secondary onto different L2 speakers
 
-**Problem #2.** Add per-service `CiliumL2AnnouncementPolicy` resources with `serviceSelector` to force lease distribution. Two policies, one per service, each pinning to a disjoint node subset:
+**Problem #2.** Add per-service `CiliumL2AnnouncementPolicy` resources with `serviceSelector` and the speaker-pool labels from A.0:
 
 ```yaml
 # infra/configs/cilium/l2-announcement-policy-adguard-primary.yaml
@@ -73,30 +95,29 @@ apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
 metadata:
   name: l2-adguard-primary
-  namespace: kube-system
 spec:
   loadBalancerIPs: true
   serviceSelector:
     matchLabels:
       app.kubernetes.io/name: adguard
-      cilium.io/lb-pool: primary
+      homelab.io/dns-pool: primary
   nodeSelector:
-    matchExpressions:
-      - key: kubernetes.io/hostname
-        operator: In
-        values: ["talos-lmh-kyf", "talos-18u-ski"]
+    matchLabels:
+      homelab.io/l2-speaker-pool: a
 ```
 
 ```yaml
 # infra/configs/cilium/l2-announcement-policy-adguard-secondary.yaml
-# pins to talos-kot-7x7 only — different node from primary
+# Same shape, dns-pool=secondary, l2-speaker-pool=b — pinned to a different worker
 ```
 
-Add a label `cilium.io/lb-pool: primary` / `secondary` to the matching services in `apps/base/adguard/service.yaml` and `apps/production/adguard/service-dns-secondary.yaml`.
+Add labels to the matching services:
+- `apps/base/adguard/service.yaml` — `homelab.io/dns-pool: primary`
+- `apps/production/adguard/service-dns-secondary.yaml` — `homelab.io/dns-pool: secondary`
 
-Then narrow the cluster-wide policy from A.1 to **exclude** AdGuard services (add a `serviceSelector` matchExpression `NotIn: [adguard]`), or split it into a default-deny + per-service-allow model.
-
-> **Trade-off:** more YAML, but per-service ownership means a node failure breaks at most one DNS IP.
+> **Note:** `homelab.io/*` is a custom label namespace local to this repo, not a Cilium API. Choosing a non-`cilium.io` prefix avoids implying upstream semantics.
+>
+> **Trade-off:** more YAML, but per-service ownership means a node failure breaks at most one DNS IP. The `homelab.io/l2-speaker-pool` labels survive node re-image as long as A.0's bootstrap step is followed.
 
 ### A.3 Tune L2 lease timing
 
@@ -127,19 +148,30 @@ Cuts speaker-failover ARP outage from ~15s to ~5s.
 
 ### A.5 Add L2 churn alert
 
-**Problem #6.** Add a rule to `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp` or new `cilium-l2`):
+**Problem #6.** Add a rule to `infra/configs/alerts/prometheus-rules.yaml` (group `cilium-bgp` or new `cilium-l2`).
+
+> **Pre-step — verify metric names against the running operator.** Cilium 1.19's L2 metric names are not stable in the docs; enumerate what's actually emitted before drafting the alert:
+> ```bash
+> kubectl -n kube-system port-forward deploy/cilium-operator 9963:9963 &
+> curl -s localhost:9963/metrics | grep -i 'l2\|lease' | grep -v '^#'
+> kill %1
+> ```
+> Use the actual metric name(s) you see in the alert below. The names below are illustrative placeholders.
 
 ```yaml
 - alert: CiliumL2LeaseChurn
   expr: |
-    rate(cilium_operator_lb_l2_acquired_leases_total[5m])
-      + rate(cilium_operator_lb_l2_released_leases_total[5m]) > 0.1
+    # Replace with verified metric names from the pre-step above.
+    rate(<l2_acquired_metric>[5m])
+      + rate(<l2_released_metric>[5m]) > 0.1
   for: 10m
   labels: { severity: warning }
   annotations:
     summary: "Cilium L2 leases churning"
     description: "More than 0.1 lease handovers/sec over 10min — speaker is flapping."
 ```
+
+Validate the rule loads: `kubectl -n monitoring exec prometheus-kube-prometheus-stack-prometheus-0 -- promtool check rules /etc/prometheus/rules/...`. If the metric doesn't exist yet, the alert silently no-ops; the validation step would catch a typo but not a missing metric — only the runtime emission check above does.
 
 ### A.6 Verify
 
@@ -294,28 +326,83 @@ write memory
 
 ### D.4 Migrate gateway IP
 
-The gateway services (`gateway-production`, `gateway-staging`) are referenced only by HTTPRoute hostnames + DNS, so the actual IP is largely transparent.
+The gateway services (`gateway-production`, `gateway-staging`) are referenced only by HTTPRoute hostnames + DNS, so the actual IP is largely transparent. Before changing the IP, inventory every place it appears.
+
+#### D.4.0 Inventory checklist (gateway IP `10.42.2.40`)
+
+Run before D.4.1. Update each location in lockstep with the IP change:
+
+```bash
+# Check the repo for hardcoded references
+grep -rn "10\.42\.2\.40" --include="*.yaml" --include="*.md" --include="*.conf" .
+```
+
+Specific places to verify (not exhaustive):
+
+| Location | What to check |
+|---|---|
+| AdGuard rewrites (UI export) | `*.burntbytes.com` and any explicit per-host A records pointing at `.40` |
+| Cloudflare zone (public DNS) | Any A record pointing at `.40` for externally exposed services |
+| `apps/base/cloudflare-tunnel/` | `cloudflared` config — does it route to a gateway IP or to a Service name? |
+| Tailscale subnet routes (if used) | Advertised routes covering `10.42.2.40` |
+| Manual `/etc/hosts` entries | Any host with hand-rolled overrides |
+| Per-app HTTPRoute resources | None should hardcode the IP, but verify no overlay does |
+
+#### D.4.1 Apply
 
 1. Allocate `10.42.3.40` to `gateway-production` via overlay annotation `lbipam.cilium.io/ip-pool: home-c-pool-v2`.
-2. Update split-horizon DNS (AdGuard internal zone) to point `*.burntbytes.com` → `10.42.3.40`.
+2. Update every location from D.4.0's inventory atomically (a single PR for repo changes; a coordinated UI/AdGuard/Cloudflare change for non-repo).
 3. Remove the old `.40` IP allocation.
 
 ### D.5 Migrate AdGuard pinned IPs (the hard one)
 
 AdGuard `.43` and `.45` are baked into wired-client DNS configs (DHCP option from Phase C, plus any manual configs).
 
+#### D.5.0 Static-DNS device inventory (BLOCKING pre-step)
+
+DHCP-managed clients pick up new resolvers automatically; **statically configured devices won't.** Walk through each non-DHCP device and enumerate where DNS is set:
+
+| Device | DNS config location | How to update |
+|---|---|---|
+| Apple TV (`.19`) | Settings → Network → configure DNS manually | UI — must be done by hand |
+| HifiBerry kitchen (`.38`) | `/etc/resolv.conf` or `/etc/systemd/resolved.conf` | SSH + edit + restart |
+| HifiBerry living-room (`.39`) | same | SSH + edit + restart |
+| `kitchen-pi` (`.143`) | NetworkManager — `nmcli con mod … ipv4.dns …` | SSH + nmcli |
+| hestia (`.10`) | TrueNAS Network → Global Configuration | Web UI |
+| Synology (`.11`) | Control Panel → Network → DSM Settings | Web UI |
+| Talos nodes (`.20`–`.25`) | Talos machine config (`spec.resolvers`) | `talosctl edit machineconfig` |
+| Anything else with `cat /etc/resolv.conf` showing `10.42.2.43` | host-specific | host-specific |
+
+Generate the list:
+
+```bash
+# DHCP leases — these update automatically
+ssh root@10.42.2.1 'cat /run/dnsmasq.leases 2>/dev/null || ip neighbor show | grep -v FAIL'
+
+# Cross-reference with static-IP devices outside DHCP
+# (manual walk through UCGF "Clients" → filter by static)
+```
+
+**Do not proceed to D.5.1 until every statically configured device has an owner and an update procedure documented.**
+
+#### D.5.1 Apply
+
 Procedure:
 1. Allocate new IPs (`10.42.3.43`, `10.42.3.45`) via per-service overlay.
 2. Update UCGF DHCP DNS option from Phase C to advertise BOTH old and new: `[10.42.3.43, 10.42.3.45, 10.42.2.43, 10.42.2.45, 1.1.1.1]`.
-3. Wait 24h for clients to pick up new leases (or force renew on critical devices).
-4. Remove old `.43` / `.45` assignments. Update DHCP option to drop them.
-5. Sweep manual DNS configs (HomeKit/Home Assistant config, anything hand-rolled) for hardcoded `10.42.2.43`.
+3. **Force-update every static device from D.5.0** in parallel with the DHCP change.
+4. Wait through the UCGF DHCP lease half-life (verify lease duration in the UCGF UI; default is often 24h, so renewal kicks in at ~12h). Force renew on critical devices: `sudo dhclient -r && sudo dhclient` (Linux) or toggle Wi-Fi (macOS/iOS).
+5. Verify each test device's `/etc/resolv.conf` (or equivalent) shows the new IPs.
+6. Remove old `.43` / `.45` assignments. Update DHCP option to drop them.
+7. Sweep the repo for `10.42.2.43`/`10.42.2.45` hardcoding: `grep -rn "10\.42\.2\.4[35]" .`
 
 ### D.6 Migrate remaining LB services
 
 Less-pinned services (snapcast, etc.) migrate via overlay annotation change. Soak each for 24h before moving on.
 
 ### D.7 Soak and verify pre-pure-BGP
+
+Routing-layer checks (necessary but not sufficient):
 
 ```bash
 # All LB IPs now in 10.42.3.x range
@@ -327,8 +414,24 @@ ssh root@10.42.2.1 'vtysh -c "show ip route 10.42.3.0/24"'
 
 # Wired VLAN-2 device reaches new IPs via routing (NOT ARP — they're cross-subnet now)
 ssh kitchen-pi 'arp -n 10.42.3.43'   # Expected: no entry (gateway routes it)
-ssh kitchen-pi 'dig @10.42.3.43 example.com +short'   # Works via UCGF
 ```
+
+**Application-layer checks (required — catches HTTPRoute / cert-binding regressions):**
+
+```bash
+# DNS resolution
+ssh kitchen-pi 'dig @10.42.3.43 example.com +short'
+
+# Full HTTPS stack against the gateway (SNI + cert + HTTPRoute match)
+ssh kitchen-pi 'curl -sk --max-time 5 -o /dev/null -w "%{http_code}\n" https://home.burntbytes.com'
+ssh kitchen-pi 'curl -sk --max-time 5 -o /dev/null -w "%{http_code}\n" https://grafana.burntbytes.com'
+# Expected: 200 (or expected redirect / auth code; NOT a connection failure or 502)
+
+# Repeat from a cross-subnet client (Mac on VLAN 4) to verify both paths
+curl -sk --max-time 5 -o /dev/null -w "%{http_code}\n" https://home.burntbytes.com
+```
+
+A 200/302/401 confirms TCP connection + TLS handshake + HTTPRoute match + backend reachability — the full stack the 2026-05-05 hestia gateway incident broke. A `dig` alone wouldn't have caught that class of bug.
 
 ### D.8 Remove old pools
 
@@ -362,22 +465,40 @@ After ≥48h of clean operation:
 
 ### E.1 Delete L2 policy resources
 
+Remove every `CiliumL2AnnouncementPolicy` resource and matching kustomization entry. Filenames depend on what Phase A.2 created — list and delete by glob, not by hardcoded names:
+
 ```bash
-# Remove every CiliumL2AnnouncementPolicy created in Phase A
-rm infra/configs/cilium/l2-announcement-policy.yaml
-rm infra/configs/cilium/l2-announcement-policy-adguard-primary.yaml
-rm infra/configs/cilium/l2-announcement-policy-adguard-secondary.yaml
-# Update kustomization.yaml accordingly
+# Enumerate every L2 policy file currently tracked
+ls infra/configs/cilium/l2-announcement-policy*.yaml
+
+# Delete them
+rm infra/configs/cilium/l2-announcement-policy*.yaml
+
+# Drop the corresponding entries from infra/configs/cilium/kustomization.yaml
+# (every line matching `l2-announcement-policy*.yaml`)
 ```
 
-### E.2 Disable L2 in Helm + roll DaemonSet
+Confirm zero policies exist in the rendered output before committing:
 
-Edit `infra/controllers/cilium/values.yaml`:
+```bash
+kustomize build infra/configs/cilium/ | grep -c CiliumL2AnnouncementPolicy
+# Expected: 0
+```
 
+### E.2 Remove L2 from Helm values + roll DaemonSet
+
+Edit `infra/controllers/cilium/values.yaml` — **remove the entire `l2announcements:` block**, including the timing values added in Phase A.3. Leaving `enabled: false` with dead `leaseDuration` keys works but is confusing for future readers.
+
+Before:
 ```yaml
 l2announcements:
-  enabled: false
+  enabled: true
+  leaseDuration: "5s"
+  leaseRenewDeadline: "3s"
+  leaseRetryPeriod: "1s"
 ```
+
+After: the block is deleted entirely (Cilium defaults to `enabled: false`).
 
 After Flux reconcile:
 
@@ -436,11 +557,48 @@ Keep on VLAN 2 (mgmt/storage):
 - Synology (`.11`) — iSCSI peer to cluster
 - UCGF (`.1`)
 
-Procedure (per device): change UCGF port-VLAN assignment for the wired port, force DHCP renew, verify routed connectivity. Snapcast multicast (Bonjour) needs UCGF mDNS reflector enabled across VLAN 2 ↔ 20 to keep auto-discovery working.
+#### F.1.0 mDNS reflector pre-flight (BLOCKING)
+
+AirPlay (Apple TV ↔ Mac/iPhone), Snapcast/Bonjour, HomeKit pairing, and Spotify Connect all rely on mDNS discovery. Without cross-VLAN mDNS reflection, splitting Apple TV onto VLAN 20 breaks AirPlay from VLAN 4 wireless devices.
+
+**Verify before any device moves:**
+
+```bash
+# 1. Confirm UCGF firmware exposes mDNS reflector
+# UniFi Network UI: Settings → Networks → <network> → Advanced → "Multicast DNS"
+# (Path varies by firmware version; "mDNS Repeater" or "Multicast DNS" both apply.)
+
+# 2. If supported, enable on BOTH VLAN 2 and VLAN 20 (and the wireless VLAN that needs to discover).
+
+# 3. Test cross-VLAN discovery BEFORE moving the Apple TV.
+#    From a Mac on the wireless VLAN: should see Apple TV and HifiBerry advertisements.
+dns-sd -B _airplay._tcp local.
+dns-sd -B _raop._tcp local.        # AirPlay receiver
+dns-sd -B _snapcast._tcp local.    # if Snapcast advertises
+```
+
+**Known limitations:** UCG-Fiber's mDNS reflector has historically struggled with `_homekit._tcp` on some firmware versions. If HomeKit pairing breaks after F.1, fall back to keeping HomeKit-paired devices on the same VLAN as their controller, or use a dedicated mDNS bridge (e.g. Avahi on a Pi).
+
+**If the pre-flight fails** (mDNS reflector unavailable or unreliable on current UCGF firmware): do not execute F.1. Either upgrade UCGF firmware to a version with stable mDNS reflection, or accept that IoT VLAN segmentation requires a dedicated mDNS bridge appliance — file as a follow-up plan.
+
+#### F.1.1 Per-device migration
+
+Procedure (per device): change UCGF port-VLAN assignment for the wired port, force DHCP renew, verify routed connectivity, verify cross-VLAN mDNS discovery still works after each move.
 
 ### F.2 Narrow BGP listen-range (Problem #11)
 
-After F.1, only cluster nodes remain on VLAN 2. Narrow the FRR `listen range`:
+After F.1, only cluster nodes remain on VLAN 2. Narrow the FRR `listen range`.
+
+Cluster nodes occupy `10.42.2.20–10.42.2.25` (6 addresses). The smallest CIDR block that covers all 6 is `10.42.2.16/28` (`.16–.31`, 16 addresses). A `/29` (8 addresses) does **not** suffice — `10.42.2.20/29` normalizes to `10.42.2.16/29` (`.16–.23`), excluding workers `.24` and `.25`.
+
+```bash
+# Verify before applying
+ipcalc 10.42.2.16/28
+# Network: 10.42.2.16/28
+# HostMin: 10.42.2.17
+# HostMax: 10.42.2.30
+# (covers all 6 cluster nodes plus a few spares)
+```
 
 ```bash
 ssh root@10.42.2.1
@@ -448,12 +606,17 @@ vtysh
 configure terminal
 router bgp 65100
   no bgp listen range 10.42.2.0/24
-  bgp listen range 10.42.2.20/29 peer-group K8S-NODES
+  bgp listen range 10.42.2.16/28 peer-group K8S-NODES
 end
 write memory
 ```
 
-`/29` covers `.16-.23` (3 CP + 3 worker + spare) — much smaller attack surface.
+After applying, confirm all 3 worker peers re-establish:
+
+```bash
+ssh root@10.42.2.1 'vtysh -c "show bgp summary"'
+# Expected: 3 dynamic peers (*10.42.2.23/.24/.25) Established
+```
 
 ### F.3 Per-service externalTrafficPolicy review (Problem #12)
 
@@ -464,9 +627,23 @@ For each LoadBalancer service in `apps/`, classify:
 
 Document the decision per-service in a comment next to the service definition.
 
-### F.4 Optional: BGP MD5 authentication
+### F.4 BGP MD5 authentication (defense-in-depth, conditional)
 
-If F.1/F.2 are deemed insufficient, add BGP password auth on both UCGF and Cilium peer-config. Out of scope unless an actual untrusted-LAN risk emerges.
+Add BGP password auth on both UCGF and Cilium peer-config to prevent any host on the BGP listen range from asserting AS 65010.
+
+**Trigger condition (must execute F.4 within 7 days if any of the following becomes true):**
+
+1. Any non-cluster device appears in the BGP listen range (e.g. a new node IP outside `10.42.2.20–.25` on the management VLAN).
+2. UCGF firmware upgrade re-broadens the listen range (e.g. by reverting `frr.conf`).
+3. F.1 is rolled back, putting non-cluster devices back on VLAN 2.
+
+Otherwise: low-priority hardening, not blocking.
+
+**Implementation sketch** (when triggered):
+
+- UCGF: `neighbor K8S-NODES password <secret>` in the BGP config.
+- Cilium: add `authSecretRef:` to `CiliumBGPPeerConfig` pointing at a SOPS-encrypted secret in `kube-system`.
+- Roll the cilium DaemonSet (per the operator gotcha in A.4).
 
 ### Phase F GO criteria
 Per sub-phase. F.1: all listed devices on new VLAN, all services still reachable. F.2: BGP peers re-establish on the narrower range. F.3: per-service migration verified.
@@ -481,19 +658,20 @@ Per sub-phase. F.1: all listed devices on new VLAN, all services still reachable
 
 ## Sequencing summary
 
-```
-Week 1  ─ Phase A (L2 hygiene + tuning)
-        └ Phase B (test plan hardening, parallel)
-        └ Phase C (DNS fallback, parallel)
+Phases serialize, but soak windows dominate the calendar. Realistic durations:
 
-Week 2  ─ Phase D start (allocate new pool, migrate gateway)
-Week 3  ─ Phase D continue (migrate AdGuard, then long-tail services)
-Week 4  ─ Phase D soak (48h+) → Phase E (pure BGP)
+| Phase | Active work | Soak / wait | Total |
+|---|---|---|---|
+| A — L2 hygiene | ~half day | 48h post-merge | ~3 days |
+| B — Test plan hardening | ~1 hour | none (procedural) | same day as A |
+| C — DNS fallback | ~1 hour | 24h DHCP propagation | ~1–2 days |
+| D — LB pool migration | ~1 day spread across sub-steps | 24h per migrated service + 48h final soak | **2–3 weeks** |
+| E — Pure BGP | ~1 hour | 24h soak | ~2 days |
+| F — Defense in depth | ~1 day per sub-phase | 24h post each | ~1 week per sub-phase |
 
-Week 5+ ─ Phase F sub-phases (IoT VLAN, listen-range, eTP review)
-```
+Total wall-clock from kickoff to Phase E completion: **~3 weeks of soak windows + ~3 days of active work**, assuming no rollbacks. Phase F sub-phases run in any order after E and don't gate each other.
 
-Each gate explicit. No phase auto-fires from the previous one.
+Each gate is explicit. No phase auto-fires from the previous one.
 
 ## Backout to current state
 

--- a/docs/reference/cilium.md
+++ b/docs/reference/cilium.md
@@ -10,7 +10,10 @@ Cilium is deployed via Flux using the official Helm chart. It runs as a DaemonSe
 
 - **Datapath**: eBPF with `kubeProxyReplacement: true` (kube-proxy is completely removed).
 - **IPAM**: Kubernetes IPAM mode.
-- **LoadBalancer IP advertisement**: BGP peering with the UCGF (UniFi Cloud Gateway Fiber). Each worker establishes an eBGP session from AS 65010 to UCGF AS 65100 and advertises every LoadBalancer IP as a /32. The UCGF installs three ECMP next-hops per /32 (one per worker), so any single-worker BGP failure leaves traffic served by the other two. **L2 announcements are no longer used** — see [`docs/plans/2026-03-08-bgp-rollout.md`](../plans/2026-03-08-bgp-rollout.md) for the migration history. The canonical UCGF FRR config is snapshotted at [`docs/reference/ucgf-bgp-frr.conf`](ucgf-bgp-frr.conf).
+- **LoadBalancer IP advertisement**: **L2 + BGP simultaneously** (as of 2026-05-06).
+  - **BGP** peering with the UCGF (UniFi Cloud Gateway Fiber): each worker establishes an eBGP session from AS 65010 to UCGF AS 65100 and advertises every LoadBalancer IP as a /32. The UCGF installs three ECMP next-hops per /32 (one per worker), so any single-worker BGP failure leaves traffic served by the other two. Cross-subnet clients (wireless, etc.) reach LB IPs via these BGP routes.
+  - **L2 announcements** for same-subnet wired clients on `10.42.2.0/24`: an elected node responds to ARP for each LB IP. Required because clients sharing a /24 with the LB pool ARP directly and never consult the UCGF's routing table. See [`docs/architecture/networking/cluster-load-balancing.md`](../architecture/networking/cluster-load-balancing.md) for the full mechanism and [`docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`](../operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md) for why both are needed.
+  - The canonical UCGF FRR config is snapshotted at [`docs/reference/ucgf-bgp-frr.conf`](ucgf-bgp-frr.conf). The forward plan to remove L2 (after migrating the LB pool to a dedicated subnet) is [`docs/plans/2026-05-06-network-resilience-and-bgp-completion.md`](../plans/2026-05-06-network-resilience-and-bgp-completion.md).
 - **Gateway API**: Cilium acts as the Gateway API controller, provisioning Envoy proxies for routing ingress traffic.
 - **Observability**: Hubble, Hubble Relay, and Hubble UI are enabled for network visibility.
 
@@ -26,7 +29,7 @@ Located in `infra/controllers/cilium/values.yaml`:
 
 - `kubeProxyReplacement: true`
 - `bgpControlPlane.enabled: true` — enables the agent's BGP module
-- `l2announcements.enabled: false` — disabled after migration (Phase 4b)
+- `l2announcements.enabled: true` — re-enabled 2026-05-05 after the wired-device regression incident; required for same-subnet wired clients on `10.42.2.0/24`
 - `gatewayAPI.enabled: true`
 - `hubble.enabled: true`
 


### PR DESCRIPTION
## Summary

- Adds incident postmortem: `docs/operations/incidents/2026-05-05-bgp-l2-wired-device-regression.md`
- Adds revised Phase 4 plan: `docs/plans/2026-05-05-bgp-phase4-revision.md`
- Updates BGP rollout plan frontmatter to `partially-reverted` with links to both docs

## What happened

Phase 4a/4b of the BGP rollout removed L2 announcements. This broke wired devices on `10.42.2.0/24` (Apple TV, HifiBerry nodes, etc.) that ARP directly for LB IPs in the same subnet — BGP routes only help clients on different VLANs that route through the UCGF. Wireless clients were unaffected.

Fix was PR #536 (restore L2 + BGP together). The correct steady state is **both running simultaneously** until the LB pool is moved to a dedicated subnet with no wired client hosts.

## What's documented

The incident doc covers: RCA, why wireless/wired behave differently, why the Phase 4a test plan missed it, resolution steps (including the Cilium config hot-reload gotcha requiring `kubectl rollout restart ds/cilium`).

The Phase 4 revision doc covers: topology gates that must pass before L2 can be removed, the topology change path (move LB pool to `10.42.3.0/24`), updated test matrix with wired-device coverage, and the DaemonSet restart requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)