### PR TITLE
deploy(flashcards): bump image to 2026-05-10-9164c02

### DIFF
--- a/apps/base/flashcards/deployment.yaml
+++ b/apps/base/flashcards/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: flashcards
-          image: ghcr.io/gjcourt/flashcards:2026-05-10
+          image: ghcr.io/gjcourt/flashcards:2026-05-10-9164c02
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
## Summary
Pull the latest flashcards image — adds 4 system-design study decks (134 cards) from [gjcourt/flashcards#10](https://github.com/gjcourt/flashcards/pull/10).

The plain \`:2026-05-10\` tag was reused for today's second build (CI tags by date + SHA), so pinning to the SHA-suffixed tag forces a fresh pull (\`imagePullPolicy: IfNotPresent\` on Talos won't re-pull a same-named tag).

## Test plan
- [x] \`kustomize build apps/production/flashcards\` ✓
- [x] \`kustomize build apps/staging/flashcards\` ✓
- [x] Tag \`2026-05-10-9164c02\` strictly > \`2026-05-10\` (lex)
- [x] Image exists at \`ghcr.io/gjcourt/flashcards:2026-05-10-9164c02\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)