### PR TITLE
feat(vllm): vision sidecar — Qwen3-VL-2B-FP8 on GPU1, port 8001

### DIFF
--- a/hosts/hestia/llms/docker-compose-vllm-vision.yml
+++ b/hosts/hestia/llms/docker-compose-vllm-vision.yml
@@ -1,0 +1,92 @@
+---
+# Production compose for the vllm-vision SCALE app on hestia.
+#
+# Sidecar to the primary vllm app (port 8000). Provides image-input capability
+# for hermes without disturbing the text endpoint.
+#
+# See docs/plans/2026-05-09-vllm-vision-sidecar.md for the design rationale.
+#
+# Configuration:
+#   model:        Qwen/Qwen3-VL-2B-Instruct-FP8 (~3.3 GB on disk, ~5+ GiB VRAM at runtime)
+#   parallelism:  TP=1, GPU1 only (device_ids: ['1'])
+#   port:         8001 (text endpoint stays on 8000)
+#   image pin:    vllm/vllm-openai:v0.20.1 (same as text endpoint)
+#
+# Headroom math (validated 2026-05-09, after iterative tuning):
+#   Initial estimate (in plan #569) was 2.4 GiB. Actual runtime needs ~5.2 GiB
+#   for model weights + vision tower + activations + KV cache. Three iterations
+#   of util tuning landed on:
+#     text endpoint --gpu-memory-utilization  0.92 → 0.85 → 0.80 → 0.72
+#     vllm-vision  --gpu-memory-utilization   0.10 → 0.20 → 0.25 (this file)
+#   At text=0.72 + vision=0.25 = 0.97 cap total, ~700 MiB margin per GPU.
+#   GPU0: ~16.8 GiB used (text only). GPU1: ~21.3 GiB used (text + vision).
+#
+# Hermes integration: vLLM's /v1/chat/completions accepts the standard OpenAI
+# multimodal content format ({"type":"image_url","image_url":{"url":...}}).
+# A future hermes config update routes image-bearing messages to port 8001.
+services:
+  vllm:
+    command:
+      - '-c'
+      - >-
+        echo "=== START $(date) [vllm-vision Qwen3-VL-2B-FP8 on GPU1] ===" >>
+        /root/.cache/huggingface/vllm-vision.log 2>&1;
+        exec vllm serve Qwen/Qwen3-VL-2B-Instruct-FP8
+        --served-model-name qwen3-vl-2b
+        --host 0.0.0.0 --port 8001
+        --dtype auto
+        --gpu-memory-utilization 0.25
+        --max-model-len 8192
+        --max-num-batched-tokens 4096
+        --enable-chunked-prefill
+        --max-num-seqs 4
+        --enable-auto-tool-choice
+        --tool-call-parser hermes
+        --trust-remote-code
+        >> /root/.cache/huggingface/vllm-vision.log 2>&1
+    container_name: vllm-vision
+    deploy:
+      resources:
+        reservations:
+          devices:
+            # Pin to GPU1 only (GPU0 + GPU1 shared by the text endpoint via TP=2,
+            # but GPU1 has the most headroom and we don't want to compete with
+            # the text endpoint's own per-GPU allocation patterns on GPU0).
+            - capabilities:
+                - gpu
+                - utility
+              device_ids:
+                - '1'
+              driver: nvidia
+    entrypoint:
+      - /bin/bash
+    environment:
+      HUGGING_FACE_HUB_TOKEN: ""  # set in SCALE UI env-var section (masked); do not commit a real token here
+      OMP_NUM_THREADS: '4'
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+      TOKENIZERS_PARALLELISM: 'false'
+    healthcheck:
+      interval: 30s
+      retries: 5
+      start_period: 600s
+      test:
+        - CMD
+        - curl
+        - '-f'
+        - http://localhost:8001/health
+      timeout: 10s
+    image: vllm/vllm-openai:v0.20.1
+    ipc: host
+    ports:
+      - '8001:8001'
+    restart: unless-stopped
+    shm_size: 8gb
+    ulimits:
+      memlock:
+        hard: -1
+        soft: -1
+      stack:
+        hard: 67108864
+        soft: 67108864
+    volumes:
+      - /mnt/main/ai/models:/root/.cache/huggingface

