### PR TITLE
chore(renovate-automerge): run every 6h instead of daily

### DIFF
--- a/infra/controllers/renovate-automerge/cronjob.yaml
+++ b/infra/controllers/renovate-automerge/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: renovate-automerge
   namespace: renovate
 spec:
-  schedule: "0 8 * * *"
+  # Every 6 hours at :00 (00:00, 06:00, 12:00, 18:00 UTC)
+  schedule: "0 */6 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
## Summary
- Bump renovate-automerge cron from \`0 8 * * *\` (08:00 UTC daily) to \`0 */6 * * *\` (every 6h: 00/06/12/18 UTC).
- Cuts worst-case PR-green-to-auto-merged wait from ~24h to ~6h.

## Test plan
- [x] \`kustomize build infra/controllers\` passes
- [ ] After merge, confirm next CronJob trigger lands at the next /6h boundary (\`kubectl get cronjob renovate-automerge -n renovate -o yaml | grep schedule\`)