### PR TITLE
chore(homeassistant): cap nightlight jitter slider at 60 min

### DIFF
--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -79,7 +79,7 @@ input_number:
     # cap. See the "Nightlight" automations in automations.yaml.
     name: Nightlight Random Offset (max)
     min: 0
-    max: 120
+    max: 60
     step: 5
     initial: 30
     unit_of_measurement: min


### PR DESCRIPTION
## Summary

User-requested: change \`input_number.nightlight_random_offset\` from \`max: 120\` → \`max: 60\`. The slider now caps at 1 hour of jitter on the chandelier turn-off time.

\`initial: 30\` stays (in range), \`step: 5\` stays.

## Side effects

- The current state of \`nightlight_random_offset\` is \`30.0\` (from earlier today's check). Within new range, so the input_number's state is preserved.
- The HA-start priming automation re-rolls \`input_number.nightlight_offset_today\` on boot using \`states('input_number.nightlight_random_offset') | int(30)\` as the upper bound — tonight's offset will be re-rolled from [0, 30] (current state, not max). Either way, well within the new cap.
- configMapGenerator hash changes → HA auto-restarts on Flux reconcile.

Aside (for the user — not part of this PR): the laundry-room-lights auto-off automation already exists and is live (\`automation.laundry_room_light_auto_off_*\` all \`state: on\` in the cluster). All three pieces — start-timer, turn-off-both, cancel-on-both-off — are in \`apps/base/homeassistant/files/automations.yaml\` already. No PR needed for that piece.