### PR TITLE
feat(netscope): bump image to 2e20747, enable Phase 2 DNS latency

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:95d7ae3@sha256:af8d1b3f71bbb3cf63898471f2a287624d30a7f7bc1adc8bf8e1af433298b88f"
+          image: "ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
## Summary

Rolls out Phase 2 metric #3 from the eBPF traffic-analyzer plan: **DNS query latency**. Third Phase 2 rollout after retransmits (#608, #613) and SRTT (#617, #620).

- New histogram: `netscope_dns_query_microseconds` (labels: node, server)
- New attach points: `udp_sendmsg` fentry + `udp_recvmsg` fexit
- In-kernel 4-tuple correlation of UDP request/response (no userspace state)
- Image: `:95d7ae3@sha256:af8d1b3...` -> `:2e20747@sha256:75d159d...` (strictly-increasing; `2e20747` is a descendant of `95d7ae3`)

## Coverage caveat

The `udp_sendmsg`/`udp_recvmsg` fentry/fexit hooks only observe **connected UDP sockets** (sockets where the client called `connect(2)` before `sendmsg`). Common resolvers (glibc, musl, systemd-resolved, CoreDNS) all do this, so the common case is covered. Raw `sendto(2)`/`recvfrom(2)` without a prior `connect(2)` is invisible to this metric.

## References

- netscope PR https://github.com/gjcourt/netscope/pull/11 (merged, build CI green)
- netscope issue https://github.com/gjcourt/netscope/issues/10 (kernel-load CI smoke — still open; this remains the deploy-validates-it pattern)

Pre-flight assessment was HIGH confidence (verifier walkthrough + /babysit). Same caveat as the previous two Phase 2 PRs: the final attach is observed post-merge in agent logs.

## Test plan

- [ ] `kustomize build apps/staging/netscope` passes (verified locally)
- [ ] `kustomize build apps/staging` passes (verified locally)
- [ ] Post-merge: Flux reconciles `apps-staging`
- [ ] `netscope-agent` DaemonSet rolling-restarts with new image on all 6 nodes
- [ ] Agent logs show 5 attached lines per pod: 1 tcx + 4 fentry/fexit (`tcp_retransmit_skb`, `tcp_rcv_established`, `udp_sendmsg`, `udp_recvmsg`)
- [ ] `netscope_dns_query_microseconds_bucket` populated on each node once DNS queries flow

Generated with [Claude Code](https://claude.com/claude-code)