### PR TITLE
feat(netscope): add netscope DaemonSet for staging

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -21,6 +21,7 @@
 - [mealie](base/mealie/)
 - [memos](base/memos/)
 - [navidrome](base/navidrome/)
+- [netscope](base/netscope/)
 - [openwebui](base/openwebui/)
 - [overture](base/overture/)
 - [signal-cli](base/signal-cli/)

--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netscope-agent
+  namespace: netscope
+  labels:
+    app.kubernetes.io/name: netscope
+    app.kubernetes.io/component: agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: netscope
+      app.kubernetes.io/component: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: netscope
+        app.kubernetes.io/component: agent
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: netscope-agent
+      hostNetwork: true
+      hostPID: false
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: agent
+          image: "ghcr.io/gjcourt/netscope:a4982ac@sha256:f838246a72add4bfb0fd1463f3bf8c93f65e8a49117950f4989e3baf93c1bc03"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NETSCOPE_IFACE
+              value: "eno1"
+          ports:
+            - name: metrics
+              containerPort: 9101
+              hostPort: 9101
+              protocol: TCP
+          securityContext:
+            privileged: false
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              add:
+                - BPF
+                - PERFMON
+                - NET_ADMIN
+                # SYS_ADMIN is required for bpf(BPF_PROG_GET_NEXT_ID),
+                # which the agent uses at startup to discover Cilium's
+                # ingress program for tcx anchor placement.
+                - SYS_ADMIN
+              drop:
+                - ALL
+          volumeMounts:
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+              mountPropagation: HostToContainer
+            - name: btf
+              mountPath: /sys/kernel/btf
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9101
+              host: 127.0.0.1
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9101
+              host: 127.0.0.1
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory
+        - name: btf
+          hostPath:
+            path: /sys/kernel/btf
+            type: Directory

--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -25,6 +25,12 @@ spec:
       hostNetwork: true
       hostPID: false
       dnsPolicy: ClusterFirstWithHostNet
+      # Intentional: schedule on every node including control-plane.
+      # Network observability is most useful when it covers all 6 nodes
+      # (3 CP + 3 worker). The agent footprint is small (~50m CPU / 64Mi
+      # memory request) and CP nodes route a non-trivial share of cluster
+      # traffic (Cilium VXLAN, control-plane API). Revisit if CP capacity
+      # becomes tight.
       tolerations:
         - operator: Exists
       containers:
@@ -41,7 +47,14 @@ spec:
               protocol: TCP
           securityContext:
             privileged: false
+            # runAsUser: 0 — eBPF tcx attach + BPF_PROG_GET_NEXT_ID
+            # discovery require UID 0; non-root would need ambient
+            # capabilities support which Talos doesn't expose.
             runAsUser: 0
+            allowPrivilegeEscalation: false
+            # readOnlyRootFilesystem deferred: the upstream agent
+            # is a scratch-image Go binary and likely tolerates it,
+            # but unverified — flip after first prod soak.
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/apps/base/netscope/kustomization.yaml
+++ b/apps/base/netscope/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - daemonset.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: netscope
+      app.kubernetes.io/component: agent
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/netscope/namespace.yaml
+++ b/apps/base/netscope/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netscope
+  labels:
+    app: netscope
+    # netscope's agent loads BPF programs and runs in the host network
+    # namespace; PSA restricted/baseline blocks both. Privileged is the
+    # required level here.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/base/netscope/serviceaccount.yaml
+++ b/apps/base/netscope/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netscope-agent
+  namespace: netscope

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - mealie
   - memos
   - navidrome
+  - netscope
   - openwebui
   - signal-cli
   - snapcast

--- a/apps/staging/netscope/kustomization.yaml
+++ b/apps/staging/netscope/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: netscope-stage
+resources:
+  - ../../base/netscope/
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  # Rename the Namespace resource itself to match `namespace:` above.
+  - target:
+      kind: Namespace
+      name: netscope
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: netscope-stage


### PR DESCRIPTION
## Summary

Wire up [netscope](https://github.com/gjcourt/netscope) — eBPF-based network traffic analyzer — as a Flux-managed app in the staging overlay. Phase 1 of [brainstorm 03-001](https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md).

What it does: a per-node DaemonSet attaches a \`tcx\` ingress eBPF program **ahead of** Cilium's \`cil_from_netdev\` and exposes per-node byte counters (\`netscope_rx_bytes_total{iface}\`) as Prometheus metrics on host port 9101. Coexists cleanly with Cilium — the program returns \`TC_ACT_UNSPEC\` and never alters packet disposition.

## What's added

- \`apps/base/netscope/\` — namespace (PSA privileged), ServiceAccount, DaemonSet
- \`apps/staging/netscope/\` — overlay renaming the namespace to \`netscope-stage\`
- Wired into \`apps/staging/kustomization.yaml\`; \`apps/README.md\` regenerated

## Image

\`ghcr.io/gjcourt/netscope:a4982ac@sha256:f838246a72add4bfb0fd1463f3bf8c93f65e8a49117950f4989e3baf93c1bc03\` — built by GHA from netscope repo's main branch.

## Capabilities + security

- \`hostNetwork: true\` (required for tcx attach to physical NIC \`eno1\`)
- \`CAP_BPF\`, \`CAP_PERFMON\`, \`CAP_NET_ADMIN\`, **\`CAP_SYS_ADMIN\`** (the last is needed for \`bpf(BPF_PROG_GET_NEXT_ID)\` — the agent enumerates loaded programs at startup to anchor before Cilium's by program ID)
- \`seccompProfile: RuntimeDefault\` to narrow SYS_ADMIN's syscall surface
- \`runAsUser: 0\`; \`privileged: false\`

## Pre-merge state

I'd been running this app outside Flux for Phase 0 validation (in the cluster's \`netscope-stage\` namespace, applied via \`kubectl apply\`). When this PR merges and Flux reconciles, it will adopt the existing namespace + objects (same names, label-compatible). The currently-running pod has been shown to:

- Attach \`count_rx\` ahead of \`cil_from_netdev\` on \`eno1\` (verified via \`bpftool net show\`)
- Increment \`netscope_rx_bytes_total{iface="eno1"}\` ~140 KB/s under steady-state load

## Test plan

- [x] \`kustomize build apps/staging/netscope\` passes
- [x] \`kustomize build apps/staging\` passes
- [ ] CI green
- [ ] After merge: Flux \`apps-staging\` Kustomization reconciles cleanly
- [ ] DaemonSet schedules on all 6 nodes (no nodeSelector now); pods report Ready
- [ ] \`netscope_rx_bytes_total\` reported by Prometheus for every node

## Notes

- Tolerations are \`Exists\` so the DaemonSet schedules on control-plane nodes too — host network signals are interesting on every node.
- The \`apps/production\` overlay is intentionally not added yet (Phase 3).
- A Flux-driven image automation policy could pin to the latest SHA automatically; for now I'm hand-pinning per repo convention.
- Per-app runbook (\`docs/operations/apps/netscope.md\`) is a follow-up after deploy validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)