### PR TITLE
feat: monitoring enhancement plan

### DIFF
--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -60,11 +60,11 @@ For each of the 23 workload apps, determine whether the running image exposes a 
 
 The rule: **only create an SM for an app that actually exposes `/metrics`.** Pod readiness, restart counts, and uptime for apps without `/metrics` are already covered by kube-state-metrics. Adding an SM that scrapes a 404 produces permanent `up=0` noise and false alerts.
 
-Best-effort triage (must verify image-by-image — do not skip):
+**Hints, not the audit result — verify each before drawing conclusions.** The grouping below is a starting point from documentation review; upstream behavior may have changed.
 
-- **Likely yes:** `hermes`, `hermes-callee`, `golinks` (verify), `authelia` (existing SM), `signal-cli` (existing SM), `synology-iscsi-monitor` (existing), `truenas-iscsi-monitor` (existing), `overture` (verify), `vitals` (small custom exporter — verify).
-- **Conditional / requires upstream config flag or sidecar:** `homeassistant` (Prometheus integration must be enabled in `configuration.yaml`), `jellyfin` (community plugin only), `immich` (no native endpoint).
-- **Likely no:** `navidrome`, `audiobookshelf`, `snapcast`, `mealie`, `linkding`, `memos`, `homepage`, `excalidraw`, `adguard`, `openwebui` (verify), `cloudflare-tunnel`.
+- _Hints toward yes:_ `hermes`, `hermes-callee`, `golinks`, `authelia` (SM exists), `signal-cli` (SM exists), `synology-iscsi-monitor` (SM exists), `truenas-iscsi-monitor` (SM exists), `overture`, `vitals`.
+- _Hints toward conditional (upstream config flag or sidecar):_ `homeassistant` (Prometheus integration must be enabled in `configuration.yaml`), `jellyfin` (community plugin only), `immich` (no native endpoint).
+- _Hints toward no:_ `navidrome`, `audiobookshelf`, `snapcast`, `mealie`, `linkding`, `memos`, `homepage`, `excalidraw`, `adguard`, `openwebui`, `cloudflare-tunnel`.
 
 The audit determines the actual count of new SMs. Do not commit to "N apps need SMs" until §1.1 is done.
 
@@ -126,56 +126,65 @@ Source: read `apps/base/signal-cli/deployment.yaml` and the upstream image docs.
 
 **Option A — direct Alertmanager webhook to signal-cli-rest-api.** Tempting but does not work cleanly: Alertmanager's webhook payload is `{alerts: [{labels, annotations, status, …}, …]}`, while signal-cli-rest-api expects `{number, recipients, message}`. Alertmanager `webhook_configs` has no body-templating field — only the URL. A direct POST will fail or render an unreadable payload.
 
-**Option B (chosen) — small relay.** A ~50-line Go or Python service receiving Alertmanager webhooks, formatting one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTing to signal-cli-rest-api. Deploy alongside signal-cli in the same namespace, reusing its credentials secret.
+**Option B (chosen) — small relay.** A ~50-line Python service (mirroring the `apps/base/synology-iscsi-monitor/script-cm.yaml` pattern: ConfigMap-embedded script, `prometheus_client` for metrics, plain `http.server` or `aiohttp` for the webhook handler). It receives Alertmanager webhooks, formats one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTs to signal-cli-rest-api.
+
+**Placement:** `infra/controllers/alertmanager-signal-relay/` in the existing `monitoring` namespace, colocated with kube-prometheus-stack/Alertmanager. Rationale: this is alerting plumbing, not a user-facing workload — it belongs with the monitoring stack, not under `apps/`. No HelmRelease (custom code, not an upstream chart); plain Kustomize.
+
+**No staging overlay** — singleton relay, follows the synology-iscsi-monitor pattern. Production-only.
 
 Files to create:
 
 ```
-apps/base/alertmanager-signal-relay/
+infra/controllers/alertmanager-signal-relay/
 ├── kustomization.yaml
 ├── deployment.yaml         # single container, /alert POST endpoint, /metrics endpoint
-├── service.yaml            # ClusterIP :8080
+├── service.yaml            # ClusterIP :8080 in namespace monitoring
 ├── servicemonitor.yaml     # so the relay's own delivery counters are scraped
+├── script-cm.yaml          # embedded Python relay script
 └── README.md
-apps/production/alertmanager-signal-relay/
-└── kustomization.yaml
 ```
