### PR TITLE
feat: thermalscope — Prometheus thermal exporter for hestia

### DIFF
--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -30,6 +30,7 @@ on:
         options:
           - all
           - llama-cpp
+          - thermalscope
       dry_run:
         description: 'Connect, query, and diff without calling app.update'
         required: false
@@ -49,6 +50,8 @@ jobs:
         include:
           - name: llama-cpp
             file: hosts/hestia/llms/docker-compose-llama-cpp.yml
+          - name: thermalscope
+            file: hosts/hestia/monitoring/docker-compose.yml
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/hosts/hestia/monitoring/README.md
+++ b/hosts/hestia/monitoring/README.md
@@ -1,13 +1,14 @@
-# monitoring — GPU metrics on hestia
+# monitoring — hestia thermals + GPU metrics
 
-GPU utilization monitoring for the 4090 on hestia.
+Thermal/GPU observability for hestia.
 
 ## Services
 
 | File | Purpose |
 |------|---------|
 | `docker-compose-nvtop.yml` | nvtop — interactive GPU process viewer |
+| `docker-compose.yml` | thermalscope — Prometheus thermal/GPU exporter on `:9102` |
 
 ## Deployment
 
-Deploy as a TrueNAS Custom App. Paste the YAML into SCALE UI → Apps → Custom App.
+Deploy as a TrueNAS Custom App. Paste the YAML into SCALE UI → Apps → Custom App. Subsequent updates to `docker-compose.yml` flow through `.github/workflows/deploy-hestia.yml`.

--- a/hosts/hestia/monitoring/docker-compose.yml
+++ b/hosts/hestia/monitoring/docker-compose.yml
@@ -1,6 +1,20 @@
+# thermalscope — Prometheus thermal/GPU exporter for hestia.
+#
+# Reads /sys/class/hwmon (CPU k10temp Tctl/Tccd + 9 NVMe drives) and runs
+# nvidia-smi for GPU temp/power/utilization/fan/clock. Exposes :9102/metrics
+# on the host network. Source: github.com/gjcourt/thermalscope.
+#
+# Image is pinned to an explicit short-SHA tag per the homelab image
+# discipline rule. To roll forward, build a new tag in thermalscope and bump
+# the value below — never use :main or :latest here.
+#
+# No healthcheck is declared because the runtime image
+# (gcr.io/distroless/static-debian12) has no shell and no curl/wget — any
+# CMD-SHELL test would always fail. Prometheus's up{job="thermalscope"}
+# scrape success is the real health signal.
 services:
   thermalscope:
-    image: ghcr.io/gjcourt/thermalscope:main
+    image: ghcr.io/gjcourt/thermalscope:21e45e9
     container_name: thermalscope
     restart: unless-stopped
     privileged: true
@@ -9,9 +23,3 @@ services:
       - /sys/class/hwmon:/sys/class/hwmon:ro
       - /sys/class/thermal:/sys/class/thermal:ro
       - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9102/healthz || exit 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s

--- a/hosts/hestia/monitoring/docker-compose.yml
+++ b/hosts/hestia/monitoring/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  thermalscope:
+    image: ghcr.io/gjcourt/thermalscope:main
+    container_name: thermalscope
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    volumes:
+      - /sys/class/hwmon:/sys/class/hwmon:ro
+      - /sys/class/thermal:/sys/class/thermal:ro
+      - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9102/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/hosts/hestia/monitoring/docker-compose.yml
+++ b/hosts/hestia/monitoring/docker-compose.yml
@@ -14,7 +14,7 @@
 # scrape success is the real health signal.
 services:
   thermalscope:
-    image: ghcr.io/gjcourt/thermalscope:21e45e9
+    image: ghcr.io/gjcourt/thermalscope:37e615a
     container_name: thermalscope
     restart: unless-stopped
     privileged: true

--- a/infra/configs/dashboards/kustomization.yaml
+++ b/infra/configs/dashboards/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - node-details-cm.yaml
   - overture-cm.yaml
   - storage-csi-cm.yaml
+  - thermalscope-cm.yaml

--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -333,8 +333,13 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "${datasource}"},
-              "expr": "thermalscope_collector_up{instance=\"hestia\"}",
-              "legendFormat": "{{subsystem}}"
+              "expr": "thermalscope_hwmon_up{instance=\"hestia\"}",
+              "legendFormat": "hwmon"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_up{instance=\"hestia\"}",
+              "legendFormat": "gpu"
             }
           ],
           "title": "Collector Status",

