### PR TITLE
feat(netscope): add DNS latency dashboard panels (Phase 2 #3)

### DIFF
--- a/infra/configs/dashboards/netscope-cm.yaml
+++ b/infra/configs/dashboards/netscope-cm.yaml
@@ -286,6 +286,115 @@ data:
               }
             }
           }
+        },
+        {
+          "id": 29,
+          "gridPos": { "x": 0, "y": 55, "w": 24, "h": 1 },
+          "type": "row",
+          "title": "Phase 2 — DNS query latency",
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "id": 30,
+          "gridPos": { "x": 0, "y": 56, "w": 24, "h": 10 },
+          "type": "timeseries",
+          "title": "DNS Query Rate per Node",
+          "description": "rate(netscope_dns_query_microseconds_count[5m]) by nodename — DNS queries/sec observed per node by the eBPF probe. Headline volume signal: control-plane nodes typically show higher query rates from kube-apiserver and CoreDNS upstream resolution; sustained spikes on a worker indicate a chatty pod.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (nodename) (rate(netscope_dns_query_microseconds_count[5m]))",
+              "legendFormat": "{{nodename}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 31,
+          "gridPos": { "x": 0, "y": 66, "w": 24, "h": 10 },
+          "type": "timeseries",
+          "title": "DNS Query Latency Percentiles",
+          "description": "histogram_quantile over netscope_dns_query_microseconds_bucket aggregated cluster-wide. p50 tracks the typical in-cluster CoreDNS response (~sub-ms); p95/p99 capture slow resolutions (upstream forwarders, NXDOMAIN retries, cold caches). The eBPF collector measures wall time between query egress and matching response.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "histogram_quantile(0.50, sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p50"
+            },
+            {
+              "refId": "B",
+              "expr": "histogram_quantile(0.95, sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p95"
+            },
+            {
+              "refId": "C",
+              "expr": "histogram_quantile(0.99, sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 5
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 32,
+          "gridPos": { "x": 0, "y": 76, "w": 24, "h": 12 },
+          "type": "heatmap",
+          "title": "DNS Query Latency Distribution",
+          "description": "sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le) — cumulative-bucket heatmap of DNS query latency cluster-wide. The percentile panel shows trend, this panel shows shape: a tight band near 1ms means CoreDNS is handling most queries from cache; a smear up into the 100ms+ band means upstream forwarders or NXDOMAIN retries are showing through. Y-axis is seconds on a log scale because buckets span ~1µs to ~8s.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le)",
+              "legendFormat": "{{le}}",
+              "format": "heatmap"
+            }
+          ],
+          "options": {
+            "calculate": false,
+            "yAxis": {
+              "unit": "s",
+              "axisLabel": "DNS latency",
+              "scale": { "type": "log", "log": 2 }
+            },
+            "color": { "mode": "scheme", "scheme": "Spectral", "steps": 64, "reverse": true },
+            "cellGap": 1,
+            "tooltip": { "show": true, "yHistogram": true },
+            "legend": { "show": true }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "scaleDistribution": { "type": "log", "log": 2 },
+                "hideFrom": { "tooltip": false, "viz": false, "legend": false }
+              }
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

Extends the Netscope overview dashboard (`infra/configs/dashboards/netscope-cm.yaml`, UID `netscope-overview`) with a "Phase 2 — DNS query latency" section, visualizing the histogram emitted by Phase 2 metric #3 (`netscope_dns_query_microseconds_*`). Existing panels (ids 1, 2, 3, 10, 11, 19–23) are untouched.

## Panels added

- **id=29 — row separator** "Phase 2 — DNS query latency"
- **id=30 — DNS Query Rate per Node** (timeseries, unit `ops`)
  ```promql
  sum by (nodename) (rate(netscope_dns_query_microseconds_count[5m]))
  ```
  Volume signal: CP nodes typically show more activity from kube-apiserver and CoreDNS upstream resolution; a chatty pod shows up as a sustained worker spike.
- **id=31 — DNS Query Latency Percentiles** (timeseries, unit `s`) — p50/p95/p99 via
  ```promql
  histogram_quantile(<q>, sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le))
  ```
- **id=32 — DNS Query Latency Distribution** (heatmap, log Y, unit `s`)
  ```promql
  sum(rate(netscope_dns_query_microseconds_bucket[5m])) by (le)
  ```
  `options.calculate: false` + target `format: heatmap` + `scaleDistribution: log` for Y — same shape as the SRTT heatmap (id=23).

## Why these panels

Observed cluster-wide signal at submit time:
- ~747 samples / 5 min cluster-wide
- p50 ≈ 816 µs (in-cluster CoreDNS cache hits)
- p95 ≈ 115 ms
- p99 ≈ 845 ms — a slow tail worth seeing on a heatmap, not just a percentile line

The combination of the rate panel (volume), percentile panel (trend), and heatmap (shape) is the same triplet used for SRTT (panels 20/22/23) and lets us spot whether a regression is a volume spike, a latency drift, or a new tail mode.

## Validation

- `python3 -c 'import yaml,json;cm=yaml.safe_load(open("infra/configs/dashboards/netscope-cm.yaml"));json.loads(cm["data"]["netscope.json"])'` — passes
- `kustomize build infra/configs/dashboards` — passes (4257 lines)
- Panel ids in order: `[1, 2, 3, 10, 11, 19, 20, 21, 22, 23, 29, 30, 31, 32]`

## Test plan

- [ ] Merge → Flux reconciles `infra-configs` → Grafana sidecar picks up the updated ConfigMap
- [ ] Open the "Netscope (eBPF Network Traffic)" dashboard (UID `netscope-overview`)
- [ ] Verify the new "Phase 2 — DNS query latency" row appears below the SRTT distribution heatmap
- [ ] Panel 30 renders one line per node with sub-`ops` values
- [ ] Panel 31 renders three percentile lines (expect p50 sub-ms, p99 in the hundreds of ms)
- [ ] Panel 32 renders a log-Y heatmap with samples banded across the 1µs–1s range

🤖 Generated with [Claude Code](https://claude.com/claude-code)