### PR TITLE
feat: add tag prefixes to digest-pinned images + bump immich/memos

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               app.kubernetes.io/name: adguard
       containers:
         - name: adguard
-          image: adguard/adguardhome@sha256:f29c58a91f79387cbbbb042e140814f58e830d457d44af03d662c8df43db9dea
+          image: adguard/adguardhome:v0.107.74@sha256:f29c58a91f79387cbbbb042e140814f58e830d457d44af03d662c8df43db9dea
           envFrom:
             - configMapRef:
                 name: adguard-container-env

--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
 
       containers:
-        - image: ghcr.io/advplyr/audiobookshelf@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
+        - image: ghcr.io/advplyr/audiobookshelf:2.34.0@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
           name: audiobookshelf
           ports:
             - containerPort: 13378

--- a/apps/base/authelia/deployment.yaml
+++ b/apps/base/authelia/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: authelia
           # authelia 4.39.19
-          image: authelia/authelia@sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463
+          image: authelia/authelia:4.39.19@sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463
           args:
             - --config
             - /config/configuration.yaml

--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /config
       containers:
-        - image: ghcr.io/home-assistant/home-assistant@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867
+        - image: ghcr.io/home-assistant/home-assistant:2026.5.1@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867
           name: homeassistant
           ports:
             - containerPort: 8123

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: homepage
-          image: "ghcr.io/gethomepage/homepage@sha256:690ac1f79e33000c176c2a28229ed00b49b44781e8a63f280a8ece22c161f099"
+          image: "ghcr.io/gethomepage/homepage:v1.13.0@sha256:690ac1f79e33000c176c2a28229ed00b49b44781e8a63f280a8ece22c161f099"
           env:
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: gethomepage.dev # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server@sha256:8ac5a6d471fbb6fcfec6bc34854dd5a947c1795547f0d9345d9bf1803d1209e3
+          image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
           ports:
             - name: http
               containerPort: 2283
@@ -97,7 +97,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning@sha256:531d2bccbe20d0412496e36455715a18d692911eca5e2ee37d32e1e4f50e14bb
+          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
           ports:
             - name: http
               containerPort: 3003

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: jellyfin
-          image: jellyfin/jellyfin@sha256:1694ff069f0c9dafb283c36765175606866769f5d72f2ed56b6a0f1be922fc37
+          image: jellyfin/jellyfin:10.11.8@sha256:1694ff069f0c9dafb283c36765175606866769f5d72f2ed56b6a0f1be922fc37
           ports:
             - containerPort: 8096
               name: http

--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         # mealie v3.16.0
-        - image: ghcr.io/mealie-recipes/mealie@sha256:d570139f1891346131d02f8e4d1853100ae4846474958ca6c68cfe1648058467
+        - image: ghcr.io/mealie-recipes/mealie:v3.17.0@sha256:d570139f1891346131d02f8e4d1853100ae4846474958ca6c68cfe1648058467
           name: mealie
           ports:
             - containerPort: 9000

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
         - name: memos
-          image: neosmemo/memos@sha256:6088f656db8ffa928338d174295b35403d7b7c0015dce93bbc8a48ceb6932362
+          image: neosmemo/memos:0.28.0@sha256:06066de94333c091ee67c2ad5dec5f15bf5f35b31498c90092f9915dd05e9f92
           ports:
             - containerPort: 5230
 

--- a/apps/base/navidrome/deployment.yaml
+++ b/apps/base/navidrome/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: navidrome
           # navidrome 0.61.2
-          image: ghcr.io/navidrome/navidrome@sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2
+          image: ghcr.io/navidrome/navidrome:0.61.2@sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2
           ports:
             - containerPort: 4533
               name: http


### PR DESCRIPTION
## Summary

The 2026-05-09 image-update audit found that renovate was not generating PRs for **digest-only-pinned** deployments because its regex needs a \`:tag\` to follow. This PR fixes that for ~10 apps in one sweep, plus picks up the two real version updates that have accumulated.

## Changes

### Real version bumps (digest changed)

| App | From | To |
|---|---|---|
| immich-server | digest only | v2.7.5 + new digest |
| immich-machine-learning | digest only | v2.7.5 + new digest |
| memos | digest only | 0.28.0 + new digest |

### Tag prefix added (digest unchanged — already at upstream latest)

| App | Tag added |
|---|---|
| adguardhome | v0.107.74 |
| audiobookshelf | 2.34.0 |
| authelia | 4.39.19 |
| home-assistant | 2026.5.1 |
| homepage | v1.13.0 |
| jellyfin | 10.11.8 |
| mealie | v3.17.0 |
| navidrome | 0.61.2 |

For these apps, the pinned digest already matched upstream-latest at audit time — so this is a no-op runtime change, just a structural change so renovate can track them going forward.

## Out of scope

- **excalidraw**: uses \`:latest\` with no semver release stream. Needs a different approach (or accept the volatility).
- **linkding**: slow-cadence project; current pin is fine.
- **signal-cli**: PR #568 just landed; leaving alone for soak.
- **hermes-agent**: NousResearch publishes dated tags but the deployment intentionally tracks the digest. Renovate already has a digest-bump PR shape for it (see merged #565).
- **Helm chart bumps** (cilium, cert-manager, democratic-csi): each is a known soak surface; should be its own PR.

## Test plan

- [x] \`kustomize build apps/production/<app>\` passes for every modified app.
- [ ] After merge + Flux reconcile (~10 min), verify all 10 deployments roll cleanly:
  - immich-server + immich-machine-learning are real image swaps; expect a brief pod restart on each.
  - The other 8 are no-op image refs (same digest); pod template hash is unchanged → no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-merge correction (added 2026-05-09)

The claim under **Test plan** that 8 of the apps are *no-op image refs (same digest); pod template hash is unchanged → no restart* was **incorrect**. Kubernetes hashes the **image string**, not just the digest, when computing the pod-template hash. Adding a tag prefix changes the string from `registry/repo@sha256:X` to `registry/repo:tag@sha256:X` — a different string, even if it resolves to the same content — so all 10 deployments rolled, not just the 2 with real version bumps.

Verified after the actual rollout:
- All 10 affected pods restarted on Flux reconcile (~4 min after merge)
- All came up clean (same digest = identical image content)
- One unrelated incident: the `immich-machine-learning` pod had been wedged for 4d21h pre-merge (failing probes, refusing to terminate); the rollout collided with it and required a force-delete to clear

Future rollouts of the same shape (tag-prefix-only, no digest change) should expect a one-shot restart of every affected app, not zero. Worth coordinating with maintenance windows for stateful workloads.

Follow-up PR: #579 propagates the tag prefix into the production immich-ml override that was missed by the sweep.