### PR TITLE
fix(unpoller): rotate to local-only admin credentials

### DIFF
--- a/infra/controllers/unpoller/helmrelease.yaml
+++ b/infra/controllers/unpoller/helmrelease.yaml
@@ -50,32 +50,36 @@ spec:
       limits:
         memory: 256Mi
 
-    # Inject the UniFi API key via the cnfg ENV mechanism. Unpoller calls
-    # cnfg.UnmarshalENV(i, "UP") which uses xml struct tags as path
-    # components separated by underscores. The relevant struct chain is:
+    # Inject UniFi credentials via env vars. unpoller's cnfg layer maps
+    # `[unifi.defaults]` TOML keys to UP_UNIFI_DEFAULT_<KEY> env vars.
     #
-    #   InputUnifi  xml:"unifi"
-    #     Config.Default (Controller) xml:"default"
-    #       Controller.APIKey         xml:"api_key"
+    # Originally tried API-key auth (UP_UNIFI_DEFAULT_API_KEY) but the
+    # local UCG-Fiber console doesn't expose a "create local API key"
+    # surface in its UI (only the unifi.ui.com cloud account exposes
+    # an `api-keys` page, and those keys have no authority on the
+    # local controller — verified by 401 at /proxy/network/status).
     #
-    # Therefore the env var name is UP_UNIFI_DEFAULT_API_KEY.
-    # Source: github.com/unpoller/unpoller/pkg/inputunifi/input.go
+    # Falling back to user/pass auth against a local read-only admin
+    # account (Settings → Control Plane → Admins & Users → Create
+    # New Admin → "Restrict to local access only" → role: View Only).
     envVariables:
-      - name: UP_UNIFI_DEFAULT_API_KEY
+      - name: UP_UNIFI_DEFAULT_USER
         valueFrom:
           secretKeyRef:
             name: unpoller-unifi-creds
-            key: api_key
+            key: user
+      - name: UP_UNIFI_DEFAULT_PASS
+        valueFrom:
+          secretKeyRef:
+            name: unpoller-unifi-creds
+            key: pass
 
     unpoller:
-      # TOML config baked into the chart-managed Secret. The api_key is
-      # intentionally absent here — it comes from the envVariables block
-      # above (env wins over file in cnfg). User/pass are left empty so
-      # unpoller falls into the "APIKey != ''" branch in input.go and
-      # skips user/pass auth entirely.
+      # TOML config baked into the chart-managed Secret. user/pass are
+      # intentionally absent here — they come from envVariables above.
       config: |
         # Unpoller primary config (managed by Flux HelmRelease).
-        # api_key is injected via UP_UNIFI_DEFAULT_API_KEY env var.
+        # user/pass injected via UP_UNIFI_DEFAULT_USER / _PASS env vars.
         [poller]
           debug = false
           quiet = false
@@ -105,7 +109,9 @@ spec:
 
         [unifi.defaults]
           url = "https://10.42.1.1"
-          # user/pass intentionally empty — API key auth via env var
+          # user/pass intentionally empty — injected via env vars
+          # (UP_UNIFI_DEFAULT_USER / UP_UNIFI_DEFAULT_PASS); the
+          # cnfg layer fills these at runtime.
           user = ""
           pass = ""
           sites = ["all"]

--- a/infra/controllers/unpoller/secret.sops.yaml
+++ b/infra/controllers/unpoller/secret.sops.yaml
@@ -26,20 +26,20 @@ metadata:
   namespace: monitoring
 type: Opaque
 stringData:
-  user: ENC[AES256_GCM,data:4beharRuWECBY8kBA2JGU9dawLJttXcCIKg=,iv:vFN07hXhq8L25cq7o6FtG0cPQ5poi361YDDN0Fsmpyo=,tag:dLe7upLjM0EAnjT20jvzyw==,type:str]
-  pass: ENC[AES256_GCM,data:brZAK3afT2GY0q0vie6Tk4de4Q==,iv:k47tefhcJgQD6eEWo3hGYkvUiSr9Yq0bWqMosqlAzTQ=,tag:UpJsiE0pxAejQxey+WNw9A==,type:str]
+  user: ENC[AES256_GCM,data:9GXH+yuIuCU=,iv:n10sCW7q/Pw7+o1h9dwCWB1ZHf8RtuMhGsLqvXS/SAU=,tag:IlKpFViNXPHJ4h32SWbqLQ==,type:str]
+  pass: ENC[AES256_GCM,data:+gBgCOXmde6paLP1zG54l2JNlQ==,iv:/7letphH76x0lkB/RIImTTltVSxaPjRh4N8fdlHsHlY=,tag:5hX8sG8eTlm30nFCCzB5Xg==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Z3pqTE44RzRrODh5RmF3
-        TFlqYUlubVgzcUF1ZzV4ZUNobFoybVc5ZHlVCkZpQmcwV0hKMUVRQVVoZjd5SHZS
-        YVZadi9nMERxTjBqczkvUVZScXc0dzQKLS0tIFY1QlBFdHUrMG9CUzFxR05wNW1j
-        RTBFdGlFV3B5OXRHbU5hWnZtczV4OUUKU7A4LPAqWviRqVel1ezoaPEnp/W4NAIL
-        p0fdH2g84JgBz70LFsQ1jQZx544BMz9xEI/eFHc4UPt9ebKJvApYkg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzSG9MV0d0VzN4Y0tLWXJ5
+        Ui9pOWF5OW5VN0k4bEozUnBnM0UvRFZFbEY0CjBZc3JNTno1enhGcFRxT1lEOFRP
+        S25IZGxvNVRKRXhHSkplZzNQYnRoWW8KLS0tIGJjOStXNkxTbUovM0xKdFpSNjFO
+        cWE5L0hTRmxsU252a1FpYVp0N09OZ1EKU2F9PDZNnYuussVR5myq3Xs1zEwOM2yx
+        wqijwLP0uC0XgMXbRaoc4fyUGpR2fxwitdf7vCA4f+6IZjrJJzpZIQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-15T02:16:57Z"
-  mac: ENC[AES256_GCM,data:WJ8wbFRgf963CQQQgq/KaVHthLUP0d715vUC4Wsmi6pLghNoCKqr0+ujO3u2VYLsS6J7cNtlGAGdyHCsU+VehkBUhhyIzwLkLPpt9PLH0FXymlhbbN8Rw+bXVUokx0PH2wqOBfj58Ruf1/wcweOVDFUWdripEmLrn0dsk0wDvhM=,iv:BBMeva3LrptqJy49ji29sou5d+ld71Wmj9ac8Stfvwk=,tag:YoDI3QnDdmqWVFXuUJZWqw==,type:str]
+  lastmodified: "2026-05-15T03:03:21Z"
+  mac: ENC[AES256_GCM,data:6pTff8oQ7n5XX/WDRUNZUxWV4pyCR17P8eUR/iGz7rxG6M10GNrVe2/+HTH7fJJUZn7Nb7xpMgWErvAq6CIjAzHXdZHa4yR3+wdf0MNlNH8BcoAeNdwD/GASC9WVj99pIZeVMijQ5upM68/ssDOMm8ArBNFj0efWeIMbQFuqW+M=,iv:SZ8VQ3Syawil/dGHwaNBMGRgg/jjiPLk2CflE1hFE+U=,tag:jH14wza0HyoVwrFgoGO0hg==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.12.1

--- a/infra/controllers/unpoller/secret.sops.yaml
+++ b/infra/controllers/unpoller/secret.sops.yaml
@@ -26,19 +26,20 @@ metadata:
   namespace: monitoring
 type: Opaque
 stringData:
-  api_key: ENC[AES256_GCM,data:+5HZmbk0ptiDzb5vbBOedK8XdWETgs9PCGhJH0x9yr4=,iv:OaUOK2gntqhaDfn92eZHQ1n6OKAjGjcr4/zmS+5hN6s=,tag:VTNwamqK94LHjzw4BtN7zg==,type:str]
+  user: ENC[AES256_GCM,data:4beharRuWECBY8kBA2JGU9dawLJttXcCIKg=,iv:vFN07hXhq8L25cq7o6FtG0cPQ5poi361YDDN0Fsmpyo=,tag:dLe7upLjM0EAnjT20jvzyw==,type:str]
+  pass: ENC[AES256_GCM,data:brZAK3afT2GY0q0vie6Tk4de4Q==,iv:k47tefhcJgQD6eEWo3hGYkvUiSr9Yq0bWqMosqlAzTQ=,tag:UpJsiE0pxAejQxey+WNw9A==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwRTBsV3VNM3hsdlE0d0Z2
-        K0d3R1NTanhJRElaZnpVTGxMWU1DTmVPNG5FCnlZWkdMZkhRZVdwdUV4U21aVmZR
-        b1JOb0RpdmQ4VHlUNnIyMGVHT0dsNDgKLS0tIElGbUFvdVdkZDV1TVRNSytWK1R3
-        aG1YVWZ0QWVyUUhVNFFnemM2c0s0ZVkKgsWq1UsC/nyJD7ae+C7k+IBgRw7d/Uvs
-        7SnbLPd0Lx4HjJhffhoq7Rw3xSd/Ma/7Sir1HpchOZseW8+VW6DXHA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Z3pqTE44RzRrODh5RmF3
+        TFlqYUlubVgzcUF1ZzV4ZUNobFoybVc5ZHlVCkZpQmcwV0hKMUVRQVVoZjd5SHZS
+        YVZadi9nMERxTjBqczkvUVZScXc0dzQKLS0tIFY1QlBFdHUrMG9CUzFxR05wNW1j
+        RTBFdGlFV3B5OXRHbU5hWnZtczV4OUUKU7A4LPAqWviRqVel1ezoaPEnp/W4NAIL
+        p0fdH2g84JgBz70LFsQ1jQZx544BMz9xEI/eFHc4UPt9ebKJvApYkg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-15T01:06:18Z"
-  mac: ENC[AES256_GCM,data:H2D3Eind36LO8MJiITcExDu9Ti4lamq+DkvfOQ3Lqu2N6iYOmj/UXnFkQpL5QJ7VZE0f3s8fm7OJWdJ18z7Lg4cPB0Q6VpwY18k6r24TDwwfX8TW+/H4l9IZ6oJlYIIsziTQ9YrlXgwZTKK8m0UEbhpJcpStztlmKiXzkcPJ2VM=,iv:7o90m6DRGGz6CTAWd+SDGjNYYtLnLmsIEf9eGb+Q8Ps=,tag:7YGGiE7mf8/JoKXKUzHqAA==,type:str]
+  lastmodified: "2026-05-15T02:16:57Z"
+  mac: ENC[AES256_GCM,data:WJ8wbFRgf963CQQQgq/KaVHthLUP0d715vUC4Wsmi6pLghNoCKqr0+ujO3u2VYLsS6J7cNtlGAGdyHCsU+VehkBUhhyIzwLkLPpt9PLH0FXymlhbbN8Rw+bXVUokx0PH2wqOBfj58Ruf1/wcweOVDFUWdripEmLrn0dsk0wDvhM=,iv:BBMeva3LrptqJy49ji29sou5d+ld71Wmj9ac8Stfvwk=,tag:YoDI3QnDdmqWVFXuUJZWqw==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.12.1


### PR DESCRIPTION
## Summary

Pod from #688 is auth-failing with HTTP 499 — the secret committed in #688 had `gjcourt+unpoller@gmail.com` as the username, which is a UI.com cloud-account email. The local UCG-Fiber controller doesn't accept cloud SSO credentials via `/api/auth/login` (it needs a local-only admin with a plain username).

Operator rotated the secret on this branch to a new local-only admin's creds.

## Diff

Only `infra/controllers/unpoller/secret.sops.yaml` changes — the `user:` and `pass:` ciphertexts are different, reflecting the new local-only account.

## Test plan

- [x] Confirmed only the secret file changes between this branch and master
- [ ] After merge + Flux reconcile: unpoller pod restarts and authenticates successfully
- [ ] Pod logs no longer show 499 / "authentication failed"
- [ ] `unpoller_device_temperature_celsius` series appear in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)