### PR TITLE
feat(homeassistant): move Control dashboard to GitOps-managed YAML

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -102,6 +102,13 @@ spec:
             - name: config-file
               mountPath: /config/automations.yaml
               subPath: automations.yaml
+            # Lovelace YAML-mode dashboards. ConfigMap data keys cannot
+            # contain `/`, so the dashboard file is stored as a flat key
+            # (dashboards_control.yaml) and subPath-mounted into the
+            # /config/dashboards/ directory HA expects.
+            - name: config-file
+              mountPath: /config/dashboards/control.yaml
+              subPath: dashboards_control.yaml
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -5,13 +5,25 @@ default_config:
 frontend:
   themes: !include_dir_merge_named themes
 
-# Lovelace runs in storage mode (the default). All dashboards (Map, Floor Plan,
-# Switchboard, Control) are registered in /config/.storage/lovelace_dashboards
-# and edited via the HA UI's Lovelace editor. We do not register any YAML-mode
-# dashboards from this file: HA's slug validator hard-rejects single-word slugs
-# like `control` / `switchboard`, and `mode: yaml` in the storage registry is
-# silently ignored (HA always uses LovelaceStorage for storage-registered
-# dashboards regardless of the `mode` field).
+# Lovelace dashboards. Default + Map / Floor Plan / Switchboard stay
+# UI-managed (storage mode). Only the Control dashboard is migrated to
+# YAML mode here — its source-of-truth lives at files/dashboards/control.yaml
+# and is bundled into the homeassistant-config ConfigMap by the
+# configMapGenerator. Edits go through PRs.
+#
+# Note: HA's lovelace.dashboards schema rejects single-word slug keys
+# (must contain a hyphen). We use `home-control` as the slug — the
+# dashboard renders with the configured `title:` ("Control") regardless
+# of the slug, only the URL path (/home-control) reflects the slug.
+lovelace:
+  mode: storage           # default + other dashboards stay UI-managed
+  dashboards:
+    home-control:
+      mode: yaml
+      filename: dashboards/control.yaml
+      title: Control
+      icon: mdi:view-dashboard
+      show_in_sidebar: true
 
 # Auto-off helpers. Each has:
 #   timer.<name>_timer       — counts down once triggered

--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -1,0 +1,156 @@
+views:
+- title: Control
+  type: sections
+  max_columns: 3
+  sections:
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Bathroom Fan Timers
+      heading_style: title
+    - type: markdown
+      content: '**How it works:** when a bathroom exhaust fan switch turns on, a timer starts using the per-bathroom **Minutes** value. When the timer expires, the switch turns off automatically. Flipping the switch off manually cancels the timer.'
+  - type: grid
+    column_span: 1
+    cards:
+    - type: heading
+      heading: Hall Bathroom
+      heading_style: title
+    - type: tile
+      entity: switch.hall_bathroom_exhaust_fan
+      name: Fan
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: timer.hall_bathroom_fan_timer
+      name: Timer
+    - type: tile
+      entity: input_number.hall_bathroom_fan_minutes
+      name: Minutes
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: button
+      name: Cancel Timer
+      icon: mdi:timer-off
+      tap_action:
+        action: call-service
+        service: timer.cancel
+        data:
+          entity_id: timer.hall_bathroom_fan_timer
+  - type: grid
+    column_span: 1
+    cards:
+    - type: heading
+      heading: Master Bathroom
+      heading_style: title
+    - type: tile
+      entity: switch.master_bathroom_exhaust_fan
+      name: Fan
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: timer.master_bathroom_fan_timer
+      name: Timer
+    - type: tile
+      entity: input_number.master_bathroom_fan_minutes
+      name: Minutes
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: button
+      name: Cancel Timer
+      icon: mdi:timer-off
+      tap_action:
+        action: call-service
+        service: timer.cancel
+        data:
+          entity_id: timer.master_bathroom_fan_timer
+  - type: grid
+    column_span: 1
+    cards:
+    - type: heading
+      heading: Powder Bathroom
+      heading_style: title
+    - type: tile
+      entity: switch.powder_bathroom_exhaust_fan
+      name: Fan
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: timer.powder_bathroom_fan_timer
+      name: Timer
+    - type: tile
+      entity: input_number.powder_bathroom_fan_minutes
+      name: Minutes
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: button
+      name: Cancel Timer
+      icon: mdi:timer-off
+      tap_action:
+        action: call-service
+        service: timer.cancel
+        data:
+          entity_id: timer.powder_bathroom_fan_timer
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Nightlight
+      heading_style: title
+    - type: markdown
+      content: '**How it works:** at sundown, if the master Lutron switch is off, turn it on and set both chandelier LEDs to **Preset Brightness**. If the switch is already on, only LEDs that are currently off get bumped to preset; running LEDs are left alone. At the **Turn-Off Time + today''s jitter**, the master switch turns off.'
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Dining Room Chandelier
+      heading_style: title
+    - type: tile
+      entity: switch.dining_room_chandelier
+      name: Master Switch
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: light.0xa4c138b55dac7973
+      name: Chandelier Central
+      color: amber
+    - type: tile
+      entity: light.0xa4c138a9f6011cac
+      name: Chandelier Flowers
+      color: amber
+    - type: tile
+      entity: sensor.nightlight_turn_off_time
+      name: Tonight's Off Time
+      color: blue
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Nightlight Settings
+      heading_style: title
+    - type: tile
+      entity: input_number.nightlight_brightness
+      name: Preset Brightness
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: tile
+      entity: input_datetime.nightlight_turnoff_time
+      name: Turn-Off Time
+    - type: tile
+      entity: input_number.nightlight_random_offset
+      name: Jitter (max)
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: tile
+      entity: input_number.nightlight_offset_today
+      name: Jitter (today)

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -22,6 +22,11 @@ configMapGenerator:
       - configuration.yaml=files/configuration.yaml
       - automations.yaml=files/automations.yaml
       - binary_sensors.yaml=files/binary_sensors.yaml
