### PR TITLE
feat(netscope): add Grafana dashboard

### DIFF
--- a/infra/configs/dashboards/kustomization.yaml
+++ b/infra/configs/dashboards/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - application-health-cm.yaml
   - cluster-overview-cm.yaml
   - control-plane-cm.yaml
+  - netscope-cm.yaml
   - networking-gateway-cm.yaml
   - node-details-cm.yaml
   - overture-cm.yaml

--- a/infra/configs/dashboards/netscope-cm.yaml
+++ b/infra/configs/dashboards/netscope-cm.yaml
@@ -1,0 +1,151 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netscope-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  netscope.json: |
+    {
+      "title": "Netscope (eBPF Network Traffic)",
+      "uid": "netscope-overview",
+      "tags": ["homelab", "netscope", "ebpf"],
+      "schemaVersion": 38,
+      "refresh": "30s",
+      "time": { "from": "now-1h", "to": "now" },
+      "timepicker": {},
+      "panels": [
+        {
+          "id": 1,
+          "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+          "type": "stat",
+          "title": "Nodes Reporting",
+          "description": "Count of netscope-agent scrape targets currently up. Should equal the number of nodes in the cluster (6); a smaller number means at least one DaemonSet pod is unhealthy or has lost its scrape endpoint.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "count(up{job=\"netscope-agent\"} == 1)",
+              "legendFormat": "up"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "yellow" },
+                { "value": 6, "color": "green" }
+              ]
+            }
+          }
+        },
+        {
+          "id": 2,
+          "gridPos": { "x": 6, "y": 0, "w": 9, "h": 4 },
+          "type": "stat",
+          "title": "Cluster Ingress Rate (B/s)",
+          "description": "sum(rate(netscope_rx_bytes_total[5m])) — total bytes/sec received at tcx ingress across every node's primary interface. Sanity check that all DaemonSet pods are publishing data.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(netscope_rx_bytes_total[5m]))",
+              "legendFormat": "cluster B/s"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            }
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value"
+          }
+        },
+        {
+          "id": 3,
+          "gridPos": { "x": 15, "y": 0, "w": 9, "h": 4 },
+          "type": "stat",
+          "title": "Per-Node Scrape Status",
+          "description": "up{job=\"netscope-agent\"} broken out per node. A 0 here means Prometheus has lost a scrape target — investigate before trusting traffic graphs.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "up{job=\"netscope-agent\"}",
+              "legendFormat": "{{nodename}}"
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "" },
+            "colorMode": "background",
+            "textMode": "value_and_name",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "green" }
+              ]
+            }
+          }
+        },
+        {
+          "id": 10,
+          "gridPos": { "x": 0, "y": 4, "w": 24, "h": 10 },
+          "type": "timeseries",
+          "title": "Per-Node Receive Rate (B/s)",
+          "description": "rate(netscope_rx_bytes_total[5m]) by nodename — bytes/sec at tcx ingress on each node's primary interface. The headline panel: one line per node, gaps indicate scrape loss, sustained spikes indicate a noisy node.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (nodename) (rate(netscope_rx_bytes_total[5m]))",
+              "legendFormat": "{{nodename}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 11,
+          "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
+          "type": "timeseries",
+          "title": "Total Cluster Ingress Rate (B/s)",
+          "description": "sum(rate(netscope_rx_bytes_total[5m])) — single line view of cluster-wide ingress, useful for capacity-planning.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(netscope_rx_bytes_total[5m]))",
+              "legendFormat": "cluster"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 20
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        }
+      ]
+    }


### PR DESCRIPTION
## Summary

Adds a Grafana dashboard for the netscope eBPF traffic-analyzer DaemonSet
(`netscope_rx_bytes_total`). Ships as a ConfigMap in the `monitoring`
namespace with `grafana_dashboard: "1"`, auto-discovered by the
kube-prometheus-stack sidecar — same pattern as the other dashboards in
`infra/configs/dashboards/`.

- **UID**: `netscope-overview` (string UID, hand-set so it doesn't collide).
- **Tags**: `homelab`, `netscope`, `ebpf`.
- **Time picker**: default 1h, refresh 30s.

### Panels

- **Per-node receive rate (timeseries)** — `sum by (nodename) (rate(netscope_rx_bytes_total[5m]))`. One line per node, byte/sec at tcx ingress on the host's primary interface. The headline panel.
- **Total cluster ingress rate (timeseries + stat)** — `sum(rate(netscope_rx_bytes_total[5m]))`. Sanity check that all nodes are reporting.
- **Per-node scrape status (stat)** — `up{job="netscope-agent"}` broken out by `nodename`. Red on any 0.
- **Nodes reporting (stat)** — `count(up{job="netscope-agent"} == 1)`. Surfaces scrape gaps at a glance (green at 6, our cluster size).

The `nodename` label was promoted in the ServiceMonitor relabeling that
landed in #603, so per-node grouping works without joining through
`kube_pod_info`.

### Project plan

Phase 1 exit-criteria deliverable for the eBPF-based network traffic
analyzer:
https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md

### Test plan

- [x] `kustomize build infra/configs` passes locally
- [x] `kustomize build apps/{staging,production}` and `infra/controllers` pass locally (no regressions)
- [x] `yamllint -c .yamllint infra/configs/dashboards/netscope-cm.yaml infra/configs/dashboards/kustomization.yaml` passes
- [x] JSON inside the ConfigMap parses cleanly (`yaml.safe_load` then `json.loads` round-trip)
- [ ] CI: `Test Flux Reconciliation` and `Lint` workflows green
- [ ] After merge: Grafana sidecar picks up the ConfigMap and the dashboard appears under tag `netscope`; per-node receive-rate lines render for all 6 nodes