### PR TITLE
fix(unpoller): switch from API-key to local user/pass auth

### DIFF
--- a/infra/controllers/unpoller/helmrelease.yaml
+++ b/infra/controllers/unpoller/helmrelease.yaml
@@ -50,32 +50,36 @@ spec:
       limits:
         memory: 256Mi
 
-    # Inject the UniFi API key via the cnfg ENV mechanism. Unpoller calls
-    # cnfg.UnmarshalENV(i, "UP") which uses xml struct tags as path
-    # components separated by underscores. The relevant struct chain is:
+    # Inject UniFi credentials via env vars. unpoller's cnfg layer maps
+    # `[unifi.defaults]` TOML keys to UP_UNIFI_DEFAULT_<KEY> env vars.
     #
-    #   InputUnifi  xml:"unifi"
-    #     Config.Default (Controller) xml:"default"
-    #       Controller.APIKey         xml:"api_key"
+    # Originally tried API-key auth (UP_UNIFI_DEFAULT_API_KEY) but the
+    # local UCG-Fiber console doesn't expose a "create local API key"
+    # surface in its UI (only the unifi.ui.com cloud account exposes
+    # an `api-keys` page, and those keys have no authority on the
+    # local controller — verified by 401 at /proxy/network/status).
     #
-    # Therefore the env var name is UP_UNIFI_DEFAULT_API_KEY.
-    # Source: github.com/unpoller/unpoller/pkg/inputunifi/input.go
+    # Falling back to user/pass auth against a local read-only admin
+    # account (Settings → Control Plane → Admins & Users → Create
+    # New Admin → "Restrict to local access only" → role: View Only).
     envVariables:
-      - name: UP_UNIFI_DEFAULT_API_KEY
+      - name: UP_UNIFI_DEFAULT_USER
         valueFrom:
           secretKeyRef:
             name: unpoller-unifi-creds
-            key: api_key
+            key: user
+      - name: UP_UNIFI_DEFAULT_PASS
+        valueFrom:
+          secretKeyRef:
+            name: unpoller-unifi-creds
+            key: pass
 
     unpoller:
-      # TOML config baked into the chart-managed Secret. The api_key is
-      # intentionally absent here — it comes from the envVariables block
-      # above (env wins over file in cnfg). User/pass are left empty so
-      # unpoller falls into the "APIKey != ''" branch in input.go and
-      # skips user/pass auth entirely.
+      # TOML config baked into the chart-managed Secret. user/pass are
+      # intentionally absent here — they come from envVariables above.
       config: |
         # Unpoller primary config (managed by Flux HelmRelease).
-        # api_key is injected via UP_UNIFI_DEFAULT_API_KEY env var.
+        # user/pass injected via UP_UNIFI_DEFAULT_USER / _PASS env vars.
         [poller]
           debug = false
           quiet = false
@@ -105,7 +109,9 @@ spec:
 
         [unifi.defaults]
           url = "https://10.42.1.1"
-          # user/pass intentionally empty — API key auth via env var
+          # user/pass intentionally empty — injected via env vars
+          # (UP_UNIFI_DEFAULT_USER / UP_UNIFI_DEFAULT_PASS); the
+          # cnfg layer fills these at runtime.
           user = ""
           pass = ""
           sites = ["all"]

--- a/infra/controllers/unpoller/secret.sops.yaml
+++ b/infra/controllers/unpoller/secret.sops.yaml
@@ -26,19 +26,20 @@ metadata:
   namespace: monitoring
 type: Opaque
 stringData:
