### PR TITLE
fix(homepage): remove siteMonitor from Pingo tile (404 noise)

### DIFF
--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -124,7 +124,10 @@
         icon: mdi-dns
         href: https://vpn.burntbytes.com
         description: DNS updater for vpn.burntbytes.com
-        siteMonitor: https://vpn.burntbytes.com
+        # No siteMonitor: pingo is a CronJob (DNS updater for vpn.burntbytes.com),
+        # not an HTTP service — there is no HTTPRoute for vpn.burntbytes.com,
+        # so any probe returns 404 from the gateway. The href stays clickable
+        # for the operator; the dashboard simply omits the status dot.
 
 - Monitoring:
     - Cluster Resources:


### PR DESCRIPTION
## Summary

The Pingo tile on home.burntbytes.com shows a red status dot because its `siteMonitor` probe hits `https://vpn.burntbytes.com` and gets `HTTP 404` from Envoy. **Pingo is a CronJob — not an HTTP service.** There is no Service, no HTTPRoute, no listener. `vpn.burntbytes.com` is the host pingo *manages* (it updates the Cloudflare A record every 5 minutes), not something it serves.

This was introduced in #586 (`feat(homepage): address dashboard layout critique`), which added `siteMonitor:` to every tile en masse. That change is great for the ~20 real HTTP services, but pingo is the odd one out.

## Diagnosis chain

1. `curl -skI https://vpn.burntbytes.com` -> `HTTP/2 404 server: envoy`
2. Probed `/, /health, /healthz, /ready, /readyz, /api, /metrics, /status, /update` — every path returns 404
3. From inside the cluster (`kubectl exec homepage-prod ... wget vpn.burntbytes.com`) -> same 404
4. `infra/controllers/pingo/` contains: namespace, secret, **CronJob** (`schedule: */5 * * * *`), and a kustomization. **No Service, no Deployment, no HTTPRoute.**
5. `kubectl get httproute -A | grep -iE 'pingo|vpn'` -> empty
6. The image (`ghcr.io/gjcourt/pingo:2026-02-25`) is a one-shot DDNS updater — runs, hits the Cloudflare API, exits.

Root cause: **case A from the diagnostic playbook** — pingo doesn't serve `/` (it doesn't serve anything), so the gateway has no route for the host and Envoy correctly returns 404.

## Fix

Drop the `siteMonitor` field from the Pingo tile. The `href` stays so the tile is still clickable in the dashboard layout. The status dot simply won't render for this tile, which is the honest signal — there is nothing to monitor.

A comment is left in-place explaining *why* the field is omitted, so a future drive-by add-it-back PR doesn't reintroduce the bug.

## Alternatives considered

- **Add `/healthz` to pingo** — would require turning the CronJob into a Deployment (or running a sidecar), adding a Service, and an HTTPRoute. Substantially larger change. Out of scope; not currently warranted just for a status dot.
- **Point `siteMonitor` at a path that returns 200** — none exists. All paths 404.
- **Remove the tile entirely** — the link is still useful as a documentation pointer (operator clicks through to remember what `vpn.burntbytes.com` is for), so keeping it dark-but-clickable is preferable.

## Test plan

- [x] `kustomize build apps/production/homepage` succeeds with the change.
- [ ] After merge + Flux reconcile, confirm in the dashboard that the Pingo tile no longer shows a red status dot (it should render with no status indicator at all).
- [ ] Confirm the Pingo `href` still navigates (or fails gracefully — irrelevant to the tile rendering).

## Notes

- Touched only the production overlay; staging didn't have `siteMonitor` on the Pingo tile (the layout-critique PR only updated production).
- No infra change. No image bump. Single-line YAML edit (plus an explanatory comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)