### PR TITLE
feat(homeassistant): add nightlight automation

### DIFF
--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -10,16 +10,11 @@
   trigger:
     - platform: state
       entity_id:
-        - switch.*_exhaust_fan
+        - switch.hall_bathroom_exhaust_fan
+        - switch.master_bathroom_exhaust_fan
+        - switch.powder_bathroom_exhaust_fan
       from: "off"
       to: "on"
-  condition:
-    # Only bathroom exhaust fans
-    - condition: template
-      value_template: >
-        {{ "bathroom" in trigger.to_state.entity_id | lower or
-           "bath" in trigger.to_state.entity_id | lower or
-           "powder" in trigger.to_state.entity_id | lower }}
   action:
     - variables:
         # Extract bathroom name from entity ID
@@ -113,29 +108,29 @@
     - platform: sun
       event: sunset
   action:
-    # Turn on dining room chandelier if off
+    # Turn on dining room chandelier if off (Lutron Caseta switch)
     - condition: state
-      entity_id: light.dining_room_chandelier
+      entity_id: switch.dining_room_chandelier
+      state: "off"
+    - service: switch.turn_on
+      target:
+        entity_id: switch.dining_room_chandelier
+    # Turn on chandelier_central at target brightness if off (MiBoxer LED)
+    - condition: state
+      entity_id: light.0xa4c138b55dac7973
       state: "off"
     - service: light.turn_on
       target:
-        entity_id: light.dining_room_chandelier
-    # Turn on chandelier_central at target brightness if off
-    - condition: state
-      entity_id: light.chandelier_central
-      state: "off"
-    - service: light.turn_on
-      target:
-        entity_id: light.chandelier_central
+        entity_id: light.0xa4c138b55dac7973
       data:
         brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
-    # Turn on chandelier_flowers at target brightness if off
+    # Turn on chandelier_flowers at target brightness if off (MiBoxer LED)
     - condition: state
-      entity_id: light.chandelier_flowers
+      entity_id: light.0xa4c138a9f6011cac
       state: "off"
     - service: light.turn_on
       target:
-        entity_id: light.chandelier_flowers
+        entity_id: light.0xa4c138a9f6011cac
       data:
         brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
 
@@ -155,13 +150,14 @@
 - alias: "Nightlight — turn off dining room chandelier"
   description: "Turn off the dining room chandelier at configurable time + random offset."
   trigger:
-    - platform: time
-      at: "{{ states('sensor.nightlight_turnoff_time') }}"
+    - platform: template
+      value_template: >
+        {{ now().strftime('%H:%M') == states('sensor.nightlight_turnoff_time') }}
   condition:
     - condition: state
-      entity_id: light.dining_room_chandelier
+      entity_id: switch.dining_room_chandelier
       state: "on"
   action:
-    - service: light.turn_off
+    - service: switch.turn_off
       target:
-        entity_id: light.dining_room_chandelier
+        entity_id: switch.dining_room_chandelier

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -102,10 +102,16 @@ template:
       - name: "Nightlight Turn Off Time"
         unique_id: nightlight_turnoff_time
         state: >
-          {{
-            base_time = strptime(state_attr('input_datetime.nightlight_turnoff_time', 'timestamp') or '23:00', '%H:%M')
-            base_minutes = base_time.hour * 60 + base_time.minute
-            offset = states('sensor.nightlight_random_offset') | int(0)
-            total_minutes = (base_minutes + offset) % 1440
-            '%02d:%02d' | format(total_minutes // 60, total_minutes % 60)
-          }}
+          {% set ts = state_attr('input_datetime.nightlight_turnoff_time', 'timestamp') %}
+          {% if ts is none %}
+            {% set base_minutes = 23 * 60 %}
+          {% elif ts is string %}
+            {% set base_time = strptime(ts, '%H:%M') %}
+            {% set base_minutes = base_time.hour * 60 + base_time.minute %}
+          {% else %}
+            {# timestamp is seconds since midnight %}
+            {% set base_minutes = ts | int %}
+          {% endif %}
+          {% set offset = states('sensor.nightlight_random_offset') | int(0) %}
+          {% set total_minutes = (base_minutes + offset) % 1440 %}
+          {{ '%02d:%02d' | format(total_minutes // 60, total_minutes % 60) }}

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -43,6 +43,22 @@ input_number:
     initial: 30
     unit_of_measurement: min
     mode: slider
+  nightlight_brightness:
+    name: Nightlight Brightness
+    min: 1
+    max: 100
+    step: 1
+    initial: 6
+    unit_of_measurement: "%"
+    mode: slider
+  nightlight_random_offset:
+    name: Nightlight Random Offset
+    min: 0
+    max: 120
+    step: 5
+    initial: 30
+    unit_of_measurement: min
+    mode: slider
 
 timer:
   hall_bathroom_fan_timer:
@@ -63,25 +79,6 @@ http:
     - 10.244.0.0/16  # Trust Cluster Pod CIDR
     - 10.42.2.0/24 # Trust Node Network (Envoy HostNetwork)
     - 127.0.0.1
-
-# Nightlight input helpers
-input_number:
-  nightlight_brightness:
-    name: Nightlight Brightness
-    min: 1
-    max: 100
-    step: 1
-    initial: 6
-    unit_of_measurement: "%"
-    mode: slider
-  nightlight_random_offset:
-    name: Nightlight Random Offset
-    min: 0
-    max: 120
-    step: 5
-    initial: 30
-    unit_of_measurement: min
-    mode: slider
 
 input_datetime:
   nightlight_turnoff_time:


### PR DESCRIPTION
Add configurable nightlight automation for the dining room chandelier.

- Sundown on with configurable brightness for MiBoxer LED components
- Configurable turn-off time + daily random offset
- Template sensor handles input_datetime timestamp (int/string/none)
- Correct entity IDs: switch.dining_room_chandelier, light.0xa4c138b55dac7973, light.0xa4c138a9f6011cac
- Dashboard uses type: input_datetime card
- Bathroom fan trigger uses explicit entity list