### PR TITLE
fix(vllm): tool-call-parser hermes → qwen3_xml for Qwen3.6 family

### DIFF
--- a/hosts/hestia/llms/docker-compose-vllm.yml
+++ b/hosts/hestia/llms/docker-compose-vllm.yml
@@ -44,7 +44,7 @@ services:
         --enable-chunked-prefill
         --max-num-seqs 4
         --enable-auto-tool-choice
-        --tool-call-parser hermes
+        --tool-call-parser qwen3_xml
         --trust-remote-code
         >> /root/.cache/huggingface/vllm.log 2>&1
     container_name: vllm


### PR DESCRIPTION
## Summary

Tool calling against the production text endpoint was silently broken. Switching the tool-call parser from \`hermes\` to \`qwen3_xml\` fixes it.

## Symptom

Hermes (the local CLI agent) wasn't getting tool calls back from the vLLM endpoint. Probe with a standard OpenAI \`tools\` array → \`tool_choice: auto\` payload returned:

\`\`\`json
{
  "finish_reason": "stop",
  "tool_calls": [],
  "content": "Thinking Process: ...\n<tool_call>\n<function=get_weather>\n<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
}
\`\`\`

## Root cause

\`cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit\` was fine-tuned to emit **XML-style** tool calls (the format above), not the Nous Hermes JSON format that \`--tool-call-parser hermes\` expects. The hermes parser tried to JSON-decode the XML and threw \`JSONDecodeError: Expecting value\` (visible in the vllm.log). Result: empty \`tool_calls\` array, raw XML stuck in \`content\`. The model was right; the parser was wrong.

vLLM v0.20.1 ships \`qwen3_xml\` specifically for this dialect.

## Fix

One-line compose change: \`--tool-call-parser hermes\` → \`--tool-call-parser qwen3_xml\`.

## Verified

Re-ran the same probe against the running endpoint after the switch:

\`\`\`json
{
  "finish_reason": "tool_calls",
  "tool_calls": [
    {
      "id": "chatcmpl-tool-...",
      "type": "function",
      "function": {
        "name": "get_weather",
        "arguments": "{\"city\": \"Tokyo\"}"
      }
    }
  ]
}
\`\`\`

Standard OpenAI shape. Hermes will pick this up correctly.

## Test plan

- [x] Live SCALE app updated via midclt; vllm redeployed; \`/health\` 200
- [x] Tool-call probe now returns properly-shaped \`tool_calls\` array with \`finish_reason: "tool_calls"\`
- [x] No regression in plain text responses (medium decode still ~192 t/s — same model, same other flags)
- [ ] Reviewed for merge

## Out of scope

The model still includes a "Thinking Process: ... </think>" preamble in the \`content\` field of every response despite \`chat_template_kwargs.enable_thinking: false\`. Doesn't break tool calling (hermes uses the structured \`tool_calls\` field on tool-call turns) but may leak into UI on plain text turns. Separate fix.

## Cross-references

- Phase 6 v2 promotion (where the original \`hermes\` parser was set): #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)