### PR TITLE
feat(homeassistant): add laundry room light auto-off timer

### DIFF
--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -217,15 +217,21 @@
           - light.laundry_room_cove
       continue_on_error: true
 
-- alias: "Laundry room light auto-off — cancel timer when manually switched off"
-  description: "If either laundry room light is turned off before the timer expires, cancel the timer."
+- alias: "Laundry room light auto-off — cancel timer when both lights off"
+  description: "If both laundry room lights are turned off before the timer expires, cancel the timer."
   trigger:
     - platform: state
       entity_id:
         - light.laundry_room_main_lights
         - light.laundry_room_cove
-      from: "on"
-      to: "off"
+  condition:
+    # Only cancel if BOTH lights are off
+    - condition: state
+      entity_id: light.laundry_room_main_lights
+      state: "off"
+    - condition: state
+      entity_id: light.laundry_room_cove
+      state: "off"
   action:
     - service: timer.cancel
       target:

--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -166,7 +166,7 @@
 # Laundry room light auto-off timer
 # ============================================================================
 # When either laundry room light turns on, start a timer. When the timer
-# expires, turn off both lights. If either light is manually turned off
+# expires, turn off both lights. If both lights are manually turned off
 # before the timer expires, cancel the timer.
 #
 # Input helper:

--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -161,3 +161,73 @@
     - service: switch.turn_off
       target:
         entity_id: switch.dining_room_chandelier
+
+# ============================================================================
+# Laundry room light auto-off timer
+# ============================================================================
+# When either laundry room light turns on, start a timer. When the timer
+# expires, turn off both lights. If either light is manually turned off
+# before the timer expires, cancel the timer.
+#
+# Input helper:
+#   input_number.laundry_room_light_minutes — configurable timeout (default 30 min)
+#
+# Timer:
+#   timer.laundry_room_light_timer — counts down once either light turns on
+
+- alias: "Laundry room light auto-off — start timer"
+  description: "When a laundry room light turns on, start a timer. Turns off both lights when timer expires."
+  trigger:
+    - platform: state
+      entity_id:
+        - light.laundry_room_main_lights
+        - light.laundry_room_cove
+      from: "off"
+      to: "on"
+  action:
+    - variables:
+        timer_entity: "timer.laundry_room_light_timer"
+        delay_minutes: >
+          {{ states('input_number.laundry_room_light_minutes') | default('30') | int(30) }}
+        delay_seconds: "{{ delay_minutes * 60 }}"
+    # Start the timer with configured duration
+    - service: timer.start
+      target:
+        entity_id: "{{ timer_entity }}"
+      data:
+        duration: "{{ delay_seconds }}"
+  mode: restart
+
+- alias: "Laundry room light auto-off — turn off lights"
+  description: "When the laundry room light timer expires, turn off both lights."
+  trigger:
+    - platform: event
+      event_type: timer.finished
+  condition:
+    # Only laundry room light timer (not other timers in the house)
+    - condition: template
+      value_template: >
+        {{ "timer.laundry_room_light_timer" in trigger.event.data.entity_id | lower }}
+  action:
+    # Turn off both laundry room lights
+    - service: light.turn_off
+      target:
+        entity_id:
+          - light.laundry_room_main_lights
+          - light.laundry_room_cove
+      continue_on_error: true
+
+- alias: "Laundry room light auto-off — cancel timer when manually switched off"
+  description: "If either laundry room light is turned off before the timer expires, cancel the timer."
+  trigger:
+    - platform: state
+      entity_id:
+        - light.laundry_room_main_lights
+        - light.laundry_room_cove
+      from: "on"
+      to: "off"
+  action:
+    - service: timer.cancel
+      target:
+        entity_id: timer.laundry_room_light_timer
+      continue_on_error: true

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -59,6 +59,14 @@ input_number:
     initial: 30
     unit_of_measurement: min
     mode: slider
+  laundry_room_light_minutes:
+    name: Laundry Room Light Timer
+    min: 5
+    max: 120
+    step: 5
+    initial: 30
+    unit_of_measurement: min
+    mode: slider
 
 timer:
   hall_bathroom_fan_timer:
@@ -67,6 +75,8 @@ timer:
     name: Master Bathroom Fan Timer
   powder_bathroom_fan_timer:
     name: Powder Bathroom Fan Timer
+  laundry_room_light_timer:
+    name: Laundry Room Light Timer
 
 automation: !include automations.yaml
 script: !include scripts.yaml

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -13,11 +13,20 @@ frontend:
 # silently ignored (HA always uses LovelaceStorage for storage-registered
 # dashboards regardless of the `mode` field).
 
-# Bathroom-fan auto-off helpers. Each bathroom has:
-#   timer.<name>_fan_timer       — counts down once the switch flips on
-#   input_number.<name>_fan_minutes — operator-configurable timeout per bathroom
-# The auto-off automation in automations.yaml ties them to the corresponding
-# Lutron Caseta switch entities (switch.<name>_exhaust_fan).
+# Auto-off helpers. Each has:
+#   timer.<name>_timer       — counts down once triggered
+#   input_number.<name>_minutes — operator-configurable timeout
+#
+# Bathroom fans (via Lutron Caseta switches):
+#   timer.hall_bathroom_fan_timer / input_number.hall_bathroom_fan_minutes
+#   timer.master_bathroom_fan_timer / input_number.master_bathroom_fan_minutes
+#   timer.powder_bathroom_fan_timer / input_number.powder_bathroom_fan_minutes
+#
+# Laundry room lights (via Lutron Caseta):
+#   timer.laundry_room_light_timer / input_number.laundry_room_light_minutes
+#
+# The auto-off automations in automations.yaml tie them to the corresponding
+# Lutron Caseta switch/light entities.
 input_number:
   hall_bathroom_fan_minutes:
     name: Hall Bathroom Fan Timer


### PR DESCRIPTION
## Summary

Add an auto-off timer for the laundry room lights, similar to the existing bathroom fan auto-off timers.

## Changes

- **configuration.yaml**: Add  helper (5-120 min, default 30) and  definition
- **automations.yaml**: Add three automation rules:
  1. Start timer when either light turns on
  2. Turn off both lights when timer expires
  3. Cancel timer when either light is manually switched off

## Entities

-  (Lutron Caseta)
-  (Lutron Caseta)

## Behavior

- When either  or  turns on, a configurable timer starts
- When the timer expires, both lights are turned off
- If either light is manually turned off before the timer expires, the timer is cancelled
- The timeout is configurable via  in the HA UI (default: 30 minutes)