### PR TITLE
feat: deploy prometheus-ipmi-exporter on hestia for BMC fan/temp metrics

### DIFF
--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -31,6 +31,7 @@ on:
           - all
           - llama-cpp
           - thermalscope
+          - ipmi-exporter
       dry_run:
         description: 'Connect, query, and diff without calling app.update'
         required: false
@@ -52,6 +53,8 @@ jobs:
             file: hosts/hestia/llms/docker-compose-llama-cpp.yml
           - name: thermalscope
             file: hosts/hestia/monitoring/docker-compose.yml
+          - name: ipmi-exporter
+            file: hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
+++ b/hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
@@ -1,0 +1,33 @@
+# prometheus-ipmi-exporter for hestia.
+#
+# Reads /dev/ipmi0 (in-band BMC, ASRock Rack) and exposes :9290/metrics on
+# the host network. No credentials needed — the host owns the BMC, so the
+# IPMI device file is the auth boundary. The exporter speaks to the BMC
+# via OpenIPMI; ipmitool / freeipmi are bundled in the upstream image.
+#
+# Why this exists: hwmon on hestia only surfaces CPU (k10temp), NVMe, and
+# GPU temps — no chassis fan tach inputs. The BMC SDR has FAN1_1..FAN5_1
+# (1000-1400 RPM at idle), CPU/inlet/DDR5/M.2 temps, and PSU current
+# placeholders. ipmi-exporter is the only practical way to surface those
+# series to Prometheus on this hardware.
+#
+# Image is pinned to an explicit upstream release tag per the homelab
+# image discipline rule. Bump deliberately; never use :latest or :main.
+#
+# privileged=true + the /dev/ipmi0 device map are both required:
+# OpenIPMI's ioctl on the device node needs CAP_SYS_RAWIO, which the
+# device map alone does not grant inside a non-privileged container.
+services:
+  ipmi-exporter:
+    image: prometheuscommunity/ipmi-exporter:v1.10.1
+    container_name: ipmi-exporter
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    devices:
+      - /dev/ipmi0:/dev/ipmi0
+    command:
+      - --config.file=/config/ipmi.yml
+      - --web.listen-address=:9290
+    volumes:
+      - ./ipmi-exporter-config.yml:/config/ipmi.yml:ro

--- a/hosts/hestia/monitoring/ipmi-exporter-config.yml
+++ b/hosts/hestia/monitoring/ipmi-exporter-config.yml
@@ -1,0 +1,28 @@
+# prometheus-ipmi-exporter config for hestia.
+#
+# The default module uses the in-band /dev/ipmi0 driver (no `driver:`
+# override needed — `open` is the upstream default and matches our
+# host-owns-BMC topology). Collectors:
+#
+#   - ipmi     — SDR sensor readings (fans, temps, voltage, current)
+#   - dcmi     — chassis power draw if the BMC advertises DCMI
+#   - bmc      — BMC firmware/IPMI version info
+#   - chassis  — chassis state (power on/off, intrusion)
+#
+# `sel` is intentionally NOT enabled here: it scrapes the System Event
+# Log which on a healthy host produces zero useful series but adds
+# latency and risks flooding logs after a real fault. Add it back if we
+# ever want SEL-driven alerting.
+#
+# exclude_sensor_ids is empty — first deploy collects everything so we
+# can see which "ns" / "No Reading" sensors (FAN6_1, FAN1_2..FAN6_2,
+# FAN_PSU1/2, PSU IOUT) actually emit metrics vs. get silently dropped
+# by the exporter. Tune in a follow-up if the noise floor is too high.
+modules:
+  default:
+    collectors:
+      - ipmi
+      - dcmi
+      - bmc
+      - chassis
+    exclude_sensor_ids: []

--- a/infra/configs/ipmi-exporter/kustomization.yaml
+++ b/infra/configs/ipmi-exporter/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - scrapeconfig.yaml
+  - prometheus-rule.yaml

