### PR TITLE
feat(homepage): address dashboard layout critique

### DIFF
--- a/apps/production/homepage/configmap-patch.yaml
+++ b/apps/production/homepage/configmap-patch.yaml
@@ -11,21 +11,20 @@ data:
     layout:
       Media:
         style: column
-        rows: 8
+        rows: 10
       Tools:
         style: column
-        rows: 8
+        rows: 10
       Infrastructure:
         style: column
-        rows: 8
+        rows: 10
       Monitoring:
         style: column
-        rows: 8
+        rows: 10
     background:
       image: https://images.unsplash.com/photo-1502790671504-542ad42d5189?auto=format&fit=crop&w=2560&q=80
       blur: sm
-      opacity: 50
-    cardBlur: md
+      opacity: 30
     theme: dark
     color: slate
 
@@ -40,14 +39,29 @@ data:
         - learning:
             - abbr: LR
               href: https://github.com/gjcourt/learning
+        - GitHub Inbox:
+            - abbr: GHI
+              href: https://github.com/notifications
+        - ghcr.io:
+            - abbr: GCR
+              href: https://github.com/orgs/gjcourt/packages
 
     - Reference:
         - Kubernetes Docs:
-            - abbr: K8s
+            - abbr: K8S
               href: https://kubernetes.io/docs/
         - Cilium Docs:
             - abbr: CIL
               href: https://docs.cilium.io/
+        - Flux Docs:
+            - abbr: FLX
+              href: https://fluxcd.io/flux/
+        - CNPG Docs:
+            - abbr: CNP
+              href: https://cloudnative-pg.io/documentation/
+        - Renovate:
+            - abbr: REN
+              href: https://developer.mend.io/github/gjcourt
 
   widgets.yaml: |
     - kubernetes:

--- a/apps/production/homepage/deployment-patch.yaml
+++ b/apps/production/homepage/deployment-patch.yaml
@@ -11,6 +11,9 @@ spec:
           envFrom:
             - secretRef:
                 name: homepage-synology
+            - secretRef:
+                name: homepage-adguard
+                optional: true
           env:
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: home.burntbytes.com

--- a/apps/production/homepage/secret-adguard.yaml.example
+++ b/apps/production/homepage/secret-adguard.yaml.example
@@ -1,0 +1,25 @@
+# AdGuard credentials for homepage widget (production).
+#
+# To enable the AdGuard widget on the homepage dashboard:
+#   1. Copy this file to `secret-adguard.yaml` (drop the .example suffix).
+#   2. Replace the two placeholder values with the real AdGuard admin
+#      credentials.
+#   3. Encrypt with SOPS: `sops -e -i secret-adguard.yaml`
+#   4. Add `secret-adguard.yaml` to apps/production/homepage/kustomization.yaml
+#      under `resources:`.
+#   5. Commit + open a PR. After Flux reconciles, the AdGuard widget
+#      starts displaying queries-blocked / total-queries on the
+#      homepage tile.
+#
+# Until the secret exists in-cluster, the deployment tolerates the
+# missing secretRef (optional: true in deployment-patch.yaml) and the
+# widget renders empty. No outage risk if you delay this.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: homepage-adguard
+  namespace: homepage-prod
+type: Opaque
+stringData:
+  HOMEPAGE_VAR_ADGUARD_USER: REPLACE_ME
+  HOMEPAGE_VAR_ADGUARD_PASS: REPLACE_ME

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -41,10 +41,10 @@
         href: https://chat.burntbytes.com
         description: AI chat interface (frontend for vLLM)
         siteMonitor: https://chat.burntbytes.com
-    - vLLM:
-        icon: vllm.png
+    - Hestia:
+        icon: truenas-scale.png
         href: https://hestia.burntbytes.com
-        description: LLM inference server (Qwen3 on RTX 4090)
+        description: TrueNAS GPU server (vLLM, signal-cli, RTX 4090)
         siteMonitor: https://hestia.burntbytes.com
     - Overture:
         icon: mdi-rss

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -3,66 +3,91 @@
         icon: immich.png
         href: https://photos.burntbytes.com
         description: Photo and video management
+        siteMonitor: https://photos.burntbytes.com
     - Jellyfin:
         icon: jellyfin.png
         href: https://jellyfin.burntbytes.com
         description: Media streaming server
