### PR TITLE
fix(homepage): use Cilium-visible label for AdGuard egress selector

### DIFF
--- a/apps/base/homepage/networkpolicy.yaml
+++ b/apps/base/homepage/networkpolicy.yaml
@@ -54,15 +54,23 @@ spec:
             - port: "6443"
               protocol: TCP
     # AdGuard widget — cluster-internal admin Service in adguard-prod.
-    # The adguard-admin Service exposes 8080, but its targetPort is the
-    # `http` named port → AdGuard pod port 80. Cilium evaluates egress
-    # after DNAT, so the policy must match the post-DNAT pod port (80),
-    # not the Service port (8080). The previous `port: "8080"` matched
-    # nothing, dropping the widget API call.
+    # Two Cilium gotchas in one rule:
+    #   1) The adguard-admin Service exposes 8080, but its targetPort is the
+    #      `http` named port → AdGuard pod port 80. Cilium evaluates egress
+    #      after DNAT, so the policy must match the post-DNAT pod port (80),
+    #      not the Service port (8080).
+    #   2) Cilium only promotes a subset of pod labels into its policy-visible
+    #      identity (notably the `app.kubernetes.io/*` prefix). It does NOT
+    #      promote `statefulset.kubernetes.io/pod-name`. A previous version of
+    #      this rule used that label (mirroring the adguard-admin Service's
+    #      pod selector) and matched zero identities — Hubble showed
+    #      `policy-verdict:none EGRESS DENIED`. Use `app.kubernetes.io/name`
+    #      instead; that broadens to all adguard pods (adguard-0 + adguard-1),
+    #      but the Service itself still routes only to adguard-0.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: adguard-prod
-            statefulset.kubernetes.io/pod-name: adguard-0
+            app.kubernetes.io/name: adguard
       toPorts:
         - ports:
             - port: "80"


### PR DESCRIPTION
## Summary

Fixes a regression introduced by PR #598. The AdGuard widget egress rule
on the homepage CNP used \`statefulset.kubernetes.io/pod-name: adguard-0\`
as its endpoint selector — correct at the Kubernetes Service layer
(matches the adguard-admin Service's own pod selector), but **Cilium
does not promote that label into its policy-visible identity**.

Hubble showed the actual outcome on the live cluster post-merge:

\`\`\`
homepage-prod/homepage-84ccfc7bc8-rxclf:46586 (ID:6350) <> adguard-prod/adguard-0:80 (ID:40391)
  policy-verdict:none EGRESS DENIED (TCP Flags: SYN)
\`\`\`

Cilium-visible identity labels for \`adguard-0\` (cluster query):

\`\`\`
k8s:app.kubernetes.io/name=adguard         ← we should match this
k8s:io.kubernetes.pod.namespace=adguard-prod
(... namespace labels ...)
# no statefulset.kubernetes.io/pod-name
\`\`\`

## Fix

One-line change: replace \`statefulset.kubernetes.io/pod-name: adguard-0\`
with \`app.kubernetes.io/name: adguard\` in the homepage CNP's egress
rule. The rule now matches \`adguard-0\` AND \`adguard-1\` (both labelled
the same), but the \`adguard-admin\` Service still routes only to
\`adguard-0\` via its own pod selector. No security regression.

Also expanded the rule's inline comment to document **both** Cilium
gotchas this rule has fallen into:

1. Post-DNAT port semantics (port 8080 → 80 — the fix in #598).
2. Identity-label visibility (\`app.kubernetes.io/*\` is promoted;
   \`statefulset.kubernetes.io/*\` is not — the fix in this PR).

## Test plan

- [x] \`kustomize build apps/production/homepage\` passes
- [x] \`kustomize build apps/staging/homepage\` passes
- [ ] After merge + Flux reconcile, confirm via Hubble:
  - \`homepage → adguard-0:80\` policy-verdict changes from \`none EGRESS DENIED\` to \`L3-L4 EGRESS ALLOWED\`
  - \`wget http://adguard-admin.adguard-prod.svc.cluster.local:8080/control/status\` from the homepage pod returns 401 (the secret is still missing, but the network path is now open)

## Out of scope

- AdGuard secret provisioning — operator-only (per \`feedback_sops_modifications_operator_only.md\`).
- Same pattern review for other CNPs in the repo that may use \`statefulset.kubernetes.io/pod-name\` — surface as separate audit.