+      # Lovelace dashboards bundled as flat keys (K8s ConfigMap data keys
+      # cannot contain `/`). The Deployment mounts each via subPath into
+      # /config/dashboards/<name>.yaml so HA finds them at the path declared
+      # in lovelace.dashboards.<slug>.filename.
+      - dashboards_control.yaml=files/dashboards/control.yaml
 
 labels:
   - includeSelectors: false


### PR DESCRIPTION
## Summary

The **Control** dashboard previously lived in HA's UI-managed `.storage/` state — tweaks were silent and unauditable. This PR moves only the Control dashboard to YAML mode so its source-of-truth lives in the repo at `apps/base/homeassistant/files/dashboards/control.yaml` and edits go through PRs.

The other 3 dashboards (map, switchboard, floorplan) remain in `.storage` mode (UI-managed) — only Control migrates.

## Files

- **new** `apps/base/homeassistant/files/dashboards/control.yaml` — captured from the live config (post sections-layout cleanup + the `sensor.nightlight_turn_off_time` entity_id fix from PR #619).
- **mod** `apps/base/homeassistant/files/configuration.yaml` — adds a `lovelace:` block declaring `dashboards.home-control` in YAML mode; default + other dashboards stay in storage mode.
- **mod** `apps/base/homeassistant/kustomization.yaml` — bundles the dashboard file into the existing `homeassistant-config` ConfigMap.
- **mod** `apps/base/homeassistant/deployment.yaml` — adds a `subPath` volumeMount for the dashboard file at `/config/dashboards/control.yaml`.

## Slug name (deviation from task spec)

The task spec proposed `dashboards.control:` (single-word slug), but HA's lovelace YAML validator hard-rejects single-word slugs — see commit `ca592f8` ("remove invalid lovelace.dashboards YAML block") which reverted a previous attempt at exactly this migration. The error was:

```
Invalid config for 'lovelace': Url path needs to contain a hyphen (-)
  for dictionary value 'lovelace->dashboards'
```

So this PR uses **`home-control`** as the slug. The dashboard renders with `title: Control` (operator-visible name unchanged); only the URL path becomes `/home-control` instead of `/control`. After merge, operators can re-pin the dashboard from the sidebar if needed.

## Mount-path approach (Path B variant)

K8s ConfigMap data keys cannot contain `/` (validation error: `a valid config key must consist of alphanumeric characters, '-', '_' or '.'`). Verified empirically:

```
The ConfigMap "test-..." is invalid: data[sub/foo.yaml]: Invalid value:
  "sub/foo.yaml": a valid config key must consist of alphanumeric
  characters, '-', '_' or '.'
```

So the dashboard ships as a flat key `dashboards_control.yaml` and the Deployment mirrors the existing per-key `subPath` mount pattern to land it at `/config/dashboards/control.yaml` where HA expects it. No init container, no separate ConfigMap — same content-hash auto-restart mechanism (PR #513) carries over.

## Manual operator step required BEFORE merging

The existing storage-mode Control dashboard **must be deleted via HA UI**:

1. Open https://hass.burntbytes.com
2. Settings -> Dashboards
3. Click **Control** -> three-dot menu (top-right) -> **Delete**
4. Confirm deletion

If the storage dashboard is not deleted first, HA registers both entries and the YAML one will conflict (or be ignored) on integration setup.

After this step, merge this PR. HA will pick up the new YAML dashboard on the configMapGenerator-driven auto-restart (Deployment rolls because the ConfigMap hash changed from `homeassistant-config-gdfg22mbgt` to `homeassistant-config-cb85m46bcd`).

## Test plan

- [x] `kustomize build apps/production/homeassistant` passes
- [x] `kustomize build apps/staging/homeassistant` passes
- [x] Rendered ConfigMap contains `dashboards_control.yaml` data key
- [x] Rendered Deployment subPath-mounts it at `/config/dashboards/control.yaml`
- [x] YAML <-> JSON round-trip with `/tmp/ha-dashboard-control-fixed.json` is exact (with top-level `title:` dropped per spec)
- [x] No plaintext secrets in diff
- [ ] Operator deletes storage-mode Control dashboard via HA UI (see step above)
- [ ] After merge + Flux reconcile + HA restart: dashboard renders identically to its pre-merge state at /home-control
- [ ] Editing `files/dashboards/control.yaml` -> merging a PR -> Flux reconcile auto-restarts HA and applies the new dashboard layout

## DO NOT MERGE

This PR is staged for operator review. Merge only after the storage-mode Control dashboard has been deleted from HA UI.