### PR TITLE
fix(pingo): re-enable DDNS updater

### DIFF
--- a/infra/controllers/kustomization.yaml
+++ b/infra/controllers/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - kube-prometheus-stack
   - loki
   - mosquitto
-  # - pingo
+  - pingo
   - promtail
   - renovate
   - renovate-automerge


### PR DESCRIPTION
## Summary

Re-enables the `pingo` CronJob by uncommenting the entry in `infra/controllers/kustomization.yaml`.

## Background

- Pingo was disabled in commit `2478b5d` (2026-02-25 14:49 PST) via a direct-to-master push with no PR and no rationale in the commit message.
- All manifests are still in tree (cronjob, namespace, encrypted secret, ghcr pull secret) — image pinned to `ghcr.io/gjcourt/pingo:2026-02-25`.
- `vpn.burntbytes.com` currently resolves to `10.42.2.40` (the prod app-gateway LoadBalancer, a LAN-only address) — external VPN access via that hostname is broken until pingo runs once and updates the Cloudflare A record.
- User confirmed this was a forgotten temporary disable, not a deliberate retirement.

## Test plan

- [x] `kustomize build infra/controllers` passes
- [ ] After merge + Flux reconcile: `pingo` namespace exists; CronJob `pingo/pingo` exists.
- [ ] Manually triggered Job runs to completion with exit 0; logs show successful Cloudflare API call.
- [ ] `vpn.burntbytes.com` resolves to the actual current public IP (not 10.42.2.40).