### PR TITLE
fix(probes): close remaining liveness/readiness gaps + codify in adding-an-app docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ See `docs/architecture/` for component-level architecture (DNS strategy, gateway
 5. Namespace follows the convention (production unsuffixed, staging `-stage`)
 6. New CNPG clusters: iSCSI PVC provisioned and StorageClass correct
 7. Docs updated if the change affects a runbook or architecture doc
+8. Every container has a `readinessProbe`; a `livenessProbe` is added only with a signal distinct from readiness (see `docs/operations/2026-05-02-adding-an-app.md#health-probes`)
 
 ## Documentation
 

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -180,6 +180,20 @@ spec:
             - name: redis
               containerPort: 6379
               protocol: TCP
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 5m

--- a/apps/production/cloudflare-tunnel/deployment.yaml
+++ b/apps/production/cloudflare-tunnel/deployment.yaml
@@ -23,13 +23,25 @@ spec:
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
-          livenessProbe:
+          # cloudflared's /ready returns 200 only when the tunnel is connected,
+          # so it's a readiness signal, not a crash signal. Liveness gets a TCP
+          # probe on the same metrics port — it answers "is the process alive"
+          # without flapping when the tunnel briefly reconnects.
+          readinessProbe:
             httpGet:
               path: /ready
               port: 2000
-            failureThreshold: 1
-            initialDelaySeconds: 10
+            initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 2000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
               cpu: 10m

--- a/docs/operations/2026-05-02-adding-an-app.md
+++ b/docs/operations/2026-05-02-adding-an-app.md
@@ -24,6 +24,65 @@ tags: [operations, kustomize, apps]
    ```
 7. Open a PR against `master`. CI will build into the `staging` branch automatically; Flux will deploy to the `<app>-stage` namespace. Validate there before merging.
 
+## Health probes
+
+Every container needs a `readinessProbe`. A `livenessProbe` is added **only when it carries a distinct signal** from readiness — never share path + timing, because a single flap on a shared probe co-restarts the pod.
+
+Probe-type selection (in order of preference):
+
+1. **HTTP** — `httpGet` on a documented health endpoint (`/health`, `/healthz`, `/ready`, etc.).
+2. **TCP** — `tcpSocket` on the service port when the app has no HTTP health endpoint (e.g. mosquitto MQTT on 1883).
+3. **Exec** — `exec: command: [...]` for opaque daemons or sidecars without a network listener (e.g. `redis-cli ping`, `pgrep -x <process-name>`).
+
+### Locked timings
+
+```yaml
+readinessProbe:
+  <httpGet|tcpSocket|exec>: ...
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+livenessProbe:
+  <httpGet|tcpSocket|exec>: ...
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 6
+```
+
+Readiness is tight (catches problems fast, gates traffic). Liveness is loose (only restarts on persistent failure — the cost of a wrong restart is high).
+
+### Startup probe (optional)
+
+Add a `startupProbe` only when the app's cold-start exceeds the liveness `initialDelaySeconds + periodSeconds * failureThreshold` budget — otherwise liveness can kill the pod mid-boot. Pattern:
+
+```yaml
+startupProbe:
+  httpGet: { path: /health, port: http }
+  failureThreshold: 30
+  periodSeconds: 10        # ~5 min budget
+```
+
+Examples in repo: `apps/base/jellyfin/`, `apps/base/openwebui/`.
+
+### When to skip a probe
+
+Skip rather than add a meaningless probe. Recorded skips (and why):
+
+- **homeassistant**: no anonymous health endpoint; `/api/*` requires a long-lived token (would expand secret blast radius).
+- **cert-manager controller** (Helm): leader-elected — readiness on a non-leader replica is semantically meaningless. Upstream chart deliberately doesn't expose the override.
+- **CSI sidecars / chart-internal sidecars** (e.g. `config-reloader`, Grafana sc-* sidecars): upstream Helm chart authors omit by design.
+
+If you skip, add a one-line comment in the manifest (or HelmRelease values) explaining why.
+
+### Don't co-restart
+
+If liveness and readiness must hit the same path, distinguish them by timing per the locked values above (readiness tight, liveness loose) — but prefer different probe types (e.g. `httpGet` for readiness, `tcpSocket` for liveness on the same port). See `apps/production/cloudflare-tunnel/deployment.yaml` for the canonical example.
+
+Background: the rationale and the apps that closed the initial probe gaps are tracked in `docs/plans/2026-05-04-phase2-5-completion.md` ("PR A — Health probes").
+
 ## Image naming
 
 CI tags images as `YYYY-MM-DD` (first build of the day) then `YYYY-MM-DD-N` for subsequent builds. Image bumps in `apps/{staging,production}/<app>/deployment.yaml` must be strictly greater than the currently deployed tag.

--- a/docs/plans/2026-05-04-phase2-5-completion.md
+++ b/docs/plans/2026-05-04-phase2-5-completion.md
@@ -141,3 +141,26 @@ Once all four PRs land, update `docs/plans/2026-05-02-critique-remediation.md`
 `status:` to `complete` and open the default-deny
 `CiliumClusterwideNetworkPolicy` rollout (Phase 1.1 step 4) namespace by
 namespace, starting with `excalidraw` (stateless canary).
+
+## Follow-up landed (2026-05-09)
+
+A cluster-wide probe re-audit on 2026-05-09 surfaced four workloads that
+PR #408 didn't cover (because they live outside `apps/base/` or are
+inline sidecars). Closed in a follow-up PR alongside lifting the probe
+conventions into the onboarding doc + AGENTS.md quality gate:
+
+- `apps/production/cloudflare-tunnel/deployment.yaml` — `/ready` moved
+  from livenessProbe (mislabeled, `failureThreshold: 1` was aggressive)
+  to readinessProbe; new TCP livenessProbe on :2000.
+- `infra/controllers/mosquitto/deployment.yaml` — TCP L+R on :1883.
+- `infra/controllers/zigbee2mqtt/deployment.yaml` — `httpGet /` readiness
+  + TCP liveness on :8080.
+- `apps/base/immich/deployment.yaml` (`immich-redis` Deployment) —
+  `redis-cli ping` exec probes for both L and R.
+- `docs/operations/2026-05-02-adding-an-app.md` — new "Health probes"
+  section with locked timings, probe-type selection, "don't co-restart"
+  rule, and skip rationale.
+- `AGENTS.md` — added probes line to "Quality gate before push".
+
+Deliberate skip: `cert-manager` controller readinessProbe — upstream
+Helm chart doesn't expose the override (controller is leader-elected).

--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -26,6 +26,20 @@ spec:
               name: mqtt
             - containerPort: 9001
               name: websockets
+          readinessProbe:
+            tcpSocket:
+              port: mqtt
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: mqtt
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           volumeMounts:
             - name: config
               mountPath: /mosquitto/config/mosquitto.conf

--- a/infra/controllers/zigbee2mqtt/deployment.yaml
+++ b/infra/controllers/zigbee2mqtt/deployment.yaml
@@ -38,6 +38,25 @@ spec:
           env:
             - name: ZIGBEE2MQTT_DATA
               value: /app/data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # Liveness uses a TCP probe so a UI hiccup doesn't co-restart with
+          # readiness. zigbee2mqtt has no documented /healthz endpoint — the
+          # frontend serves the SPA on /, which is fine for readiness but
+          # not a strong "process alive" signal on its own.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           volumeMounts:
             - name: data
               mountPath: /app/data


### PR DESCRIPTION
## Summary

A cluster-wide probe re-audit on 2026-05-09 surfaced four workloads that PR #408 ("health probes baseline") didn't cover — three live outside `apps/base/` (so they were out of scope for #408) and one is an inline `immich-redis` Deployment. This PR closes those gaps and lifts the probe conventions into the spots a future contributor (or future-Claude) will actually look — the onboarding doc and AGENTS.md quality gate — so this can't drift again.

## Manifest changes

| Workload | File | Before | After |
|---|---|---|---|
| `cloudflare-tunnel/cloudflared` | `apps/production/cloudflare-tunnel/deployment.yaml` | `livenessProbe httpGet /ready :2000` (mislabeled — `/ready` is a readiness signal; `failureThreshold: 1` was aggressive) | **R**: `httpGet /ready :2000` (tight). **L**: `tcpSocket :2000` (loose). Distinct signals. |
| `mosquitto/mosquitto` | `infra/controllers/mosquitto/deployment.yaml` | No probes (MQTT broker, no HTTP) | **R + L**: `tcpSocket :1883` (mqtt port) |
| `zigbee2mqtt/zigbee2mqtt` | `infra/controllers/zigbee2mqtt/deployment.yaml` | No probes (HTTP UI on :8080) | **R**: `httpGet / :8080` (frontend SPA returns 200). **L**: `tcpSocket :8080` (distinct from R) |
| `immich/immich-redis` | `apps/base/immich/deployment.yaml` | No probes on inline Redis Deployment | **R + L**: `exec ["redis-cli", "ping"]` |

All probes use the locked timings from PR #408 — readiness `init=5/period=10/timeout=3/threshold=3`, liveness `init=30/period=20/timeout=5/threshold=6`.

### Deliberate skip — cert-manager controller readinessProbe

The upstream Helm chart deliberately doesn't expose a controller readinessProbe override because the controller is leader-elected — a readiness probe on a non-leader replica is semantically meaningless. Following upstream rather than forking the chart for a flapping/meaningless probe. Documented in the new "When to skip a probe" section.

## Documentation changes

- **`docs/operations/2026-05-02-adding-an-app.md`** — new "Health probes" section: probe-type selection (HTTP → TCP → exec), the locked timings as a YAML reference, startupProbe pattern for slow-start apps, the "don't co-restart" rule, and when/why to skip a probe with concrete examples (homeassistant, cert-manager, CSI sidecars).
- **`AGENTS.md`** — adds item 8 to the "Quality gate before push" checklist: every container has a `readinessProbe`; a `livenessProbe` is added only with a signal distinct from readiness.
- **`docs/plans/2026-05-04-phase2-5-completion.md`** — appends a "Follow-up landed" closing note recording the file-by-file changes from this PR.

## Test plan

- [x] `kustomize build apps/production/cloudflare-tunnel` passes
- [x] `kustomize build apps/production/immich` passes
- [x] `kustomize build apps/staging/immich` passes
- [x] `kustomize build infra/controllers` passes
- [x] Rendered probes verified via `python yaml.safe_load_all` extraction — mosquitto, zigbee2mqtt, immich-redis Deployments all show probes with the locked timings
- [ ] After merge & Flux reconcile: `kubectl get pod -n cloudflare-tunnel` shows readinessProbe `/ready` and livenessProbe `tcpSocket`
- [ ] `kubectl get pod -n mosquitto` is `Ready 1/1`
- [ ] `kubectl get pod -n zigbee2mqtt` is `Ready 1/1`
- [ ] `kubectl get pod -n immich-prod -l component=redis` is `Ready 1/1`
- [ ] `kubectl get pods -A | grep -vE 'Running|Completed'` returns zero

## References
- PR #408 — health probes baseline (the original probe pass that landed PR A of phase2-5)
- PR #483 — homeassistant/homepage probe path fixes
- `docs/plans/2026-05-04-phase2-5-completion.md` — phase2-5 plan (PR A — Health probes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)