--- a/infra/configs/ipmi-exporter/prometheus-rule.yaml
+++ b/infra/configs/ipmi-exporter/prometheus-rule.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ipmi-exporter-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: ipmi-exporter
+      rules:
+        - alert: IPMIScraperDown
+          expr: up{job="ipmi-exporter"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ipmi-exporter on hestia is not reachable"
+            description: "No metrics have been scraped from hestia:9290 for 5 minutes."
+
+        # Fan stall: BMC reports a fan at <200 RPM. We only alert on fans
+        # whose state is "ok" (sensor present & reading) to avoid firing
+        # on unpopulated fan headers, which the exporter exposes as 0.
+        # The `state` label is ipmi-exporter's name for the SDR
+        # availability flag — "0" = nominal/ok.
+        - alert: IPMIFanStalled
+          expr: ipmi_fan_speed_rpm{job="ipmi-exporter"} < 200 and ipmi_fan_speed_state{job="ipmi-exporter"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "hestia chassis fan {{ $labels.name }} stalled"
+            description: "{{ $labels.name }} is reading {{ $value }} RPM (threshold 200)."

--- a/infra/configs/ipmi-exporter/scrapeconfig.yaml
+++ b/infra/configs/ipmi-exporter/scrapeconfig.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: hestia-ipmi-exporter
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  staticConfigs:
+    - targets:
+        - 10.42.2.10:9290
+      labels:
+        instance: hestia
+  # Force the job label to "ipmi-exporter" so PrometheusRule alerts
+  # (which match on job="ipmi-exporter") align with the scraped series —
+  # the operator otherwise auto-names the job
+  # "scrapeConfig/monitoring/hestia-ipmi-exporter".
+  relabelings:
+    - targetLabel: job
+      replacement: ipmi-exporter
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  metricsPath: /metrics

--- a/infra/configs/kustomization.yaml
+++ b/infra/configs/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - cilium
   - dashboards
   - gateway
+  - ipmi-exporter
   - network-policies
   - thermalscope


### PR DESCRIPTION
## Summary

- Deploys `prometheus-ipmi-exporter` v1.10.1 as a TrueNAS Custom App on hestia, reading `/dev/ipmi0` in-band from the ASRock Rack BMC.
- Surfaces chassis fan RPMs (`FAN1_1..FAN5_1`), BMC-side CPU/DDR5/inlet temps, and PSU current placeholders — none of which hwmon exposes. The host owns the BMC, so no IPMI credentials are needed; the device file is the auth boundary.
- Wires the cluster side: `ScrapeConfig` in `monitoring` (label `release: kube-prometheus-stack`, job forced to `ipmi-exporter`) plus a `PrometheusRule` with `IPMIScraperDown` and `IPMIFanStalled` (RPM < 200 AND state == Nominal, to skip unpopulated headers).

## Sanity check (run on hestia before this PR)

```
$ ls -la /dev/ipmi0
crw------- 1 root root 240, 0 May 14 00:33 /dev/ipmi0

$ sudo ipmitool sdr type Fan
FAN1_1   | 11h | ok  | 29.1  | 1400 RPM
FAN2_1   | 12h | ok  | 29.2  | 1200 RPM
FAN3_1   | 13h | ok  | 29.3  | 1000 RPM
FAN4_1   | 14h | ok  | 29.4  | 1000 RPM
FAN5_1   | 15h | ok  | 29.5  | 1000 RPM
FAN6_1   | 16h | ns  | ...   | No Reading       # unpopulated
FAN_PSU1 | 39h | ns  | ...   | No Reading       # PSU lacks tach
```

The active fans plus rich BMC temps (`TEMP_CPU`, `TEMP_INLET1/2`, `TEMP_DDR5_*`, `TEMP_CARD_SIDE1/2`) all read fine. Deployment can work.

## First-deploy gotcha

`scripts/truenas-update-app.sh` (used by the runner) only calls `app.update`, which requires the Custom App to already exist. The operator must run `app.create` once before this PR's auto-deploy can take over — either:

1. Create "ipmi-exporter" via SCALE UI -> Apps -> Custom App and paste the compose, **or**
2. Run an adapted version of `/tmp/create_thermalscope.py` from the prior session (post-merge step).

## Why no "fan high RPM" alert

A spinning-up fan is the system *responding* to heat, not a problem. The temperature alerts in `infra/configs/thermalscope/prometheus-rule.yaml` already catch the underlying cause. A high-RPM alert would page on every workload spike.

## Out of scope

Dashboard wiring (a "Chassis Fans" row in the thermalscope Grafana dashboard) is intentionally deferred to a follow-up PR; this one ships the data path only.

## Test plan

- [ ] `kustomize build infra/configs` passes (verified locally)
- [ ] `docker manifest inspect prometheuscommunity/ipmi-exporter:v1.10.1` succeeds (verified — multi-arch incl. linux/amd64)
- [ ] After merge: operator runs `app.create` once (UI or adapted Python script)
- [ ] `curl http://10.42.2.10:9290/metrics | grep ipmi_fan_speed_rpm` returns named fans with non-zero RPMs
- [ ] Prometheus shows `up{job="ipmi-exporter"} == 1`
- [ ] `IPMIFanStalled` does **not** fire spuriously on unpopulated fan headers (`state != 0` short-circuits the alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)