--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -1,0 +1,390 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thermalscope-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  thermalscope.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "title": "CPU",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "orange", "value": 75},
+                  {"color": "red", "value": 85}
+                ]
+              },
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+          "id": 1,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_cpu_temperature_celsius{instance=\"hestia\", sensor=\"Tctl\"}",
+              "legendFormat": "Tctl (control)"
+            }
+          ],
+          "title": "CPU Control Temperature (Tctl)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+          "id": 2,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_cpu_temperature_celsius{instance=\"hestia\", sensor=~\"Tccd.*\"}",
+              "legendFormat": "{{sensor}}"
+            }
+          ],
+          "title": "CPU Die Temperatures (Tccd1–4)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+          "id": 101,
+          "title": "NVMe Drives",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "orange", "value": 55},
+                  {"color": "red", "value": 65}
+                ]
+              },
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 16, "x": 0, "y": 10},
+          "id": 3,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "right"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_nvme_temperature_celsius{instance=\"hestia\", sensor=\"Composite\"}",
+              "legendFormat": "{{device}}"
+            }
+          ],
+          "title": "NVMe Drive Temperatures",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "orange", "value": 55},
+                  {"color": "red", "value": 65}
+                ]
+              },
+              "unit": "celsius",
+              "min": 0,
+              "max": 90
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 10},
+          "id": 4,
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "orientation": "horizontal", "displayMode": "gradient"},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_nvme_temperature_celsius{instance=\"hestia\", sensor=\"Composite\"}",
+              "legendFormat": "{{device}}"
+            }
+          ],
+          "title": "NVMe Current Temps",
+          "type": "bargauge"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+          "id": 102,
+          "title": "GPU Thermals & Power",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "orange", "value": 75},
+                  {"color": "red", "value": 83}
+                ]
+              },
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 19},
+          "id": 5,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_temperature_celsius{instance=\"hestia\"}",
+              "legendFormat": "GPU {{gpu}}"
+            }
+          ],
+          "title": "GPU Temperature",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "watt",
+              "max": 500
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 19},
+          "id": 6,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_power_draw_watts{instance=\"hestia\"}",
+              "legendFormat": "GPU {{gpu}}"
+            }
+          ],
+          "title": "GPU Power Draw",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 19},
+          "id": 7,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_fan_speed_ratio{instance=\"hestia\"}",
+              "legendFormat": "GPU {{gpu}} fan"
+            }
+          ],
+          "title": "GPU Fan Speed",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 27},
+          "id": 103,
+          "title": "GPU Utilization & Clock",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
+          "id": 8,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_sm_utilization_ratio{instance=\"hestia\"}",
+              "legendFormat": "GPU {{gpu}} SM"
+            }
+          ],
+          "title": "GPU SM Utilization",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
+          "id": 9,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_memory_utilization_ratio{instance=\"hestia\"}",
+              "legendFormat": "GPU {{gpu}} memory"
+            }
+          ],
+          "title": "GPU Memory Utilization",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "unit": "mhz"
+            }
+          },
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
+          "id": 10,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_gpu_sm_clock_hz{instance=\"hestia\"} / 1e6",
+              "legendFormat": "GPU {{gpu}}"
+            }
+          ],
+          "title": "GPU SM Clock",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 36},
+          "id": 104,
+          "title": "Collector Health",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "green", "value": 1}
+                ]
+              },
+              "mappings": [
+                {"options": {"0": {"text": "DOWN"}, "1": {"text": "UP"}}, "type": "value"}
+              ]
+            }
+          },
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 37},
+          "id": 11,
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "orientation": "horizontal", "colorMode": "background"},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_collector_up{instance=\"hestia\"}",
+              "legendFormat": "{{subsystem}}"
+            }
+          ],
+          "title": "Collector Status",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 1, "spanNulls": false},
+              "unit": "s"
+            }
+          },
+          "gridPos": {"h": 4, "w": 16, "x": 8, "y": 37},
+          "id": 12,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "scrape_duration_seconds{job=\"thermalscope\", instance=\"hestia\"}",
+              "legendFormat": "scrape duration"
+            }
+          ],
+          "title": "Scrape Duration",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["hestia", "thermals", "gpu"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource",
+            "label": "Datasource"
+          }
+        ]
+      },
+      "time": {"from": "now-3h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "ThermalScope — Hestia",
+      "uid": null,
+      "version": 1
+    }

--- a/infra/configs/kustomization.yaml
+++ b/infra/configs/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - dashboards
   - gateway
   - network-policies
+  - thermalscope

