### PR TITLE
chore(netscope): bump image to 1c0081d, enable Phase 2 metrics

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:579e662@sha256:4caec2a1650be7b0623f27adf121c1b39c1a9dac48af5edbb1ca224fdb7308d2"
+          image: "ghcr.io/gjcourt/netscope:1c0081d@sha256:83ec159e2a8ce10ea38e5ea7a84871ede061bf3babdf7e06a4c8dbd58a7d16ff"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
## Summary

Bumps the netscope agent image from `579e662` to `1c0081d`, which is the merge commit for PRs gjcourt/netscope#6 and gjcourt/netscope#7. This lights up Phase 2 of the eBPF traffic analyzer plan.

New metrics that activate post-rollout (once Flux reconciles and the DaemonSet pods restart on all 6 nodes):

- `netscope_tcp_retransmits_total` (counter) — fentry on `tcp_retransmit_skb`
- `netscope_tcp_srtt_microseconds` (histogram, 24 log2 buckets) — fentry on `tcp_rcv_established`

Each agent should attach 3 eBPF programs after this rollout: tcx ingress (Phase 1) + 2 fentry (Phase 2).

This resets the Phase 1 (`netscope_rx_bytes_total`) soak window — expected per the project state.

Image: `ghcr.io/gjcourt/netscope:1c0081d@sha256:83ec159e2a8ce10ea38e5ea7a84871ede061bf3babdf7e06a4c8dbd58a7d16ff`

Plan: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md

Previous bump: #608

## Test plan

- [ ] `kustomize build apps/staging/netscope` passes (verified locally)
- [ ] `kustomize build apps/staging` passes (verified locally)
- [ ] Post-merge, Flux reconciles `apps-staging` and DaemonSet pods restart with the new image
- [ ] Agent logs on each of the 6 nodes show 3 attached programs (tcx ingress + 2 fentry)
- [ ] `netscope_tcp_retransmits_total` appears in Prometheus
- [ ] `netscope_tcp_srtt_microseconds_bucket` appears in Prometheus
- [ ] `netscope_rx_bytes_total` continues to flow (no regression on Phase 1)

**DO NOT MERGE** — awaiting explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)