### PR TITLE
deploy(flashcards): bump image to 2026-05-10-ca112b2

### DIFF
--- a/apps/base/flashcards/deployment.yaml
+++ b/apps/base/flashcards/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: flashcards
-          image: ghcr.io/gjcourt/flashcards:2026-05-10-9164c02
+          image: ghcr.io/gjcourt/flashcards:2026-05-10-ca112b2
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
Pulls in the new `sd-estimation` deck from gjcourt/flashcards#11.

`kustomize build apps/{staging,production}/flashcards` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)