### PR TITLE
fix(homeassistant): convert input_datetime timestamp seconds → minutes

### DIFF
--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -125,8 +125,8 @@ template:
             {% set base_time = strptime(ts, '%H:%M') %}
             {% set base_minutes = base_time.hour * 60 + base_time.minute %}
           {% else %}
-            {# timestamp is seconds since midnight #}
-            {% set base_minutes = ts | int %}
+            {# timestamp is SECONDS since midnight (verified live: 23:00 → 82800) #}
+            {% set base_minutes = (ts | int) // 60 %}
           {% endif %}
           {% set offset = states('sensor.nightlight_random_offset') | int(0) %}
           {% set total_minutes = (base_minutes + offset) % 1440 %}


### PR DESCRIPTION
## Summary

The \`sensor.nightlight_turn_off_time\` template treats the \`input_datetime\` \`timestamp\` attribute as minutes-since-midnight, but HA actually returns it as **seconds**-since-midnight. With \`input_datetime.nightlight_turnoff_time = '23:00'\`, \`timestamp = 82800\`. The template did \`(82800 + offset) % 1440 = 725\` → rendered \`12:05\` instead of the expected \`23:05\`. Off by 11 hours.

## Verified live

Before fix:
\`\`\`
sensor.nightlight_turn_off_time = '12:05'   ← wrong
input_datetime.nightlight_turnoff_time → timestamp = 82800 (= 23 hours)
\`\`\`

The fix divides the integer-timestamp branch by 60 so \`base_minutes\` is in minutes. The other two branches (none → fallback 23:00; string → strptime) already produce minutes correctly and are unchanged.

## Test plan

- [x] \`kustomize build apps/production/homeassistant\` passes
- [ ] After merge + reconcile, \`sensor.nightlight_turn_off_time\` reads \`23:MM\` (where MM is the daily random offset 0–30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)