+        siteMonitor: https://jellyfin.burntbytes.com
     - Navidrome:
         icon: navidrome.png
         href: https://music.burntbytes.com
         description: Music server and streamer
+        siteMonitor: https://music.burntbytes.com
     - Kitchen:
         icon: mdi-speaker
         href: http://10.42.2.38
         description: HifiBerry OS – Kitchen
+        siteMonitor: http://10.42.2.38
     - Living Room:
         icon: mdi-speaker
         href: http://10.42.2.39
         description: HifiBerry OS – Living Room
+        siteMonitor: http://10.42.2.39
     - Snapcast:
         icon: mdi-speaker-multiple
         href: https://snapcast.burntbytes.com
         description: Multi-room audio (Snapweb)
+        siteMonitor: https://snapcast.burntbytes.com
     - Audiobookshelf:
         icon: audiobookshelf.png
         href: https://audiobooks.burntbytes.com
         description: Audiobook and podcast server
+        siteMonitor: https://audiobooks.burntbytes.com
 
 - Tools:
-    - Chat:
-        icon: mdi-chat
+    - OpenWebUI:
+        icon: openwebui.png
         href: https://chat.burntbytes.com
-        description: AI chat interface
+        description: AI chat interface (frontend for vLLM)
+        siteMonitor: https://chat.burntbytes.com
+    - vLLM:
+        icon: mdi-brain
+        href: https://hestia.burntbytes.com
+        description: LLM inference server (Qwen3 on RTX 4090)
+        siteMonitor: https://hestia.burntbytes.com
+    - Overture:
+        icon: mdi-rss
+        href: https://overture.burntbytes.com
+        description: Personal feed / aggregation
+        siteMonitor: https://overture.burntbytes.com
     - Vitals:
         icon: mdi-heart-pulse
         href: https://vitals.burntbytes.com
         description: Health and fitness tracker
+        siteMonitor: https://vitals.burntbytes.com
     - Memos:
         icon: memos.png
         href: https://memos.burntbytes.com
         description: Lightweight note-taking service
+        siteMonitor: https://memos.burntbytes.com
     - Linkding:
         icon: linkding.png
         href: https://links.burntbytes.com
         description: Bookmark manager
+        siteMonitor: https://links.burntbytes.com
     - Mealie:
         icon: mealie.png
         href: https://mealie.burntbytes.com
         description: Recipe management
+        siteMonitor: https://mealie.burntbytes.com
     - GoLinks:
         icon: mdi-link-variant
         href: https://go.burntbytes.com
         description: URL shortener
+        siteMonitor: https://go.burntbytes.com
     - Excalidraw:
         icon: excalidraw.png
         href: https://excalidraw.burntbytes.com
         description: Virtual whiteboard for sketching
+        siteMonitor: https://excalidraw.burntbytes.com
 
 - Infrastructure:
     - Synology NAS:
         icon: synology-dsm.png
         href: https://10.42.2.11:5001
         description: Network storage
+        siteMonitor: http://10.42.2.11:5000
         widget:
           type: diskstation
           url: https://10.42.2.11:5001
@@ -72,22 +97,32 @@
         icon: home-assistant.png
         href: https://hass.burntbytes.com
         description: Home automation platform
+        siteMonitor: https://hass.burntbytes.com
     - AdGuard Home:
         icon: adguard-home.png
         href: https://adguard.burntbytes.com
         description: DNS ad blocker
+        siteMonitor: https://adguard.burntbytes.com
+        widget:
+          type: adguard
+          url: https://adguard.burntbytes.com
+          username: "{{HOMEPAGE_VAR_ADGUARD_USER}}"
+          password: "{{HOMEPAGE_VAR_ADGUARD_PASS}}"
     - Authelia:
         icon: mdi-shield-account
         href: https://auth.burntbytes.com
         description: Authentication portal (SSO)
+        siteMonitor: https://auth.burntbytes.com
     - Zigbee2MQTT:
         icon: zigbee2mqtt.png
         href: https://zigbee.burntbytes.com
         description: Zigbee to MQTT Bridge
+        siteMonitor: https://zigbee.burntbytes.com
     - Pingo:
         icon: mdi-dns
         href: https://vpn.burntbytes.com
         description: DNS updater for vpn.burntbytes.com
