### PR TITLE
feat(homepage): add learning repo to Developer bookmarks

### DIFF
--- a/apps/production/homepage/configmap-patch.yaml
+++ b/apps/production/homepage/configmap-patch.yaml
@@ -37,6 +37,9 @@ data:
         - brainstorm:
             - abbr: BS
               href: https://github.com/gjcourt/brainstorm
+        - learning:
+            - abbr: LR
+              href: https://github.com/gjcourt/learning
 
     - Reference:
         - Kubernetes Docs:


### PR DESCRIPTION
## Summary
- Add \`gjcourt/learning\` to the Developer section on homepage, next to homelab (HL) and brainstorm (BS).
- Abbreviation: \`LR\`.

## Test plan
- [x] \`kustomize build apps/production/homepage\` passes
- [ ] After merge + Flux reconcile, the Learning bookmark appears in the Developer section on homepage.burntbytes.com