### PR TITLE
feat(dashboards): add Offramps Burned stat to overture dashboard

### DIFF
--- a/infra/configs/dashboards/overture-cm.yaml
+++ b/infra/configs/dashboards/overture-cm.yaml
@@ -28,13 +28,20 @@ data:
             "thresholds": { "steps": [{ "value": 0, "color": "green" }, { "value": 0.01, "color": "red" }] } }
         },
         {
-          "id": 3, "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+          "id": 3, "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
           "type": "stat", "title": "Onramps Minted (total)",
           "targets": [{ "expr": "sum(acme_onramp_operations_total{step=\"minted\"})", "legendFormat": "minted" }],
           "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
         },
         {
-          "id": 4, "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+          "id": 9, "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+          "type": "stat", "title": "Offramps Burned (total)",
+          "description": "Successful offramp completions. Each one represents an on-chain transferFromWithMemo + burn pair; AcmeUSD supply has been retired and the user's ledger balance debited.",
+          "targets": [{ "expr": "sum(acme_offramp_operations_total{outcome=\"ok\"})", "legendFormat": "burned" }],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+        },
+        {
+          "id": 4, "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
           "type": "stat", "title": "Transfers (total)",
           "targets": [{ "expr": "sum(acme_transfer_operations_total{outcome=\"ok\"})", "legendFormat": "ok" }],
           "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }


### PR DESCRIPTION
## Summary

Adds a headline-stat counter for offramp burns to the Overture dashboard, paralleling the existing \"Onramps Minted (total)\" panel. The metric (`acme_offramp_operations_total{outcome=\"ok\"}`) has been emitted all along — only the dashboard panel was missing.

Top-row layout shifted from `w=6,6,6,6` to `w=6,6,4,4,4` to fit the new panel without touching the time-series layout below.

## Why now

Following the [tempo-interview offramp burn fix](https://github.com/gjcourt/tempo-interview) that makes burns properly retire user tokens on-chain (transferFromWithMemo + burn), it's worth being able to verify in Grafana that burns are happening at the expected rate. Without this panel, an operator has to write the PromQL by hand to see burn counts.

## Test plan

- [x] `kustomize build infra/configs` passes
- [x] Embedded JSON parses (`python3 -m json.tool`)
- [ ] After merge + Flux reconcile, the new stat appears on https://grafana.burntbytes.com (Overture dashboard) showing the running offramp count

🤖 Generated with [Claude Code](https://claude.com/claude-code)