### PR TITLE
fix(netscope): bump image to 95d7ae3 — SRTT helper-based fix

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:e80a0d6@sha256:6948afeda1ef78cdcf2e02c9f976e0d257424415f59ebf072388ca5422bf4747"
+          image: "ghcr.io/gjcourt/netscope:95d7ae3@sha256:af8d1b3f71bbb3cf63898471f2a287624d30a7f7bc1adc8bf8e1af433298b88f"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
## Summary

Roll forward the netscope DaemonSet image from `:e80a0d6` to `:95d7ae3` to unstick a partial rollout — third iteration on the SRTT verifier issue.

- `:e80a0d6` (PR #617, merged) replaced `BPF_CORE_READ` with direct field access in the SRTT `fentry` program, but the verifier still rejects it with "access beyond struct sock" — the cast from `struct sock *` to `struct tcp_sock *` is not verifier-blessed on its own.
- netscope PR #9 (merged as `95d7ae3` on `main`) switches to the standard kernel idiom `bpf_skc_to_tcp_sock()`, which is the helper the verifier accepts for type narrowing. CI for `95d7ae3` is green (build run `25644542729`).
- Digest pinned to `sha256:af8d1b3f71bbb3cf63898471f2a287624d30a7f7bc1adc8bf8e1af433298b88f`.

Current cluster state (pre-merge):
- 5 pods on the older healthy `:579e662` image
- 1 pod on `talos-2mz-rfj` crashlooping on `:e80a0d6`

Image-tag invariant: `95d7ae3` is strictly later on `main` than `e80a0d6` (`git log --oneline e80a0d6..95d7ae3` confirms one commit forward).

Meta follow-up: netscope issue #10 tracks adding a CI kernel-load smoke test so verifier regressions surface before they hit the cluster.

Refs:
- netscope PR #9: https://github.com/gjcourt/netscope/pull/9
- netscope issue #10 (CI kernel-load smoke): https://github.com/gjcourt/netscope/issues/10
- Plan: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md

## Test plan

- [ ] Merge to `master`; Flux `apps-staging` reconciles within ~10m
- [ ] Crashlooping pod on `talos-2mz-rfj` exits `CrashLoopBackOff` and goes `Ready`
- [ ] Remaining 5 pods on `:579e662` roll one-by-one to `:95d7ae3` (DaemonSet rolling update completes)
- [ ] Agent logs on every node show all three "attached" lines (tcx + 2 fentry programs) with no verifier errors
- [ ] `netscope_tcp_retransmits_total` appears in Prometheus with non-zero values
- [ ] `netscope_tcp_srtt_microseconds_bucket` appears in Prometheus with non-zero values