### PR TITLE
fix(unpoller): correct switch temp filter + add fan-level alert

### DIFF
--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -614,7 +614,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "${datasource}"},
-              "expr": "unpoller_device_temperature_celsius{type=\"usw\",temp_area=\"general\"}",
+              "expr": "unpoller_device_temperature_celsius{type=\"usw\"}",
               "legendFormat": "{{name}}"
             }
           ],
@@ -649,7 +649,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "${datasource}"},
-              "expr": "count(unpoller_device_temperature_celsius{type=\"usw\",temp_area=\"general\"} > 70) or vector(0)",
+              "expr": "count(unpoller_device_temperature_celsius{type=\"usw\"} > 70) or vector(0)",
               "legendFormat": "Switches overheating"
             },
             {

--- a/infra/configs/unpoller/prometheus-rule.yaml
+++ b/infra/configs/unpoller/prometheus-rule.yaml
@@ -23,20 +23,37 @@ spec:
         # PoE switch (USW) board temperature. unpoller exports
         # `unpoller_device_temperature_celsius` with labels:
         #   {type, site_name, name, source, temp_area, temp_type, tag}
-        # For switches `type="usw"`; we additionally guard on
-        # `temp_area="general"` so we only alert on the board sensor
-        # (not SFP module temperatures, which are also exported under
-        # `unpoller_usw_sfp_temperature`).
+        # For the USWED42 (rack switch) at firmware 7.4.1.16850, the
+        # actual labels observed are:
+        #   type="usw", temp_area="", temp_type="general", tag="board"
+        # NOTE: "general" lives on `temp_type`, NOT `temp_area`. The
+        # previous version of this rule filtered on temp_area="general"
+        # and silently never matched. Filter on type="usw" only — the
+        # switch emits exactly one temperature series, so additional
+        # qualifiers aren't needed.
         # 65°C is conservative for unifi PoE switches (most are rated
-        # for 0-45°C ambient).
+        # for 0–45°C ambient).
         - alert: UniFiPoESwitchTempHigh
-          expr: unpoller_device_temperature_celsius{type="usw",temp_area="general"} > 65
+          expr: unpoller_device_temperature_celsius{type="usw"} > 65
           for: 10m
           labels:
             severity: warning
           annotations:
             summary: "UniFi switch {{ $labels.name }} is hot"
-            description: "PoE switch {{ $labels.name }} board temperature is {{ $value }}°C (threshold 65°C)."
+            description: "PoE switch {{ $labels.name }} temperature is {{ $value }}°C (threshold 65°C)."
+
+        # Switch cooling escalation — fires when the switch's internal
+        # fan controller has ramped fan_level to ≥80 (UniFi exposes a
+        # 0–100 fan level; >=80 indicates sustained thermal stress
+        # regardless of what the board sensor currently reads).
+        - alert: UniFiSwitchFanHigh
+          expr: unpoller_device_fan_level{type="usw"} >= 80
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "UniFi switch {{ $labels.name }} fan is ramped up"
+            description: "Fan level for {{ $labels.name }} is {{ $value }} (threshold 80) — the switch is working hard to stay cool."
 
         # UCG-Fiber / UDM gateway temperature. Type-label coverage
         # widened to `udm|uxg|ucg|ugw` because unpoller's promunifi


### PR DESCRIPTION
## Summary

After #691 brought unpoller online, switch metrics were flowing — but our **alert and dashboard panel for the PoE switch were silently empty** because the filter was wrong:

- We filtered: `unpoller_device_temperature_celsius{type=\"usw\", temp_area=\"general\"}`
- Actual labels on the USWED42 (firmware 7.4.1.16850): `type=\"usw\", temp_area=\"\", temp_type=\"general\", tag=\"board\"`

`general` lives on `temp_type`, not `temp_area`. The filter never matched.

## Fix

- Drop `temp_area=\"general\"` from the switch temp alert + dashboard panel + overheating composite expr — `type=\"usw\"` alone is sufficient (the switch emits exactly one temperature series).
- Add a new alert `UniFiSwitchFanHigh` — fires when `unpoller_device_fan_level{type=\"usw\"} >= 80` for 5m. Catches sustained thermal stress even when board temp doesn't cross the 65°C line.

## Observed values right now (Rack Switch)

| metric | value |
|---|---|
| `unpoller_device_temperature_celsius` | 61°C |
| `unpoller_device_fan_level` | 28 |
| `unpoller_device_cpu_utilization_ratio` | 0.115 |
| `unpoller_device_memory_utilization_ratio` | 0.063 |
| `unpoller_device_max_power_total` | 972W (PoE budget) |

## Test plan

- [x] `kustomize build infra/configs` passes
- [ ] After merge: dashboard's PoE Switch Temperatures stat panel shows 61°C (currently empty)
- [ ] PromQL `unpoller_device_temperature_celsius{type=\"usw\"} > 65` correctly returns the series when temp crosses threshold (verified by lowering threshold temporarily; not required for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)