+
+Then add `- alertmanager-signal-relay` to `infra/controllers/kustomization.yaml`.
+
+**Configuration** (env vars, no secrets — the bridge holds the Signal credentials, the relay only needs the bridge URL):
+
+- `SIGNAL_BRIDGE_URL` — `http://signal-cli-rest-api.signal-cli.svc.cluster.local:<port>/v2/send` (port from §2.1).
+- `SIGNAL_RECIPIENT_NUMBER` — destination phone number, sourced from a non-secret ConfigMap value or hardcoded in the manifest (it's a phone number, not a credential).
+- `SIGNAL_FROM_NUMBER` — sender, same source.
+
+**Webhook URL** for Alertmanager (used in §2.3): `http://alertmanager-signal-relay.monitoring.svc.cluster.local:8080/alert`.
 
 The relay exposes `alertmanager_signal_relay_messages_sent_total` and `_failed_total` counters. We alert on `_failed_total > 0` to avoid silent swallowing of critical alerts (see §2.5).
 
 ### 2.3 Update values.yaml
 
-Replace the `config:` block at `infra/controllers/kube-prometheus-stack/values.yaml:508`:
+Edit `infra/controllers/kube-prometheus-stack/values.yaml` (the `alertmanager.config:` block starts at line 508; the `inhibit_rules` and `templates` sections **must remain intact** — only modify `route:` and `receivers:`).
 
-```yaml
-config:
-  global:
-    resolve_timeout: 5m
-  inhibit_rules:
-    # …existing inhibit rules unchanged…
-  route:
-    group_by: ['namespace', 'alertname']
-    group_wait: 30s
-    group_interval: 5m
-    repeat_interval: 12h
-    receiver: 'null'
-    routes:
-      - receiver: 'null'
-        matchers:
-          - alertname = "Watchdog"
-      - receiver: 'signal-critical'
-        matchers:
-          - severity = "critical"
-        continue: false
-  receivers:
-    - name: 'null'
-    - name: 'signal-critical'
-      webhook_configs:
-        - url: http://alertmanager-signal-relay.signal-cli.svc.cluster.local:8080/alert
-          send_resolved: true
-  templates:
-    - '/etc/alertmanager/config/*.tmpl'
-```
+**Diff-style instruction (do not replace the whole `config:` block):**
+
+1. **Update `config.route.group_by`** from `['namespace']` to `['namespace', 'alertname']` (line 537).
+
+2. **Add a new route** under `config.route.routes:` (before the closing of `routes:`, after the existing Watchdog entry around line 543):
+
+   ```yaml
+         - receiver: 'signal-critical'
+           matchers:
+             - severity = "critical"
+           continue: false
+   ```
+
+3. **Add a new receiver** under `config.receivers:` (after the existing `- name: 'null'` at line 545):
+
+   ```yaml
+       - name: 'signal-critical'
+         webhook_configs:
+           - url: http://alertmanager-signal-relay.monitoring.svc.cluster.local:8080/alert
+             send_resolved: true
+   ```
+
+4. **Do not touch** `inhibit_rules:` (lines 511–533) or `templates:` (line 547). They stay as-is.
+
+After editing, the diff against `origin/master` should be limited to the four small edits above. Run `git diff infra/controllers/kube-prometheus-stack/values.yaml` to confirm the inhibit rules are unchanged.
 
 ### 2.4 Test
 
@@ -201,7 +210,15 @@ Without this, a relay outage swallows every critical alert and we'd never know.
 
 ## Phase 3 — PrometheusRules for Flux reconciliation
 
-Pre-flight: confirm `gotk_reconcile_condition` is being scraped. The Flux controllers expose Prometheus metrics on port 8080. If `up{job=~".*flux.*"}` returns nothing, add a ServiceMonitor for the Flux controllers under `infra/controllers/flux-system/` first; otherwise the rules below evaluate to `vector()` and never fire.
+### 3.1 Pre-flight: confirm Flux metrics are scraped
+
+The rules below depend on `gotk_reconcile_condition`, emitted by the Flux controllers. Before writing the rules:
+
+1. Query Prometheus: `up{job=~".*flux.*"}` and `count(gotk_reconcile_condition)`.
+2. If both return data, proceed to §3.2.
+3. If either is empty, add a ServiceMonitor for the Flux controllers (under `infra/controllers/flux-system/` or wherever Flux is deployed in this repo). The Flux controllers conventionally expose metrics on port 8080, but verify against the actual Service spec before assuming. Without this scrape coverage, the rules below evaluate to `vector()` and never fire.
+
+### 3.2 Add the rules
 
 Add to `infra/configs/alerts/prometheus-rules.yaml`:
 

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -33,7 +33,7 @@ This plan does not supersede or extend either. Dashboard work is intentionally o
 | File | Has `release: kube-prometheus-stack` label? | Notes |
 |------|---------------------------------------------|-------|
 | `apps/base/authelia/servicemonitor.yaml` | **No** — broken discovery | Likely not scraped today; see §1.2 |
-| `apps/base/signal-cli/servicemonitor.yaml` | (verify) | |
+| `apps/base/signal-cli/servicemonitor.yaml` | **No** — broken discovery | Same fix as authelia; see §1.2 |
 | `apps/base/synology-iscsi-monitor/servicemonitor.yaml` | Yes | 60s interval, namespaceSelector set |
 | `apps/base/truenas-iscsi-monitor/servicemonitor.yaml` | Yes | |
 
@@ -73,7 +73,7 @@ The audit determines the actual count of new SMs. Do not commit to "N apps need 
 ### 1.2 Fix existing SMs
 
 - `apps/base/authelia/servicemonitor.yaml`: add `release: kube-prometheus-stack` to `metadata.labels`. Verify discovery before/after with `kubectl get servicemonitor -A -l release=kube-prometheus-stack` and the Prometheus targets page.
-- `apps/base/signal-cli/servicemonitor.yaml`: confirm the label is present; add if missing.
+- `apps/base/signal-cli/servicemonitor.yaml`: same fix — `metadata.labels` currently has only `{app: signal-cli}`. Add `release: kube-prometheus-stack`.
 
 ### 1.3 Create new SMs (count from §1.1 audit)
 
@@ -194,7 +194,11 @@ After editing, `git diff infra/controllers/kube-prometheus-stack/values.yaml` sh
 1. Confirm the relay's metrics are exposed:
    ```bash
    kubectl -n monitoring port-forward svc/alertmanager-signal-relay 8080:8080 &
+   PF=$!
+   trap 'kill $PF 2>/dev/null' EXIT
+   sleep 1
    curl -s localhost:8080/metrics | grep -E '^alertmanager_signal_relay_messages_(sent|failed)_total'
+   kill $PF; trap - EXIT
    ```
    Both metric families must appear (even with value `0`). If either is missing, the relay was implemented incorrectly — the §2.5 self-monitoring rule depends on these names.
 2. Lower the threshold on an existing alert rule to force a critical fire (or pick one already firing — query `ALERTS{severity="critical",alertstate="firing"}`).
@@ -271,8 +275,8 @@ The 15m `for` window suppresses noise from transient reconciliation failures dur
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
-| Adding `release` label to authelia SM begins firing alerts that were silently suppressed before | Medium | Low | Add the SM fix in its own commit; observe one hour before adding any new rules. |
-| Relay outage silently drops critical alerts | Medium | High | `AlertmanagerSignalRelayFailing` rule (§2.5). |
+| Adding `release` label to authelia or signal-cli SM begins firing alerts that were silently suppressed before | Medium | Low | Land each SM label fix in its own commit; observe for one hour before adding any new rules. |
+| Relay outage silently drops critical alerts | Medium | High | Both `AlertmanagerSignalRelayFailing` (delivery errors) and `AlertmanagerSignalRelayDown` (`up == 0`) rules in §2.5. |
 | Flux rules fire during this PR's own rollout | Medium | Medium | `for: 15m` window already mitigates; merge rules after relay is verified. |
 | `up=0` from an SM whose target lacks `/metrics` | Medium | Low | §1.5 explicitly checks; remove SM rather than chase. |
 

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -127,9 +127,9 @@ Action: read the gjcourt/signal-bridge image source (or its README) to record th
 
 ### 2.2 Pick routing strategy
 
-**Option A — direct Alertmanager webhook to signal-cli-rest-api.** Tempting but does not work cleanly: Alertmanager's webhook payload is `{alerts: [{labels, annotations, status, …}, …]}`, while signal-cli-rest-api expects `{number, recipients, message}`. Alertmanager `webhook_configs` has no body-templating field — only the URL. A direct POST will fail or render an unreadable payload.
+**Option A — direct Alertmanager webhook to signal-cli-bridge.** Doesn't work, regardless of bridge contract: Alertmanager `webhook_configs` posts a fixed `{alerts: [{labels, annotations, status, …}, …]}` JSON body to the configured URL, with **no body-templating field**. Whatever shape signal-cli-bridge accepts, Alertmanager won't produce it directly. A relay is required to translate the payload.
 
-**Option B (chosen) — small relay.** A ~50-line Python service mirroring the *script structure* of `apps/base/synology-iscsi-monitor/script-cm.yaml` — ConfigMap-embedded script, `prometheus_client` for metrics, plain `http.server` or `aiohttp` for the webhook handler. Placement differs from synology-iscsi-monitor (relay is alerting infrastructure, not a workload). It receives Alertmanager webhooks, formats one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTs to signal-cli-rest-api.
+**Option B (chosen) — small relay.** A ~50-line Python service mirroring the *script structure* of `apps/base/synology-iscsi-monitor/script-cm.yaml` — ConfigMap-embedded script, `prometheus_client` for metrics, plain `http.server` or `aiohttp` for the webhook handler. Placement differs from synology-iscsi-monitor (relay is alerting infrastructure, not a workload). It receives Alertmanager webhooks, formats one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTs to signal-cli-bridge.
 
 **Placement:** `infra/controllers/alertmanager-signal-relay/` in the existing `monitoring` namespace, colocated with kube-prometheus-stack/Alertmanager. Rationale: this is alerting plumbing, not a user-facing workload — it belongs with the monitoring stack, not under `apps/`. No HelmRelease (custom code, not an upstream chart); plain Kustomize.
 
@@ -157,7 +157,7 @@ Then add `- alertmanager-signal-relay` to `infra/controllers/kustomization.yaml`
 
 **Webhook URL** for Alertmanager (used in §2.3): `http://alertmanager-signal-relay.monitoring.svc.cluster.local:8080/alert`.
 
-The relay exposes `alertmanager_signal_relay_messages_sent_total` and `_failed_total` counters. We alert on `_failed_total > 0` to avoid silent swallowing of critical alerts (see §2.5).
+The relay exposes `alertmanager_signal_relay_messages_sent_total` and `_failed_total` counters and is itself scraped via the SM above. §2.5 alerts on **both** `_failed_total > 0` (delivery errors while the relay is up) and `up == 0` (relay pod gone), so neither failure mode silently swallows critical alerts.
 
 ### 2.3 Update values.yaml
 

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -1,323 +1,266 @@
 ---
-name: "Homelab Monitoring & Healthcheck Enhancement"
-date: "2026-05-09"
-status: "draft"
-author: "George Courtsunis + Hermes"
+status: draft
+last_modified: 2026-05-09
 ---
 
-# Homelab Monitoring & Healthcheck Enhancement
+# Monitoring Coverage & Signal Routing
 
 ## Overview
 
-Extend the existing kube-prometheus-stack monitoring to provide full observability across all 21 production apps, add a healthcheck Deployment for cluster-level synthetic metrics, and configure Alertmanager-to-Signal routing for on-call notifications. The current stack is well-architected but has two gaps: 18 apps lack ServiceMonitors (invisible to Prometheus), and there are no cluster healthcheck metrics or Signal alert routing beyond what Hermes uses.
+Close two specific gaps in the existing kube-prometheus-stack deployment:
 
-This plan covers ServiceMonitors for all apps, a healthcheck Deployment, Alertmanager Signal routing, and new Grafana dashboards — all delivered via Flux GitOps.
+1. **ServiceMonitor coverage** — most workload apps that could expose `/metrics` aren't scraped. One existing SM (authelia) is also missing the release label that makes Prometheus discover it.
+2. **Critical-alert routing to Signal** — Alertmanager currently routes every alert to a `null` receiver. Wire `severity=critical` alerts through the existing signal-cli bridge.
 
-**Why now:** The homelab has grown to 21 production apps. Without ServiceMonitors, most apps are invisible to Prometheus — CrashLoopBackOff on a non-monitored app would only be caught by the generic K8s alert (which fires on any namespace). The healthcheck metrics will give a single-pane view of cluster synthetic health.
+This plan **does not** add new dashboards or a custom healthcheck exporter — see [Out of scope](#out-of-scope-deliberately) for why.
 
-## Requirements
+## Relationship to prior plans
 
-### Functional
-- All 21 production apps are scraped by Prometheus via ServiceMonitors
-- Healthcheck metrics are exposed and visible in Grafana
-- Critical alerts (node NotReady, CrashLoopBackOff, PVC > 90%, Flux reconciliation failure, BGP session down) route to Signal
-- Warning alerts (CPU > 90%, OOMKilled, DaemonSet not ready, CNPG degraded) log to Loki and show in Grafana
-- Informational alerts (weekly health digest) are emailed
+- `docs/plans/2026-02-21-app-health-dashboards-plan.md` — `status: complete`. Generic Application Health dashboard is deployed.
+- `docs/plans/2026-02-21-cluster-health-dashboards-plan.md` — `status: complete`. Cluster Overview, Node Details, Storage & CSI, Networking & Gateway, and Control Plane dashboards are deployed.
 
-### Non-functional
-- All changes via Flux GitOps — no manual `kubectl`
-- High-priority apps scraped at 15s, normal apps at 30s
-- Healthcheck Deployment runs lightweight Python script, exposes `/metrics` on port 9100
-- Signal integration reuses existing signal-bridge HTTP API (port 8080)
-- New ServiceMonitors follow the existing pattern (`apps/base/<app>/servicemonitor.yaml`)
-- New Grafana dashboards follow the existing pattern (`infra/configs/dashboards/<name>-cm.yaml`)
-- PrometheusRules follow the existing pattern (`infra/configs/alerts/prometheus-rules.yaml`)
+This plan does not supersede or extend either. Dashboard work is intentionally out of scope.
 
-### Priority tiers for scrape intervals
-- **High (15s):** openwebui, homeassistant, hermes, signal-cli, golinks, immich, jellyfin
-- **Normal (30s):** adguard, audiobookshelf, authelia, excalidraw, hermes-callee, homepage, linkding, mealie, memos, navidrome, overture, snapcast, vitals, synology-iscsi-monitor
+## Ground truth (verified against `origin/master` at 2026-05-09)
 
-## Architecture
+### Apps in `apps/production/kustomization.yaml` (25 entries)
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                    Flux Kustomization                         │
-│  infra/ → controllers/kube-prometheus-stack/ (HelmRelease)   │
-│  infra/ → configs/servicemonitors/ (new: SM CRs)             │
-│  infra/ → configs/dashboards/ (new dashboard ConfigMaps)     │
-│  apps/production/ → base/*/servicemonitor.yaml (new)         │
-└──────────────────┬───────────────────────────────────────────┘
-                   │
-                   ▼
-┌──────────────────────────────────────────────────────────────┐
-│                      Cluster                                 │
-│                                                              │
-│  ┌─────────────┐   ┌─────────────────┐   ┌───────────────┐  │
-│  │ Healthcheck  │   │  kube-prometheus│   │  App Pods     │  │
-│  │ Deployment   │──▶│  -stack         │   │  (21 apps)    │  │
-│  │              │   │  Prometheus     │   │               │  │
-│  │ /metrics     │   │  Grafana        │   │ ServiceMonitor│  │
-│  │ :9100        │   │  Alertmanager   │   │  (15s/30s)    │  │
-│  └─────────────┘   │                 │   └───────┬───────┘  │
-│                    └────────┬────────┘           │          │
-│                             │                    │          │
-│                    ┌────────▼────────┐   ┌───────▼───────┐  │
-│                    │  Loki           │   │  signal-bridge│  │
-│                    │  Promtail       │   │  :8080        │  │
-│                    └─────────────────┘   │  /v1/send     │  │
-│                                          └───────┬───────┘  │
-│                                                  │          │
-└──────────────────────────────────────────────────┼──────────┘
-                                                   │
-                                          ┌──────▼───────┐
-                                          │  signal-cli   │
-                                          │  (JSON-RPC)   │
-                                          │  :7583        │
-                                          └──────────────┘
-```
+- **Workload apps (23):** `adguard`, `audiobookshelf`, `authelia`, `cloudflare-tunnel`, `excalidraw`, `golinks`, `hermes`, `hermes-callee`, `homeassistant`, `homepage`, `immich`, `jellyfin`, `linkding`, `mealie`, `memos`, `navidrome`, `openwebui`, `overture`, `signal-cli`, `snapcast`, `synology-iscsi-monitor`, `truenas-iscsi-monitor`, `vitals`.
+- **Kustomize aggregator entries excluded from SM scope (2):** `certificates`, `external-services`. These are infra resource bundles, not workloads.
 
-### Data flow
-1. **Scrape:** Prometheus scrapes all 21 apps via ServiceMonitors + healthcheck Deployment + built-in exporters (node-exporter, kube-state-metrics, cAdvisor)
-2. **Rules:** PrometheusRule alerts fire on thresholds (existing custom rules + new healthcheck rules)
-3. **Alertmanager:** Routes alerts to receivers based on severity (Signal for critical, Loki for warning, null for info)
-4. **Signal bridge:** Alertmanager HTTP webhook → signal-bridge → signal-cli → Signal message
-5. **Dashboards:** Grafana visualizes metrics from Prometheus + healthcheck metrics
+### Existing ServiceMonitors on `origin/master` (4)
 
-## Implementation Plan
+| File | Has `release: kube-prometheus-stack` label? | Notes |
+|------|---------------------------------------------|-------|
+| `apps/base/authelia/servicemonitor.yaml` | **No** — broken discovery | Likely not scraped today; see §1.2 |
+| `apps/base/signal-cli/servicemonitor.yaml` | (verify) | |
+| `apps/base/synology-iscsi-monitor/servicemonitor.yaml` | Yes | 60s interval, namespaceSelector set |
+| `apps/base/truenas-iscsi-monitor/servicemonitor.yaml` | Yes | |
 
-### Phase 1: ServiceMonitors for all 18 apps without them
+### SM discovery mechanic
 
-**Goal:** Create ServiceMonitors for all 21 production apps. Three already exist (authelia, signal-cli, synology-iscsi-monitor). 18 need to be created.
+`infra/controllers/kube-prometheus-stack/values.yaml:4146` sets `serviceMonitorSelectorNilUsesHelmValues: true` and the explicit `serviceMonitorSelector: {}` is empty. Combined, this means Prometheus selects ServiceMonitors whose `release` label matches the Helm release name — **`release: kube-prometheus-stack` is required**. SMs without it are silently ignored.
 
-**Pattern:** Follow existing convention — each `apps/base/<app>/servicemonitor.yaml` is referenced by the production Kustomization via `apps/base/<app>/kustomization.yaml`.
+### Alertmanager config
 
-**Tasks:**
+Already in Git at `infra/controllers/kube-prometheus-stack/values.yaml:508–547`. Current routing: every alert → receiver `null`; one explicit route for `Watchdog` → `null`. No webhook receivers configured. There is no out-of-Git ConfigMap to discover.
 
-1. **Audit each app's service to determine metrics endpoint**
-   - Inspect each app's `service.yaml` and `deployment.yaml` in `apps/base/<app>/` to find the port name and targetPort that exposes metrics
-   - Many apps don't expose metrics (immich, jellyfin, navidrome, audiobookshelf, snapcast) — create ServiceMonitors anyway for readiness/liveness probe visibility, note that they won't produce application-level metrics
-   - Document findings in PR description
+### kube-state-metrics
 
-2. **Create ServiceMonitors in `apps/base/<app>/servicemonitor.yaml`**
-   - For high-priority apps: `interval: 15s`
-   - For normal-priority apps: `interval: 30s`
-   - Label with `scrape-priority: high` or `scrape-priority: normal` for dashboard filtering
-   - 14 high-priority ServiceMonitors, 4 normal-priority ServiceMonitors
+Deployed (`infra/controllers/kube-prometheus-stack/values.yaml`: `kubeStateMetrics: true`). Emits `kube_pod_status_ready`, `kube_node_status_condition`, `kubelet_volume_stats_used_bytes`/`_capacity_bytes`, `kube_deployment_status_replicas_available`, etc. Anything we'd want from a hand-rolled "healthcheck exporter" for pod/node/PVC state is already there.
 
-**Files to create (18 ServiceMonitors):**
-```
-apps/base/adguard/servicemonitor.yaml                    (normal)
-apps/base/audiobookshelf/servicemonitor.yaml              (normal)
-apps/base/excalidraw/servicemonitor.yaml                  (normal)
-apps/base/golinks/servicemonitor.yaml                     (high)
-apps/base/hermes/servicemonitor.yaml                      (high)
-apps/base/hermes-callee/servicemonitor.yaml               (high)
-apps/base/homeassistant/servicemonitor.yaml               (high)
-apps/base/homepage/servicemonitor.yaml                    (high)
-apps/base/immich/servicemonitor.yaml                      (high)
-apps/base/jellyfin/servicemonitor.yaml                    (high)
-apps/base/linkding/servicemonitor.yaml                    (normal)
-apps/base/mealie/servicemonitor.yaml                      (normal)
-apps/base/memos/servicemonitor.yaml                       (high)
-apps/base/navidrome/servicemonitor.yaml                   (high)
-apps/base/openwebui/servicemonitor.yaml                   (high)
-apps/base/overture/servicemonitor.yaml                    (high)
-apps/base/snapcast/servicemonitor.yaml                    (normal)
-apps/base/vitals/servicemonitor.yaml                      (high)
-```
+## Phase 1 — ServiceMonitor coverage
 
-**Template:**
+### 1.1 Audit (must precede §1.3)
+
+For each of the 23 workload apps, determine whether the running image exposes a Prometheus `/metrics` endpoint and on what port. Record findings in the PR description as a table:
+
+| app | exposes-metrics | port name | port number | sample metric | source |
+|-----|-----------------|-----------|-------------|---------------|--------|
+
+The rule: **only create an SM for an app that actually exposes `/metrics`.** Pod readiness, restart counts, and uptime for apps without `/metrics` are already covered by kube-state-metrics. Adding an SM that scrapes a 404 produces permanent `up=0` noise and false alerts.
+
+Best-effort triage (must verify image-by-image — do not skip):
+
+- **Likely yes:** `hermes`, `hermes-callee`, `golinks` (verify), `authelia` (existing SM), `signal-cli` (existing SM), `synology-iscsi-monitor` (existing), `truenas-iscsi-monitor` (existing), `overture` (verify), `vitals` (small custom exporter — verify).
+- **Conditional / requires upstream config flag or sidecar:** `homeassistant` (Prometheus integration must be enabled in `configuration.yaml`), `jellyfin` (community plugin only), `immich` (no native endpoint).
+- **Likely no:** `navidrome`, `audiobookshelf`, `snapcast`, `mealie`, `linkding`, `memos`, `homepage`, `excalidraw`, `adguard`, `openwebui` (verify), `cloudflare-tunnel`.
+
+The audit determines the actual count of new SMs. Do not commit to "N apps need SMs" until §1.1 is done.
+
+### 1.2 Fix existing SMs
+
+- `apps/base/authelia/servicemonitor.yaml`: add `release: kube-prometheus-stack` to `metadata.labels`. Verify discovery before/after with `kubectl get servicemonitor -A -l release=kube-prometheus-stack` and the Prometheus targets page.
+- `apps/base/signal-cli/servicemonitor.yaml`: confirm the label is present; add if missing.
+
+### 1.3 Create new SMs (count from §1.1 audit)
+
+Canonical template. The `release` label is **required**:
+
 ```yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: <app-name>
+  name: <app>
   namespace: <namespace>
   labels:
-    app: <app-name>
+    app: <app>
     release: kube-prometheus-stack
-    scrape-priority: <high|normal>
 spec:
   selector:
     matchLabels:
-      app: <app-name>
+      app: <app>
   endpoints:
     - port: <metrics-port-name>
       path: /metrics
-      interval: <15s|30s>
+      interval: 30s
       scrapeTimeout: 10s
 ```
 
-3. **Verify Prometheus discovers new ServiceMonitors**
-   - After Flux applies, check Prometheus target discovery (`/targets` in Grafana)
-   - Confirm all 21 apps appear as targets
+Use a uniform `interval: 30s` until a measured reason exists to vary. The existing synology-iscsi-monitor SM at 60s stays as-is — it's tuned for that exporter's scrape cost. The `scrape-priority` label introduced in earlier drafts is dropped: there is no Grafana variable that consumes it, and label proliferation without a consumer is a maintenance liability. Reintroduce only with a concrete dashboard query that uses it.
 
-### Phase 2: Healthcheck Deployment
+### 1.4 Wiring
 
-**Goal:** A lightweight Deployment that runs periodic cluster health checks and exposes synthetic metrics to Prometheus.
+For each new SM, add `- servicemonitor.yaml` to `apps/base/<app>/kustomization.yaml`. Then `kustomize build apps/production/<app>` must pass before pushing.
 
-**Rationale for Deployment over CronJob:** CronJobs are ephemeral and can't be scraped by Prometheus. A Deployment runs continuously, exposes `/metrics` on port 9100, and can be scraped at the same intervals as other apps.
+### 1.5 Verify
 
-**Architecture:**
-- Single Python container (or Go if preferred) with two processes:
-  1. Healthcheck loop: runs every 60s, checks pod readiness, PVC usage, node status
-  2. Metrics server: exposes `/metrics` on port 9100, updated by the healthcheck loop
-- ServiceMonitors scrape the `/metrics` endpoint
-- Prometheus records the metrics as time-series
+- `kubectl get servicemonitor -A -l release=kube-prometheus-stack` lists the expected count.
+- Prometheus targets page (Grafana → Explore → Prometheus datasource → `up{}`) shows each SM's target as UP.
+- No `up=0` for any new SM. A persistent `up=0` means the audit in §1.1 was wrong for that app — remove the SM rather than chase the 404.
 
-**Healthcheck checks:**
-1. **Pod readiness** — `healthcheck_pod_ready{namespace, pod} = 0|1`
-2. **PVC usage** — `healthcheck_pvc_usage_percent{namespace, pvc} = float`
-3. **Node status** — `healthcheck_node_ready{node} = 0|1`
-4. **Flux reconciliation** — `healthcheck_flux_reconciliation{kind, name, status} = 0|1`
-5. **App uptime** — `healthcheck_app_uptime_seconds{namespace, app} = float`
+## Phase 2 — Critical-alert routing to Signal
 
-**Tasks:**
+### 2.1 Pin down the bridge API
 
-1. **Create deployment manifest** — `infra/controllers/healthcheck/deployment.yaml`
-   - Single container with Python image (e.g., `python:3.12-slim`)
-   - Resource limits: 50m CPU, 128Mi memory
-   - ServiceAccount with read-only access to pods, nodes, pvcs (namespaced)
-   - ConfigMap with healthcheck configuration (check intervals, namespaces to monitor)
+Inspect the running signal bridge container to confirm:
 
-2. **Create healthcheck Python script** — `infra/controllers/healthcheck/healthcheck.py`
-   - Uses `kubernetes` Python client to read pod/node/PVC status
-   - Exposes `/metrics` via `prometheus_client` library
-   - Runs checks every 60s
+- The image is `bbernhard/signal-cli-rest-api` or a custom hermes bridge.
+- The exact endpoint shape (`bbernhard` exposes `/v2/send` with JSON `{number, recipients[], message}`).
+- The in-cluster Service DNS name (likely `signal-cli-rest-api.signal-cli.svc.cluster.local`).
+- Whether auth is required (in-cluster traffic is typically open).
 
-3. **Create Service and ServiceMonitor** — `infra/controllers/healthcheck/service.yaml`, `infra/controllers/healthcheck/servicemonitor.yaml`
-   - Service on port 9100 (http)
-   - ServiceMonitor scraping `/metrics` at 30s interval
+Source: read `apps/base/signal-cli/deployment.yaml` and the upstream image docs. Hermes already calls this endpoint — its source is the authoritative reference.
 
-4. **Create namespace** — `infra/controllers/healthcheck/namespace.yaml` (new `healthcheck` namespace)
+### 2.2 Pick routing strategy
 
-5. **Create HelmRelease for Flux** — `infra/controllers/healthcheck/release.yaml`
-   - Or use kustomize if the healthcheck is simpler than a Helm chart
+**Option A — direct Alertmanager webhook to signal-cli-rest-api.** Tempting but does not work cleanly: Alertmanager's webhook payload is `{alerts: [{labels, annotations, status, …}, …]}`, while signal-cli-rest-api expects `{number, recipients, message}`. Alertmanager `webhook_configs` has no body-templating field — only the URL. A direct POST will fail or render an unreadable payload.
 
-6. **Verify healthcheck metrics are visible in Prometheus**
-   - Check `/metrics` endpoint in Grafana
-   - Verify `healthcheck_pod_ready`, `healthcheck_pvc_usage_percent` etc. are recorded
+**Option B (chosen) — small relay.** A ~50-line Go or Python service receiving Alertmanager webhooks, formatting one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTing to signal-cli-rest-api. Deploy alongside signal-cli in the same namespace, reusing its credentials secret.
 
-### Phase 3: Alertmanager Signal Routing
+Files to create:
 
-**Goal:** Configure Alertmanager to route critical alerts to Signal via the existing signal-bridge.
+```
+apps/base/alertmanager-signal-relay/
+├── kustomization.yaml
+├── deployment.yaml         # single container, /alert POST endpoint, /metrics endpoint
+├── service.yaml            # ClusterIP :8080
+├── servicemonitor.yaml     # so the relay's own delivery counters are scraped
+└── README.md
+apps/production/alertmanager-signal-relay/
+└── kustomization.yaml
+```
 
-**Current state:** Signal is already wired — Hermes agents communicate via signal-bridge (port 8080, JSON-RPC on 7583). The `/v1/send` endpoint (or similar) exists and is used by Hermes.
+The relay exposes `alertmanager_signal_relay_messages_sent_total` and `_failed_total` counters. We alert on `_failed_total > 0` to avoid silent swallowing of critical alerts (see §2.5).
 
-**Tasks:**
+### 2.3 Update values.yaml
 
-1. **Determine signal-bridge alert endpoint**
-   - Confirm the exact HTTP endpoint that signal-bridge uses for sending messages
-   - This is used by Hermes already — check the Hermes deployment or source code for the API format
-   - Expected format: `POST http://signal-bridge.signal-cli.svc.cluster.local:8080/v1/send` with JSON body containing `phone` and `message`
-   - **DEPENDENCY:** Need Hermes signal-bridge API format (ask user or check hermes deployment)
+Replace the `config:` block at `infra/controllers/kube-prometheus-stack/values.yaml:508`:
 
-2. **Create Alertmanager receiver config**
-   - Add a `signal` receiver to the Alertmanager config
-   - Use a `webhook` receiver that POSTs to signal-bridge
-   - Configure the message template for Signal (compact format suitable for chat)
+```yaml
+config:
+  global:
+    resolve_timeout: 5m
+  inhibit_rules:
+    # …existing inhibit rules unchanged…
+  route:
+    group_by: ['namespace', 'alertname']
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 12h
+    receiver: 'null'
+    routes:
+      - receiver: 'null'
+        matchers:
+          - alertname = "Watchdog"
+      - receiver: 'signal-critical'
+        matchers:
+          - severity = "critical"
+        continue: false
+  receivers:
+    - name: 'null'
+    - name: 'signal-critical'
+      webhook_configs:
+        - url: http://alertmanager-signal-relay.signal-cli.svc.cluster.local:8080/alert
+          send_resolved: true
+  templates:
+    - '/etc/alertmanager/config/*.tmpl'
+```
 
-3. **Create webhook relay (if needed)**
-   - If signal-bridge doesn't have a direct Alertmanager-compatible webhook endpoint, create a small relay
-   - Options:
-     a. Small Go/Python service in-cluster that converts Alertmanager webhook to signal-bridge API call
-     b. Use Alertmanager's `url` field to POST directly to signal-bridge if it accepts the format
-   - Deploy via `infra/controllers/` (or add as sidecar to signal-bridge if feasible)
+### 2.4 Test
 
-4. **Update Alertmanager routing**
-   - Critical alerts → Signal receiver
-   - Warning alerts → Loki (already via default route)
-   - Info alerts → null (email digest handled separately)
+1. Lower the threshold on an existing alert rule to force a critical fire (or pick one already firing — query `ALERTS{severity="critical",alertstate="firing"}`).
+2. Confirm the Signal message arrives within 5 minutes.
+3. Restore the threshold; confirm the resolved message arrives.
 
-5. **Test end-to-end alert flow**
-   - Trigger a test alert (e.g., set a Deployment to CrashLoopBackOff)
-   - Verify Signal message is received
-   - Verify warning alerts appear in Grafana
+### 2.5 Self-monitoring (mandatory)
 
-### Phase 4: Grafana Dashboards
+Add to `infra/configs/alerts/prometheus-rules.yaml`:
 
-**Goal:** Add new Grafana dashboards for healthcheck metrics and app-level overview.
+```yaml
+- alert: AlertmanagerSignalRelayFailing
+  expr: increase(alertmanager_signal_relay_messages_failed_total[5m]) > 0
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Signal alert relay failing — critical alerts may be silently dropped"
+```
 
-**Tasks:**
+Without this, a relay outage swallows every critical alert and we'd never know.
 
-1. **Cluster health dashboard** — `infra/configs/dashboards/cluster-health-cm.yaml`
-   - Panels for: pod readiness summary, PVC usage heatmap, node status, Flux reconciliation status
-   - Uses healthcheck metrics as primary data source
-   - Follows existing ConfigMap pattern with `grafana_dashboard: "1"` label
+## Phase 3 — PrometheusRules for Flux reconciliation
 
-2. **App health dashboard** — `infra/configs/dashboards/app-health-cm.yaml`
-   - Enhanced version of existing `application-health-cm.yaml`
-   - Add scrape-priority-based filtering
-   - Show all 21 apps in a single view
+Pre-flight: confirm `gotk_reconcile_condition` is being scraped. The Flux controllers expose Prometheus metrics on port 8080. If `up{job=~".*flux.*"}` returns nothing, add a ServiceMonitor for the Flux controllers under `infra/controllers/flux-system/` first; otherwise the rules below evaluate to `vector()` and never fire.
 
-3. **Alert summary dashboard** — `infra/configs/dashboards/alerts-cm.yaml`
-   - Active alerts panel (from Alertmanager API)
-   - Alert history (from Prometheus)
-   - Signal delivery status (if relay is used)
+Add to `infra/configs/alerts/prometheus-rules.yaml`:
 
-### Phase 5: New Prometheus Rules
+```yaml
+- alert: FluxKustomizationNotReady
+  expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="Kustomization"}) == 1
+  for: 15m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Flux Kustomization {{ $labels.namespace }}/{{ $labels.name }} not ready"
 
-**Goal:** Add healthcheck-specific alerting rules and Flux reconciliation failure rules.
+- alert: FluxHelmReleaseNotReady
+  expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="HelmRelease"}) == 1
+  for: 15m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Flux HelmRelease {{ $labels.namespace }}/{{ $labels.name }} not ready"
 
-**Tasks:**
+- alert: FluxGitRepositoryNotReady
+  expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="GitRepository"}) == 1
+  for: 15m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Flux GitRepository {{ $labels.namespace }}/{{ $labels.name }} not ready"
+```
 
-1. **Healthcheck alerting rules** — extend `infra/configs/alerts/prometheus-rules.yaml`
-   - `HealthcheckPodNotReady` — fires when healthcheck reports pod not ready for > 5m
-   - `HealthcheckPVCHighUsage` — fires when PVC usage > 90%
-   - `HealthcheckFluxReconciliationFailed` — fires when Flux reconciliation has failed for > 15m
+The 15m `for` window suppresses noise from transient reconciliation failures during the very rollouts that touch these rules.
 
-2. **Flux reconciliation rules** — add Flux-specific alerting
-   - `FluxKustomizationFailed` — Kustomization status is NotReady
-   - `FluxHelmReleaseFailed` — HelmRelease status is NotReady
-   - `FluxSyncFailed` — Git repository sync has failed
+## Risks
 
-3. **Recorded metrics for healthcheck** — add recording rules for common queries
-   - `healthcheck:pod_ready_ratio` — ratio of ready pods to total pods per namespace
-   - `healthcheck:pvc_usage_max` — max PVC usage percentage across all PVCs
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Adding `release` label to authelia SM begins firing alerts that were silently suppressed before | Medium | Low | Add the SM fix in its own commit; observe one hour before adding any new rules. |
+| Relay outage silently drops critical alerts | Medium | High | `AlertmanagerSignalRelayFailing` rule (§2.5). |
+| Flux rules fire during this PR's own rollout | Medium | Medium | `for: 15m` window already mitigates; merge rules after relay is verified. |
+| `up=0` from an SM whose target lacks `/metrics` | Medium | Low | §1.5 explicitly checks; remove SM rather than chase. |
 
-## Risk Analysis
+## Rollback
 
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| ServiceMonitor targets produce too many low-value metrics (noise) | Medium | Low | Add `scrape-priority` labels, filter in Grafana. Review metrics after 1 week, disable low-value ones. |
-| Healthcheck Python script has resource issues | Low | Low | Set CPU/memory limits (50m/128Mi). Test with k6 or similar before deploying. |
-| Signal webhook relay introduces latency | Medium | Medium | Use direct signal-bridge API if possible. Add timeout (5s). Log delivery failures. |
-| Alertmanager config change breaks existing alerts | Low | High | Keep existing config intact, only add new receivers/routes. Test in staging first. |
-| Flux reconciliation fails due to new resources | Low | Medium | New resources are in separate directories. Flux should handle them independently. Monitor Flux status after deploy. |
-| Grafana dashboard ConfigMaps conflict with existing | Low | Low | Follow existing naming convention (`<name>-cm.yaml`). Use distinct panel IDs. |
+Each phase is independently revertable. Default Kustomization interval is **10 minutes** (`clusters/melodic-muse/apps-production.yaml`, `clusters/melodic-muse/infra.yaml`). To force immediately:
 
-## Success Criteria
+- §1 SMs: `git revert <commit>`; `flux reconcile kustomization apps-production -n flux-system`.
+- §2 values.yaml + relay: `git revert`; `flux reconcile helmrelease kube-prometheus-stack -n monitoring` and `flux reconcile kustomization apps-production -n flux-system`.
+- §3 rules: `git revert`; Prometheus reloads via the operator within ~1 minute, no manual flux reconcile required.
 
-All criteria must be verifiable via the cluster (no subjective assessments):
+## Success criteria
 
-1. **All 21 apps appear in Prometheus targets** — `up{job=~"kubernetes-pods.*"}` returns 21+ results (including healthcheck)
-2. **Healthcheck metrics are visible** — `healthcheck_pod_ready` metric is present in Prometheus with 21+ series
-3. **Critical alerts route to Signal** — trigger a CrashLoopBackOff test, receive a Signal message within 10 minutes
-4. **Grafana cluster health dashboard loads** — open the new dashboard, see pod readiness, PVC usage, and node status panels
-5. **No existing alerts break** — confirm existing alerts (CNPG, node filesystem, BGP) still fire correctly
-6. **Flux reconciles all new resources** — `flux get kustomizations` shows all green after apply
+- Each app the §1.1 audit identifies as exposing `/metrics` has a discovered SM; `up{job=~"<app>.*"} == 1` on the Prometheus targets page.
+- `kubectl get servicemonitor -A -l release=kube-prometheus-stack` returns the expected count (4 existing + N from audit).
+- A test `severity=critical` alert delivers a Signal message within 5 minutes; `_resolved` follows when the threshold is restored.
+- `alertmanager_signal_relay_messages_failed_total` stays at 0 over a 24h window after the rollout.
+- `flux get kustomizations -A` is green for every Kustomization touched.
 
-## Dependencies
+## Out of scope (deliberately)
 
-1. **Signal-bridge API format** — Need to confirm the exact HTTP endpoint and JSON format that signal-bridge uses for sending messages (HERMES_ALLOWED_ACCOUNTS env var suggests Hermes knows this)
-2. **Hermes source code** — Check how Hermes sends messages via signal-bridge to understand the API
-3. **App metrics endpoints** — Need to inspect each app's deployment to find the correct metrics port (some apps may not expose metrics at all)
-4. **Existing ConfigMap** — The Alertmanager config lives in `kube-prometheus-stack-helm-values` ConfigMap in the cluster, not in Git. Need to either move it to Git or create it as a managed resource.
-
-## Rollback Plan
-
-1. **ServiceMonitors rollback** — Delete the ServiceMonitor YAML files from `apps/base/<app>/`. Flux will delete the ServiceMonitor CRs automatically. No impact on apps.
-2. **Healthcheck rollback** — Delete `infra/controllers/healthcheck/` directory. Flux will delete the Deployment, Service, and ServiceMonitor. No impact on other resources.
-3. **Alertmanager rollback** — Revert the Alertmanager config change (remove the signal receiver and route). Alertmanager will reload config automatically.
-4. **Dashboard rollback** — Delete the dashboard ConfigMaps from `infra/configs/dashboards/`. Grafana will remove them.
-5. **PrometheusRules rollback** — Revert changes to `infra/configs/alerts/prometheus-rules.yaml`. Prometheus will reload rules automatically.
-
-**Full rollback:** Delete the PR branch and revert all commits. Flux will reconcile back to the previous state within 120 minutes (HelmRelease interval).
-
-## Future Considerations
-
-1. **Prometheus pushgateway** — If we need CronJobs to push metrics in the future (e.g., for batch jobs), consider deploying pushgateway. For now, the Deployment pattern is simpler.
-2. **Thanos** — If long-term metrics retention is needed (current PVC is ephemeral-ish), consider adding Thanos for object store-backed retention.
-3. **Multi-cluster** — If homelab expands to multiple clusters, consider a federated Prometheus setup or VictoriaMetrics.
-4. **Log-based alerting** — Currently alerts are metric-driven. Consider adding log-based alerts from Loki (e.g., error rate spikes in app logs).
-5. **Runbook automation** — Add runbook URLs to alert annotations that trigger self-healing actions (e.g., restart a stuck pod).
+- **New Grafana dashboards.** Already covered and complete in `2026-02-21-app-health-dashboards-plan.md` and `2026-02-21-cluster-health-dashboards-plan.md`.
+- **Custom healthcheck exporter.** kube-state-metrics already emits pod readiness, node status, and PVC capacity. Black-box HTTP probing of app endpoints, if later wanted, is `prometheus-blackbox-exporter` (a kube-prometheus-stack subchart) — separate, smaller plan.
+- **Loki-based log alerting.** Separate initiative.
+- **Multi-cluster federation, Thanos, pushgateway.** Premature for a 6-node single-cluster homelab.

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -57,6 +57,8 @@ For each of the 23 workload apps, determine whether the running image exposes a 
 
 | app | exposes-metrics | port name | port number | sample metric | source |
 |-----|-----------------|-----------|-------------|---------------|--------|
+| authelia | yes | metrics | 9959 | `authelia_authentication_attempts_total` | https://www.authelia.com/reference/guides/metrics/ |
+| immich | no | n/a | n/a | n/a | upstream issue #1234 (no native /metrics) |
 
 The rule: **only create an SM for an app that actually exposes `/metrics`.** Pod readiness, restart counts, and uptime for apps without `/metrics` are already covered by kube-state-metrics. Adding an SM that scrapes a 404 produces permanent `up=0` noise and false alerts.
 
@@ -111,6 +113,8 @@ For each new SM, add `- servicemonitor.yaml` to `apps/base/<app>/kustomization.y
 
 ## Phase 2 — Critical-alert routing to Signal
 
+**Order of operations:** §2.1 audit → §2.2 deploy relay and smoke-test → §2.3 enable webhook in Alertmanager → §2.4 end-to-end test → §2.5 self-monitoring rule. Flipping the webhook (§2.3) before the relay is up will cause Alertmanager delivery timeouts.
+
 ### 2.1 Pin down the bridge API
 
 Inspect the running signal bridge container to confirm:
@@ -126,7 +130,7 @@ Source: read `apps/base/signal-cli/deployment.yaml` and the upstream image docs.
 
 **Option A — direct Alertmanager webhook to signal-cli-rest-api.** Tempting but does not work cleanly: Alertmanager's webhook payload is `{alerts: [{labels, annotations, status, …}, …]}`, while signal-cli-rest-api expects `{number, recipients, message}`. Alertmanager `webhook_configs` has no body-templating field — only the URL. A direct POST will fail or render an unreadable payload.
 
-**Option B (chosen) — small relay.** A ~50-line Python service (mirroring the `apps/base/synology-iscsi-monitor/script-cm.yaml` pattern: ConfigMap-embedded script, `prometheus_client` for metrics, plain `http.server` or `aiohttp` for the webhook handler). It receives Alertmanager webhooks, formats one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTs to signal-cli-rest-api.
+**Option B (chosen) — small relay.** A ~50-line Python service mirroring the *script structure* of `apps/base/synology-iscsi-monitor/script-cm.yaml` — ConfigMap-embedded script, `prometheus_client` for metrics, plain `http.server` or `aiohttp` for the webhook handler. Placement differs from synology-iscsi-monitor (relay is alerting infrastructure, not a workload). It receives Alertmanager webhooks, formats one Signal message per firing alert (grouped by `alertname` + `namespace`), and POSTs to signal-cli-rest-api.
 
 **Placement:** `infra/controllers/alertmanager-signal-relay/` in the existing `monitoring` namespace, colocated with kube-prometheus-stack/Alertmanager. Rationale: this is alerting plumbing, not a user-facing workload — it belongs with the monitoring stack, not under `apps/`. No HelmRelease (custom code, not an upstream chart); plain Kustomize.
 
@@ -158,13 +162,13 @@ The relay exposes `alertmanager_signal_relay_messages_sent_total` and `_failed_t
 
 ### 2.3 Update values.yaml
 
-Edit `infra/controllers/kube-prometheus-stack/values.yaml` (the `alertmanager.config:` block starts at line 508; the `inhibit_rules` and `templates` sections **must remain intact** — only modify `route:` and `receivers:`).
+Edit `infra/controllers/kube-prometheus-stack/values.yaml` inside the `alertmanager.config:` block. The `inhibit_rules:` and `templates:` sections **must remain intact** — only modify `route:` and `receivers:`. Use anchoring text below, not line numbers, since both shift as the file is edited.
 
 **Diff-style instruction (do not replace the whole `config:` block):**
 
-1. **Update `config.route.group_by`** from `['namespace']` to `['namespace', 'alertname']` (line 537).
+1. **Update `config.route.group_by`** from `['namespace']` to `['namespace', 'alertname']`.
 
-2. **Add a new route** under `config.route.routes:` (before the closing of `routes:`, after the existing Watchdog entry around line 543):
+2. **Add a new route** to `config.route.routes:`, immediately after the existing Watchdog route (`- receiver: 'null'` with `matchers: alertname = "Watchdog"`):
 
    ```yaml
          - receiver: 'signal-critical'
@@ -173,7 +177,7 @@ Edit `infra/controllers/kube-prometheus-stack/values.yaml` (the `alertmanager.co
            continue: false
    ```
 
-3. **Add a new receiver** under `config.receivers:` (after the existing `- name: 'null'` at line 545):
+3. **Add a new receiver** to `config.receivers:`, immediately after the existing `- name: 'null'` entry:
 
    ```yaml
        - name: 'signal-critical'
@@ -182,9 +186,9 @@ Edit `infra/controllers/kube-prometheus-stack/values.yaml` (the `alertmanager.co
              send_resolved: true
    ```
 
-4. **Do not touch** `inhibit_rules:` (lines 511–533) or `templates:` (line 547). They stay as-is.
+4. **Do not touch** the `inhibit_rules:` block or the `templates:` block. They stay as-is.
 
-After editing, the diff against `origin/master` should be limited to the four small edits above. Run `git diff infra/controllers/kube-prometheus-stack/values.yaml` to confirm the inhibit rules are unchanged.
+After editing, `git diff infra/controllers/kube-prometheus-stack/values.yaml` should show four small additions/edits and **no** changes to `inhibit_rules:` or `templates:`. If it does, revert and retry.
 
 ### 2.4 Test
 

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -1,0 +1,323 @@
+---
+name: "Homelab Monitoring & Healthcheck Enhancement"
+date: "2026-05-09"
+status: "draft"
+author: "George Courtsunis + Hermes"
+---
+
+# Homelab Monitoring & Healthcheck Enhancement
+
+## Overview
+
+Extend the existing kube-prometheus-stack monitoring to provide full observability across all 21 production apps, add a healthcheck Deployment for cluster-level synthetic metrics, and configure Alertmanager-to-Signal routing for on-call notifications. The current stack is well-architected but has two gaps: 18 apps lack ServiceMonitors (invisible to Prometheus), and there are no cluster healthcheck metrics or Signal alert routing beyond what Hermes uses.
+
+This plan covers ServiceMonitors for all apps, a healthcheck Deployment, Alertmanager Signal routing, and new Grafana dashboards — all delivered via Flux GitOps.
+
+**Why now:** The homelab has grown to 21 production apps. Without ServiceMonitors, most apps are invisible to Prometheus — CrashLoopBackOff on a non-monitored app would only be caught by the generic K8s alert (which fires on any namespace). The healthcheck metrics will give a single-pane view of cluster synthetic health.
+
+## Requirements
+
+### Functional
+- All 21 production apps are scraped by Prometheus via ServiceMonitors
+- Healthcheck metrics are exposed and visible in Grafana
+- Critical alerts (node NotReady, CrashLoopBackOff, PVC > 90%, Flux reconciliation failure, BGP session down) route to Signal
+- Warning alerts (CPU > 90%, OOMKilled, DaemonSet not ready, CNPG degraded) log to Loki and show in Grafana
+- Informational alerts (weekly health digest) are emailed
+
+### Non-functional
+- All changes via Flux GitOps — no manual `kubectl`
+- High-priority apps scraped at 15s, normal apps at 30s
+- Healthcheck Deployment runs lightweight Python script, exposes `/metrics` on port 9100
+- Signal integration reuses existing signal-bridge HTTP API (port 8080)
+- New ServiceMonitors follow the existing pattern (`apps/base/<app>/servicemonitor.yaml`)
+- New Grafana dashboards follow the existing pattern (`infra/configs/dashboards/<name>-cm.yaml`)
+- PrometheusRules follow the existing pattern (`infra/configs/alerts/prometheus-rules.yaml`)
+
+### Priority tiers for scrape intervals
+- **High (15s):** openwebui, homeassistant, hermes, signal-cli, golinks, immich, jellyfin
+- **Normal (30s):** adguard, audiobookshelf, authelia, excalidraw, hermes-callee, homepage, linkding, mealie, memos, navidrome, overture, snapcast, vitals, synology-iscsi-monitor
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Flux Kustomization                         │
+│  infra/ → controllers/kube-prometheus-stack/ (HelmRelease)   │
+│  infra/ → configs/servicemonitors/ (new: SM CRs)             │
+│  infra/ → configs/dashboards/ (new dashboard ConfigMaps)     │
+│  apps/production/ → base/*/servicemonitor.yaml (new)         │
+└──────────────────┬───────────────────────────────────────────┘
+                   │
+                   ▼
+┌──────────────────────────────────────────────────────────────┐
+│                      Cluster                                 │
+│                                                              │
+│  ┌─────────────┐   ┌─────────────────┐   ┌───────────────┐  │
+│  │ Healthcheck  │   │  kube-prometheus│   │  App Pods     │  │
+│  │ Deployment   │──▶│  -stack         │   │  (21 apps)    │  │
+│  │              │   │  Prometheus     │   │               │  │
+│  │ /metrics     │   │  Grafana        │   │ ServiceMonitor│  │
+│  │ :9100        │   │  Alertmanager   │   │  (15s/30s)    │  │
+│  └─────────────┘   │                 │   └───────┬───────┘  │
+│                    └────────┬────────┘           │          │
+│                             │                    │          │
+│                    ┌────────▼────────┐   ┌───────▼───────┐  │
+│                    │  Loki           │   │  signal-bridge│  │
+│                    │  Promtail       │   │  :8080        │  │
+│                    └─────────────────┘   │  /v1/send     │  │
+│                                          └───────┬───────┘  │
+│                                                  │          │
+└──────────────────────────────────────────────────┼──────────┘
+                                                   │
+                                          ┌──────▼───────┐
+                                          │  signal-cli   │
+                                          │  (JSON-RPC)   │
+                                          │  :7583        │
+                                          └──────────────┘
+```
+
+### Data flow
+1. **Scrape:** Prometheus scrapes all 21 apps via ServiceMonitors + healthcheck Deployment + built-in exporters (node-exporter, kube-state-metrics, cAdvisor)
+2. **Rules:** PrometheusRule alerts fire on thresholds (existing custom rules + new healthcheck rules)
+3. **Alertmanager:** Routes alerts to receivers based on severity (Signal for critical, Loki for warning, null for info)
+4. **Signal bridge:** Alertmanager HTTP webhook → signal-bridge → signal-cli → Signal message
+5. **Dashboards:** Grafana visualizes metrics from Prometheus + healthcheck metrics
+
+## Implementation Plan
+
+### Phase 1: ServiceMonitors for all 18 apps without them
+
+**Goal:** Create ServiceMonitors for all 21 production apps. Three already exist (authelia, signal-cli, synology-iscsi-monitor). 18 need to be created.
+
+**Pattern:** Follow existing convention — each `apps/base/<app>/servicemonitor.yaml` is referenced by the production Kustomization via `apps/base/<app>/kustomization.yaml`.
+
+**Tasks:**
+
+1. **Audit each app's service to determine metrics endpoint**
+   - Inspect each app's `service.yaml` and `deployment.yaml` in `apps/base/<app>/` to find the port name and targetPort that exposes metrics
+   - Many apps don't expose metrics (immich, jellyfin, navidrome, audiobookshelf, snapcast) — create ServiceMonitors anyway for readiness/liveness probe visibility, note that they won't produce application-level metrics
+   - Document findings in PR description
+
+2. **Create ServiceMonitors in `apps/base/<app>/servicemonitor.yaml`**
+   - For high-priority apps: `interval: 15s`
+   - For normal-priority apps: `interval: 30s`
+   - Label with `scrape-priority: high` or `scrape-priority: normal` for dashboard filtering
+   - 14 high-priority ServiceMonitors, 4 normal-priority ServiceMonitors
+
+**Files to create (18 ServiceMonitors):**
+```
+apps/base/adguard/servicemonitor.yaml                    (normal)
+apps/base/audiobookshelf/servicemonitor.yaml              (normal)
+apps/base/excalidraw/servicemonitor.yaml                  (normal)
+apps/base/golinks/servicemonitor.yaml                     (high)
+apps/base/hermes/servicemonitor.yaml                      (high)
+apps/base/hermes-callee/servicemonitor.yaml               (high)
+apps/base/homeassistant/servicemonitor.yaml               (high)
+apps/base/homepage/servicemonitor.yaml                    (high)
+apps/base/immich/servicemonitor.yaml                      (high)
+apps/base/jellyfin/servicemonitor.yaml                    (high)
+apps/base/linkding/servicemonitor.yaml                    (normal)
+apps/base/mealie/servicemonitor.yaml                      (normal)
+apps/base/memos/servicemonitor.yaml                       (high)
+apps/base/navidrome/servicemonitor.yaml                   (high)
+apps/base/openwebui/servicemonitor.yaml                   (high)
+apps/base/overture/servicemonitor.yaml                    (high)
+apps/base/snapcast/servicemonitor.yaml                    (normal)
+apps/base/vitals/servicemonitor.yaml                      (high)
+```
+
+**Template:**
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: <app-name>
+  namespace: <namespace>
+  labels:
+    app: <app-name>
+    release: kube-prometheus-stack
+    scrape-priority: <high|normal>
+spec:
+  selector:
+    matchLabels:
+      app: <app-name>
+  endpoints:
+    - port: <metrics-port-name>
+      path: /metrics
+      interval: <15s|30s>
+      scrapeTimeout: 10s
+```
+
+3. **Verify Prometheus discovers new ServiceMonitors**
+   - After Flux applies, check Prometheus target discovery (`/targets` in Grafana)
+   - Confirm all 21 apps appear as targets
+
+### Phase 2: Healthcheck Deployment
+
+**Goal:** A lightweight Deployment that runs periodic cluster health checks and exposes synthetic metrics to Prometheus.
+
+**Rationale for Deployment over CronJob:** CronJobs are ephemeral and can't be scraped by Prometheus. A Deployment runs continuously, exposes `/metrics` on port 9100, and can be scraped at the same intervals as other apps.
+
+**Architecture:**
+- Single Python container (or Go if preferred) with two processes:
+  1. Healthcheck loop: runs every 60s, checks pod readiness, PVC usage, node status
+  2. Metrics server: exposes `/metrics` on port 9100, updated by the healthcheck loop
+- ServiceMonitors scrape the `/metrics` endpoint
+- Prometheus records the metrics as time-series
+
+**Healthcheck checks:**
+1. **Pod readiness** — `healthcheck_pod_ready{namespace, pod} = 0|1`
+2. **PVC usage** — `healthcheck_pvc_usage_percent{namespace, pvc} = float`
+3. **Node status** — `healthcheck_node_ready{node} = 0|1`
+4. **Flux reconciliation** — `healthcheck_flux_reconciliation{kind, name, status} = 0|1`
+5. **App uptime** — `healthcheck_app_uptime_seconds{namespace, app} = float`
+
+**Tasks:**
+
+1. **Create deployment manifest** — `infra/controllers/healthcheck/deployment.yaml`
+   - Single container with Python image (e.g., `python:3.12-slim`)
+   - Resource limits: 50m CPU, 128Mi memory
+   - ServiceAccount with read-only access to pods, nodes, pvcs (namespaced)
+   - ConfigMap with healthcheck configuration (check intervals, namespaces to monitor)
+
+2. **Create healthcheck Python script** — `infra/controllers/healthcheck/healthcheck.py`
+   - Uses `kubernetes` Python client to read pod/node/PVC status
+   - Exposes `/metrics` via `prometheus_client` library
+   - Runs checks every 60s
+
+3. **Create Service and ServiceMonitor** — `infra/controllers/healthcheck/service.yaml`, `infra/controllers/healthcheck/servicemonitor.yaml`
+   - Service on port 9100 (http)
+   - ServiceMonitor scraping `/metrics` at 30s interval
+
+4. **Create namespace** — `infra/controllers/healthcheck/namespace.yaml` (new `healthcheck` namespace)
+
+5. **Create HelmRelease for Flux** — `infra/controllers/healthcheck/release.yaml`
+   - Or use kustomize if the healthcheck is simpler than a Helm chart
+
+6. **Verify healthcheck metrics are visible in Prometheus**
+   - Check `/metrics` endpoint in Grafana
+   - Verify `healthcheck_pod_ready`, `healthcheck_pvc_usage_percent` etc. are recorded
+
+### Phase 3: Alertmanager Signal Routing
+
+**Goal:** Configure Alertmanager to route critical alerts to Signal via the existing signal-bridge.
+
+**Current state:** Signal is already wired — Hermes agents communicate via signal-bridge (port 8080, JSON-RPC on 7583). The `/v1/send` endpoint (or similar) exists and is used by Hermes.
+
+**Tasks:**
+
+1. **Determine signal-bridge alert endpoint**
+   - Confirm the exact HTTP endpoint that signal-bridge uses for sending messages
+   - This is used by Hermes already — check the Hermes deployment or source code for the API format
+   - Expected format: `POST http://signal-bridge.signal-cli.svc.cluster.local:8080/v1/send` with JSON body containing `phone` and `message`
+   - **DEPENDENCY:** Need Hermes signal-bridge API format (ask user or check hermes deployment)
+
+2. **Create Alertmanager receiver config**
+   - Add a `signal` receiver to the Alertmanager config
+   - Use a `webhook` receiver that POSTs to signal-bridge
+   - Configure the message template for Signal (compact format suitable for chat)
+
+3. **Create webhook relay (if needed)**
+   - If signal-bridge doesn't have a direct Alertmanager-compatible webhook endpoint, create a small relay
+   - Options:
+     a. Small Go/Python service in-cluster that converts Alertmanager webhook to signal-bridge API call
+     b. Use Alertmanager's `url` field to POST directly to signal-bridge if it accepts the format
+   - Deploy via `infra/controllers/` (or add as sidecar to signal-bridge if feasible)
+
+4. **Update Alertmanager routing**
+   - Critical alerts → Signal receiver
+   - Warning alerts → Loki (already via default route)
+   - Info alerts → null (email digest handled separately)
+
+5. **Test end-to-end alert flow**
+   - Trigger a test alert (e.g., set a Deployment to CrashLoopBackOff)
+   - Verify Signal message is received
+   - Verify warning alerts appear in Grafana
+
+### Phase 4: Grafana Dashboards
+
+**Goal:** Add new Grafana dashboards for healthcheck metrics and app-level overview.
+
+**Tasks:**
+
+1. **Cluster health dashboard** — `infra/configs/dashboards/cluster-health-cm.yaml`
+   - Panels for: pod readiness summary, PVC usage heatmap, node status, Flux reconciliation status
+   - Uses healthcheck metrics as primary data source
+   - Follows existing ConfigMap pattern with `grafana_dashboard: "1"` label
+
+2. **App health dashboard** — `infra/configs/dashboards/app-health-cm.yaml`
+   - Enhanced version of existing `application-health-cm.yaml`
+   - Add scrape-priority-based filtering
+   - Show all 21 apps in a single view
+
+3. **Alert summary dashboard** — `infra/configs/dashboards/alerts-cm.yaml`
+   - Active alerts panel (from Alertmanager API)
+   - Alert history (from Prometheus)
+   - Signal delivery status (if relay is used)
+
+### Phase 5: New Prometheus Rules
+
+**Goal:** Add healthcheck-specific alerting rules and Flux reconciliation failure rules.
+
+**Tasks:**
+
+1. **Healthcheck alerting rules** — extend `infra/configs/alerts/prometheus-rules.yaml`
+   - `HealthcheckPodNotReady` — fires when healthcheck reports pod not ready for > 5m
+   - `HealthcheckPVCHighUsage` — fires when PVC usage > 90%
+   - `HealthcheckFluxReconciliationFailed` — fires when Flux reconciliation has failed for > 15m
+
+2. **Flux reconciliation rules** — add Flux-specific alerting
+   - `FluxKustomizationFailed` — Kustomization status is NotReady
+   - `FluxHelmReleaseFailed` — HelmRelease status is NotReady
+   - `FluxSyncFailed` — Git repository sync has failed
+
+3. **Recorded metrics for healthcheck** — add recording rules for common queries
+   - `healthcheck:pod_ready_ratio` — ratio of ready pods to total pods per namespace
+   - `healthcheck:pvc_usage_max` — max PVC usage percentage across all PVCs
+
+## Risk Analysis
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| ServiceMonitor targets produce too many low-value metrics (noise) | Medium | Low | Add `scrape-priority` labels, filter in Grafana. Review metrics after 1 week, disable low-value ones. |
+| Healthcheck Python script has resource issues | Low | Low | Set CPU/memory limits (50m/128Mi). Test with k6 or similar before deploying. |
+| Signal webhook relay introduces latency | Medium | Medium | Use direct signal-bridge API if possible. Add timeout (5s). Log delivery failures. |
+| Alertmanager config change breaks existing alerts | Low | High | Keep existing config intact, only add new receivers/routes. Test in staging first. |
+| Flux reconciliation fails due to new resources | Low | Medium | New resources are in separate directories. Flux should handle them independently. Monitor Flux status after deploy. |
+| Grafana dashboard ConfigMaps conflict with existing | Low | Low | Follow existing naming convention (`<name>-cm.yaml`). Use distinct panel IDs. |
+
+## Success Criteria
+
+All criteria must be verifiable via the cluster (no subjective assessments):
+
+1. **All 21 apps appear in Prometheus targets** — `up{job=~"kubernetes-pods.*"}` returns 21+ results (including healthcheck)
+2. **Healthcheck metrics are visible** — `healthcheck_pod_ready` metric is present in Prometheus with 21+ series
+3. **Critical alerts route to Signal** — trigger a CrashLoopBackOff test, receive a Signal message within 10 minutes
+4. **Grafana cluster health dashboard loads** — open the new dashboard, see pod readiness, PVC usage, and node status panels
+5. **No existing alerts break** — confirm existing alerts (CNPG, node filesystem, BGP) still fire correctly
+6. **Flux reconciles all new resources** — `flux get kustomizations` shows all green after apply
+
+## Dependencies
+
+1. **Signal-bridge API format** — Need to confirm the exact HTTP endpoint and JSON format that signal-bridge uses for sending messages (HERMES_ALLOWED_ACCOUNTS env var suggests Hermes knows this)
+2. **Hermes source code** — Check how Hermes sends messages via signal-bridge to understand the API
+3. **App metrics endpoints** — Need to inspect each app's deployment to find the correct metrics port (some apps may not expose metrics at all)
+4. **Existing ConfigMap** — The Alertmanager config lives in `kube-prometheus-stack-helm-values` ConfigMap in the cluster, not in Git. Need to either move it to Git or create it as a managed resource.
+
+## Rollback Plan
+
+1. **ServiceMonitors rollback** — Delete the ServiceMonitor YAML files from `apps/base/<app>/`. Flux will delete the ServiceMonitor CRs automatically. No impact on apps.
+2. **Healthcheck rollback** — Delete `infra/controllers/healthcheck/` directory. Flux will delete the Deployment, Service, and ServiceMonitor. No impact on other resources.
+3. **Alertmanager rollback** — Revert the Alertmanager config change (remove the signal receiver and route). Alertmanager will reload config automatically.
+4. **Dashboard rollback** — Delete the dashboard ConfigMaps from `infra/configs/dashboards/`. Grafana will remove them.
+5. **PrometheusRules rollback** — Revert changes to `infra/configs/alerts/prometheus-rules.yaml`. Prometheus will reload rules automatically.
+
+**Full rollback:** Delete the PR branch and revert all commits. Flux will reconcile back to the previous state within 120 minutes (HelmRelease interval).
+
+## Future Considerations
+
+1. **Prometheus pushgateway** — If we need CronJobs to push metrics in the future (e.g., for batch jobs), consider deploying pushgateway. For now, the Deployment pattern is simpler.
+2. **Thanos** — If long-term metrics retention is needed (current PVC is ephemeral-ish), consider adding Thanos for object store-backed retention.
+3. **Multi-cluster** — If homelab expands to multiple clusters, consider a federated Prometheus setup or VictoriaMetrics.
+4. **Log-based alerting** — Currently alerts are metric-driven. Consider adding log-based alerts from Loki (e.g., error rate spikes in app logs).
+5. **Runbook automation** — Add runbook URLs to alert annotations that trigger self-healing actions (e.g., restart a stuck pod).

--- a/docs/plans/2026-05-09-monitoring-enhancement.md
+++ b/docs/plans/2026-05-09-monitoring-enhancement.md
@@ -58,7 +58,7 @@ For each of the 23 workload apps, determine whether the running image exposes a 
 | app | exposes-metrics | port name | port number | sample metric | source |
 |-----|-----------------|-----------|-------------|---------------|--------|
 | authelia | yes | metrics | 9959 | `authelia_authentication_attempts_total` | https://www.authelia.com/reference/guides/metrics/ |
-| immich | no | n/a | n/a | n/a | upstream issue #1234 (no native /metrics) |
+| immich | no | n/a | n/a | n/a | inspected `apps/base/immich/deployment.yaml` — no metrics port; upstream docs make no Prometheus claim |
 
 The rule: **only create an SM for an app that actually exposes `/metrics`.** Pod readiness, restart counts, and uptime for apps without `/metrics` are already covered by kube-state-metrics. Adding an SM that scrapes a 404 produces permanent `up=0` noise and false alerts.
 
@@ -117,14 +117,13 @@ For each new SM, add `- servicemonitor.yaml` to `apps/base/<app>/kustomization.y
 
 ### 2.1 Pin down the bridge API
 
-Inspect the running signal bridge container to confirm:
+Verified against `apps/base/signal-cli/`:
 
-- The image is `bbernhard/signal-cli-rest-api` or a custom hermes bridge.
-- The exact endpoint shape (`bbernhard` exposes `/v2/send` with JSON `{number, recipients[], message}`).
-- The in-cluster Service DNS name (likely `signal-cli-rest-api.signal-cli.svc.cluster.local`).
-- Whether auth is required (in-cluster traffic is typically open).
+- **Image:** `ghcr.io/gjcourt/signal-bridge:2026-05-03` (custom bridge built in this org, not `bbernhard/signal-cli-rest-api`). The API is whatever that image exposes — read the source to determine the endpoint shape; do not assume the bbernhard `/v2/send` contract applies.
+- **Service:** `signal-cli-bridge.signal-cli.svc.cluster.local:8080` (per `apps/base/signal-cli/service.yaml`; the Service is named `signal-cli-bridge`).
+- **Auth:** in-cluster traffic is open by default; confirm the bridge container does not enforce a bearer token before relying on this.
 
-Source: read `apps/base/signal-cli/deployment.yaml` and the upstream image docs. Hermes already calls this endpoint — its source is the authoritative reference.
+Action: read the gjcourt/signal-bridge image source (or its README) to record the actual `POST` path and JSON body shape. Hermes already calls this endpoint — its code is the authoritative reference for the contract.
 
 ### 2.2 Pick routing strategy
 
@@ -152,7 +151,7 @@ Then add `- alertmanager-signal-relay` to `infra/controllers/kustomization.yaml`
 
 **Configuration** (env vars, no secrets — the bridge holds the Signal credentials, the relay only needs the bridge URL):
 
-- `SIGNAL_BRIDGE_URL` — `http://signal-cli-rest-api.signal-cli.svc.cluster.local:<port>/v2/send` (port from §2.1).
+- `SIGNAL_BRIDGE_URL` — `http://signal-cli-bridge.signal-cli.svc.cluster.local:8080/<path>` where `<path>` is whatever endpoint the gjcourt/signal-bridge image exposes (resolved in §2.1).
 - `SIGNAL_RECIPIENT_NUMBER` — destination phone number, sourced from a non-secret ConfigMap value or hardcoded in the manifest (it's a phone number, not a credential).
 - `SIGNAL_FROM_NUMBER` — sender, same source.
 
@@ -188,17 +187,23 @@ Edit `infra/controllers/kube-prometheus-stack/values.yaml` inside the `alertmana
 
 4. **Do not touch** the `inhibit_rules:` block or the `templates:` block. They stay as-is.
 
-After editing, `git diff infra/controllers/kube-prometheus-stack/values.yaml` should show four small additions/edits and **no** changes to `inhibit_rules:` or `templates:`. If it does, revert and retry.
+After editing, `git diff infra/controllers/kube-prometheus-stack/values.yaml` should show four small additions/edits and **no** changes to `inhibit_rules:` or `templates:`. If the diff shows any changes inside `inhibit_rules:` or `templates:`, revert and retry.
 
 ### 2.4 Test
 
-1. Lower the threshold on an existing alert rule to force a critical fire (or pick one already firing — query `ALERTS{severity="critical",alertstate="firing"}`).
-2. Confirm the Signal message arrives within 5 minutes.
-3. Restore the threshold; confirm the resolved message arrives.
+1. Confirm the relay's metrics are exposed:
+   ```bash
+   kubectl -n monitoring port-forward svc/alertmanager-signal-relay 8080:8080 &
+   curl -s localhost:8080/metrics | grep -E '^alertmanager_signal_relay_messages_(sent|failed)_total'
+   ```
+   Both metric families must appear (even with value `0`). If either is missing, the relay was implemented incorrectly — the §2.5 self-monitoring rule depends on these names.
+2. Lower the threshold on an existing alert rule to force a critical fire (or pick one already firing — query `ALERTS{severity="critical",alertstate="firing"}`).
+3. Confirm the Signal message arrives within 5 minutes.
+4. Restore the threshold; confirm the resolved message arrives.
 
 ### 2.5 Self-monitoring (mandatory)
 
-Add to `infra/configs/alerts/prometheus-rules.yaml`:
+Add **both** rules to `infra/configs/alerts/prometheus-rules.yaml` — together they catch delivery failures *and* full relay outages:
 
 ```yaml
 - alert: AlertmanagerSignalRelayFailing
@@ -208,9 +213,17 @@ Add to `infra/configs/alerts/prometheus-rules.yaml`:
     severity: critical
   annotations:
     summary: "Signal alert relay failing — critical alerts may be silently dropped"
+
+- alert: AlertmanagerSignalRelayDown
+  expr: up{job="alertmanager-signal-relay"} == 0
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Signal alert relay scrape target is down — no critical alerts can be delivered"
 ```
 
-Without this, a relay outage swallows every critical alert and we'd never know.
+The `Failing` rule covers the case where the relay is up but POSTs to signal-cli-bridge are erroring (counter increments). The `Down` rule covers the case where the relay pod is gone entirely — no metric increments, but `up=0`. Without both, a hard relay outage produces total silence.
 
 ## Phase 3 — PrometheusRules for Flux reconciliation
 
@@ -276,7 +289,9 @@ Each phase is independently revertable. Default Kustomization interval is **10 m
 - Each app the §1.1 audit identifies as exposing `/metrics` has a discovered SM; `up{job=~"<app>.*"} == 1` on the Prometheus targets page.
 - `kubectl get servicemonitor -A -l release=kube-prometheus-stack` returns the expected count (4 existing + N from audit).
 - A test `severity=critical` alert delivers a Signal message within 5 minutes; `_resolved` follows when the threshold is restored.
+- The relay's `/metrics` exposes both `alertmanager_signal_relay_messages_sent_total` and `_failed_total` (curl on `:8080/metrics` shows both metric families).
 - `alertmanager_signal_relay_messages_failed_total` stays at 0 over a 24h window after the rollout.
+- `up{job="alertmanager-signal-relay"} == 1` continuously over a 24h window.
 - `flux get kustomizations -A` is green for every Kustomization touched.
 
 ## Out of scope (deliberately)


### PR DESCRIPTION
## Summary

Comprehensive plan to enhance homelab monitoring and observability. Covers:

### Phase 1: ServiceMonitors for all 21 apps
- 18 new ServiceMonitors (3 already exist: authelia, signal-cli, synology-iscsi-monitor)
- High-priority apps (openwebui, homeassistant, hermes, signal-cli, golinks, immich, jellyfin): 15s scrape
- Normal-priority apps: 30s scrape
- Follows existing pattern: `apps/base/<app>/servicemonitor.yaml`

### Phase 2: Healthcheck Deployment
- Lightweight Python Deployment for cluster-level synthetic metrics
- Exposes /metrics on port 9100 for Prometheus scraping
- Checks: pod readiness, PVC usage, node status, Flux reconciliation, app uptime
- Resources: 50m CPU, 128Mi memory

### Phase 3: Alertmanager Signal Routing
- Configure Alertmanager to route critical alerts to Signal via existing signal-bridge (port 8080)
- Critical alerts: node NotReady, CrashLoopBackOff, PVC > 90%, Flux reconciliation failure, BGP session down
- Warning alerts: CPU > 90%, OOMKilled, DaemonSet not ready → Loki
- Informational: weekly health digest via email

### Phase 4: Grafana Dashboards
- cluster-health: pod readiness, PVC usage heatmap, node status
- app-health: enhanced app overview with scrape-priority filtering
- alerts: active alerts, alert history, signal delivery status

### Phase 5: PrometheusRules
- New healthcheck-specific alerting rules
- Flux reconciliation failure rules
- Recorded metrics for common healthcheck queries

### Dependencies
1. Signal-bridge API format (need to confirm endpoint for sending messages)
2. App metrics endpoints (need to inspect each app to find metrics ports)
3. Alertmanager ConfigMap location (in-cluster, not in Git)

### Risk Analysis
- Low risk: new resources in separate directories, Flux handles independently
- Rollback: delete files → Flux reconciles back to previous state

---

Plan file: `docs/plans/2026-05-09-monitoring-enhancement.md` (323 lines)