### PR TITLE
chore(thermalscope): bump image to 88170e1 for amdgpu support

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -34,10 +34,11 @@ spec:
       containers:
         - name: agent
           # Pin to a digest per the homelab image-discipline rule. Tag
-          # `d470623` is the current thermalscope main SHA (May 2026).
-          # A follow-up PR will bump to the SHA that adds amdgpu chip
-          # support once that lands in thermalscope.
-          image: "ghcr.io/gjcourt/thermalscope:d470623@sha256:af1c2d64a54ffb4168ab8424a704a3b9b49efe8d1b4cdb9f4f64f18cdd70b0c3"
+          # `88170e1` is the thermalscope main SHA that adds amdgpu
+          # hwmon chip handling (thermalscope PR #3), exposing
+          # `thermalscope_amdgpu_temperature_celsius` on nodes with
+          # an AMD GPU present.
+          image: "ghcr.io/gjcourt/thermalscope:88170e1@sha256:df4839459c785db2e4988521be3448dc10a3a4baa0645bea93f8d3c777db11fe"
           imagePullPolicy: IfNotPresent
           ports:
             - name: metrics


### PR DESCRIPTION
## Summary
- Bumps the cluster-wide `thermalscope-agent` DaemonSet from `:d470623` → `:88170e1` (digest-pinned).
- New image is thermalscope `main` after PR #3 (amdgpu hwmon chip handling); nodes with an AMD GPU present will begin exporting `thermalscope_amdgpu_temperature_celsius{sensor=...,chip_index=...}` on `:9102/metrics`.
- Tag is strictly newer than the previously deployed `d470623` (per homelab image-discipline rule).

## Image pin
```
ghcr.io/gjcourt/thermalscope:88170e1@sha256:df4839459c785db2e4988521be3448dc10a3a4baa0645bea93f8d3c777db11fe
```
Digest fetched from the GHCR package versions API for the `88170e1` tag.

## Test plan
- [x] `kustomize build apps/staging/thermalscope` passes
- [x] `kustomize build apps/production/thermalscope` passes
- [ ] After merge: Flux reconciles `apps-staging`, DaemonSet pods rollout with the new image
- [ ] `kubectl -n thermalscope-stage exec ds/thermalscope -- wget -qO- localhost:9102/metrics | grep amdgpu` returns the new metric on AMD-GPU nodes
- [ ] Prometheus picks up `thermalscope_amdgpu_temperature_celsius`

🤖 Generated with [Claude Code](https://claude.com/claude-code)