--- a/hosts/hestia/llms/docker-compose-vllm.yml
+++ b/hosts/hestia/llms/docker-compose-vllm.yml
@@ -38,7 +38,7 @@ services:
         --host 0.0.0.0 --port 8000
         --tensor-parallel-size 2
         --dtype auto
-        --gpu-memory-utilization 0.92
+        --gpu-memory-utilization 0.72
         --max-model-len 163840
         --kv-cache-dtype fp8
         --enable-chunked-prefill


### PR DESCRIPTION
## Summary

Step 2 of the vision sidecar plan (#569). Stands up a second vLLM container (\`vllm-vision\` SCALE app) on port 8001 serving \`Qwen/Qwen3-VL-2B-Instruct-FP8\` for image-input requests, while preserving the Phase 6 v2 text endpoint on port 8000.

Both endpoints are RUNNING simultaneously on hestia.

## Final memory split

The plan estimated the 2B FP8 model would need ~2.4 GiB. **Actual runtime is ~5.2 GiB** (model + vision tower + activations + KV cache). Three iterations to find a working pair:

| Iteration | Text util | Vision util | Outcome |
|---|---|---|---|
| Plan target | 0.92 | 0.10 | Vision OOM at startup (1.86 GiB free, 2.35 needed) |
| Iter 2 | 0.85 | 0.10 | Vision crash mid-load |
| Iter 3 | 0.80 | 0.20 | Vision OOM after 4.05 GiB use (cap was 4.92) |
| **Final (this PR)** | **0.72** | **0.25** | ✅ **Both endpoints running** |

GPU1 total used: ~21.3 GiB of 24.5 GiB. Margin ~700 MiB per GPU. KV pool for text endpoint shrunk from 1.78M → ~700K tokens; \`--max-num-seqs 4\` still has ~6× concurrency at full 160K context, so the cap isn't operational.

## Sidecar gauntlet results (steps 1–5)

| Step | Probe | Result |
|---|---|---|
| 1 | Text-only via vision endpoint | ✅ 0.72 s, "Hello! How are you?" |
| 2 | Single-image smoke | ✅ 0.42 s, multimodal pipe end-to-end |
| 3 | 2-image multi-content | ✅ 0.21 s, multi-image content blocks accepted |
| 4 | 4 concurrent image-bearing | ✅ 0/4 errors, continuous batching works |
| 5 | Co-tenancy snapshot (2 text + 2 vision parallel) | ✅ both 200, text 2.97 s avg / vision 0.38 s avg, no interference |

**Step 6 (30-min co-tenancy soak)** and **Step 7 (long text+image turn)** are pending — to be run as a follow-up after this PR merges.

## Files

- \`hosts/hestia/llms/docker-compose-vllm.yml\`: text endpoint utilization 0.92 → 0.72 (post-iteration)
- \`hosts/hestia/llms/docker-compose-vllm-vision.yml\`: NEW sidecar compose

The SCALE apps already match these configs via \`midclt\` updates — this PR brings the canonical YAML in sync.

## Test plan

- [x] vllm RUNNING (port 8000, qwen3.6-35b-a3b-awq, 160K context)
- [x] vllm-vision RUNNING (port 8001, qwen3-vl-2b)
- [x] Sidecar gauntlet steps 1–5 PASS
- [ ] 30-min co-tenancy soak (step 6) — queued for follow-up
- [ ] Long text+image probe (step 7) — queued for follow-up
- [ ] Hermes routing — separate PR (deferred per plan #569)

## Cross-references

- Sidecar plan: #569
- Initial util tweak (0.95 → 0.92): #571
- Phase 6 v2 promotion: #559
- Parent plan: #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)