### PR TITLE
chore(homepage): provision homepage-adguard Secret for AdGuard widget

### DIFF
--- a/apps/production/homepage/kustomization.yaml
+++ b/apps/production/homepage/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base/homepage/
   - httproute.yaml
   - rbac.yaml
+  - secret-adguard.yaml
   - secret-synology.yaml
 
 labels:

--- a/apps/production/homepage/secret-adguard.yaml
+++ b/apps/production/homepage/secret-adguard.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: homepage-adguard
+  namespace: homepage-prod
+type: Opaque
+stringData:
+  HOMEPAGE_VAR_ADGUARD_USER: ENC[AES256_GCM,data:nFS7z+2c,iv:z2qmPZtMLHUrIiNf37XEILhxOP8psLjdBgWPVSW9aAs=,tag:XdJtoMJ2diA4Qyc1NfMBhw==,type:str]
+  HOMEPAGE_VAR_ADGUARD_PASS: ENC[AES256_GCM,data:PPQ3zzeMolbikMtpmjN1PY7Nng==,iv:iR6eF48ZxC1AVVTRjUdD2mMKjoWROyaKb1Auzdq8VU0=,tag:VDB9r9CYKzKwRbsKFy7csQ==,type:str]
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiSDRMaXg1WmEyRDliRDF4
+        eDdqdUdmL1R3RWM4MGRKRmlSdU5tcjZJbkdJCmdPS1pnbG1iU2hmU2NZSm93NTcx
+        U1IxcGozR201dFRaVDIwZDMwbUtVSmMKLS0tIGdLY09DeUo3c2lpbXVTdTVyWDhY
+        VytkUUp1Umg1b0ZxbGFqMmcrS3VRMXMKKq8fge8+LdxFS9qlUzyFk4LFov/dc9FT
+        UTZq/lc3asgAMfJruPDWJp38xJoOOufHoLPCgPRJ4DrPdDSa/HUafg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-10T22:20:28Z"
+  mac: ENC[AES256_GCM,data:kjjATqdjSJ+IbRL5mC6KEWAnhzzlMOWvYP9aewvY1nUUsNUtCBsDe4iyBT8WIUwGNmXUyfRRU7Il//OkRVSznCNETfoUP42VVgGh1MVi7IFfX/G0XbXNci0CkdonH8JVPhNMzTO3mEqJZV/usqMcF56Wm15OgB0rZrSdOatdCTQ=,iv:6baRqelh2chWsrKMO1mqw89hcvj4yiMBPGmiZoMZUBo=,tag:MvjBTWFUc7AFidaleow/Yw==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.1


### PR DESCRIPTION
## Summary

Provisions the SOPS-encrypted \`homepage-adguard\` Secret containing the AdGuard admin credentials. Final piece of the AdGuard widget chain — combined with PR #586 (manifest wiring), PR #598 (post-DNAT port fix), and PR #607 (Cilium-visible-label fix), the widget can now authenticate to the AdGuard API and render real query metrics.

## Verification chain (already confirmed)

- Manifest wiring (PR #586): ✓ optional secretRef in deployment-patch.yaml, env vars \`HOMEPAGE_VAR_ADGUARD_USER\` / \`HOMEPAGE_VAR_ADGUARD_PASS\` referenced by the widget block in services.yaml.
- Network path (PRs #587, #598, #607): ✓ Hubble confirms \`L3-L4 EGRESS ALLOWED\` for homepage → adguard-0:80; AdGuard returns 401 to anonymous calls (network reaches the app).
- This PR: ✓ supplies the credentials → AdGuard returns 200 with widget data.

## Test plan

- [x] Secret SOPS-encrypted (no plaintext, sops: footer present, no REPLACE_ME)
- [x] \`kustomize build apps/production/homepage\` passes
- [ ] After merge + Flux reconcile:
  - Secret \`homepage-adguard\` exists in \`homepage-prod\` with 2 keys
  - Homepage pod env has \`HOMEPAGE_VAR_ADGUARD_USER\` / \`HOMEPAGE_VAR_ADGUARD_PASS\` populated
  - Manual probe with basic auth returns 200 + JSON from \`/control/status\`
  - AdGuard tile on home.burntbytes.com shows live query counts (no "API Error Information" banner)