### PR TITLE
chore(netscope): bump image to 579e662, drop NETSCOPE_IFACE override

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,11 +35,8 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:a4982ac@sha256:f838246a72add4bfb0fd1463f3bf8c93f65e8a49117950f4989e3baf93c1bc03"
+          image: "ghcr.io/gjcourt/netscope:579e662@sha256:4caec2a1650be7b0623f27adf121c1b39c1a9dac48af5edbb1ca224fdb7308d2"
           imagePullPolicy: IfNotPresent
-          env:
-            - name: NETSCOPE_IFACE
-              value: "eno1"
           ports:
             - name: metrics
               containerPort: 9101

--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -37,6 +37,10 @@ spec:
         - name: agent
           image: "ghcr.io/gjcourt/netscope:579e662@sha256:4caec2a1650be7b0623f27adf121c1b39c1a9dac48af5edbb1ca224fdb7308d2"
           imagePullPolicy: IfNotPresent
+          # NETSCOPE_IFACE intentionally unset — the agent discovers the
+          # IPv4 default-route interface at startup from /proc/net/route.
+          # Set explicitly here (e.g. value: "eno1") to pin to a specific
+          # NIC and skip discovery.
           ports:
             - name: metrics
               containerPort: 9101


### PR DESCRIPTION
## Summary

- Bump `ghcr.io/gjcourt/netscope` from `a4982ac` to `579e662` (gjcourt/netscope#5 — runtime default-route discovery from `/proc/net/route`).
- Drop the `NETSCOPE_IFACE=eno1` env override from the DaemonSet. The agent now auto-discovers its egress interface; pinning it forward would mask any discovery regressions during rollout.

## Why drop the env

The previous build defaulted to `eno1` only because that was hardcoded in the agent. Now that the agent reads the default route at startup, every Talos node will independently pick `eno1` (because that *is* the default-route iface on every node in this cluster), but we exercise the discovery path on each pod rather than short-circuiting it. If discovery breaks on some future hardware refresh, we'd rather see that immediately than silently fall through to a stale override.

## Image digest

```
ghcr.io/gjcourt/netscope:579e662@sha256:4caec2a1650be7b0623f27adf121c1b39c1a9dac48af5edbb1ca224fdb7308d2
```

`579e662` is a strictly later commit on `gjcourt/netscope` `main` than `a4982ac` — image tag invariant holds.

## Validation

- [x] `kustomize build apps/staging/netscope` passes
- [x] `kustomize build apps/staging` passes
- [x] Rendered DaemonSet shows new image digest and no `NETSCOPE_IFACE` env entry

## Test plan (post-merge)

- [ ] Flux reconciles `apps-staging` (or `flux reconcile kustomization apps-staging -n flux-system`)
- [ ] `kubectl -n netscope get ds netscope-agent -o yaml | grep image:` shows `579e662@sha256:4caec2a1...`
- [ ] `kubectl -n netscope get pods -o wide` — all 6 agent pods Running, one per node, with the new image digest
- [ ] On every node, `kubectl -n netscope logs ds/netscope-agent` contains an iface-selection line with `source=default-route iface=eno1`
- [ ] `netscope_rx_bytes_total` continues to increment on each node (`sum by (node) (rate(netscope_rx_bytes_total[5m])) > 0`) without the env override

## Out of scope

- The standalone `deploy/daemonset.yaml` and Helm chart values inside the netscope repo still reference `NETSCOPE_IFACE` — those live in a different repo and are addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)