### PR TITLE
chore(homepage): add Flashcards tile under Tools

### DIFF
--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -84,6 +84,11 @@
         href: https://excalidraw.burntbytes.com
         description: Virtual whiteboard for sketching
         siteMonitor: https://excalidraw.burntbytes.com
+    - Flashcards:
+        icon: mdi-cards
+        href: https://flashcards.burntbytes.com
+        description: Spaced-repetition flashcards (FSRS)
+        siteMonitor: https://flashcards.burntbytes.com/healthz
 
 - Infrastructure:
     - Synology NAS:

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -88,6 +88,7 @@
         icon: mdi-cards
         href: https://flashcards.burntbytes.com
         description: Spaced-repetition flashcards (FSRS)
+        # nginx /healthz returns 200 "ok"; root path is a SPA so probe the healthz endpoint.
         siteMonitor: https://flashcards.burntbytes.com/healthz
 
 - Infrastructure:

--- a/apps/staging/homepage/services.yaml
+++ b/apps/staging/homepage/services.yaml
@@ -53,6 +53,10 @@
         icon: excalidraw.png
         href: https://excalidraw.stage.burntbytes.com
         description: Virtual whiteboard for sketching
+    - Flashcards:
+        icon: mdi-cards
+        href: https://flashcards.stage.burntbytes.com
+        description: Spaced-repetition flashcards (FSRS)
 
 - Infrastructure:
     - Synology NAS:


### PR DESCRIPTION
## Summary
Surfaces the newly-deployed [flashcards](https://flashcards.burntbytes.com) app on the homepage dashboard alongside the other Tools.

- Production: \`siteMonitor: https://flashcards.burntbytes.com/healthz\` (nginx returns 200 with body \`ok\`)
- Staging: no \`siteMonitor\` — staging instance turns over between branch rebuilds, no point red-flagging it

## Test plan
- [x] \`kustomize build apps/production/homepage\` ✓
- [x] \`kustomize build apps/staging/homepage\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)