+        siteMonitor: https://vpn.burntbytes.com
 
 - Monitoring:
     - Cluster Resources:
@@ -120,7 +155,8 @@
         icon: grafana.png
         href: https://grafana.burntbytes.com
         description: Metrics dashboard
-    - Loki:
-        icon: loki.png
+        siteMonitor: https://grafana.burntbytes.com
+    - Logs:
+        icon: grafana.png
         href: https://grafana.burntbytes.com/explore?schemaVersion=1&panes=%7B%22jZ4%22:%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22homepage-prod%5C%22%7D%22%7D%5D%7D%7D
-        description: Cluster logs (via Grafana)
+        description: Cluster logs (Grafana → Loki)

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -105,7 +105,9 @@
         siteMonitor: https://adguard.burntbytes.com
         widget:
           type: adguard
-          url: https://adguard.burntbytes.com
+          # Cluster-internal Service URL avoids the gateway round-trip
+          # and TLS termination just for widget polling.
+          url: http://adguard-admin.adguard-prod.svc.cluster.local:8080
           username: "{{HOMEPAGE_VAR_ADGUARD_USER}}"
           password: "{{HOMEPAGE_VAR_ADGUARD_PASS}}"
     - Authelia:

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -37,12 +37,12 @@
 
 - Tools:
     - OpenWebUI:
-        icon: openwebui.png
+        icon: open-webui.png
         href: https://chat.burntbytes.com
         description: AI chat interface (frontend for vLLM)
         siteMonitor: https://chat.burntbytes.com
     - vLLM:
-        icon: mdi-brain
+        icon: vllm.png
         href: https://hestia.burntbytes.com
         description: LLM inference server (Qwen3 on RTX 4090)
         siteMonitor: https://hestia.burntbytes.com


### PR DESCRIPTION
## Summary

Addresses all 10 findings from the homepage-layout `/critique` (5 moderate + 5 minor).

### Moderate
- **Live up/down status** — added `siteMonitor:` to every service tile. Highest-leverage change; the dashboard now shows status dots rather than just links.
- **Missing apps surfaced** — added OpenWebUI (renamed from generic "Chat" with the proper brand icon), vLLM (hestia.burntbytes.com), and Overture.
- **Mislabel fixes** — "Loki" renamed to "Logs" (it's a Grafana deeplink, not a separate service).
- **AdGuard widget** — wired up. Deployment `envFrom` references an optional `homepage-adguard` secret; the actual SOPS-encrypted secret comes via `secret-adguard.yaml.example` (operator action — see template for steps).
- **Bookmarks expanded** — Developer +2 (GitHub Inbox, ghcr.io), Reference +3 (Flux, CNPG, Renovate).

### Minor
- Abbreviations normalized to uppercase (K8s → K8S).
- `cardBlur: md` dropped; background opacity 50 → 30 to improve card contrast.
- Layout `rows: 8` → `10` to absorb the new Tools tiles without column wrap.

### Operator follow-up (post-merge)
The AdGuard widget will render empty until the operator:
1. Copies `secret-adguard.yaml.example` → `secret-adguard.yaml`, fills in real creds, encrypts with SOPS.
2. Adds `secret-adguard.yaml` to `apps/production/homepage/kustomization.yaml`.

The deployment uses `optional: true` on the secretRef so the missing secret doesn't block rollout in the meantime.

### Out of scope
- HifiBerry IP → DNS rewrites (operator-side AdGuard config, not a homelab-repo change).
- Background image swap (style preference; left as-is).
- GoLinks brand icon (no upstream brand asset; \`mdi-link-variant\` retained).

## Test plan
- [x] \`kustomize build apps/production/homepage\` passes (616 lines)
- [ ] After merge + Flux reconcile, verify homepage.burntbytes.com:
  - [ ] Status dots appear next to every service
  - [ ] OpenWebUI / vLLM / Overture tiles present in Tools
  - [ ] All five new bookmarks (GitHub Inbox, ghcr.io, Flux, CNPG, Renovate) present
  - [ ] AdGuard tile shows queries metrics (only after operator adds the secret)
  - [ ] Card text readable on the lighter parts of the background photo