### PR TITLE
feat(immich): prefer high-airflow worker nodes via nodeAffinity

### DIFF
--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -24,6 +24,20 @@ spec:
     spec:
       serviceAccountName: immich
       automountServiceAccountToken: false
+      # Prefer the high-airflow worker nodes (labeled cpu-tier=high) so
+      # the CPU-heavy server doesn't bake the warmer control-plane nodes.
+      # Soft preference — scheduler falls back to any node if the labeled
+      # ones are unavailable (drain, NotReady, etc.).
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: homelab.gjcourt.dev/cpu-tier
+                    operator: In
+                    values:
+                      - high
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -92,6 +106,16 @@ spec:
     spec:
       serviceAccountName: immich
       automountServiceAccountToken: false
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: homelab.gjcourt.dev/cpu-tier
+                    operator: In
+                    values:
+                      - high
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -163,6 +187,16 @@ spec:
     spec:
       serviceAccountName: immich
       automountServiceAccountToken: false
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: homelab.gjcourt.dev/cpu-tier
+                    operator: In
+                    values:
+                      - high
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -61,3 +61,17 @@ spec:
     limits:
       memory: "4Gi"
       cpu: "2000m"
+  # Prefer high-airflow worker nodes (cpu-tier=high) to co-locate the
+  # postgres replicas with the immich-server pods and keep heat off the
+  # warmer control-plane nodes. Soft preference — falls back to other
+  # nodes when needed (drain, NotReady, replica count > labeled nodes).
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: homelab.gjcourt.dev/cpu-tier
+                operator: In
+                values:
+                  - high

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -34,6 +34,20 @@ spec:
       memory: "4Gi"
       cpu: "2000m"
 
+  # Prefer high-airflow worker nodes (cpu-tier=high). See production
+  # database.yaml for rationale. Soft preference — 3 replicas across 2
+  # labeled nodes means one replica lands elsewhere, which is fine.
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: homelab.gjcourt.dev/cpu-tier
+                operator: In
+                values:
+                  - high
+
   postgresql:
     shared_preload_libraries:
       - "vectors.so"


### PR DESCRIPTION
## Summary

Immich-server has been the cluster's #1 CPU pod (~1000m sustained, ML embedding + thumbnail work) and lands on whatever node the scheduler picks. Currently that's `talos-v2l-hng` — a control-plane node in a physical position with poor airflow — and Tctl there reached **77.9°C** (vs ~59°C on two cooler worker nodes idling).

Add a **soft** (`preferredDuringSchedulingIgnoredDuringExecution`, weight 100) nodeAffinity to all four Immich workloads (server, machine-learning, redis, CNPG postgres) targeting nodes labeled `homelab.gjcourt.dev/cpu-tier=high`. The label was applied imperatively to `talos-18u-ski` and `talos-kot-7x7`. When the operator physically repositions the rack later, the label can move with whichever nodes end up with the best airflow — no code change needed.

## Why soft and not hard

Required (hard pin) would leave Immich stuck Pending if both labeled nodes were unavailable (drain, NotReady, etc). Soft preference lets the scheduler fall back gracefully. For the 3-replica postgres cluster, 2 replicas land on labeled nodes and the 3rd falls through — exactly the spread we want.

## Test plan

- [x] `kustomize build apps/staging/immich` passes
- [x] `kustomize build apps/production/immich` passes
- [x] `kubectl diff` shows the expected 4 affinity blocks per environment
- [x] Nodes already labeled: `kubectl get nodes -L homelab.gjcourt.dev/cpu-tier` shows `high` on .24/.25
- [ ] After merge + Flux: `kubectl get pods -n immich-prod -o wide` shows immich-server on talos-18u-ski or talos-kot-7x7 (existing pod won't move until restart — may need `kubectl delete pod` to force)
- [ ] Within 30 min: Tctl on talos-v2l-hng drops noticeably as immich-server moves away

## Rollback

If the affinity causes problems (e.g. labeled nodes become unschedulable for unrelated reasons), `kubectl label node talos-18u-ski talos-kot-7x7 homelab.gjcourt.dev/cpu-tier-` removes the label and the soft preference becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)