### PR TITLE
fix(homepage): probe Hestia tile at /ui/ to avoid 302 -> http 500

### DIFF
--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -45,7 +45,10 @@
         icon: truenas-scale.png
         href: https://hestia.burntbytes.com
         description: TrueNAS GPU server (vLLM, signal-cli, RTX 4090)
-        siteMonitor: https://hestia.burntbytes.com
+        # TrueNAS root path returns a 302 to http://hestia.burntbytes.com/ui/
+        # (a scheme-downgrading redirect served by TrueNAS itself), which the
+        # homepage siteMonitor renders as HTTP 500. /ui/ returns 200 directly.
+        siteMonitor: https://hestia.burntbytes.com/ui/
     - Overture:
         icon: mdi-rss
         href: https://overture.burntbytes.com


### PR DESCRIPTION
## Summary

The Hestia homepage tile's `siteMonitor` was rendering as HTTP 500 in the dashboard. Root cause: TrueNAS UI returns a 302 at `https://hestia.burntbytes.com/` whose `Location` header points at `http://hestia.burntbytes.com/ui/` — a scheme downgrade (HTTPS → HTTP) baked into the TrueNAS UI itself. The homepage siteMonitor probe surfaces that scheme-downgrading redirect as a 500.

Probing `/ui/` directly avoids the redirect and returns 200 OK. Only the `siteMonitor` URL changes; the `href` stays at the bare hostname so click-through still lands on the TrueNAS root.

## Diagnosis chain

| Probe | Result |
|---|---|
| `curl -skI https://hestia.burntbytes.com` (mac) | `HTTP/2 302` → `Location: http://hestia.burntbytes.com/ui/` |
| `curl -skI https://hestia.burntbytes.com/ui/` (mac) | `HTTP/2 200` |
| `wget -S --spider https://hestia.burntbytes.com` (homepage pod) | 302 → 301 → 200 (3-hop scheme bouncing) |
| `wget -S --spider https://hestia.burntbytes.com/ui/` (homepage pod) | `HTTP/1.1 200 OK` (single hop) |

Backend is healthy (TrueNAS-26.0.0-BETA.1, 78482-byte response body served on `/ui/`). The HTTPRoute (`apps/production/external-services/hestia.yaml`) is fine — it terminates TLS at the gateway and proxies plaintext HTTP to `10.42.2.10:80` exactly as documented. The fault is in the probe target choice, not the gateway/route.

This is **option 1** from the investigation playbook ("fix the homepage tile") — no HTTPRoute or TrueNAS-side change needed.

## Test plan
- [ ] Flux reconciles `apps-production`, ConfigMap rolls, homepage pod picks up new services.yaml
- [ ] Hestia tile shows 200 / green status badge instead of HTTP 500
- [ ] Click-through on the tile still lands on the TrueNAS root (which redirects you to `/ui/` as before)
- [ ] No regression in adjacent tiles (Overture, Vitals, Chat, etc.)

## Notes for parallel agents

This PR touches `apps/production/homepage/services.yaml` (Tools section, Hestia tile lines only — `siteMonitor` value + 3 lines of comment). The parallel Pingo subagent will work in `~/src/homelab/.worktrees/fix-pingo-404` against the same file but a different tile. Branches are independent off `origin/master`; whichever PR merges first will require the second to rebase its single-tile edit, which is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)