-  api_key: ENC[AES256_GCM,data:+5HZmbk0ptiDzb5vbBOedK8XdWETgs9PCGhJH0x9yr4=,iv:OaUOK2gntqhaDfn92eZHQ1n6OKAjGjcr4/zmS+5hN6s=,tag:VTNwamqK94LHjzw4BtN7zg==,type:str]
+  user: ENC[AES256_GCM,data:4beharRuWECBY8kBA2JGU9dawLJttXcCIKg=,iv:vFN07hXhq8L25cq7o6FtG0cPQ5poi361YDDN0Fsmpyo=,tag:dLe7upLjM0EAnjT20jvzyw==,type:str]
+  pass: ENC[AES256_GCM,data:brZAK3afT2GY0q0vie6Tk4de4Q==,iv:k47tefhcJgQD6eEWo3hGYkvUiSr9Yq0bWqMosqlAzTQ=,tag:UpJsiE0pxAejQxey+WNw9A==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwRTBsV3VNM3hsdlE0d0Z2
-        K0d3R1NTanhJRElaZnpVTGxMWU1DTmVPNG5FCnlZWkdMZkhRZVdwdUV4U21aVmZR
-        b1JOb0RpdmQ4VHlUNnIyMGVHT0dsNDgKLS0tIElGbUFvdVdkZDV1TVRNSytWK1R3
-        aG1YVWZ0QWVyUUhVNFFnemM2c0s0ZVkKgsWq1UsC/nyJD7ae+C7k+IBgRw7d/Uvs
-        7SnbLPd0Lx4HjJhffhoq7Rw3xSd/Ma/7Sir1HpchOZseW8+VW6DXHA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Z3pqTE44RzRrODh5RmF3
+        TFlqYUlubVgzcUF1ZzV4ZUNobFoybVc5ZHlVCkZpQmcwV0hKMUVRQVVoZjd5SHZS
+        YVZadi9nMERxTjBqczkvUVZScXc0dzQKLS0tIFY1QlBFdHUrMG9CUzFxR05wNW1j
+        RTBFdGlFV3B5OXRHbU5hWnZtczV4OUUKU7A4LPAqWviRqVel1ezoaPEnp/W4NAIL
+        p0fdH2g84JgBz70LFsQ1jQZx544BMz9xEI/eFHc4UPt9ebKJvApYkg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-15T01:06:18Z"
-  mac: ENC[AES256_GCM,data:H2D3Eind36LO8MJiITcExDu9Ti4lamq+DkvfOQ3Lqu2N6iYOmj/UXnFkQpL5QJ7VZE0f3s8fm7OJWdJ18z7Lg4cPB0Q6VpwY18k6r24TDwwfX8TW+/H4l9IZ6oJlYIIsziTQ9YrlXgwZTKK8m0UEbhpJcpStztlmKiXzkcPJ2VM=,iv:7o90m6DRGGz6CTAWd+SDGjNYYtLnLmsIEf9eGb+Q8Ps=,tag:7YGGiE7mf8/JoKXKUzHqAA==,type:str]
+  lastmodified: "2026-05-15T02:16:57Z"
+  mac: ENC[AES256_GCM,data:WJ8wbFRgf963CQQQgq/KaVHthLUP0d715vUC4Wsmi6pLghNoCKqr0+ujO3u2VYLsS6J7cNtlGAGdyHCsU+VehkBUhhyIzwLkLPpt9PLH0FXymlhbbN8Rw+bXVUokx0PH2wqOBfj58Ruf1/wcweOVDFUWdripEmLrn0dsk0wDvhM=,iv:BBMeva3LrptqJy49ji29sou5d+ld71Wmj9ac8Stfvwk=,tag:YoDI3QnDdmqWVFXuUJZWqw==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.12.1


### PR DESCRIPTION
## Summary

Discovery from the failed deployment:
- UniFi has **two separate API-key systems**: `unifi.ui.com/settings/api-keys` is for the **UI.com cloud account** (Site Manager), not the local controller.
- The UCG-Fiber's local console UI doesn't expose a "create local controller API key" surface (confirmed: not under Control Plane).
- The cloud key has no authority on the local controller's API → unpoller v3.2.0 gets 401 at `/proxy/network/status`.

Switch to user/pass auth, which is well-documented and works against any local admin account.

## Code changes

- `infra/controllers/unpoller/helmrelease.yaml`:
  - `envVariables` now sets `UP_UNIFI_DEFAULT_USER` + `UP_UNIFI_DEFAULT_PASS` instead of `UP_UNIFI_DEFAULT_API_KEY`
  - TOML config comments updated; user/pass still empty in-file (env vars override)
- Image stays at v3.2.0 (it supports both flows; no reason to downgrade)

## Operator next steps

This PR also requires you to rotate the secret's contents. **The HelmRelease will fail to mount the secret** until you swap the encrypted key from `api_key` → `user`/`pass`. Two commands:

```bash
# In a fresh worktree on fix/unpoller-userpass-auth
sops infra/controllers/unpoller/secret.sops.yaml
# In the editor: under stringData, REMOVE the api_key line and ADD:
#   user: <local-admin-username>
#   pass: <local-admin-password>
# Save & quit. sops re-encrypts atomically.

git commit -am "fix(unpoller): swap secret from api_key to user/pass"
git push
```

Then mark the PR ready and merge.

To create the local admin (if not yet done):
1. Open **https://10.42.1.1** directly
2. Settings → Control Plane → Admins & Users → **Create New Admin**
3. **"Restrict to local access only"** (this is the critical bit)
4. Role: **View Only** for Network application

## Test plan

- [x] `kustomize build infra/controllers` passes
- [ ] After secret rotation + merge: pod re-rolls with user/pass env vars
- [ ] No more "Auth or Connection Error" in pod logs
- [ ] `unpoller_device_temperature_celsius` series start appearing in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)