### PR TITLE
feat(cnpg): spread postgres replicas across nodes via cross-cluster anti-affinity

### DIFF
--- a/apps/production/golinks/database.yaml
+++ b/apps/production/golinks/database.yaml
@@ -14,6 +14,22 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
+  # Cross-cluster anti-affinity: prefer nodes that aren't already running
+  # other CNPG postgres pods (label `policy-type: database`, inherited by
+  # every CNPG pod via inheritedMetadata.labels). This is additive to the
+  # CNPG-default intra-cluster anti-affinity (weight=100, spreads this
+  # cluster's 3 replicas across nodes via kubernetes.io/hostname).
+  # Weight 50 keeps the in-cluster spread dominant; this is a soft tiebreaker
+  # to smooth concentration across the ~11 CNPG clusters in the homelab.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
   storage:
     # Actual usage: ~488Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -65,6 +65,13 @@ spec:
   # postgres replicas with the immich-server pods and keep heat off the
   # warmer control-plane nodes. Soft preference — falls back to other
   # nodes when needed (drain, NotReady, replica count > labeled nodes).
+  #
+  # additionalPodAntiAffinity adds cross-cluster spread: prefer nodes that
+  # aren't already running other CNPG postgres pods (label
+  # `policy-type: database`, inherited from inheritedMetadata). Weight 50
+  # keeps the CNPG-default intra-cluster anti-affinity (weight=100,
+  # spreading these 3 replicas across distinct nodes) dominant. See
+  # apps/production/golinks/database.yaml for full rationale.
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -75,3 +82,11 @@ spec:
                 operator: In
                 values:
                   - high
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname

--- a/apps/production/linkding/database.yaml
+++ b/apps/production/linkding/database.yaml
@@ -19,6 +19,19 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
+
   storage:
     # Actual usage: ~602Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/production/memos/database.yaml
+++ b/apps/production/memos/database.yaml
@@ -19,6 +19,19 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
+
   storage:
     # Actual usage: ~633Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/production/overture/database.yaml
+++ b/apps/production/overture/database.yaml
@@ -14,6 +14,18 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
   storage:
     size: 5Gi
     storageClass: truenas-iscsi-ssd

--- a/apps/production/vitals/database.yaml
+++ b/apps/production/vitals/database.yaml
@@ -14,6 +14,18 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
   storage:
     # Actual usage: ~178Mi; minimum LUN size on Synology iSCSI is 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/staging/golinks/database.yaml
+++ b/apps/staging/golinks/database.yaml
@@ -14,6 +14,18 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
   storage:
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -37,6 +37,12 @@ spec:
   # Prefer high-airflow worker nodes (cpu-tier=high). See production
   # database.yaml for rationale. Soft preference — 3 replicas across 2
   # labeled nodes means one replica lands elsewhere, which is fine.
+  #
+  # additionalPodAntiAffinity adds cross-cluster spread: prefer nodes that
+  # aren't already running other CNPG postgres pods (label
+  # `policy-type: database`). Weight 50 keeps the in-cluster anti-affinity
+  # (CNPG default weight=100) dominant. See
+  # apps/production/golinks/database.yaml for full rationale.
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -47,6 +53,14 @@ spec:
                 operator: In
                 values:
                   - high
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
 
   postgresql:
     shared_preload_libraries:

--- a/apps/staging/linkding/database.yaml
+++ b/apps/staging/linkding/database.yaml
@@ -19,6 +19,19 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
+
   storage:
     size: 2Gi
 

--- a/apps/staging/memos/database.yaml
+++ b/apps/staging/memos/database.yaml
@@ -19,6 +19,19 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
+
   storage:
     # Actual usage: ~634Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/staging/vitals/database.yaml
+++ b/apps/staging/vitals/database.yaml
@@ -14,6 +14,18 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
+  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
+  # for full rationale. Soft (weight=50) preference to land new pods on
+  # nodes that don't already host other CNPG postgres pods.
+  affinity:
+    additionalPodAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                policy-type: database
+            topologyKey: kubernetes.io/hostname
   storage:
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).


### PR DESCRIPTION
## Summary

- Add soft `additionalPodAntiAffinity` (weight=50, `policy-type: database`, `topologyKey: kubernetes.io/hostname`) to every CNPG `Cluster` manifest.
- Goal: when scheduling a new postgres pod, prefer nodes with fewer other CNPG pods. Smooth out the lmh-kyf=8 / kot-7x7=2 imbalance.
- Additive, weak — does not fight the CNPG-default intra-cluster anti-affinity (weight=100). Existing `nodeAffinity` on the two immich clusters is preserved.

## Why

Today's pod distribution across the 6 nodes (verified live):

| node | CNPG pods |
|---|---|
| ykb-uir | 9 |
| lmh-kyf | 8 |
| 18u-ski | 8 |
| v2l-hng | 4 |
| kot-7x7 | 2 |
| 2mz-rfj | 2 |

The CNPG default `enablePodAntiAffinity: true` only spreads one cluster's three replicas across distinct nodes — it does nothing to keep cluster A's replica off the same node as cluster B's. lmh-kyf hosts 8 different postgres replicas and runs warm under steady-state DB workload.

With 11 clusters x 3 replicas = 33 pods on 6 nodes we still need ~5-6 per node. This PR is smoothing, not elimination.

## Files touched (11)

- `apps/production/golinks/database.yaml`
- `apps/production/immich/database.yaml` (extended existing `nodeAffinity`)
- `apps/production/linkding/database.yaml`
- `apps/production/memos/database.yaml`
- `apps/production/overture/database.yaml`
- `apps/production/vitals/database.yaml`
- `apps/staging/golinks/database.yaml`
- `apps/staging/immich/database.yaml` (extended existing `nodeAffinity`)
- `apps/staging/linkding/database.yaml`
- `apps/staging/memos/database.yaml`
- `apps/staging/vitals/database.yaml`

All clusters were already labeled `inheritedMetadata.labels.policy-type: "database"` — no label backfill needed.

## Validation

- `kustomize build apps/production` and `apps/staging` pass.
- `additionalPodAntiAffinity` is the documented CNPG field on `AffinityConfiguration`: https://cloudnative-pg.io/documentation/current/cnpg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration
- Built output contains exactly 11 occurrences (5 staging + 6 production).

## Rotation

This PR does not trigger pod rotation — CNPG only re-evaluates affinity on rolling restart / upgrade / failover. Options post-merge:

- (a) Let the spread happen gradually on the next CNPG upgrade.
- (b) `kubectl cnpg restart <cluster> -n <ns>` against the warmest nodes (lmh-kyf, ykb-uir, 18u-ski) to accelerate.

Rotation of stateful primary DBs is risky — operator decision, not automated here.

## Test plan

- [ ] CI `kustomize build` passes (matches local).
- [ ] After merge, Flux reconciles `apps-production` and `apps-staging` without errors.
- [ ] Optional: rotate one CNPG cluster and confirm the new pod lands on a less-loaded node (e.g. v2l-hng / kot-7x7 / 2mz-rfj).

Generated with Claude Code.