### PR TITLE
fix(ipmi-exporter): run as root so freeipmi binaries can exec under TrueNAS

### DIFF
--- a/hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
+++ b/hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
@@ -18,6 +18,15 @@
 # OpenIPMI's ioctl on the device node needs CAP_SYS_RAWIO, which the
 # device map alone does not grant inside a non-privileged container.
 #
+# user: "0:0" is also required. The upstream image runs as `nobody`
+# (uid 65534), but /dev/ipmi0 on the host is mode 600 root:root — so
+# the unprivileged user can't open it even inside a privileged
+# container. Running as root inside the container is fine because the
+# container is already privileged; the security boundary is the IPMI
+# device file and the in-band BMC, not the container's user. Without
+# this, freeipmi binaries fail with "permission denied" trying to
+# exec ipmi-sensors / ipmi-dcmi / bmc-info.
+#
 # Why inline `configs:` instead of a bind-mounted file:
 # TrueNAS Custom Apps take *only* the compose YAML — they don't sync
 # co-located files from the repo onto the host. A relative bind mount
@@ -33,6 +42,7 @@ services:
     container_name: ipmi-exporter
     restart: unless-stopped
     privileged: true
+    user: "0:0"
     network_mode: host
     devices:
       - /dev/ipmi0:/dev/ipmi0


### PR DESCRIPTION
## Summary

- PR #670 fixed the config-loading crashloop. The container now starts but all four collectors fail with `permission denied` trying to exec the freeipmi helper binaries (`ipmi-sensors`, `ipmi-dcmi`, `bmc-info`, `ipmi-chassis`). Result: `ipmi_up{collector="..."} == 0` for everything.
- The upstream image runs as `nobody` and depends on file caps / setuid on the helper binaries. Under TrueNAS Custom Apps the container ends up with `SecurityOpt=label=disable` and no extra caps, so the suid path is suppressed and `nobody` can't exec the helpers.
- Adds `user: "0:0"`. The container is already `privileged: true`, so dropping to root inside is not a meaningful security regression — the security boundary is the in-band BMC and the IPMI device file, not the container's UID.

## Validation

Verified directly on hestia with `docker run` mimicking the new compose:

```
docker run --rm --privileged --user 0:0 \
  --device /dev/ipmi0:/dev/ipmi0 \
  --entrypoint /usr/sbin/ipmi-sensors \
  prometheuscommunity/ipmi-exporter:v1.10.1

ID | Name         | Type    | Reading | Units | Event
1  | VOLT_3V3SB   | Voltage | 3.38    | V     | 'OK'
2  | VOLT_5VSB    | Voltage | 5.04    | V     | 'OK'
... (86 SDR records total, including FAN1_1..FAN5_1 RPMs)
```

## Test plan

- [x] Verified `ipmi-sensors` runs as root inside the privileged container on hestia
- [ ] After merge: `up{job="ipmi-exporter"} == 1` and `ipmi_fan_speed_rpm` series appear with `name="FAN1_1"..."FAN5_1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)