### PR TITLE
fix(homeassistant): correct Jinja comment tag in nightlight template

### DIFF
--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -106,7 +106,7 @@ template:
             {% set base_time = strptime(ts, '%H:%M') %}
             {% set base_minutes = base_time.hour * 60 + base_time.minute %}
           {% else %}
-            {# timestamp is seconds since midnight %}
+            {# timestamp is seconds since midnight #}
             {% set base_minutes = ts | int %}
           {% endif %}
           {% set offset = states('sensor.nightlight_random_offset') | int(0) %}


### PR DESCRIPTION
## Summary

`apps/base/homeassistant/files/configuration.yaml:109` closes a Jinja comment with \`%}\` instead of \`#}\`. HA fails to parse the \`sensor.nightlight_turnoff_time\` template sensor on every startup with:

> Invalid config for 'template' at configuration.yaml, line 101: invalid template (TemplateSyntaxError: Missing end of comment tag) for dictionary value 'sensor->0->state'

The sensor never loads → \`Nightlight — turn off dining room chandelier\` automation can't fire.

## Origin

PR #538 squash-merged the nightlight feature. Two earlier fix commits (\`86af04c\`, \`66a0817\`) had corrected the Jinja syntax; both were reverted (\`806680c\`, \`7e2e910\`) before #538 re-merged. The second fix's correct \`{# ... #}\` tag came back with a fat-finger \`%}\`.

## Verified after merge

- [ ] Confirm \`kubectl logs deploy/homeassistant -n homeassistant-prod\` no longer shows the TemplateSyntaxError after the next pod rollout
- [ ] Confirm \`sensor.nightlight_turnoff_time\` resolves to a value in HA Developer Tools → States

## Test plan

- [x] \`kustomize build apps/production/homeassistant\` passes
- [x] \`kustomize build apps/staging/homeassistant\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)