### PR TITLE
feat(thermalscope): cluster-wide DaemonSet on all 6 Talos nodes

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: thermalscope-agent
+  namespace: thermalscope
+  labels:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/component: agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thermalscope
+        app.kubernetes.io/component: agent
+    spec:
+      serviceAccountName: thermalscope-agent
+      hostNetwork: true
+      hostPID: false
+      dnsPolicy: ClusterFirstWithHostNet
+      # Intentional: schedule on every node including control-plane.
+      # Thermal observability is most useful when it covers all 6 nodes
+      # (3 CP + 3 worker). The agent footprint is tiny (10m CPU /
+      # 16Mi memory request) and the CP nodes have CPU/NVMe sensors that
+      # we want visible. Talos CP nodes carry the standard
+      # `node-role.kubernetes.io/control-plane:NoSchedule` taint; the
+      # `operator: Exists` toleration with no key matches every taint,
+      # which is what we want.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: agent
+          # Pin to a digest per the homelab image-discipline rule. Tag
+          # `d470623` is the current thermalscope main SHA (May 2026).
+          # A follow-up PR will bump to the SHA that adds amdgpu chip
+          # support once that lands in thermalscope.
+          image: "ghcr.io/gjcourt/thermalscope:d470623@sha256:af1c2d64a54ffb4168ab8424a704a3b9b49efe8d1b4cdb9f4f64f18cdd70b0c3"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9102
+              hostPort: 9102
+              protocol: TCP
+          securityContext:
+            privileged: false
+            # runAsUser: 0 — hwmon sysfs entries (tempN_input etc.) are
+            # readable as root without any added capabilities. Non-root
+            # would work for most sensors but is unreliable across
+            # vendors, so we keep root and drop ALL caps.
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              # No `add:` block — unlike netscope, thermalscope does not
+              # use BPF/PERFMON/NET_ADMIN/SYS_ADMIN; hwmon is plain
+              # sysfs reads.
+          volumeMounts:
+            - name: hwmon
+              mountPath: /sys/class/hwmon
+              readOnly: true
+            - name: thermal
+              mountPath: /sys/class/thermal
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9102
+              host: 127.0.0.1
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # No livenessProbe: per AGENTS.md health-probes guidance, a
+          # livenessProbe is only added when it has a signal distinct
+          # from readiness. thermalscope is a stateless Go HTTP server
+          # — if /healthz stops responding, readiness recovery is
+          # sufficient (kubelet stops routing scrapes, Prometheus
+          # `up{job="thermalscope"}` alert fires). A liveness restart
+          # would not unstick anything readiness wouldn't.
+      volumes:
+        - name: hwmon
+          hostPath:
+            path: /sys/class/hwmon
+            type: Directory
+        - name: thermal
+          hostPath:
+            path: /sys/class/thermal
+            type: Directory

--- a/apps/base/thermalscope/kustomization.yaml
+++ b/apps/base/thermalscope/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - daemonset.yaml
+  - service.yaml
+  - servicemonitor.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/component: agent
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/thermalscope/namespace.yaml
+++ b/apps/base/thermalscope/namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: thermalscope
+  labels:
+    app: thermalscope
+    # thermalscope runs hostNetwork and mounts hostPath sysfs paths
+    # (/sys/class/hwmon, /sys/class/thermal). PSA baseline forbids
+    # hostNetwork; restricted additionally forbids hostPath volumes and
+    # runAsNonRoot=false. We need root for hwmon sysfs reads, so
+    # privileged is the required level.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/base/thermalscope/service.yaml
+++ b/apps/base/thermalscope/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thermalscope-agent
+  namespace: thermalscope
+  labels:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: agent
+spec:
+  type: ClusterIP
+  # Headless: Endpoints carry the host IPs (the agent runs hostNetwork)
+  # rather than ephemeral pod IPs, which is what we want for per-node
+  # scrape targets. ServiceMonitor below scrapes via these Endpoints.
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: agent
+  ports:
+    - name: metrics
+      port: 9102
+      targetPort: metrics
+      protocol: TCP

--- a/apps/base/thermalscope/serviceaccount.yaml
+++ b/apps/base/thermalscope/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thermalscope-agent
+  namespace: thermalscope

--- a/apps/base/thermalscope/servicemonitor.yaml
+++ b/apps/base/thermalscope/servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thermalscope-agent
+  namespace: thermalscope
+  labels:
+    # kube-prometheus-stack's Prometheus instance selects ServiceMonitors
+    # by helm-default release label (serviceMonitorSelectorNilUsesHelmValues=true,
+    # serviceMonitorSelector={}). Without this label our SM is invisible to it.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/component: agent
+  # No namespaceSelector — defaults to the SM's own namespace, which is
+  # exactly the per-environment scope we want (the staging overlay
+  # rewrites this SM's namespace to thermalscope-stage).
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      relabelings:
+        # Promote the pod's node name to `instance` so each Talos node
+        # appears as a distinct Prometheus target (e.g.
+        # instance="talos-ykb-uir"). The existing hestia ScrapeConfig
+        # sets instance="hestia"; together they make
+        # up{job="thermalscope"} cover 7 targets — hestia plus the 6
+        # cluster nodes — each with a unique `instance` label.
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: instance
+          action: replace
+        # Force `job=thermalscope` so the existing PrometheusRule
+        # alerts (which match on job="thermalscope") fire for the
+        # DaemonSet targets too. Without this, prometheus-operator
+        # auto-derives a job name from the ServiceMonitor metadata
+        # (e.g. "thermalscope/thermalscope-agent") which would not
+        # match the alerts.
+        - targetLabel: job
+          replacement: thermalscope
+      metricRelabelings:
+        # Drop the per-pod label: under hostNetwork the pod identity is
+        # the node, and pod names churn on restart, adding cardinality
+        # without signal.
+        - action: labeldrop
+          regex: pod

