### PR TITLE
fix(homeassistant): rewire nightlight automation (single offset source + per-LED idempotence)

### DIFF
--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -89,66 +89,105 @@
 # ============================================================================
 # Nightlight automation
 # ============================================================================
-# At sundown, turn on the dining room chandelier and chandelier components
-# at a configurable brightness. At a configurable time (+ random offset),
-# turn off the dining room chandelier.
+# At sundown, bring up the dining room chandelier components at a configurable
+# brightness. At a configurable time (+ daily-random jitter), turn off the
+# dining room chandelier.
+#
+# Sunset behavior depends on the master Lutron switch:
+#   - Master OFF → turn master on, force both LED chandeliers to preset
+#                  brightness (LEDs may come up at factory default when
+#                  the switch re-powers them; force-set ensures preset).
+#   - Master ON  → leave master alone. For each LED, turn it on at preset
+#                  only if currently off; otherwise leave it alone
+#                  (someone's actively using the chandelier).
 #
 # Input helpers:
 #   input_number.nightlight_brightness       — target brightness % (default 6)
-#   input_number.nightlight_random_offset    — max offset minutes (default 30)
+#   input_number.nightlight_random_offset    — MAX jitter minutes (default 30)
+#   input_number.nightlight_offset_today     — today's actual jitter (auto)
 #   input_datetime.nightlight_turnoff_time   — base turnoff time (default 23:00)
 #
-# Template sensors:
-#   sensor.nightlight_random_offset          — daily random 0..max
-#   sensor.nightlight_turnoff_time           — base time + offset → HH:MM
+# Template sensor:
+#   sensor.nightlight_turnoff_time           — base time + today's offset → HH:MM
 
 - alias: "Nightlight — turn on at sundown"
-  description: "Turn on dining room chandelier and chandelier components at sundown."
+  description: "Turn on dining room chandelier components at sundown."
   trigger:
     - platform: sun
       event: sunset
   action:
-    # Turn on dining room chandelier if off (Lutron Caseta switch)
-    - condition: state
-      entity_id: switch.dining_room_chandelier
-      state: "off"
-    - service: switch.turn_on
-      target:
-        entity_id: switch.dining_room_chandelier
-    # Turn on chandelier_central at target brightness if off (MiBoxer LED)
-    - condition: state
-      entity_id: light.0xa4c138b55dac7973
-      state: "off"
-    - service: light.turn_on
-      target:
-        entity_id: light.0xa4c138b55dac7973
-      data:
-        brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
-    # Turn on chandelier_flowers at target brightness if off (MiBoxer LED)
-    - condition: state
-      entity_id: light.0xa4c138a9f6011cac
-      state: "off"
-    - service: light.turn_on
-      target:
-        entity_id: light.0xa4c138a9f6011cac
-      data:
-        brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
+    - choose:
+        # Case 1: master switch is OFF → turn master on, force both LEDs
+        # to preset brightness (LEDs may auto-power-on at factory default
+        # when the Lutron switch re-powers them).
+        - conditions:
+            - condition: state
+              entity_id: switch.dining_room_chandelier
+              state: "off"
+          sequence:
+            - service: switch.turn_on
+              target:
+                entity_id: switch.dining_room_chandelier
+            - service: light.turn_on
+              target:
+                entity_id:
+                  - light.0xa4c138b55dac7973  # chandelier_central (MiBoxer)
+                  - light.0xa4c138a9f6011cac  # chandelier_flowers (MiBoxer)
+              data:
+                brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
+      # Case 2 (default): master is already ON. Don't touch master.
+      # For each LED, only turn on if currently off; leave running LEDs alone.
+      default:
+        - if:
+            - condition: state
+              entity_id: light.0xa4c138b55dac7973
+              state: "off"
+          then:
+            - service: light.turn_on
+              target:
+                entity_id: light.0xa4c138b55dac7973
+              data:
+                brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
+        - if:
+            - condition: state
+              entity_id: light.0xa4c138a9f6011cac
+              state: "off"
+          then:
+            - service: light.turn_on
+              target:
+                entity_id: light.0xa4c138a9f6011cac
+              data:
+                brightness: "{{ states('input_number.nightlight_brightness') | int(6) }}"
 
-- alias: "Nightlight — reset random offset at midnight"
-  description: "Generate a new random offset each day at midnight."
+- alias: "Nightlight — pick today's random offset at midnight"
+  description: "At midnight, choose today's jitter from [0, max] and store it."
   trigger:
     - platform: time
       at: "00:00:01"
   action:
     - service: input_number.set_value
       target:
-        entity_id: input_number.nightlight_random_offset
+        entity_id: input_number.nightlight_offset_today
       data:
-        value: >
-          {{ range(0, states('input_number.nightlight_random_offset') | int(120) + 1) | random }}
+        value: "{{ range(0, states('input_number.nightlight_random_offset') | int(30) + 1) | random }}"
+
+- alias: "Nightlight — prime today's offset on HA start"
+  description: >
+    On Home Assistant startup, re-roll today's offset so the first night
+    after a restart isn't pinned to the input_number.initial value (0).
+    Also covers the case where the user just bumped the max.
+  trigger:
+    - platform: homeassistant
+      event: start
+  action:
+    - service: input_number.set_value
+      target:
+        entity_id: input_number.nightlight_offset_today
+      data:
+        value: "{{ range(0, states('input_number.nightlight_random_offset') | int(30) + 1) | random }}"
 
 - alias: "Nightlight — turn off dining room chandelier"
