### PR TITLE
fix(immich): add :v2.7.5 tag prefix to production ML image override

### DIFF
--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -151,7 +151,12 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning@sha256:35b56970279afa31009822609f03fc892effe0107fdb796e5dae57979dc3267c
+          # Per-arch (linux/amd64) digest of :v2.7.5; this overrides the base
+          # multi-arch index pin so the GPU-accelerated build runs in production.
+          # When bumping: update both the tag and the digest from
+          # `docker manifest inspect ghcr.io/immich-app/immich-machine-learning:vX.Y.Z`
+          # → pick the linux/amd64 entry's digest.
+          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:35b56970279afa31009822609f03fc892effe0107fdb796e5dae57979dc3267c
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
## Summary

PR #575 added tag prefixes to digest-only image refs across ~10 apps so renovate could track them. The production overlay's \`apps/production/immich/deployment-patch.yaml\` hardcodes a per-arch (linux/amd64) digest for \`immich-machine-learning\` (for GPU acceleration), which **overrides** the base-layer change — and that override didn't get the tag prefix in the sweep.

This PR fixes the gap so renovate can follow the production ML pin.

## What changed

\`\`\`diff
- image: ghcr.io/immich-app/immich-machine-learning@sha256:35b56970...
+ # Per-arch (linux/amd64) digest of :v2.7.5; this overrides the base
+ # multi-arch index pin so the GPU-accelerated build runs in production.
+ # When bumping: update both the tag and the digest from
+ # \`docker manifest inspect ghcr.io/immich-app/immich-machine-learning:vX.Y.Z\`
+ # → pick the linux/amd64 entry's digest.
+ image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:35b56970...
\`\`\`

Same image content (digest unchanged) — pod spec hash WILL change because the image string differs, so expect a single rolling restart of \`immich-machine-learning\` on Flux reconcile.

## Why the dual pin

| Where | Image ref | Why |
|---|---|---|
| \`apps/base/immich/deployment.yaml\` | \`:v2.7.5@sha256:a2501141\` (multi-arch index) | Ergonomic for non-GPU clusters / staging |
| \`apps/production/immich/deployment-patch.yaml\` | \`:v2.7.5@sha256:35b56970\` (linux/amd64-specific) | GPU-accelerated build runs only on the prod nodes |

Both pin to v2.7.5; one is the index, one is the per-arch digest of that index.

## Test plan

- [x] \`kustomize build apps/production/immich\` passes; rendered image is \`:v2.7.5@sha256:35b56970...\`
- [ ] After merge + Flux reconcile, the immich-ml pod rolls cleanly (single restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)