### PR TITLE
chore: scale GPU-dependent apps to 0 (hestia GPU removed for sale)

### DIFF
--- a/apps/base/hermes/deployment.yaml
+++ b/apps/base/hermes/deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     app: hermes
 spec:
-  replicas: 1
+  # Disabled 2026-05-10: GPUs removed from hestia for sale, vLLM at
+  # http://10.42.2.10:8000 is unavailable. Applies to both hermes and
+  # hermes-callee (which overlays this base). Restore replicas to 1 once
+  # GPU inference is back online.
+  replicas: 0
   revisionHistoryLimit: 5
   strategy:
     type: Recreate

--- a/apps/base/openwebui/deployment.yaml
+++ b/apps/base/openwebui/deployment.yaml
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: openwebui
 spec:
-  replicas: 1
+  # Disabled 2026-05-10: GPUs removed from hestia for sale, vLLM at
+  # http://10.42.2.10:8000 is unavailable. Restore replicas to 1 once
+  # GPU inference is back online (or the upstream URL is repointed).
+  replicas: 0
   revisionHistoryLimit: 5
   selector:
     matchLabels:

--- a/apps/base/signal-cli/deployment.yaml
+++ b/apps/base/signal-cli/deployment.yaml
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: signal-cli
 spec:
-  replicas: 1
+  # Disabled 2026-05-10: signal-cli's only consumer was hermes, which is
+  # itself disabled following the hestia GPU removal. Restore replicas to
+  # 1 if any new Signal-bound workload needs the bridge.
+  replicas: 0
   revisionHistoryLimit: 5
   strategy:
     type: Recreate

--- a/apps/production/homepage/services.yaml
+++ b/apps/production/homepage/services.yaml
@@ -39,12 +39,13 @@
     - OpenWebUI:
         icon: open-webui.png
         href: https://chat.burntbytes.com
-        description: AI chat interface (frontend for vLLM)
-        siteMonitor: https://chat.burntbytes.com
+        # Disabled 2026-05-10: hestia GPU removed for sale; openwebui scaled
+        # to 0. siteMonitor dropped so the tile doesn't render permanently red.
+        description: AI chat interface (disabled — hestia GPU removed)
     - Hestia:
         icon: truenas-scale.png
         href: https://hestia.burntbytes.com
-        description: TrueNAS GPU server (vLLM, signal-cli, RTX 4090)
+        description: TrueNAS NAS (GPU removed 2026-05-10)
         # TrueNAS root path returns a 302 to http://hestia.burntbytes.com/ui/
         # (a scheme-downgrading redirect served by TrueNAS itself), which the
         # homepage siteMonitor renders as HTTP 500. /ui/ returns 200 directly.

--- a/hosts/hestia/llms/README.md
+++ b/hosts/hestia/llms/README.md
@@ -1,5 +1,11 @@
 # llms — GPU inference on hestia
 
+> **Disabled 2026-05-10:** GPUs removed from hestia for sale. All compose
+> files in this directory are inactive — the SCALE Custom Apps (`llama`,
+> `vllm`) have been stopped and should not be restarted until GPU
+> hardware is restored. Downstream consumers (`openwebui`, `hermes`,
+> `hermes-callee`) are scaled to 0 in the apps overlays.
+
 LLM inference services for the GPU box on hestia (RTX 4090, 24 GB VRAM).
 
 ## Services


### PR DESCRIPTION
## Summary
- GPUs are being removed from hestia for sale on 2026-05-10, taking vLLM at `http://10.42.2.10:8000` offline indefinitely.
- Scale all in-cluster vLLM clients to `replicas: 0` in the base manifests so Flux stops trying to keep them running.
- Add a header note to `hosts/hestia/llms/README.md` flagging the SCALE Custom Apps (`llama`, `vllm`) as stopped.

## Affected workloads (all rendered with `replicas: 0`)
- `openwebui-prod`, `openwebui-stage`
- `hermes-prod`, `hermes-stage`
- `hermes-callee-prod`, `hermes-callee-stage`

In-cluster `signal-cli` and `overture-prod` (CNPG on TrueNAS iSCSI) do *not* depend on the GPUs and are intentionally left untouched — they were paused separately for the powerdown and will resume once hestia is back.

## Restoring
When GPU inference is back online (or the upstream URL is repointed), revert this PR (or set `replicas: 1` on each base) and restart the SCALE Custom Apps on hestia.

## Test plan
- [x] `kustomize build` passes for `apps/{production,staging}/{openwebui,hermes,hermes-callee}`
- [x] Rendered overlays show `replicas: 0`
- [ ] After merge: `flux reconcile kustomization apps-production -n flux-system` confirms zero pods