### PR TITLE
fix(signal-cli): add liveness probe to recover from JVM OOM zombie state

### DIFF
--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -46,6 +46,17 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 10
+          # A JVM OOM that kills the daemon-listener thread leaves the process
+          # alive but no longer accepting on 7583, so without a liveness probe
+          # the pod stays Running indefinitely while signal-bridge crashloops
+          # against a dead 127.0.0.1:7583. Force a restart on probe failure.
+          livenessProbe:
+            tcpSocket:
+              port: json-rpc
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           env:
             # Default JVM MaxRAMPercentage (~25%) caps the heap far below the
             # cgroup limit, so the container shows free RAM while the JVM


### PR DESCRIPTION
## Summary
- Adds a TCP liveness probe to the `signal-cli` container so a JVM OOM that kills the daemon-listener thread (process alive, port :7583 dead) triggers a kubelet restart instead of leaving the pod NotReady forever.
- Resolves the current cluster outage where `signal-cli` has been zombied for ~4d16h (restart count 0, but :7583 unreachable), causing `signal-bridge` to crashloop (restart count 674) and `hermes-{prod,callee-prod,stage,callee-stage}` to CrashLoopBackOff downstream.

## Root cause
`apps/base/signal-cli/deployment.yaml` had only a readiness probe on the JVM container. When the JVM throws `OutOfMemoryError: Java heap space` in `daemon-listener` (seen in logs around 2026-05-04), the listener thread dies but the process stays up, so the container's `Running` state is honored by kubelet indefinitely. Readiness flips off (signal-bridge can't connect) but no restart is ever issued.

PR #470 (heap bump to 2GiB / 3Gi limit) addressed one trigger, but didn't fix the recovery path. This PR adds the recovery path so the same class of failure self-heals in ~2 minutes regardless of cause.

## Probe timing
- `initialDelaySeconds: 60` — JVM startup (`signal-cli daemon`) + linked-account warmup takes ~30s; 60s is comfortably above that.
- `periodSeconds: 30` + `failureThreshold: 3` — total ~90s to declare dead, conservative enough to ride out short GC pauses.
- `timeoutSeconds: 5` — generous for a TCP-only probe.

## Test plan
- [x] `kustomize build apps/production/signal-cli` passes
- [x] `kustomize build apps/staging/signal-cli` passes
- [ ] After merge & Flux reconcile: `kubectl rollout status -n signal-cli deploy/signal-cli` reaches Ready
- [ ] `kubectl get pods -n signal-cli` shows both containers Ready (signal-cli + signal-bridge)
- [ ] `kubectl get pods -n hermes-prod -l app=hermes` shows Ready (downstream recovery)
- [ ] Sanity: `kubectl describe pod -n signal-cli ...` shows the new Liveness line

🤖 Generated with [Claude Code](https://claude.com/claude-code)