### PR TITLE
feat(cnpg): replace anti-affinity with topology spread (maxSkew=1)

### DIFF
--- a/apps/production/golinks/database.yaml
+++ b/apps/production/golinks/database.yaml
@@ -14,22 +14,23 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
-  # Cross-cluster anti-affinity: prefer nodes that aren't already running
-  # other CNPG postgres pods (label `policy-type: database`, inherited by
-  # every CNPG pod via inheritedMetadata.labels). This is additive to the
-  # CNPG-default intra-cluster anti-affinity (weight=100, spreads this
-  # cluster's 3 replicas across nodes via kubernetes.io/hostname).
-  # Weight 50 keeps the in-cluster spread dominant; this is a soft tiebreaker
-  # to smooth concentration across the ~11 CNPG clusters in the homelab.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: balance CNPG postgres pods (label
+  # `policy-type: database`, inherited by every CNPG pod via
+  # inheritedMetadata.labels) across nodes. Unlike pod anti-affinity (which
+  # is binary per term — a node either has a matching pod or it doesn't, so
+  # offers no spreading signal once every node has at least one), topology
+  # spread constraints count pods and enforce `maxSkew`. With ~33 CNPG pods
+  # across 6 nodes, the scheduler aims for 5-6 per node. `ScheduleAnyway`
+  # keeps it a soft preference so pods don't go Pending when perfect spread
+  # isn't possible. This is additive to the CNPG-default intra-cluster
+  # anti-affinity (spreads this cluster's own 3 replicas across nodes).
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
   storage:
     # Actual usage: ~488Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -65,13 +65,6 @@ spec:
   # postgres replicas with the immich-server pods and keep heat off the
   # warmer control-plane nodes. Soft preference — falls back to other
   # nodes when needed (drain, NotReady, replica count > labeled nodes).
-  #
-  # additionalPodAntiAffinity adds cross-cluster spread: prefer nodes that
-  # aren't already running other CNPG postgres pods (label
-  # `policy-type: database`, inherited from inheritedMetadata). Weight 50
-  # keeps the CNPG-default intra-cluster anti-affinity (weight=100,
-  # spreading these 3 replicas across distinct nodes) dominant. See
-  # apps/production/golinks/database.yaml for full rationale.
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -82,11 +75,13 @@ spec:
                 operator: In
                 values:
                   - high
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database

--- a/apps/production/linkding/database.yaml
+++ b/apps/production/linkding/database.yaml
@@ -19,18 +19,16 @@ spec:
   monitoring:
     enablePodMonitor: true
 
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
 
   storage:
     # Actual usage: ~602Mi; target = 20% headroom → 1Gi.

--- a/apps/production/memos/database.yaml
+++ b/apps/production/memos/database.yaml
@@ -19,18 +19,16 @@ spec:
   monitoring:
     enablePodMonitor: true
 
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
 
   storage:
     # Actual usage: ~633Mi; target = 20% headroom → 1Gi.

--- a/apps/production/overture/database.yaml
+++ b/apps/production/overture/database.yaml
@@ -14,18 +14,16 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
   storage:
     size: 5Gi
     storageClass: truenas-iscsi-ssd

--- a/apps/production/vitals/database.yaml
+++ b/apps/production/vitals/database.yaml
@@ -14,18 +14,16 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
   storage:
     # Actual usage: ~178Mi; minimum LUN size on Synology iSCSI is 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).

--- a/apps/staging/golinks/database.yaml
+++ b/apps/staging/golinks/database.yaml
@@ -14,18 +14,16 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
   storage:
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -37,12 +37,6 @@ spec:
   # Prefer high-airflow worker nodes (cpu-tier=high). See production
   # database.yaml for rationale. Soft preference — 3 replicas across 2
   # labeled nodes means one replica lands elsewhere, which is fine.
-  #
-  # additionalPodAntiAffinity adds cross-cluster spread: prefer nodes that
-  # aren't already running other CNPG postgres pods (label
-  # `policy-type: database`). Weight 50 keeps the in-cluster anti-affinity
-  # (CNPG default weight=100) dominant. See
-  # apps/production/golinks/database.yaml for full rationale.
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -53,14 +47,16 @@ spec:
                 operator: In
                 values:
                   - high
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
 
   postgresql:
     shared_preload_libraries:

--- a/apps/staging/linkding/database.yaml
+++ b/apps/staging/linkding/database.yaml
@@ -19,18 +19,16 @@ spec:
   monitoring:
     enablePodMonitor: true
 
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
 
   storage:
     size: 2Gi

--- a/apps/staging/memos/database.yaml
+++ b/apps/staging/memos/database.yaml
@@ -19,18 +19,16 @@ spec:
   monitoring:
     enablePodMonitor: true
 
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
 
   storage:
     # Actual usage: ~634Mi; target = 20% headroom → 1Gi.

--- a/apps/staging/vitals/database.yaml
+++ b/apps/staging/vitals/database.yaml
@@ -14,18 +14,16 @@ spec:
       policy-type: "database"
   monitoring:
     enablePodMonitor: true
-  # Cross-cluster anti-affinity: see apps/production/golinks/database.yaml
-  # for full rationale. Soft (weight=50) preference to land new pods on
-  # nodes that don't already host other CNPG postgres pods.
-  affinity:
-    additionalPodAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 50
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                policy-type: database
-            topologyKey: kubernetes.io/hostname
+  # Cross-cluster spread: see apps/production/golinks/database.yaml for
+  # full rationale. Soft (ScheduleAnyway) balance of CNPG postgres pods
+  # across nodes via topologySpreadConstraints.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          policy-type: database
   storage:
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).


### PR DESCRIPTION
## Summary
- PR #678 added `additionalPodAntiAffinity` to all 11 CNPG Clusters but the constraint is a no-op: pod anti-affinity is **binary per term** (a node has at least one matching pod, or it doesn't). With 33 CNPG pods on 6 nodes, every node already has matching pods, so every node gets the same -50 penalty and the scheduler falls back to other factors. Live distribution after the PR landed: 10/10/8/4/2/2 — unchanged.
- Replace with `spec.topologySpreadConstraints` (maxSkew=1, topologyKey=hostname, whenUnsatisfiable=ScheduleAnyway). Topology spread constraints **count pods** and enforce `maxSkew`, biasing scheduler scoring toward balanced distribution. With 33 pods / 6 nodes the target is ~5-6 per node.
- `ScheduleAnyway` keeps it soft — no Pending pods if perfect spread isn't achievable (drain, taints, replica count > usable nodes).

## What this PR does
- Removes `spec.affinity.additionalPodAntiAffinity` from all 11 CNPG Cluster manifests.
- Adds `spec.topologySpreadConstraints` (top-level field on `cnpg.io Cluster`, distinct from `spec.affinity`) selecting `policy-type=database` (inherited by every CNPG pod via `inheritedMetadata.labels`).
- **Preserves** `spec.affinity.nodeAffinity` (cpu-tier=high) on `immich-prod` and `immich-stage` — Immich postgres stays pinned to cool worker nodes.

## Files touched
11 CNPG `Cluster` manifests:
- `apps/production/{golinks,immich,linkding,memos,overture,vitals}/database.yaml`
- `apps/staging/{golinks,immich,linkding,memos,vitals}/database.yaml`

No non-CNPG resources touched.

## Test plan
- [x] `kustomize build apps/production` passes
- [x] `kustomize build apps/staging` passes
- [x] `kubectl diff` shows `topologySpreadConstraints` added to all 11 clusters (and `additionalPodAntiAffinity` will be removed by Flux's server-side apply since `kustomize-controller` owns that field)
- [x] Verified `policy-type: database` is present in `inheritedMetadata.labels` on every cluster (so every CNPG pod carries the label)
- [x] Immich nodeAffinity preserved (cpu-tier=high) in both prod and staging
- [ ] After merge: observe CNPG pod distribution across nodes; expect convergence toward 5-6 per node (vs current 10/10/8/4/2/2)

## Rollback
Revert this PR. The previous state (PR #678's `additionalPodAntiAffinity`) was a no-op anyway, so reverting is safe; the CNPG-default intra-cluster anti-affinity (per-cluster, weight 100) remains untouched and continues to spread each cluster's own 3 replicas across distinct nodes.