### PR TITLE
chore(overture): scale to 0 (no longer in active use)

### DIFF
--- a/apps/base/overture/deployment.yaml
+++ b/apps/base/overture/deployment.yaml
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: overture
 spec:
-  replicas: 1
+  # Disabled 2026-05-10: overture is no longer in active use. The CNPG
+  # cluster has been hibernated separately; bringing this back up
+  # requires de-hibernating overture-db-production-cnpg-v1 first.
+  replicas: 0
   revisionHistoryLimit: 5
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
- Overture is no longer in active use; scale `apps/base/overture` to `replicas: 0`.
- CNPG cluster `overture-db-production-cnpg-v1` is already hibernated (separately, during the hestia powerdown).

## Restoring
Set `replicas: 1` and remove the `cnpg.io/hibernation` annotation from the Cluster.

## Test plan
- [x] `kustomize build apps/production/overture` passes, renders `replicas: 0`