--- a/infra/configs/thermalscope/kustomization.yaml
+++ b/infra/configs/thermalscope/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - scrapeconfig.yaml
+  - prometheus-rule.yaml

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: thermalscope-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: thermalscope
+      rules:
+        - alert: ThermalScopeScraperDown
+          expr: up{job="thermalscope"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "thermalscope exporter on hestia is not reachable"
+            description: "No metrics have been scraped from hestia:9102 for 5 minutes."
+
+        - alert: HestiaCPUTemperatureHigh
+          expr: thermalscope_cpu_temperature_celsius{instance="hestia", sensor="Tctl"} > 85
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "hestia CPU temperature is high"
+            description: "Tctl is {{ $value }}°C (threshold 85°C)."
+
+        - alert: HestiaNVMeTemperatureHigh
+          expr: thermalscope_nvme_temperature_celsius{instance="hestia"} > 65
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "hestia NVMe {{ $labels.device }} temperature is high"
+            description: "{{ $labels.device }} is {{ $value }}°C (threshold 65°C)."
+
+        - alert: HestiaGPUTemperatureHigh
+          expr: thermalscope_gpu_temperature_celsius{instance="hestia"} > 83
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "hestia GPU {{ $labels.gpu }} temperature is high"
+            description: "GPU {{ $labels.gpu }} ({{ $labels.name }}) is {{ $value }}°C (threshold 83°C)."

--- a/infra/configs/thermalscope/scrapeconfig.yaml
+++ b/infra/configs/thermalscope/scrapeconfig.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: hestia-thermalscope
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  staticConfigs:
+    - targets:
+        - 10.42.2.10:9102
+      labels:
+        instance: hestia
+        job: thermalscope
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  metricsPath: /metrics

--- a/infra/configs/thermalscope/scrapeconfig.yaml
+++ b/infra/configs/thermalscope/scrapeconfig.yaml
@@ -11,7 +11,13 @@ spec:
         - 10.42.2.10:9102
       labels:
         instance: hestia
-        job: thermalscope
+  # Force the job label to "thermalscope" so the PrometheusRule alerts
+  # (which match on job="thermalscope") align with the scraped series —
+  # the operator otherwise auto-names the job
+  # "scrapeConfig/monitoring/hestia-thermalscope".
+  relabelings:
+    - targetLabel: job
+      replacement: thermalscope
   scrapeInterval: 30s
   scrapeTimeout: 10s
   metricsPath: /metrics


### PR DESCRIPTION
## Summary

Adds [thermalscope](https://github.com/gjcourt/thermalscope) — a Go Prometheus exporter for hestia (10.42.2.10) — and wires it into the cluster monitoring stack.

**What:** CPU (k10temp Tctl + per-die Tccd), 9× NVMe drive temps, and GPU temp/power/utilization/fan/clock (when nvidia-smi is available).

**Motivation:** Mellanox 25 GbE NIC just had to be pulled from hestia after overheating triggered PCIe BadTLP errors and instability — there was no real-time thermal visibility to catch it earlier.

## Components

- **`hosts/hestia/monitoring/docker-compose.yml`** — TrueNAS Custom App; `privileged: true`, `network_mode: host`, mounts `/sys/class/hwmon` + `nvidia-smi`. First deploy is a manual paste into SCALE UI; subsequent updates flow through `deploy-hestia.yml`.
- **`infra/configs/thermalscope/scrapeconfig.yaml`** — `ScrapeConfig` CRD pointing Prometheus at `10.42.2.10:9102` with `instance="hestia"`.
- **`infra/configs/thermalscope/prometheus-rule.yaml`** — alerts for scraper down, CPU > 85°C, NVMe > 65°C, GPU > 83°C.
- **`infra/configs/dashboards/thermalscope-cm.yaml`** — Grafana dashboard ConfigMap (auto-discovered by sidecar).
- **`.github/workflows/deploy-hestia.yml`** — adds `thermalscope` matrix entry so future compose changes auto-deploy.

The exporter image is built and pushed by [gjcourt/thermalscope](https://github.com/gjcourt/thermalscope) CI to `ghcr.io/gjcourt/thermalscope:main`.

## Test plan

- [x] `kustomize build infra/configs` passes
- [x] `kustomize build infra/configs/thermalscope` passes
- [x] `kustomize build infra/configs/dashboards` passes
- [ ] Image published to ghcr.io/gjcourt/thermalscope:main (CI on the thermalscope repo)
- [ ] After merge: paste docker-compose.yml into SCALE UI as Custom App "thermalscope"
- [ ] Verify `curl http://10.42.2.10:9102/metrics | grep thermalscope_cpu` returns data
- [ ] Prometheus targets show `up{job="thermalscope"} == 1`
- [ ] Grafana dashboard "ThermalScope — Hestia" loads with CPU/NVMe panels populated
- [ ] Start vLLM → GPU panels populate
- [ ] Kill container → `ThermalScopeScraperDown` alert fires within 5m

🤖 Generated with [Claude Code](https://claude.com/claude-code)