### PR TITLE
feat(thermalscope): wire production overlay into apps/production

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -25,5 +25,6 @@ resources:
   - signal-cli
   - snapcast
   - synology-iscsi-monitor
+  - thermalscope
   - truenas-iscsi-monitor
   - vitals


### PR DESCRIPTION
## Summary

- Adds `- thermalscope` to `apps/production/kustomization.yaml` (alphabetical position, between `synology-iscsi-monitor` and `truenas-iscsi-monitor`).
- The production overlay at `apps/production/thermalscope/kustomization.yaml` was added in PR #668 but never wired into the parent kustomization, so Flux's `apps-production` wasn't reconciling it.
- Staging has been running cleanly: 6/6 `thermalscope-agent` pods Running, 0 restarts.

## Test plan

- [x] `kustomize build apps/production/thermalscope` passes
- [x] `kustomize build apps/production` passes
- [x] Staging clean (`kubectl -n thermalscope-stage get pods` → 6/6 Running)
- [x] Production namespace = `thermalscope` (plain), staging = `thermalscope-stage` — no namespace conflict
- [ ] Post-merge: `flux reconcile kustomization apps-production -n flux-system --with-source`
- [ ] Post-merge: `kubectl -n thermalscope get ds` shows 6/6 Ready
- [ ] Post-merge: Prometheus `up{job="thermalscope"}` series count check (staging + production both relabel `job=thermalscope` — if duplicates appear we'll need to differentiate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)