### PR TITLE
fix(unpoller): bump image to v3.2.0 for API key auth support

### DIFF
--- a/infra/controllers/unpoller/helmrelease.yaml
+++ b/infra/controllers/unpoller/helmrelease.yaml
@@ -34,6 +34,11 @@ spec:
   values:
     image:
       repository: docker.io/golift/unifi-poller
+      # v2.9.2 (the chart's appVersion default) does not have API key
+      # auth — APIKey was added to the Controller struct in the v3.x
+      # line. Override to v3.2.0 (latest stable as of 2026-05-12) so
+      # UP_UNIFI_DEFAULT_API_KEY env-var injection actually works.
+      tag: v3.2.0
       pullPolicy: IfNotPresent
 
     replicas: 1


### PR DESCRIPTION
## Summary

Post-merge of #683: unpoller v2.9.2 (the chart's appVersion default) **does not have API key auth** — Controller struct only has User/Pass. Pod was running but auth-failing: `UP_UNIFI_DEFAULT_API_KEY` ignored, fell back to default `unifipoller` user → 403 Forbidden.

Override `image.tag` to v3.2.0 (latest stable, 2026-05-12). Source confirmed to have:
- `APIKey string \`xml:"api_key"\`` on the Controller struct
- Auth flow: `if c.APIKey != "" { clear user/pass; use api key }`

## Test plan

- [x] `kustomize build infra/controllers` passes
- [ ] After merge: pod re-rolls with v3.2.0
- [ ] No more "Auth or Connection Error" in logs
- [ ] `unpoller_device_temperature_celsius` series appear in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)