### PR TITLE
fix(homeassistant): nightlight turn-off entity_id + bathroom timer range 4-45 min

### DIFF
--- a/apps/base/homeassistant/files/automations.yaml
+++ b/apps/base/homeassistant/files/automations.yaml
@@ -108,7 +108,7 @@
 #   input_datetime.nightlight_turnoff_time   — base turnoff time (default 23:00)
 #
 # Template sensor:
-#   sensor.nightlight_turnoff_time           — base time + today's offset → HH:MM
+#   sensor.nightlight_turn_off_time           — base time + today's offset → HH:MM
 
 - alias: "Nightlight — turn on at sundown"
   description: "Turn on dining room chandelier components at sundown."
@@ -191,7 +191,7 @@
   trigger:
     - platform: template
       value_template: >
-        {{ now().strftime('%H:%M') == states('sensor.nightlight_turnoff_time') }}
+        {{ now().strftime('%H:%M') == states('sensor.nightlight_turn_off_time') }}
   condition:
     - condition: state
       entity_id: switch.dining_room_chandelier

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -30,25 +30,25 @@ frontend:
 input_number:
   hall_bathroom_fan_minutes:
     name: Hall Bathroom Fan Timer
-    min: 5
-    max: 120
-    step: 5
+    min: 4
+    max: 45
+    step: 1
     initial: 30
     unit_of_measurement: min
     mode: slider
   master_bathroom_fan_minutes:
     name: Master Bathroom Fan Timer
-    min: 5
-    max: 120
-    step: 5
+    min: 4
+    max: 45
+    step: 1
     initial: 30
     unit_of_measurement: min
     mode: slider
   powder_bathroom_fan_minutes:
     name: Powder Bathroom Fan Timer
-    min: 5
-    max: 120
-    step: 5
+    min: 4
+    max: 45
+    step: 1
     initial: 30
     unit_of_measurement: min
     mode: slider


### PR DESCRIPTION
## Summary

Two unrelated HA-config fixes batched in one small PR:

### 1. Nightlight turn-off automation references the wrong entity_id

PR #618 added a template sensor with \`name: \"Nightlight Turn Off Time\"\` and \`unique_id: nightlight_turnoff_time\`. HA generates entity_id from the **name** (snake_case), not the unique_id. The live entity is:

- \`sensor.nightlight_turn_off_time\` (3 words underscored) ← actual
- \`sensor.nightlight_turnoff_time\` (one word) ← what the automation trigger + dashboard tile referenced

So the turn-off automation trigger compared \`now()\` to \`states('<nonexistent>')\` which always returns \"unknown\" → trigger never fires → chandelier never turns off on schedule.

**Verified live via REST /api/states**: \`sensor.nightlight_turn_off_time\` exists with \`state=\"23:13\"\` (base 23:00 + today's 13-minute jitter — also confirms PR #618's priming chain works end-to-end). Dashboard tile already corrected in-place via the HA WebSocket API; this PR fixes the GitOps source so the next ConfigMap-hash-driven restart preserves the fix.

### 2. Bathroom fan timer range

User-requested: change \`{hall,master,powder}_bathroom_fan_minutes\` from \`min: 5, max: 120, step: 5\` to \`min: 4, max: 45, step: 1\`. The initial of 30 stays within the new range.

## Test plan

- [x] \`kustomize build apps/{production,staging}/homeassistant\` passes
- [ ] After merge: HA auto-restarts via configMapGenerator hash; turn-off automation now fires when \`now() == sensor.nightlight_turn_off_time\` (will be tested at the next \`23:00 + today's jitter\` tick); bathroom timer sliders show the new range.