### PR TITLE
feat(homeassistant): add Laundry Room Lights section to Control dashboard

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -102,6 +102,59 @@ views:
     column_span: 3
     cards:
     - type: heading
+      heading: Laundry Room Lights
+      heading_style: title
+    - type: markdown
+      content: '**How it works:** when either laundry room light turns on, a timer starts using the **Minutes** value. When the timer expires, both lights turn off. Turning both lights off manually before the timer expires cancels the timer.'
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Laundry Room
+      heading_style: title
+    - type: tile
+      entity: light.laundry_room_main_lights
+      name: Main Lights
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: light.laundry_room_cove
+      name: Cove
+      color: amber
+      tap_action:
+        action: toggle
+    - type: tile
+      entity: timer.laundry_room_light_timer
+      name: Timer
+    - type: tile
+      entity: input_number.laundry_room_light_minutes
+      name: Minutes
+      features_position: bottom
+      features:
+      - type: numeric-input
+    - type: button
+      name: Cancel Timer
+      icon: mdi:timer-off
+      tap_action:
+        action: call-service
+        service: timer.cancel
+        data:
+          entity_id: timer.laundry_room_light_timer
+    - type: button
+      name: Turn Off Both
+      icon: mdi:lightbulb-off
+      tap_action:
+        action: call-service
+        service: light.turn_off
+        target:
+          entity_id:
+          - light.laundry_room_main_lights
+          - light.laundry_room_cove
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
       heading: Nightlight
       heading_style: title
     - type: markdown


### PR DESCRIPTION
## Summary

Adds a **Laundry Room Lights** section to the GitOps-managed Control dashboard, surfacing controls for the existing auto-off automation that's been running since the initial laundry timer landed.

Section placement: between the bathroom row and the Nightlight section (logically grouped with other timers).

### Tiles

- Heading: Laundry Room
- Tile: Main Lights (toggle)
- Tile: Cove (toggle)
- Tile: Timer (\`timer.laundry_room_light_timer\`)
- Tile: Minutes (\`input_number.laundry_room_light_minutes\`, numeric input)
- Button: Cancel Timer (calls \`timer.cancel\`)
- Button: Turn Off Both (calls \`light.turn_off\` on both lights)

### Entities verified live

All four entities exist in the cluster's HA state:

| entity | state |
|---|---|
| \`light.laundry_room_main_lights\` | off |
| \`light.laundry_room_cove\` | off |
| \`timer.laundry_room_light_timer\` | idle |
| \`input_number.laundry_room_light_minutes\` | 30 (default) |

## Test plan

- [x] \`kustomize build apps/{production,staging}/homeassistant\` passes
- [x] Rendered ConfigMap contains the \"Laundry Room\" string (4 hits)
- [ ] After merge + Flux reconcile: HA auto-restarts (configMapGenerator hash change); Control dashboard at https://hass.burntbytes.com/home-control shows the new section between bathrooms and Nightlight; all four entity tiles render live state.