### PR TITLE
feat(netscope): add Service + ServiceMonitor for Prometheus scrape

### DIFF
--- a/apps/base/netscope/kustomization.yaml
+++ b/apps/base/netscope/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - namespace.yaml
   - serviceaccount.yaml
   - daemonset.yaml
+  - service.yaml
+  - servicemonitor.yaml
 labels:
   - includeSelectors: false
     pairs:

--- a/apps/base/netscope/service.yaml
+++ b/apps/base/netscope/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: netscope-agent
+  namespace: netscope
+  labels:
+    app.kubernetes.io/name: netscope
+    app.kubernetes.io/component: agent
+spec:
+  type: ClusterIP
+  # Headless: Endpoints carry the host IPs (the agent runs hostNetwork)
+  # rather than ephemeral pod IPs, which is what we want for per-node
+  # scrape targets. ServiceMonitor below scrapes via these Endpoints.
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: netscope
+    app.kubernetes.io/component: agent
+  ports:
+    - name: metrics
+      port: 9101
+      targetPort: metrics
+      protocol: TCP

--- a/apps/base/netscope/servicemonitor.yaml
+++ b/apps/base/netscope/servicemonitor.yaml
@@ -23,3 +23,19 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+      # Per-node DaemonSet: promote the pod's node name to a `nodename`
+      # label so dashboards can group by node without joining through
+      # kube_pod_info. Matches the pattern established by
+      # kube-prometheus-stack's kubelet scrape (see
+      # infra/controllers/kube-prometheus-stack/values.yaml — "Add
+      # nodename label", taken from Talos discussion #7214).
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: nodename
+          action: replace
+      # Drop the per-pod label: under hostNetwork the pod identity is
+      # the node, and pod names churn on restart, adding cardinality
+      # without signal.
+      metricRelabelings:
+        - action: labeldrop
+          regex: pod

--- a/apps/base/netscope/servicemonitor.yaml
+++ b/apps/base/netscope/servicemonitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: netscope-agent
+  namespace: netscope
+  labels:
+    # kube-prometheus-stack's Prometheus instance selects ServiceMonitors
+    # by helm-default release label (serviceMonitorSelectorNilUsesHelmValues=true,
+    # serviceMonitorSelector={}). Without this label our SM is invisible to it.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: netscope
+    app.kubernetes.io/component: agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: netscope
+      app.kubernetes.io/component: agent
+  # No namespaceSelector — defaults to the SM's own namespace, which is
+  # exactly the per-environment scope we want (the staging overlay
+  # rewrites this SM's namespace to netscope-stage).
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s


### PR DESCRIPTION
## Summary

PR #599 wired netscope into Flux but only put \`prometheus.io/scrape\` annotations on the pod template. kube-prometheus-stack doesn't honor those — it discovers targets via ServiceMonitor CRs labeled \`release: kube-prometheus-stack\` (per the helm chart's default \`serviceMonitorSelectorNilUsesHelmValues=true\`). Result without this PR: metrics exposed on every node, never collected.

This was the babysit's #1 finding on #599; landing it before declaring Phase 1 complete.

## What's added

- \`apps/base/netscope/service.yaml\` — headless Service (\`clusterIP: None\`) selecting the agent pods. With \`hostNetwork: true\` the Endpoints carry host IPs, which is exactly the per-node scrape-target shape Prometheus needs.
- \`apps/base/netscope/servicemonitor.yaml\` — ServiceMonitor labeled \`release: kube-prometheus-stack\`, default namespace selector (the SM's own namespace), 30s scrape interval, 10s timeout.

## Test plan

- [x] \`kustomize build apps/staging/netscope\` renders Service + ServiceMonitor in \`netscope-stage\`
- [x] \`kustomize build apps/staging\` passes
- [ ] CI green
- [ ] After merge + Flux reconcile: \`kubectl -n netscope-stage get servicemonitor,service\` shows the new objects
- [ ] Prometheus targets page shows \`netscope-stage/netscope-agent\` endpoint(s) UP
- [ ] PromQL: \`netscope_rx_bytes_total{}\` returns time series, one per node

## Notes

- No production overlay (Phase 3); SM lives in stage only via the existing staging overlay.
- Modeled after \`apps/base/synology-iscsi-monitor/\` (the closest precedent — single-tenant DaemonSet-style exporter that also uses the \`release: kube-prometheus-stack\` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)