### PR TITLE
fix(homepage): correct NetworkPolicy selector + add widget egress rules

### DIFF
--- a/apps/base/homepage/networkpolicy.yaml
+++ b/apps/base/homepage/networkpolicy.yaml
@@ -8,11 +8,22 @@ metadata:
     app.kubernetes.io/name: homepage
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 3000; egress DNS + Kubernetes API for cluster widgets.
+  description: >-
+    Gateway ingress on 3000; egress for DNS, Kubernetes API, in-cluster widget
+    Services (AdGuard admin, Prometheus), and HTTP/HTTPS to the world for the
+    Synology DSM widget (10.42.2.11:5001), HifiBerry siteMonitor probes (LAN
+    IPs), gateway VIP siteMonitor probes (*.burntbytes.com → 10.42.2.40+
+    LoadBalancer IPs), and the Unsplash background image. The previous selector
+    (`app: homepage`) matched zero pods — homepage's pods are labelled
+    `app.kubernetes.io/name: homepage`.
   endpointSelector:
     matchLabels:
-      app: homepage
+      app.kubernetes.io/name: homepage
   ingress:
+    # Cilium Envoy (Gateway API) binds upstream sockets to a dedicated proxy IP
+    # that Cilium marks as reserved identity 8 ("ingress"). Same-node connections
+    # arrive as "host"; cross-node VXLAN connections arrive as "remote-node".
+    # All three are required. Kubelet probes are auto-exempted.
     - fromEntities:
         - host
         - remote-node
@@ -22,6 +33,7 @@ spec:
             - port: "3000"
               protocol: TCP
   egress:
+    # DNS resolution via CoreDNS.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -40,4 +52,42 @@ spec:
             - port: "443"
               protocol: TCP
             - port: "6443"
+              protocol: TCP
+    # AdGuard widget — cluster-internal admin Service in adguard-prod (port 8080).
+    # Selector matches the StatefulSet pod that adguard-admin's Service targets.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: adguard-prod
+            statefulset.kubernetes.io/pod-name: adguard-0
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Prometheus widget (Cluster Resources) — kube-prometheus-stack-prometheus
+    # in the monitoring namespace, port 9090.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # World egress on HTTP/HTTPS covers:
+    #   - Synology DSM widget on the LAN (10.42.2.11:5001 — see port rule below).
+    #   - HifiBerry siteMonitor probes (http://10.42.2.38, http://10.42.2.39).
+    #   - Gateway VIP siteMonitor probes (*.burntbytes.com → 10.42.2.40+ LB pool).
+    #   - Cloudflare-tunnel-fronted hostnames (e.g. https://hestia.burntbytes.com).
+    #   - Unsplash background image (https://images.unsplash.com).
+    # FQDN restriction would add DNS-policy complexity for a public dashboard
+    # whose tile list changes; egress to ports 80/443/5001 is the pragmatic scope.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+            - port: "5001"
               protocol: TCP


### PR DESCRIPTION
## Summary

The homepage `CiliumNetworkPolicy` was effectively **unenforced**:

- `endpointSelector` was `matchLabels: { app: homepage }`.
- The actual pods are labelled `app.kubernetes.io/name: homepage` (verified via `kubectl get pods -n homepage-prod --show-labels`).
- The selector matched **zero endpoints**, so no traffic was being filtered. That's why the existing Synology DSM widget (egress to `10.42.2.11:5001`) works despite no allow rule for it.

This PR fixes the selector and adds the egress rules homepage actually needs against the current `apps/production/homepage/services.yaml` plus the (still-unmerged) `feat/homepage-overhaul` services.yaml that adds the AdGuard and Prometheus widgets.

## Why the policy was unenforced

`CiliumNetworkPolicy.spec.endpointSelector` works like a `podSelector` — pods must match every key in `matchLabels`. None of homepage's pods have an `app` label, so the policy applied to nothing.

## What it now allows (egress)

| Rule | Destination | Why |
|---|---|---|
| CoreDNS UDP/TCP 53 | `kube-system / k8s-app=kube-dns` | Mandatory for any name resolution |
| `kube-apiserver` 443/6443 | reserved `kube-apiserver` entity | Existing — Kubernetes widget data |
| 8080 → `adguard-prod / adguard-0` | in-cluster Service | AdGuard widget URL: `http://adguard-admin.adguard-prod.svc.cluster.local:8080` |
| 9090 → `monitoring / app.kubernetes.io/name=prometheus` | in-cluster Service | Prometheus "Cluster Resources" widget |
| `world` 80/443/5001 | LAN + internet | Synology DSM (`10.42.2.11:5001`), HifiBerry LAN tiles (`10.42.2.38/39`), gateway VIP siteMonitor probes against `*.burntbytes.com` (10.42.2.40+ LB pool, including cloudflare-tunnel-fronted hosts), Unsplash background image |

Ingress is unchanged: `fromEntities: [host, remote-node, ingress]` on port 3000 — the canonical Cilium gateway pattern used by every other app netpol in this repo (authelia, golinks, openwebui).

## Judgment calls

- **`world` for HTTP/HTTPS rather than per-FQDN allowlists.** The dashboard's tile list changes regularly, several tiles route through cloudflare-tunnel (so the egress IP is not a stable LAN CIDR), and `toFQDNs` would add DNS-policy complexity for what is effectively a static-asset polling client. Other apps in the repo (snapcast, overture) use `toEntities: world` on 443 for the same reason.
- **No `world` UDP** — homepage doesn't make UDP egress.
- **No port 5001 on internal/cluster rules** — kept on the world rule only since Synology DSM is the sole consumer.

## Blast radius

This is a **security tightening**: previously zero egress was enforced. After this lands, anything not in the rules above will be dropped by Cilium. If a widget breaks after Flux reconciles, the netpol is the cause — check `hubble observe --verdict DROPPED -n homepage-prod`.

PR #586 (`feat/homepage-overhaul`) is still open against master; once this lands, that PR will rebase and the new tile list (with `Logs` rename, OpenWebUI, Hestia, Overture, AdGuard widget URL) will be covered.

## Validation

- [x] `kustomize build apps/production/homepage` passes
- [x] `kustomize build apps/staging/homepage` passes
- [x] Rendered `endpointSelector` is `app.kubernetes.io/name: homepage` (kustomization uses `includeSelectors: false`, no extra labels stamped onto selectors)
- [x] No plaintext secrets in diff

## Test plan

- [ ] Merge → wait for Flux reconcile (`flux reconcile kustomization apps-production -n flux-system`)
- [ ] Confirm homepage pod is still serving `https://home.burntbytes.com`
- [ ] Walk through every tile: AdGuard / Prometheus / Synology widgets render data; siteMonitor lights stay green for `*.burntbytes.com`, HifiBerry, Cloudflare-tunnel hosts
- [ ] `kubectl exec -n homepage-prod homepage-... -- wget -O- https://images.unsplash.com/...` succeeds (background image)
- [ ] `hubble observe --verdict DROPPED -n homepage-prod` is empty (or only shows expected denials) for at least one render cycle

## Reference

Surfaced during `/babysit` of PR #586 (`feat/homepage-overhaul`).