### PR TITLE
fix(unpoller): rotate to local-only admin credentials

### DIFF
--- a/infra/controllers/unpoller/secret.sops.yaml
+++ b/infra/controllers/unpoller/secret.sops.yaml
@@ -26,20 +26,20 @@ metadata:
   namespace: monitoring
 type: Opaque
 stringData:
-  user: ENC[AES256_GCM,data:4beharRuWECBY8kBA2JGU9dawLJttXcCIKg=,iv:vFN07hXhq8L25cq7o6FtG0cPQ5poi361YDDN0Fsmpyo=,tag:dLe7upLjM0EAnjT20jvzyw==,type:str]
-  pass: ENC[AES256_GCM,data:brZAK3afT2GY0q0vie6Tk4de4Q==,iv:k47tefhcJgQD6eEWo3hGYkvUiSr9Yq0bWqMosqlAzTQ=,tag:UpJsiE0pxAejQxey+WNw9A==,type:str]
+  user: ENC[AES256_GCM,data:9GXH+yuIuCU=,iv:n10sCW7q/Pw7+o1h9dwCWB1ZHf8RtuMhGsLqvXS/SAU=,tag:IlKpFViNXPHJ4h32SWbqLQ==,type:str]
+  pass: ENC[AES256_GCM,data:+gBgCOXmde6paLP1zG54l2JNlQ==,iv:/7letphH76x0lkB/RIImTTltVSxaPjRh4N8fdlHsHlY=,tag:5hX8sG8eTlm30nFCCzB5Xg==,type:str]
 sops:
   age:
     - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Z3pqTE44RzRrODh5RmF3
-        TFlqYUlubVgzcUF1ZzV4ZUNobFoybVc5ZHlVCkZpQmcwV0hKMUVRQVVoZjd5SHZS
-        YVZadi9nMERxTjBqczkvUVZScXc0dzQKLS0tIFY1QlBFdHUrMG9CUzFxR05wNW1j
-        RTBFdGlFV3B5OXRHbU5hWnZtczV4OUUKU7A4LPAqWviRqVel1ezoaPEnp/W4NAIL
-        p0fdH2g84JgBz70LFsQ1jQZx544BMz9xEI/eFHc4UPt9ebKJvApYkg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzSG9MV0d0VzN4Y0tLWXJ5
+        Ui9pOWF5OW5VN0k4bEozUnBnM0UvRFZFbEY0CjBZc3JNTno1enhGcFRxT1lEOFRP
+        S25IZGxvNVRKRXhHSkplZzNQYnRoWW8KLS0tIGJjOStXNkxTbUovM0xKdFpSNjFO
+        cWE5L0hTRmxsU252a1FpYVp0N09OZ1EKU2F9PDZNnYuussVR5myq3Xs1zEwOM2yx
+        wqijwLP0uC0XgMXbRaoc4fyUGpR2fxwitdf7vCA4f+6IZjrJJzpZIQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-05-15T02:16:57Z"
-  mac: ENC[AES256_GCM,data:WJ8wbFRgf963CQQQgq/KaVHthLUP0d715vUC4Wsmi6pLghNoCKqr0+ujO3u2VYLsS6J7cNtlGAGdyHCsU+VehkBUhhyIzwLkLPpt9PLH0FXymlhbbN8Rw+bXVUokx0PH2wqOBfj58Ruf1/wcweOVDFUWdripEmLrn0dsk0wDvhM=,iv:BBMeva3LrptqJy49ji29sou5d+ld71Wmj9ac8Stfvwk=,tag:YoDI3QnDdmqWVFXuUJZWqw==,type:str]
+  lastmodified: "2026-05-15T03:03:21Z"
+  mac: ENC[AES256_GCM,data:6pTff8oQ7n5XX/WDRUNZUxWV4pyCR17P8eUR/iGz7rxG6M10GNrVe2/+HTH7fJJUZn7Nb7xpMgWErvAq6CIjAzHXdZHa4yR3+wdf0MNlNH8BcoAeNdwD/GASC9WVj99pIZeVMijQ5upM68/ssDOMm8ArBNFj0efWeIMbQFuqW+M=,iv:SZ8VQ3Syawil/dGHwaNBMGRgg/jjiPLk2CflE1hFE+U=,tag:jH14wza0HyoVwrFgoGO0hg==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.12.1


### PR DESCRIPTION
## Summary

#688 deployed but auth-fails with HTTP 499 — the secret committed there had `gjcourt+unpoller@gmail.com` (a UI.com cloud account email) which the local UCG-Fiber controller rejects. Operator rotated to a local-only admin account; this PR brings that rotated secret into master.

(Re-creating from a fresh branch off master to avoid the merge-base conflict with #688's squash merge that blocked the previous attempt #690.)

## Diff

Single file: `infra/controllers/unpoller/secret.sops.yaml` — `user:` and `pass:` ciphertexts replaced with values for the new local-only account.

## Test plan

- [x] Single-file diff, clean against master
- [ ] After merge + Flux: unpoller pod restarts and authenticates
- [ ] No 499 / "authentication failed" in pod logs
- [ ] `unpoller_device_temperature_celsius` series appear in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)