-  description: "Turn off the dining room chandelier at configurable time + random offset."
+  description: "Turn off the dining room chandelier at configurable time + today's jitter."
   trigger:
     - platform: template
       value_template: >

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -61,13 +61,29 @@ input_number:
     unit_of_measurement: "%"
     mode: slider
   nightlight_random_offset:
-    name: Nightlight Random Offset
+    # Max jitter (in minutes) applied to the configured turn-off time.
+    # The actual jitter for today is picked at midnight and stored in
+    # `nightlight_offset_today` below — this entry is just the user-facing
+    # cap. See the "Nightlight" automations in automations.yaml.
+    name: Nightlight Random Offset (max)
     min: 0
     max: 120
     step: 5
     initial: 30
     unit_of_measurement: min
     mode: slider
+  nightlight_offset_today:
+    # Today's actual jitter, in minutes. Written at midnight by the
+    # "Nightlight — pick today's random offset" automation; read by the
+    # `sensor.nightlight_turnoff_time` template. Defaults to 0 on cold
+    # start; the homeassistant-start priming automation re-rolls it.
+    name: Nightlight Offset (today)
+    min: 0
+    max: 120
+    step: 1
+    initial: 0
+    unit_of_measurement: min
+    mode: box
   laundry_room_light_minutes:
     name: Laundry Room Light Timer
     min: 5
@@ -106,14 +122,15 @@ input_datetime:
     has_time: true
     initial: "23:00"
 
-# Nightlight template sensors
+# Nightlight template sensor — turn-off time = base time + today's offset.
+# Today's offset is held in input_number.nightlight_offset_today (single
+# source of truth; written at midnight by the priming automation). The
+# previous design had a template `sensor.nightlight_random_offset` that
+# read input_number.nightlight_random_offset.max (the *schema* max, always
+# 120) and produced a non-random `day_of_year % 121` value — and the
+# midnight automation simultaneously corrupted the user's max setting by
+# writing a random into the state. Both have been retired.
 template:
-  - sensor:
-      - name: "Nightlight Random Offset"
-        unique_id: nightlight_random_offset
-        state: >
-          {{ (now().strftime('%j') | int) % (state_attr('input_number.nightlight_random_offset', 'max') | default(120) | int + 1) }}
-
   - sensor:
       - name: "Nightlight Turn Off Time"
         unique_id: nightlight_turnoff_time
@@ -128,6 +145,6 @@ template:
             {# timestamp is SECONDS since midnight (verified live: 23:00 → 82800) #}
             {% set base_minutes = (ts | int) // 60 %}
           {% endif %}
-          {% set offset = states('sensor.nightlight_random_offset') | int(0) %}
+          {% set offset = states('input_number.nightlight_offset_today') | int(0) %}
           {% set total_minutes = (base_minutes + offset) % 1440 %}
           {{ '%02d:%02d' | format(total_minutes // 60, total_minutes % 60) }}


### PR DESCRIPTION
## Summary

Three bugs in the prior nightlight automation, all fixed in one PR.

### Bug 1 — midnight reset corrupts the user's max setting

The previous "Reset random offset at midnight" automation wrote a random number back into \`input_number.nightlight_random_offset\` (which is documented as MAX). Result: max decays toward 0 each night.

### Bug 2 — template sensor ignores the user setting

\`sensor.nightlight_random_offset\` read \`state_attr(..., 'max')\` — the schema cap (120), not the user's slider value. It was also not random: \`day_of_year % 121\`.

### Bug 3 — sunset automation: condition-stops-action chain

In-action \`condition:\` steps short-circuit the *entire* sequence. If the master Lutron switch was already on, neither MiBoxer LED was set.

## Fix

- New \`input_number.nightlight_offset_today\` — single source of truth for today's jitter.
- New "pick today's offset at midnight" automation writes to \`nightlight_offset_today\` (not the max).
- New "prime on HA start" automation re-rolls today's offset on HA boot (first-night safety).
- \`sensor.nightlight_turnoff_time\` now reads \`nightlight_offset_today\` directly.
- Deleted \`sensor.nightlight_random_offset\` (the broken template sensor).
- Sunset automation rewritten with \`choose:\`:
  - **Master OFF** → turn master on, force both LEDs to preset (LEDs may auto-power-on at factory default when the Lutron switch repowers).
  - **Master ON** → don't touch master. Per-LED \`if off then turn on\`; LEDs already on are left alone (someone's actively using the chandelier).

## Test plan

- [x] \`kustomize build apps/{production,staging}/homeassistant\` passes
- [x] No plaintext secrets in diff
- [ ] After merge + Flux reconcile: HA pod auto-restarts via configMapGenerator hash change; "Configuration error" + "Entity not found" warnings on the Lovelace dashboard tied to \`sensor.nightlight_random_offset\` go away.
- [ ] First sunset post-merge: master switch goes on if it was off; LEDs set to preset brightness; if master was already on with one LED off, only that LED turns on.
- [ ] Tomorrow's turn-off time will reflect a true random offset (today's was 0 if HA wasn't restarted yet; will be re-rolled at the next midnight or HA start).