--- a/apps/production/thermalscope/kustomization.yaml
+++ b/apps/production/thermalscope/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/thermalscope/

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -23,4 +23,5 @@ resources:
   - openwebui
   - signal-cli
   - snapcast
+  - thermalscope
   - vitals

--- a/apps/staging/thermalscope/kustomization.yaml
+++ b/apps/staging/thermalscope/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thermalscope-stage
+resources:
+  - ../../base/thermalscope/
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  # Rename the Namespace resource itself to match `namespace:` above.
+  - target:
+      kind: Namespace
+      name: thermalscope
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: thermalscope-stage


### PR DESCRIPTION
## Summary

Phase 6 of the thermalscope rollout: extend coverage from the existing hestia static-target scrape to every node in the `melodic-muse` cluster via a Kubernetes DaemonSet. After staging soak, `up{job=\"thermalscope\"}` will cover 7 targets — hestia plus the 6 Talos nodes — each with a distinct `instance` label.

## What's in this PR

- `apps/base/thermalscope/` — Namespace, ServiceAccount, DaemonSet, headless Service, ServiceMonitor, kustomization
- `apps/staging/thermalscope/` — staging overlay (renames namespace to `thermalscope-stage`)
- `apps/production/thermalscope/` — production overlay file (**intentionally NOT wired into `apps/production/kustomization.yaml` yet** — see below)
- `apps/staging/kustomization.yaml` — adds `thermalscope` to the staging resource list

## Mirrors netscope, with thermalscope-specific differences

- No `bpffs`/`btf` mounts and no `BPF`/`PERFMON`/`NET_ADMIN`/`SYS_ADMIN` caps — hwmon is plain sysfs reads (`runAsUser: 0` is enough).
- `/sys/class/hwmon` and `/sys/class/thermal` hostPath mounts (read-only).
- Port `9102` (containerPort + hostPort, hostNetwork: true). 9100 is node-exporter, 9101 is netscope — 9102 is collision-free (verified across the cluster).
- Tolerations `operator: Exists` to run on CP + workers; CP taints aren't currently applied on this cluster but the toleration future-proofs it.
- Resource requests `cpu: 10m / memory: 16Mi`, limit `memory: 32Mi` — comfortably under the netscope baseline (50m / 64Mi / 128Mi).
- `readinessProbe` only, no `livenessProbe` — stateless Go HTTP server; per AGENTS.md, liveness requires a distinct signal from readiness, and this agent's readiness recovery is sufficient.
- Image pinned to `ghcr.io/gjcourt/thermalscope:d470623@sha256:af1c2d64a54ffb4168ab8424a704a3b9b49efe8d1b4cdb9f4f64f18cdd70b0c3` (current main SHA). A follow-up bump will land amdgpu chip support.
- Namespace PSA `enforce/audit/warn: privileged` (hostNetwork + hostPath both require it; matches netscope's pattern).

## ServiceMonitor relabeling

Promotes `__meta_kubernetes_pod_node_name` to `instance` so each Talos node appears as a distinct Prometheus target (e.g. `instance=\"talos-ykb-uir\"`), and forces `job=thermalscope` so the existing `PrometheusRule` alerts (which match on `job=\"thermalscope\"`) fire for the DaemonSet targets uniformly with the static hestia scrape.

## Production overlay deferred to follow-up PR

The production overlay file is committed but **not** wired into `apps/production/kustomization.yaml`. After the staging soak validates the DaemonSet behavior across all 6 nodes (~24h), I'll open a one-line PR adding `- thermalscope` to that file.

## Validation

- [x] `kustomize build apps/base/thermalscope` — passes
- [x] `kustomize build apps/staging/thermalscope` — passes
- [x] `kustomize build apps/production/thermalscope` — passes
- [x] `kustomize build apps/staging` (parent) — passes
- [x] `kustomize build apps/production` (parent) — passes
- [x] No plaintext secrets in new files

## Test plan

- [ ] Wait for CI rebuild of `staging` branch
- [ ] `kubectl -n thermalscope-stage get ds` shows 6/6 ready
- [ ] `kubectl -n thermalscope-stage exec ds/thermalscope-agent -- wget -qO- http://localhost:9102/metrics | grep thermalscope_cpu` returns CPU temps
- [ ] Prometheus targets page shows 7 `up{job=\"thermalscope\"}` targets, all 1
- [ ] 24h soak before production overlay PR

Generated with [Claude Code](https://claude.com/claude-code)