### PR TITLE
fix(netscope): bump image to e80a0d6, fix SRTT verifier rejection

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:1c0081d@sha256:83ec159e2a8ce10ea38e5ea7a84871ede061bf3babdf7e06a4c8dbd58a7d16ff"
+          image: "ghcr.io/gjcourt/netscope:e80a0d6@sha256:6948afeda1ef78cdcf2e02c9f976e0d257424415f59ebf072388ca5422bf4747"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
## Summary

Roll forward the netscope DaemonSet image from `:1c0081d` to `:e80a0d6` to clear a partial-rollout stuck in CrashLoopBackOff.

- `1c0081d` (PR #613, merged) shipped a Phase-2 SRTT BPF program that used `BPF_CORE_READ` inside an `fentry` program — the kernel verifier rejects that pattern, so the agent crashloops on attach.
- netscope PR #8 (merged as `e80a0d6` on `main`) replaces `BPF_CORE_READ` with direct field access in the SRTT program. The fix is verified by netscope CI (build run `25642861032`, `success`).
- Digest pinned to `sha256:6948afeda1ef78cdcf2e02c9f976e0d257424415f59ebf072388ca5422bf4747`.

Current cluster state (pre-merge):
- 5 pods on the older healthy `:579e662` image
- 1 pod on `talos-2mz-rfj` crashlooping on `:1c0081d`

Image-tag invariant: `e80a0d6` is strictly later on `main` than both `579e662` and `1c0081d` (`git log --oneline 1c0081d..e80a0d6` confirms one commit forward).

Refs:
- netscope PR #8: https://github.com/gjcourt/netscope/pull/8
- Plan: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md

## Test plan

- [ ] Merge to `master`; Flux `apps-staging` reconciles within ~10m
- [ ] Crashlooping pod on `talos-2mz-rfj` exits `CrashLoopBackOff` and goes `Ready`
- [ ] Remaining 5 pods on `:579e662` roll one-by-one to `:e80a0d6` (DaemonSet rolling update completes)
- [ ] Agent logs on every node show all three "attached" lines (tcx + 2 fentry programs) with no verifier errors
- [ ] `netscope_tcp_retransmits_total` appears in Prometheus with non-zero values
- [ ] `netscope_tcp_srtt_microseconds_bucket` appears in Prometheus with non-zero values