### PR TITLE
fix(homepage): repair Synology siteMonitor + AdGuard widget egress/ingress

### DIFF
--- a/apps/base/adguard/networkpolicy.yaml
+++ b/apps/base/adguard/networkpolicy.yaml
@@ -76,6 +76,17 @@ spec:
               protocol: TCP
             - port: "8080"
               protocol: TCP
+    # Homepage widget (production) polls the AdGuard admin API via the
+    # adguard-admin Service (port 8080 → pod port 80). Cilium evaluates
+    # ingress after DNAT, so the rule matches the pod port (80).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: homepage-prod
+            app.kubernetes.io/name: homepage
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
   egress:
     # kube-dns / CoreDNS for in-cluster Service resolution.
     - toEndpoints:

--- a/apps/base/homepage/networkpolicy.yaml
+++ b/apps/base/homepage/networkpolicy.yaml
@@ -53,15 +53,19 @@ spec:
               protocol: TCP
             - port: "6443"
               protocol: TCP
-    # AdGuard widget — cluster-internal admin Service in adguard-prod (port 8080).
-    # Selector matches the StatefulSet pod that adguard-admin's Service targets.
+    # AdGuard widget — cluster-internal admin Service in adguard-prod.
+    # The adguard-admin Service exposes 8080, but its targetPort is the
+    # `http` named port → AdGuard pod port 80. Cilium evaluates egress
+    # after DNAT, so the policy must match the post-DNAT pod port (80),
+    # not the Service port (8080). The previous `port: "8080"` matched
+    # nothing, dropping the widget API call.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: adguard-prod
             statefulset.kubernetes.io/pod-name: adguard-0
       toPorts:
         - ports:
-            - port: "8080"
+            - port: "80"
               protocol: TCP
     # Prometheus widget (Cluster Resources) — kube-prometheus-stack-prometheus
     # in the monitoring namespace, port 9090.

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -96,7 +96,12 @@
         icon: synology-dsm.png
         href: https://10.42.2.11:5001
         description: Network storage
-        siteMonitor: http://10.42.2.11:5000
+        # DSM only exposes 5001 (HTTPS) to the homepage pod — port 5000
+        # (HTTP) is closed at the source and also outside the egress allowlist
+        # in the homepage CiliumNetworkPolicy, which made the previous
+        # `http://10.42.2.11:5000` siteMonitor return 500. Match the widget URL
+        # (5001) so both probes share one allowed flow.
+        siteMonitor: https://10.42.2.11:5001
         widget:
           type: diskstation
           url: https://10.42.2.11:5001


### PR DESCRIPTION
## Summary

Two unrelated bugs are surfacing on the home.burntbytes.com Infrastructure section. This PR fixes both.

### Issue 1 — Synology NAS tile shows "500" siteMonitor badge

- The siteMonitor URL was `http://10.42.2.11:5000` (DSM HTTP).
- From inside the homepage pod, port 5000 isn't reachable (TCP timeout). DSM has HTTP disabled at the source, **and** the homepage CiliumNetworkPolicy's `world` egress only allows 80/443/5001 — port 5000 was not in the allowlist.
- Port 5001 (HTTPS) is open and is what the widget already uses successfully (the widget data renders fine: 18d uptime, 4.5 TiB, etc.).
- Fix: point siteMonitor at `https://10.42.2.11:5001` so it shares the widget's already-allowed flow.

Probe results from the `homepage-prod` pod (busybox `nc`):

| Target | Result |
|---|---|
| `10.42.2.11:5000` | TCP timeout (closed at source + not in egress allowlist) |
| `10.42.2.11:5001` | open |

### Issue 2 — AdGuard Home tile shows "API Error Information"

Three things were stacking up to break the widget:

1. **Homepage CNP egress** allowed port **8080** to `adguard-0`. That's the `adguard-admin` Service port; its targetPort is the named `http` port → pod port **80**. Cilium evaluates policy *after* DNAT, so the post-DNAT destination port is 80, not 8080. The 8080 rule matched nothing → widget API calls dropped at egress.
2. **AdGuard CNP ingress** on port 80 only permitted `host` / `remote-node` / `ingress` (gateway path). Homepage pod identity wasn't allowed → drop on receive.
3. **Operator action still required (out of PR scope):** the `homepage-adguard` Secret containing `HOMEPAGE_VAR_ADGUARD_USER` / `HOMEPAGE_VAR_ADGUARD_PASS` does not yet exist in `homepage-prod`. PR #586 shipped the wiring with `optional: true` and a `secret-adguard.yaml.example` template; the actual SOPS-encrypted secret was deferred to the operator. Without it, the widget falls back to anonymous calls which AdGuard rejects with 401.

This PR fixes the two CNP bugs (#1 and #2) so that **once the operator provisions the secret, the widget will work end-to-end**. Without these CNP changes, just adding the secret would still produce timeouts.

The CNP changes are the minimum required to support the existing widget URL — they do **not** disable AdGuard auth, do **not** widen ingress beyond the homepage pod identity, and do **not** modify the deployment-patch's optional secretRef.

#### Operator follow-up (after this PR merges)

```bash
# 1. Copy the example template:
cp apps/production/homepage/secret-adguard.yaml.example \
   apps/production/homepage/secret-adguard.yaml

# 2. Replace REPLACE_ME placeholders with the real AdGuard admin user + password.

# 3. Encrypt with SOPS in-place:
sops -e -i apps/production/homepage/secret-adguard.yaml

# 4. Add `secret-adguard.yaml` to apps/production/homepage/kustomization.yaml
#    under `resources:`.

# 5. Commit + open a PR. After Flux reconciles, the homepage AdGuard
#    widget displays queries-blocked / total-queries / etc.
```

## Coordination

There is an in-flight refactor PR (`refactor/homepage-configmap-generator`) that moves `apps/production/homepage/services.yaml` → `apps/production/homepage/config/services.yaml`. The Synology siteMonitor tile-line edit will need a trivial rebase if that PR merges first; whoever lands second will move the one-line change to the new path. The two CNP edits in `apps/base/{homepage,adguard}/networkpolicy.yaml` are unaffected.

## Test plan

- [x] `kustomize build apps/production/homepage` passes
- [x] `kustomize build apps/staging/homepage` passes
- [x] `kustomize build apps/production/adguard` passes
- [x] `kustomize build apps/staging/adguard` passes
- [x] `git diff HEAD | grep -i "password\|secret\|key"` returns no plaintext
- [ ] After merge + Flux reconcile, Synology tile siteMonitor badge clears (no longer "500")
- [ ] After merge + Flux reconcile **and** operator provisions `homepage-adguard` secret, AdGuard widget displays metrics in place of "API Error Information"

🤖 Generated with [Claude Code](https://claude.com/claude-code)