### PR TITLE
feat(netscope): add Phase 2 dashboard panels (retransmits, SRTT)

### DIFF
--- a/infra/configs/dashboards/netscope-cm.yaml
+++ b/infra/configs/dashboards/netscope-cm.yaml
@@ -146,6 +146,146 @@ data:
             "legend": { "displayMode": "list", "placement": "bottom" },
             "tooltip": { "mode": "single" }
           }
+        },
+        {
+          "id": 19,
+          "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+          "type": "row",
+          "title": "Phase 2 — TCP depth signals",
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "id": 20,
+          "gridPos": { "x": 0, "y": 23, "w": 15, "h": 10 },
+          "type": "timeseries",
+          "title": "TCP Retransmit Rate per Node",
+          "description": "rate(netscope_tcp_retransmits_total[5m]) by nodename — TCP retransmit events/sec per node, sampled by the eBPF probe. Headline reliability signal: sustained non-zero on a worker indicates either local NIC trouble or a noisy peer; control-plane nodes typically run a low background rate from kube-apiserver traffic.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (nodename) (rate(netscope_tcp_retransmits_total[5m]))",
+              "legendFormat": "{{nodename}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 21,
+          "gridPos": { "x": 15, "y": 23, "w": 9, "h": 10 },
+          "type": "stat",
+          "title": "Cluster Retransmits (24h)",
+          "description": "sum(increase(netscope_tcp_retransmits_total[24h])) — total retransmits cluster-wide over the last 24 hours. Sits next to the per-node rate panel as a quick at-a-glance regression check.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(increase(netscope_tcp_retransmits_total[24h]))",
+              "legendFormat": "retransmits"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            }
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "green" },
+                { "value": 1000, "color": "yellow" },
+                { "value": 10000, "color": "red" }
+              ]
+            }
+          }
+        },
+        {
+          "id": 22,
+          "gridPos": { "x": 0, "y": 33, "w": 24, "h": 10 },
+          "type": "timeseries",
+          "title": "TCP Smoothed RTT Percentiles",
+          "description": "histogram_quantile over netscope_tcp_srtt_microseconds_bucket aggregated cluster-wide. p50 tracks typical pod-to-pod RTT (expect ~2ms on-cluster), p99 captures the off-cluster tail. Bucket boundaries are seconds (Prometheus convention); the eBPF collector converts from µs before bucketing.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "histogram_quantile(0.50, sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p50"
+            },
+            {
+              "refId": "B",
+              "expr": "histogram_quantile(0.95, sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p95"
+            },
+            {
+              "refId": "C",
+              "expr": "histogram_quantile(0.99, sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 5
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 23,
+          "gridPos": { "x": 0, "y": 43, "w": 24, "h": 12 },
+          "type": "heatmap",
+          "title": "TCP Smoothed RTT Distribution",
+          "description": "sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le) — cumulative-bucket heatmap of SRTT samples cluster-wide. The percentile panel shows trend, this panel shows shape: a clean horizontal band means stable latency; a vertical smear means new tail behavior. Y-axis is seconds on a log scale because buckets span ~1µs to ~8s.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le)",
+              "legendFormat": "{{le}}",
+              "format": "heatmap"
+            }
+          ],
+          "options": {
+            "calculate": false,
+            "yAxis": {
+              "unit": "s",
+              "axisLabel": "SRTT",
+              "scale": { "type": "log", "log": 2 }
+            },
+            "color": { "mode": "scheme", "scheme": "Spectral", "steps": 64, "reverse": true },
+            "cellGap": 1,
+            "tooltip": { "show": true, "yHistogram": true },
+            "legend": { "show": true }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "scaleDistribution": { "type": "log", "log": 2 },
+                "hideFrom": { "tooltip": false, "viz": false, "legend": false }
+              }
+            }
+          }
         }
       ]
     }

--- a/infra/configs/dashboards/netscope-cm.yaml
+++ b/infra/configs/dashboards/netscope-cm.yaml
@@ -198,20 +198,20 @@ data:
           ],
           "fieldConfig": {
             "defaults": {
-              "unit": "short"
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" },
+                  { "value": 200000, "color": "yellow" },
+                  { "value": 500000, "color": "red" }
+                ]
+              }
             }
           },
           "options": {
             "reduceOptions": { "calcs": ["lastNotNull"] },
-            "colorMode": "value",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "green" },
-                { "value": 1000, "color": "yellow" },
-                { "value": 10000, "color": "red" }
-              ]
-            }
+            "colorMode": "value"
           }
         },
         {


### PR DESCRIPTION
## Summary

Extend the `netscope-overview` Grafana dashboard (`infra/configs/dashboards/netscope-cm.yaml`) with four new panels backed by the now-live Phase 2 metrics (`netscope_tcp_retransmits_total`, `netscope_tcp_srtt_microseconds_bucket`). The original five Phase 1 panels (ids 1, 2, 3, 10, 11) are preserved unchanged. New panels sit under a row separator titled "Phase 2 — TCP depth signals" and use ids 20-23 to keep them clearly separate from Phase 1.

No datasource variable was added — the dashboard relies on Grafana's default datasource, matching the `overture-cm.yaml` precedent.

## Panels added

| ID | Type | Title | PromQL |
|---|---|---|---|
| 20 | timeseries | TCP Retransmit Rate per Node | `sum by (nodename) (rate(netscope_tcp_retransmits_total[5m]))` |
| 21 | stat | Cluster Retransmits (24h) | `sum(increase(netscope_tcp_retransmits_total[24h]))` |
| 22 | timeseries | TCP Smoothed RTT Percentiles | `histogram_quantile(0.50\|0.95\|0.99, sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le))` |
| 23 | heatmap | TCP Smoothed RTT Distribution | `sum(rate(netscope_tcp_srtt_microseconds_bucket[5m])) by (le)` |

Retransmit rate is the headline reliability signal; the 24h stat sits alongside it as an at-a-glance regression check. The percentile timeseries and the distribution heatmap intentionally show the same underlying SRTT histogram with two complementary views: the percentile lines surface trend (is p99 drifting?), the heatmap surfaces shape (is a new mode appearing in the tail?). They answer different questions and are both worth keeping.

The metric name says `microseconds` but bucket `le` boundaries are in seconds — Prometheus convention. The eBPF collector converts µs→s before bucketing, so `histogram_quantile` returns seconds directly and the panel `unit: "s"` renders correctly. The heatmap uses a log-scale Y axis (24 log2 buckets covering ~1µs to ~8s).

`netscope_tcp_srtt_microseconds_sum` is always 0 today (v1 collector limitation); only `_bucket` and `_count` are used, so `histogram_quantile` works but `_sum / _count` averages would be wrong — intentionally not in any panel.

## Validation

- `python3 -c 'import json,yaml; cm=yaml.safe_load(open("infra/configs/dashboards/netscope-cm.yaml")); json.loads(cm["data"]["netscope.json"])'` — dashboard JSON parses, 10 panels total (5 original + 1 row + 4 new), ids `[1, 2, 3, 10, 11, 19, 20, 21, 22, 23]`.
- `kustomize build infra/configs/dashboards` — passes.

## Test plan

- [ ] CI `kustomize build` passes.
- [ ] After merge, Flux reconciles `infra-configs` and the ConfigMap reloads in `monitoring`.
- [ ] Grafana sidecar picks up the updated dashboard (uid `netscope-overview`).
- [ ] All four new panels render with data: retransmits per node (one line per node, CP nodes higher than workers), cluster 24h retransmit total non-zero, SRTT percentiles show p50 ~ms and p99 with a higher tail, SRTT heatmap renders a band.