### PR TITLE
chore(thermalscope): bump image to d470623 (nvme device naming)

### DIFF
--- a/hosts/hestia/monitoring/docker-compose.yml
+++ b/hosts/hestia/monitoring/docker-compose.yml
@@ -14,7 +14,7 @@
 # scrape success is the real health signal.
 services:
   thermalscope:
-    image: ghcr.io/gjcourt/thermalscope:37e615a
+    image: ghcr.io/gjcourt/thermalscope:d470623
     container_name: thermalscope
     restart: unless-stopped
     privileged: true


### PR DESCRIPTION
## Summary

Picks up [thermalscope#2](https://github.com/gjcourt/thermalscope/pull/2). Live `:9102/metrics` on hestia currently shows NVMe drives labeled `device="hwmon0"`..`device="hwmon8"`; the new build relabels them to `nvme0`..`nvme8` by inspecting the `/sys/class/hwmon/hwmonN/device` symlink target on kernel 6.18 layouts.

After merge, the `deploy-hestia.yml` runner picks up the compose change and `app.update`s thermalscope automatically.

## Test plan

- [x] kustomize-affected validation: no kustomize tree touched
- [ ] After merge + Flux apply: `curl http://10.42.2.10:9102/metrics | grep thermalscope_nvme` shows `device="nvme0"` ... `device="nvme8"`
- [ ] Grafana NVMe panel legend updates accordingly (uses `{{device}}` — no dashboard change needed)

## Re fan-speed metrics

A parallel investigation found no `fan*_input` hwmon entries on any host in the rack (hestia + 6 Talos nodes are all AMD boards with no SuperIO driver and no BMC on the Talos side). Chassis fans on hestia are only reachable via IPMI — better addressed by a separate `prometheus-ipmi-exporter` workload than by extending thermalscope. Not part of this PR; surfacing for the next conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)