### PR TITLE
docs(cnpg): note observed behavior of topologySpreadConstraints

### DIFF
--- a/apps/production/golinks/database.yaml
+++ b/apps/production/golinks/database.yaml
@@ -24,6 +24,19 @@ spec:
   # keeps it a soft preference so pods don't go Pending when perfect spread
   # isn't possible. This is additive to the CNPG-default intra-cluster
   # anti-affinity (spreads this cluster's own 3 replicas across nodes).
+  #
+  # Observed behavior (2026-05-14 rebalance attempt): this constraint does
+  # NOT reactively rebalance already-placed pods. Rolling restarts of every
+  # CNPG cluster (kubectl cnpg restart) and explicit delete-and-recreate
+  # both left the distribution byte-for-byte unchanged at 10/10/8/4/2/2.
+  # Pods went through the default scheduler (not nodeName-pinned), but
+  # `ScheduleAnyway` lost to other scoring factors — probably some mix of
+  # the intra-cluster anti-affinity (weight 100), the iSCSI CSI driver's
+  # volume-locality hints, and the BalancedAllocation plugin. Kept here as
+  # a hint for future pod creations (new clusters, scale-ups). When a
+  # specific pod actually needs to move now, use explicit `nodeAffinity`
+  # (see apps/production/immich/database.yaml for the cpu-tier=high
+  # pattern that did successfully steer immich-prod onto cool nodes).
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

The topology spread constraints added in #680 do not reactively rebalance already-placed CNPG postgres pods — confirmed by rolling restart + explicit delete-and-recreate experiments today. Distribution stayed byte-for-byte identical (10/10/8/4/2/2) before and after. Document this in the master rationale comment so future readers don't repeat the experiment expecting different results.

The constraint is **kept** rather than reverted because it should still influence pod-creation-time scheduling for new clusters or replica scale-ups.

## Test plan

- [x] `kustomize build apps/production` + `apps/staging` pass
- [x] Doc-only change — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)