### PR TITLE
feat(vllm): drop gpu-memory-utilization 0.95 → 0.92 (vision sidecar prereq)

### DIFF
--- a/hosts/hestia/llms/docker-compose-vllm.yml
+++ b/hosts/hestia/llms/docker-compose-vllm.yml
@@ -38,7 +38,7 @@ services:
         --host 0.0.0.0 --port 8000
         --tensor-parallel-size 2
         --dtype auto
-        --gpu-memory-utilization 0.95
+        --gpu-memory-utilization 0.92
         --max-model-len 163840
         --kv-cache-dtype fp8
         --enable-chunked-prefill


### PR DESCRIPTION
## Summary

Step 1 of the vision sidecar plan (#569). Reduces Phase 6 v2's \`--gpu-memory-utilization\` from 0.95 to 0.92, freeing ~926 MiB per 4090 to make room for the upcoming \`vllm-vision\` sidecar.

## Measured impact

Already applied to the running SCALE app via \`midclt\` and verified before opening this PR:

| | Before (0.95) | After (0.92) | Δ |
|---|---|---|---|
| VRAM per GPU | 22,507 MiB | **21,581 MiB** | -926 MiB |
| Free per GPU | ~1.5 GiB | **~3.0 GiB** | +1.5 GiB |
| KV cache pool | 1,780,261 tokens | 1,640,398 tokens | -8% |
| Max-concurrency at 160K request | 10.87× | 10.0× | still 2.5× headroom over \`--max-num-seqs 4\` |
| Decode TPS (medium) | 194.3 | **192.9** | within noise |
| TTFT (medium) | 0.090 s | **0.090 s** | unchanged |

No user-visible regression. Phase 6 v2's stability profile is preserved.

## Test plan

- [x] Tweak applied via midclt; vllm app redeployed; \`/health\` returns 200
- [x] Benchmark re-run on \`scripts/llama-cpp-bench.py\` — decode within 1% of pre-tweak baseline
- [ ] Reviewed for merge

## Cross-references

- Plan: #569 (vision sidecar)
- Phase 6 v2 promotion: #559
- Parent plan: #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)