### PR TITLE
feat(hestia): containerized memory bandwidth benchmark (STREAM + Intel MLC)

### DIFF
--- a/docs/plans/2026-05-15-hestia-memory-benchmark.md
+++ b/docs/plans/2026-05-15-hestia-memory-benchmark.md
@@ -1,0 +1,90 @@
+---
+status: in_progress
+last_modified: 2026-05-15
+---
+
+# Hestia memory bandwidth benchmark — 6 DIMM vs 8 DIMM
+
+## Context
+
+Hestia is the TrueNAS GPU server (ASRock Rack **SIENAD8-2L2T**, **EPYC 8004 / Siena**, single socket, **6-channel DDR5**, board exposes **8 DIMM slots**). The "8 slots over 6 channels" layout means populating 8 DIMMs forces at least two channels into **2DPC**, and the platform's JEDEC table derates 2DPC channels to a lower speed grade (typically DDR5-3600 or DDR5-4000 vs DDR5-4800 at 1DPC). The whole bus usually clocks to the slowest channel.
+
+Goal: an **objective bandwidth + latency measurement** to quantify the tradeoff.
+
+- **Hypothesis A**: 8 DIMM ≈ 17–25% bandwidth loss vs 6 DIMM (the speed-grade ratio), plus a measurable loaded-latency penalty.
+- **Hypothesis B**: 8 DIMM may also raise idle latency from the extra rank pressure (longer tRC).
+- **Decision this enables**: keep the 33% extra capacity (8 DIMM) or take the bandwidth back (6 DIMM)?
+
+Current state: hestia is populated with **6 DIMMs (1DPC × 6, full speed)**. First benchmark run is the baseline; operator physically adds 2 DIMMs for the second run.
+
+No existing memory benchmark on hestia — clean slate. Reusing methodology patterns from [`scripts/llama-cpp-bench.py`](../../scripts/llama-cpp-bench.py) (stdlib-only, N runs/workload, mean±stddev, JSONL output) and the containerization pattern from [`2026-05-04-llama-cpp-benchmarking.md`](2026-05-04-llama-cpp-benchmarking.md).
+
+## Approach
+
+**Two benchmarks, containerized, run via Docker on hestia's TrueNAS host:**
+
+| Tool | Why | Output |
+|---|---|---|
+| **STREAM** (McCalpin) | Canonical sustained-bandwidth benchmark. Copy / Scale / Add / Triad kernels. ~500 LOC of C, compiled from source in the Dockerfile. | Per-kernel MB/s, best run of N |
+| **Intel MLC** | Loaded-latency curve, idle latency, peak BW with different access patterns. Binary-only (Intel license); operator pre-downloads the tarball into the build context. | Latency-vs-bandwidth curves, idle latency, NUMA-aware reads |
+
+### Methodology controls
+
+Applied identically to both runs:
+
+- CPU governor → `performance` (kill scaling mid-run)
+- C-states locked (`processor.max_cstate=1` via kernel cmdline; alternatively `idle=poll` for the benchmark window)
+- Transparent hugepages → `always`
+- **NPS mode → NPS1** for both runs (only mode guaranteed to enumerate cleanly with both 6 and 8 DIMM)
+- Thread pinning to physical cores only, no SMT siblings: `OMP_PROC_BIND=close OMP_PLACES=cores`
+- `drop_caches=3` before each run
+- STREAM array size ≥4× LLC (200M doubles = 1.6 GB/array, ~5 GB for Triad — safely past Siena's max LLC of 128 MB)
+- 5 runs per kernel per config, report **median + stddev** (matches the llama-cpp-bench pattern)
+- vLLM **stopped** for the entire benchmark window: `midclt call app.stop vllm`. `nvtop` and the GHA runner can stay (read-only, negligible RAM traffic).
+
+### Out of scope
+
+- Multi-NPS comparison (NPS2 / NPS4 won't enumerate symmetrically with 8 DIMM asymmetric — apples-to-oranges)
+- AVX-512 vectorized kernels via likwid-bench
+- GPU memory benchmarks (orthogonal — RTX 4090 GDDR6X is unaffected by host DIMM config)
+- BIOS-tunable knobs beyond what's already set (Above 4G, ReBAR, IOMMU=on — see [`2026-05-07-hestia-p2p-enablement.md`](2026-05-07-hestia-p2p-enablement.md))
+
+## Artifacts
+
+All paths relative to repo root.
+
+| Path | Purpose |
+|---|---|
+| [`hosts/hestia/bench/memory/Dockerfile`](../../hosts/hestia/bench/memory/Dockerfile) | Debian base + build-essential + numactl. Compiles STREAM from McCalpin source in-image. Expects `mlc_v3.11a.tgz` in build context. |
+| [`hosts/hestia/bench/memory/entrypoint.sh`](../../hosts/hestia/bench/memory/entrypoint.sh) | In-container runner. Executes STREAM N=5, then MLC's sub-benchmarks. Emits JSONL. |
+| [`hosts/hestia/bench/memory/run.sh`](../../hosts/hestia/bench/memory/run.sh) | Host wrapper. Pre-flight (governor, hugepages, drop_caches, vLLM-stop check, dmidecode snapshot), then `docker run`. |
+| [`hosts/hestia/bench/memory/aggregate.py`](../../hosts/hestia/bench/memory/aggregate.py) | Compares two JSONL files, emits markdown table (BW, latency, deltas, % change). Adapted from `scripts/llama-cpp-bench.py`. |
+| [`hosts/hestia/bench/memory/README.md`](../../hosts/hestia/bench/memory/README.md) | Operator-facing runbook: prerequisites, how to invoke, how to swap DIMMs, how to read results. |
+| `docs/research/2026-05-15-hestia-memory-bandwidth.md` | Results writeup. **Written after both runs** by piping `aggregate.py` to file. Includes raw JSONL paths, comparison table, MLC loaded-latency curves, verdict. |
+
+## Execution procedure
+
+1. **Pre-flight** (one-time): operator downloads Intel MLC `mlc_v3.11a.tgz` from [Intel's MLC page](https://www.intel.com/content/www/us/en/developer/articles/tool/intelr-memory-latency-checker.html) (license acceptance required) and places it in `hosts/hestia/bench/memory/`. Verify SHA matches the download.
+2. **Build the image** on hestia: `docker build -t hestia-memory-bench:1 hosts/hestia/bench/memory/`.
+3. **Capture pre-state**: `dmidecode -t memory`, `lscpu`, BIOS-reported memory speed. `run.sh` writes this to `<RESULTS_DIR>/<label>-<ts>.preflight.json`.
+4. **Stop vLLM**: `midclt call app.stop vllm`. Wait for graceful shutdown, verify GPUs idle via `nvidia-smi`.
+5. **Run 6-DIMM benchmark**: `sudo ./run.sh 6dimm`. Wall time ~45 min (STREAM 5 runs + MLC full curve).
+6. **Power down**. Operator physically adds 2 DIMMs to the 2DPC-eligible slots per the SIENAD8-2L2T manual (page 12–13).
+7. **Boot to BIOS**, verify memory enumerated correctly, capture the new memory speed grade. If it didn't derate as expected (rare but possible), note in the writeup.
+8. **Re-verify methodology controls** persist across reboot: governor, C-state, NPS mode, hugepages — all settings should persist via kernel cmdline / Tunables.
+9. **Run 8-DIMM benchmark**: `sudo ./run.sh 8dimm`.
+10. **Aggregate**: `python3 hosts/hestia/bench/memory/aggregate.py <results-6dimm>.jsonl <results-8dimm>.jsonl --out docs/research/2026-05-15-hestia-memory-bandwidth.md`.
+11. **Restart vLLM**: `midclt call app.start vllm`. Verify model loads, smoke-test `curl http://10.42.2.10:8000/v1/models`.
+12. **Commit** scripts + plan + results writeup as a PR against `gjcourt/homelab` master.
+
+## Verification
+
+Five concrete checks after both runs:
+
+1. **STREAM Triad — 6 DIMM ≥ 8 DIMM by ≥10%**. Anything less than 10% means either the platform isn't derating as documented, or the methodology is leaking noise (governor, thermals).
+2. **MLC idle latency — 8 DIMM marginally higher** (extra ranks → slightly longer tRC). Expect 2–5 ns delta.
+3. **MLC loaded-latency curve — 8 DIMM saturates earlier and at lower bandwidth**. The knee of the curve moves left.
+4. **Run-to-run stddev < 2% of mean** for both configs. If higher, a control is leaking (most likely C-state or governor).
+5. **BIOS-reported speed grade matches the JEDEC table** for the platform. If 8 DIMM stays at 4800 MT/s, something interesting is happening — write it up.
+
+The aggregator output leads with the headline number: `% bandwidth delta on STREAM Triad`. Everything else is supporting evidence.

--- a/hosts/hestia/bench/memory/.gitignore
+++ b/hosts/hestia/bench/memory/.gitignore
@@ -1,0 +1,13 @@
+# Operator drops the Intel MLC tarball here before docker build.
+# Binary, Intel-licensed — must never be committed.
+mlc_*.tgz
+mlc_*.tar.gz
+
+# Python bytecode if aggregate.py runs locally.
+__pycache__/
+*.pyc
+
+# Stray benchmark output if anyone runs the harness from this dir
+# instead of $RESULTS_DIR.
+results-*.jsonl
+*.preflight.json

--- a/hosts/hestia/bench/memory/Dockerfile
+++ b/hosts/hestia/bench/memory/Dockerfile
@@ -17,7 +17,10 @@
 #   # TODO operator: pin SHA after first build, e.g.
 #   #   sha256sum stream.c => <hex>
 
-FROM debian:bookworm-slim
+# Pinned by digest for reproducibility — refresh with:
+#   docker buildx imagetools inspect debian:bookworm-slim --raw \
+#     | python3 -c 'import hashlib,sys; print("sha256:"+hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -64,15 +67,11 @@ RUN set -eux; \
 # Intel MLC (Memory Latency Checker)
 # ----------------------------------------------------------------------------
 # Operator must place mlc_v3.11a.tgz in the build context. Intel's EULA
-# prevents an automated download.
+# prevents an automated download. Missing-file failure surfaces as a
+# COPY error from Docker; see README "Troubleshooting" for the download URL.
+#   https://www.intel.com/content/www/us/en/download/736633/intel-memory-latency-checker-intel-mlc.html
 COPY mlc_v3.11a.tgz /tmp/mlc_v3.11a.tgz
 RUN set -eux; \
-    if [ ! -f /tmp/mlc_v3.11a.tgz ]; then \
-        echo "ERROR: mlc_v3.11a.tgz not found in build context."; \
-        echo "Download from https://www.intel.com/content/www/us/en/download/736633/intel-memory-latency-checker-intel-mlc.html"; \
-        echo "and place it next to this Dockerfile, then rebuild."; \
-        exit 1; \
-    fi; \
     mkdir -p /opt/mlc; \
     tar -xzf /tmp/mlc_v3.11a.tgz -C /opt/mlc; \
     if [ ! -x /opt/mlc/Linux/mlc ]; then \

--- a/hosts/hestia/bench/memory/Dockerfile
+++ b/hosts/hestia/bench/memory/Dockerfile
@@ -1,0 +1,90 @@
+# Memory bandwidth benchmark image for hestia (EPYC 8004 / Siena).
+#
+# Builds STREAM (McCalpin) from upstream source and bundles Intel MLC
+# (Memory Latency Checker). The MLC tarball must be downloaded manually
+# from Intel's site and placed alongside this Dockerfile before building,
+# because Intel requires accepting their EULA at download time.
+#
+# Build:
+#   docker build \
+#     --build-arg STREAM_SHA256=<sha256-of-stream.c> \
+#     -t hestia-memory-bench:1 .
+#
+# After the first build, record the SHA256 of stream.c here so future builds
+# can pin it. STREAM upstream has changed historically.
+#
+# STREAM_SHA256 reference (fill in after first successful build):
+#   # TODO operator: pin SHA after first build, e.g.
+#   #   sha256sum stream.c => <hex>
+
+FROM debian:bookworm-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        numactl \
+        libnuma-dev \
+        util-linux \
+        procps \
+        wget \
+        ca-certificates \
+        tar \
+        gzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# ----------------------------------------------------------------------------
+# STREAM (McCalpin)
+# ----------------------------------------------------------------------------
+# 200M doubles per array = 1.6 GB/array; STREAM allocates 3 arrays => ~4.8 GB,
+# which is comfortably larger than Siena's max L3 (4 CCDs * 32 MB = 128 MB)
+# and clears the >= 4x-LLC headroom rule from McCalpin's notes.
+ARG STREAM_URL=https://www.cs.virginia.edu/stream/FTP/Code/stream.c
+ARG STREAM_SHA256=""
+ARG STREAM_ARRAY_SIZE=200000000
+
+RUN set -eux; \
+    cd /tmp; \
+    wget -q -O stream.c "${STREAM_URL}"; \
+    if [ -n "${STREAM_SHA256}" ]; then \
+        echo "${STREAM_SHA256}  stream.c" | sha256sum -c -; \
+    else \
+        echo "WARNING: STREAM_SHA256 not pinned; using upstream tip blindly."; \
+        echo "Run 'sha256sum stream.c' after build and add it to the Dockerfile."; \
+        sha256sum stream.c; \
+    fi; \
+    gcc -O3 -fopenmp -mcmodel=medium \
+        -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_SIZE} \
+        -DNTIMES=20 \
+        stream.c -o /usr/local/bin/stream; \
+    rm -f stream.c
+
+# ----------------------------------------------------------------------------
+# Intel MLC (Memory Latency Checker)
+# ----------------------------------------------------------------------------
+# Operator must place mlc_v3.11a.tgz in the build context. Intel's EULA
+# prevents an automated download.
+COPY mlc_v3.11a.tgz /tmp/mlc_v3.11a.tgz
+RUN set -eux; \
+    if [ ! -f /tmp/mlc_v3.11a.tgz ]; then \
+        echo "ERROR: mlc_v3.11a.tgz not found in build context."; \
+        echo "Download from https://www.intel.com/content/www/us/en/download/736633/intel-memory-latency-checker-intel-mlc.html"; \
+        echo "and place it next to this Dockerfile, then rebuild."; \
+        exit 1; \
+    fi; \
+    mkdir -p /opt/mlc; \
+    tar -xzf /tmp/mlc_v3.11a.tgz -C /opt/mlc; \
+    if [ ! -x /opt/mlc/Linux/mlc ]; then \
+        chmod +x /opt/mlc/Linux/mlc || true; \
+    fi; \
+    ln -sf /opt/mlc/Linux/mlc /usr/local/bin/mlc; \
+    rm -f /tmp/mlc_v3.11a.tgz
+
+# ----------------------------------------------------------------------------
+# Entrypoint
+# ----------------------------------------------------------------------------
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/hosts/hestia/bench/memory/README.md
+++ b/hosts/hestia/bench/memory/README.md
@@ -61,11 +61,14 @@ sudo ./run.sh 6dimm
 
 ## Aggregate
 
+Run from the repo root so the output path is unambiguous:
+
 ```bash
-python3 aggregate.py \
-    results-6dimm-<ts>.jsonl \
-    results-8dimm-<ts>.jsonl \
-    > ../../../docs/research/2026-05-15-hestia-memory-bandwidth.md
+cd ~/src/homelab
+python3 hosts/hestia/bench/memory/aggregate.py \
+    "${RESULTS_DIR:-/mnt/tank/bench/memory}/results-6dimm-<ts>.jsonl" \
+    "${RESULTS_DIR:-/mnt/tank/bench/memory}/results-8dimm-<ts>.jsonl" \
+    --out docs/research/2026-05-15-hestia-memory-bandwidth.md
 ```
 
 Diff the two JSONLs into a single markdown comparison under `docs/research/`. The aggregate script computes Δ% on STREAM Triad, idle latency delta, and a small loaded-latency table.

--- a/hosts/hestia/bench/memory/README.md
+++ b/hosts/hestia/bench/memory/README.md
@@ -61,15 +61,17 @@ sudo ./run.sh 6dimm
 
 ## Aggregate
 
-Run from the repo root so the output path is unambiguous:
+`run.sh` prints the exact JSONL path it produced at the end of each run — copy those into the command below. Run from the repo root so the output path is unambiguous:
 
 ```bash
 cd ~/src/homelab
 python3 hosts/hestia/bench/memory/aggregate.py \
-    "${RESULTS_DIR:-/mnt/tank/bench/memory}/results-6dimm-<ts>.jsonl" \
-    "${RESULTS_DIR:-/mnt/tank/bench/memory}/results-8dimm-<ts>.jsonl" \
+    "${RESULTS_DIR:-/mnt/tank/bench/memory}/6dimm-<ts>.jsonl" \
+    "${RESULTS_DIR:-/mnt/tank/bench/memory}/8dimm-<ts>.jsonl" \
     --out docs/research/2026-05-15-hestia-memory-bandwidth.md
 ```
+
+Filenames are `<label>-<utc-ts>.jsonl` (e.g. `6dimm-2026-05-15T14-23-45Z.jsonl`) — the label is what you passed to `run.sh`, the timestamp is when the run started.
 
 Diff the two JSONLs into a single markdown comparison under `docs/research/`. The aggregate script computes Δ% on STREAM Triad, idle latency delta, and a small loaded-latency table.
 

--- a/hosts/hestia/bench/memory/README.md
+++ b/hosts/hestia/bench/memory/README.md
@@ -1,0 +1,102 @@
+# Hestia memory bandwidth benchmark
+
+Measures memory bandwidth and latency on hestia (ASRock Rack SIENAD8-2L2T, EPYC 8004 / Siena, 6-channel DDR5) under two physical DIMM populations: 6 DIMMs at 1DPC × 6 channels (full JEDEC DDR5-4800) vs. 8 DIMMs with two channels at 2DPC (typically derated to DDR5-3600 or DDR5-4000). Output is a JSONL run log per config plus an aggregated comparison written to `docs/research/`.
+
+## Prerequisites
+
+- Intel MLC tarball — download from <https://www.intel.com/content/www/us/en/developer/articles/tool/intelr-memory-latency-checker.html>, accept the EULA, and place `mlc_v3.11a.tgz` in this directory before `docker build`.
+- Docker available on the host.
+- Root / `sudo` access (MLC and `numactl` pinning require it).
+- vLLM stoppable. Operator owns the recipe; recap:
+  ```bash
+  midclt call app.stop vllm
+  nvidia-smi   # confirm GPUs idle, no PIDs holding VRAM
+  ```
+- `cpupower` installed (`apt-get install linux-cpupower`) or fallback: write directly to `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`.
+- SIENAD8-2L2T board manual on hand for the DIMM-slot map: `~/Downloads/SIENAD8-2L2T.pdf` (slot layout on p. 12-13).
+
+## Build
+
+```bash
+docker build -t hestia-memory-bench:1 .
+```
+
+The build will fail loudly if `mlc_v3.11a.tgz` is missing from the build context.
+
+## Run
+
+### 1. Stop vLLM
+
+```bash
+midclt call app.stop vllm
+nvidia-smi                      # both GPUs must show 0 MiB used and no PIDs
+```
+
+If vLLM does not stop cleanly within ~60s, see Troubleshooting.
+
+### 2. Apply controls and benchmark
+
+```bash
+# Optional: override results location (default lives on the boot pool)
+export RESULTS_DIR=/mnt/tank/bench/memory
+
+# Label is whatever the operator wants — convention is the DIMM count
+sudo ./run.sh 6dimm
+```
+
+`run.sh` handles governor pinning, C-state masking, NUMA setup, container invocation, and JSONL emission. The last line printed is the absolute path to the results file — note it before continuing.
+
+## Swap DIMMs
+
+1. `sudo shutdown -h now`
+2. Open the case. Board manual: `~/Downloads/SIENAD8-2L2T.pdf` (slot layout p. 12-13). The 2DPC-eligible slots are labelled in the manual.
+3. Move DIMMs:
+   - **6 → 8**: add 2 DIMMs to the 2DPC slots.
+   - **8 → 6**: remove the 2 DIMMs from the 2DPC slots.
+4. Boot to BIOS. Verify all DIMMs detected and note the configured memory speed grade (DDR5-4800 vs. derated).
+5. Boot to OS. Re-run:
+   ```bash
+   sudo ./run.sh 8dimm    # or 6dimm
+   ```
+
+## Aggregate
+
+```bash
+python3 aggregate.py \
+    results-6dimm-<ts>.jsonl \
+    results-8dimm-<ts>.jsonl \
+    > ../../../docs/research/2026-05-15-hestia-memory-bandwidth.md
+```
+
+Diff the two JSONLs into a single markdown comparison under `docs/research/`. The aggregate script computes Δ% on STREAM Triad, idle latency delta, and a small loaded-latency table.
+
+## Restore service
+
+```bash
+midclt call app.start vllm
+# smoke test
+curl -sS http://10.42.2.10:8000/v1/models | jq '.data[].id'
+```
+
+## Interpreting results
+
+- **STREAM Triad Δ%** — the headline number. Expect 6DIMM to win by the ratio of (4800 / configured 8DIMM speed), minus a few percent for 2DPC overhead.
+- **Idle latency delta** — typically a few ns; 8DIMM tends to be slightly higher.
+- **Loaded-latency curve** — 8DIMM's "knee" (where latency starts climbing under bandwidth pressure) shifts left, i.e. the bus saturates sooner.
+- **Run-to-run stddev** — should be <2%. Higher means controls leaked; see Troubleshooting.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `mlc_v3.11a.tgz not found` at build time | Tarball wasn't placed next to the Dockerfile | Download from Intel, accept EULA, drop in this directory, rebuild. |
+| 8DIMM didn't derate the bus | CPU silicon binning or BIOS auto-bump kept the bus at 4800 | Inspect the preflight JSON for `Configured Memory Speed` (from `dmidecode -t memory`). If it really is 4800 at 2DPC, document it — that's the answer. |
+| Run-to-run stddev > 2% | C-states or turbo bouncing leaked through | Check `/sys/devices/system/cpu/cpu0/cpuidle/state*/disable` — all non-C0/C1 should be `1`. Retry with `idle=poll` on the kernel cmdline. |
+| vLLM won't stop cleanly | Worker stuck on a CUDA op | Grace period 60s, then `midclt call app.kill vllm`. Confirm with `nvidia-smi`. |
+
+## Related
+
+- Plan: [`docs/plans/2026-05-15-hestia-memory-benchmark.md`](../../../../docs/plans/2026-05-15-hestia-memory-benchmark.md)
+- Methodology precedent: [`docs/plans/2026-05-04-llama-cpp-benchmarking.md`](../../../../docs/plans/2026-05-04-llama-cpp-benchmarking.md)
+- Harness inspiration: [`scripts/llama-cpp-bench.py`](../../../../scripts/llama-cpp-bench.py)
+- Board manual: `~/Downloads/SIENAD8-2L2T.pdf`

--- a/hosts/hestia/bench/memory/aggregate.py
+++ b/hosts/hestia/bench/memory/aggregate.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Aggregate two hestia memory-benchmark JSONL runs into a comparison writeup.
+
+Consumes the JSONL output produced by the in-repo memory benchmark harness
+(STREAM + Intel MLC) for two configurations of the same host — typically a
+"6dimm" (1 DIMM-per-channel, full speed) run and an "8dimm" (mixed 1DPC/2DPC,
+derated) run on the EPYC 8004 Siena server — and emits a markdown writeup
+suitable to commit under `docs/research/`.
+
+The headline number is STREAM Triad: median over the 5 runs per config, with
+stddev as the spread, and a signed delta in MB/s and percent. MLC idle
+latency, max-bandwidth-by-pattern, and the loaded-latency curve are reported
+side-by-side. Missing sub-benchmarks degrade gracefully to `n/a`.
+
+USAGE
+
+    python3 aggregate.py <jsonl-a> <jsonl-b>            # markdown to stdout
+    python3 aggregate.py <jsonl-a> <jsonl-b> --out FILE # write to FILE
+
+The first JSONL argument is "A", the second is "B"; deltas are computed as
+(B - A) so a negative percent means B is slower than A. Labels for each
+column come from the `meta` event embedded in each file.
+
+DEPENDENCIES
+
+    Python 3.9+ standard library only — json, statistics, argparse, pathlib,
+    datetime. No pandas, no numpy.
+
+Designed to pair with the harness in `hosts/hestia/bench/memory/` per the
+plan in `docs/plans/2026-05-15-hestia-memory-benchmark.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+# Kernel display order in the STREAM table. Matches McCalpin's canonical
+# Copy / Scale / Add / Triad order so the table reads top-to-bottom in the
+# same order the benchmark prints them.
+STREAM_KERNELS = ["Copy", "Scale", "Add", "Triad"]
+
+# MLC max-bandwidth pattern keys (as emitted by the harness) and their
+# human-readable labels for the comparison table.
+MLC_PATTERNS = [
+    ("all_reads", "All reads"),
+    ("3_1_reads_writes", "3:1 reads/writes"),
+    ("2_1_reads_writes", "2:1 reads/writes"),
+    ("1_1_reads_writes", "1:1 reads/writes"),
+    ("stream_triad_like", "Stream triad-like"),
+]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    """Parse a JSONL file into a list of event dicts. Tolerates blank lines."""
+    events: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, raw in enumerate(f, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"{path}:{lineno}: invalid JSON: {e}") from e
+    return events
+
+
+def find_meta(events: list[dict]) -> dict:
+    for ev in events:
+        if ev.get("event") == "meta":
+            return ev
+    return {}
+
+
+def find_done(events: list[dict]) -> dict:
+    for ev in events:
+        if ev.get("event") == "done":
+            return ev
+    return {}
+
+
+def stream_runs_by_kernel(events: list[dict]) -> dict[str, list[float]]:
+    """Return rate (MB/s) lists keyed by kernel name."""
+    out: dict[str, list[float]] = {k: [] for k in STREAM_KERNELS}
+    for ev in events:
+        if ev.get("event") != "stream_run":
+            continue
+        kernel = ev.get("kernel")
+        rate = ev.get("rate_mb_per_s")
+        if kernel in out and isinstance(rate, (int, float)):
+            out[kernel].append(float(rate))
+    return out
+
+
+def mlc_idle(events: list[dict]) -> Optional[dict]:
+    for ev in events:
+        if ev.get("event") == "mlc_idle_latency":
+            return ev
+    return None
+
+
+def mlc_max_bandwidth(events: list[dict]) -> dict[str, float]:
+    """Pattern → bandwidth_mb_per_s."""
+    out: dict[str, float] = {}
+    for ev in events:
+        if ev.get("event") != "mlc_max_bandwidth":
+            continue
+        pattern = ev.get("pattern")
+        bw = ev.get("bandwidth_mb_per_s")
+        if isinstance(pattern, str) and isinstance(bw, (int, float)):
+            out[pattern] = float(bw)
+    return out
+
+
+def mlc_loaded_curve(events: list[dict]) -> list[dict]:
+    """List of {inject_delay, latency_ns, bandwidth_mb_per_s} in file order."""
+    curve = [ev for ev in events if ev.get("event") == "mlc_loaded_latency"]
+    # Sort by inject_delay if present so adjacent rows are comparable.
+    curve.sort(key=lambda e: e.get("inject_delay", 0))
+    return curve
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def fmt_mb(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:,.0f}"
+
+
+def fmt_mb_pm(median: Optional[float], stdev: Optional[float]) -> str:
+    """Format a median ± stddev MB/s pair."""
+    if median is None:
+        return "n/a"
+    if stdev is None:
+        return f"{median:,.0f}"
+    return f"{median:,.0f} ± {stdev:,.0f}"
+
+
+def fmt_pct(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value > 0 else ("" if value == 0 else "")
+    # negatives already carry their own sign; positives get an explicit +
+    if value > 0:
+        return f"+{value:.1f}%"
+    return f"{value:.1f}%"
+
+
+def fmt_delta_mb(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    if value > 0:
+        return f"+{value:,.0f}"
+    return f"{value:,.0f}"
+
+
+def fmt_ns(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f} ns"
+
+
+def fmt_delta_ns(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    if value > 0:
+        return f"+{value:.1f}"
+    return f"{value:.1f}"
+
+
+def signed_pct(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    """(b - a) / a * 100. None if either side missing or a == 0."""
+    if a is None or b is None or a == 0:
+        return None
+    return (b - a) / a * 100.0
+
+
+def signed_diff(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    if a is None or b is None:
+        return None
+    return b - a
+
+
+def median_and_stdev(values: list[float]) -> tuple[Optional[float], Optional[float]]:
+    if not values:
+        return (None, None)
+    med = statistics.median(values)
+    sd = statistics.stdev(values) if len(values) >= 2 else 0.0
+    return (med, sd)
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def render(path_a: Path, path_b: Path) -> str:
+    events_a = load_jsonl(path_a)
+    events_b = load_jsonl(path_b)
+
+    meta_a = find_meta(events_a)
+    meta_b = find_meta(events_b)
+    done_a = find_done(events_a)
+    done_b = find_done(events_b)
+
+    label_a = str(meta_a.get("label") or path_a.stem)
+    label_b = str(meta_b.get("label") or path_b.stem)
+
+    # Host descriptor — assume A is authoritative for the shared host fields,
+    # fall back to B if A is missing them.
+    host = meta_a.get("host") or meta_b.get("host") or "unknown"
+    cpu = meta_a.get("cpu") or meta_b.get("cpu") or "unknown CPU"
+    numa = meta_a.get("numa_nodes", meta_b.get("numa_nodes", "?"))
+    cores = meta_a.get("physical_cores", meta_b.get("physical_cores", "?"))
+
+    # Measurement date — pull from meta.ts (ISO 8601), fall back to "unknown".
+    ts_raw = meta_a.get("ts") or meta_b.get("ts")
+    date_str = "unknown"
+    if isinstance(ts_raw, str):
+        try:
+            # tolerate trailing Z
+            dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            date_str = dt.strftime("%Y-%m-%d")
+        except ValueError:
+            date_str = ts_raw
+
+    out: list[str] = []
+
+    out.append(f"# Hestia memory bandwidth — {label_a} vs {label_b}")
+    out.append("")
+    out.append(f"**Measured:** {date_str}")
+    out.append(
+        f"**Host:** {host} ({cpu}, {numa} NUMA "
+        f"node{'s' if isinstance(numa, int) and numa != 1 else ''}, "
+        f"{cores} physical cores)"
+    )
+    out.append("**Tools:** STREAM (McCalpin, NTIMES=20), Intel MLC v3.11a")
+    out.append("")
+
+    # ---------------- Headline ----------------
+    runs_a = stream_runs_by_kernel(events_a)
+    runs_b = stream_runs_by_kernel(events_b)
+
+    triad_a_med, triad_a_sd = median_and_stdev(runs_a["Triad"])
+    triad_b_med, triad_b_sd = median_and_stdev(runs_b["Triad"])
+    triad_delta_pct = signed_pct(triad_a_med, triad_b_med)
+
+    if triad_delta_pct is None:
+        headline_delta = "n/a"
+    else:
+        # Decide which label is the faster one for the parenthetical
+        if triad_delta_pct < 0:
+            faster_label = label_a
+            unexpected = ""
+        elif triad_delta_pct > 0:
+            faster_label = label_b
+            # If B is the higher-density / typically-derated config, surface
+            # that as "unexpected" so the operator notices. We can't know for
+            # certain — heuristic: if label_b contains "8" and label_a "6",
+            # B-faster is unexpected.
+            unexpected = ", unexpected" if ("8" in label_b and "6" in label_a) else ""
+        else:
+            faster_label = "tie"
+            unexpected = ""
+        sign = "+" if triad_delta_pct > 0 else ""
+        if faster_label == "tie":
+            headline_delta = f"Δ = {sign}{triad_delta_pct:.1f}% (tie)"
+        else:
+            headline_delta = (
+                f"Δ = {sign}{triad_delta_pct:.1f}% ({faster_label} faster{unexpected})"
+            )
+
+    out.append("## Headline")
+    out.append("")
+    out.append(
+        f"**STREAM Triad: {label_a} = {fmt_mb(triad_a_med)} MB/s · "
+        f"{label_b} = {fmt_mb(triad_b_med)} MB/s · {headline_delta}**"
+    )
+    out.append("")
+
+    # ---------------- STREAM table ----------------
+    out.append("## STREAM (sustained bandwidth)")
+    out.append("")
+    out.append("5 runs per kernel per config. Reported: median ± stddev across runs, in MB/s.")
+    out.append("")
+    out.append(f"| Kernel | {label_a} | {label_b} | Δ MB/s | Δ % |")
+    out.append("|---|---:|---:|---:|---:|")
+    for kernel in STREAM_KERNELS:
+        a_med, a_sd = median_and_stdev(runs_a[kernel])
+        b_med, b_sd = median_and_stdev(runs_b[kernel])
+        d_mb = signed_diff(a_med, b_med)
+        d_pct = signed_pct(a_med, b_med)
+        out.append(
+            f"| {kernel:<6} | {fmt_mb_pm(a_med, a_sd)} | {fmt_mb_pm(b_med, b_sd)} "
+            f"| {fmt_delta_mb(d_mb)} | {fmt_pct(d_pct)} |"
+        )
+    out.append("")
+
+    # ---------------- MLC idle latency ----------------
+    idle_a = mlc_idle(events_a)
+    idle_b = mlc_idle(events_b)
+
+    out.append("## MLC idle latency")
+    out.append("")
+    out.append(f"| Pattern | {label_a} | {label_b} | Δ ns |")
+    out.append("|---|---:|---:|---:|")
+    for key, label in [("random_ns", "Random"), ("sequential_ns", "Sequential")]:
+        a_val = idle_a.get(key) if idle_a else None
+        b_val = idle_b.get(key) if idle_b else None
+        a_str = fmt_ns(a_val) if isinstance(a_val, (int, float)) else "n/a"
+        b_str = fmt_ns(b_val) if isinstance(b_val, (int, float)) else "n/a"
+        d = signed_diff(
+            a_val if isinstance(a_val, (int, float)) else None,
+            b_val if isinstance(b_val, (int, float)) else None,
+        )
+        out.append(f"| {label} | {a_str} | {b_str} | {fmt_delta_ns(d)} |")
+    out.append("")
+
+    # ---------------- MLC max bandwidth ----------------
+    maxbw_a = mlc_max_bandwidth(events_a)
+    maxbw_b = mlc_max_bandwidth(events_b)
+
+    out.append("## MLC max bandwidth (different access patterns)")
+    out.append("")
+    out.append(f"| Pattern | {label_a} | {label_b} | Δ % |")
+    out.append("|---|---:|---:|---:|")
+    for key, label in MLC_PATTERNS:
+        a_val = maxbw_a.get(key)
+        b_val = maxbw_b.get(key)
+        a_str = f"{fmt_mb(a_val)} MB/s" if a_val is not None else "n/a"
+        b_str = f"{fmt_mb(b_val)} MB/s" if b_val is not None else "n/a"
+        d_pct = signed_pct(a_val, b_val)
+        out.append(f"| {label} | {a_str} | {b_str} | {fmt_pct(d_pct)} |")
+    out.append("")
+
+    # ---------------- MLC loaded-latency curve ----------------
+    curve_a = mlc_loaded_curve(events_a)
+    curve_b = mlc_loaded_curve(events_b)
+
+    out.append("## MLC loaded-latency curve")
+    out.append("")
+    out.append(
+        'Latency (ns) vs offered load (MB/s). The "knee" — where latency '
+        "jumps as bandwidth approaches saturation — is the practical ceiling."
+    )
+    out.append("")
+
+    def render_curve(label: str, curve: list[dict]) -> None:
+        out.append(f"{label}:")
+        out.append("")
+        if not curve:
+            out.append("_n/a — MLC loaded-latency data not present in run._")
+            out.append("")
+            return
+        out.append("| Inject delay | Bandwidth | Latency |")
+        out.append("|---:|---:|---:|")
+        for row in curve:
+            delay = row.get("inject_delay")
+            bw = row.get("bandwidth_mb_per_s")
+            lat = row.get("latency_ns")
+            delay_str = f"{delay}" if delay is not None else "n/a"
+            bw_str = f"{fmt_mb(bw)} MB/s" if isinstance(bw, (int, float)) else "n/a"
+            lat_str = f"{lat:.1f} ns" if isinstance(lat, (int, float)) else "n/a"
+            out.append(f"| {delay_str} | {bw_str} | {lat_str} |")
+        out.append("")
+
+    render_curve(label_a, curve_a)
+    render_curve(label_b, curve_b)
+
+    # ---------------- Run quality ----------------
+    # Triad stddev / mean, as a sanity check on variance. Anything > 2% is
+    # noise-floor noise and shouldn't be trusted; flag with ⚠.
+    def stddev_pct(values: list[float]) -> Optional[float]:
+        if len(values) < 2:
+            return None
+        m = statistics.mean(values)
+        if m == 0:
+            return None
+        return statistics.stdev(values) / m * 100.0
+
+    sd_a = stddev_pct(runs_a["Triad"])
+    sd_b = stddev_pct(runs_b["Triad"])
+
+    def ok_mark(sd: Optional[float]) -> str:
+        if sd is None:
+            return "n/a"
+        return "✓" if sd < 2.0 else "⚠"
+
+    sd_a_str = f"{sd_a:.1f}%" if sd_a is not None else "n/a"
+    sd_b_str = f"{sd_b:.1f}%" if sd_b is not None else "n/a"
+
+    # Combined OK marker: ✓ only if both pass; otherwise ⚠.
+    both_ok = (
+        sd_a is not None and sd_b is not None and sd_a < 2.0 and sd_b < 2.0
+    )
+    triad_ok_marker = "✓ (<2%)" if both_ok else "⚠"
+    if sd_a is None or sd_b is None:
+        triad_ok_marker = ok_mark(sd_a if sd_a is not None else sd_b)
+
+    dur_a = done_a.get("duration_s") if done_a else None
+    dur_b = done_b.get("duration_s") if done_b else None
+    dur_a_str = f"{dur_a:.0f} s" if isinstance(dur_a, (int, float)) else "n/a"
+    dur_b_str = f"{dur_b:.0f} s" if isinstance(dur_b, (int, float)) else "n/a"
+
+    out.append("## Run quality")
+    out.append("")
+    out.append(f"| Metric | {label_a} | {label_b} | OK? |")
+    out.append("|---|---:|---:|:-:|")
+    out.append(
+        f"| STREAM Triad stddev (% of mean) | {sd_a_str} | {sd_b_str} | {triad_ok_marker} |"
+    )
+    out.append(f"| Total wall time | {dur_a_str} | {dur_b_str} | |")
+    out.append("")
+
+    # ---------------- Provenance ----------------
+    out.append("## Provenance")
+    out.append("")
+    out.append(f"- {label_a}: `{path_a}`")
+    out.append(f"- {label_b}: `{path_b}`")
+    out.append("- Aggregator: `hosts/hestia/bench/memory/aggregate.py`")
+    out.append("- Plan: `docs/plans/2026-05-15-hestia-memory-benchmark.md`")
+    out.append("")
+
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("jsonl_a", type=Path, help='first JSONL run (becomes "A" in output)')
+    ap.add_argument("jsonl_b", type=Path, help='second JSONL run (becomes "B" in output)')
+    ap.add_argument("--out", type=Path, default=None, help="write markdown to FILE (default: stdout)")
+    args = ap.parse_args()
+
+    for p in (args.jsonl_a, args.jsonl_b):
+        if not p.exists():
+            print(f"error: {p} does not exist", file=sys.stderr)
+            return 2
+
+    md = render(args.jsonl_a, args.jsonl_b)
+
+    if args.out is None:
+        sys.stdout.write(md)
+        if not md.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        args.out.write_text(md if md.endswith("\n") else md + "\n", encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hosts/hestia/bench/memory/aggregate.py
+++ b/hosts/hestia/bench/memory/aggregate.py
@@ -381,8 +381,11 @@ def render(path_a: Path, path_b: Path) -> str:
     # Triad stddev / mean, as a sanity check on variance. Anything > 2% is
     # noise-floor noise and shouldn't be trusted; flag with ⚠.
     def stddev_pct(values: list[float]) -> Optional[float]:
+        # Matches median_and_stdev(): a single sample has zero spread.
+        # Returning 0.0 rather than None keeps the run-quality table aligned
+        # with the STREAM table (which renders "value ± 0.0" for n=1).
         if len(values) < 2:
-            return None
+            return 0.0 if values else None
         m = statistics.mean(values)
         if m == 0:
             return None

--- a/hosts/hestia/bench/memory/entrypoint.sh
+++ b/hosts/hestia/bench/memory/entrypoint.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Container entrypoint for the hestia memory benchmark.
+#
+# Usage: entrypoint.sh <label>
+#   e.g. entrypoint.sh 6dimm
+#        entrypoint.sh 8dimm
+#
+# Runs STREAM (5 iterations) and Intel MLC (idle latency, loaded latency,
+# max bandwidth, bandwidth matrix), emitting a JSONL stream to
+# /results/<label>-<utc-timestamp>.jsonl.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Args
+# ----------------------------------------------------------------------------
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+    echo "error: label is required as first positional arg (e.g. 6dimm, 8dimm)" >&2
+    exit 64
+fi
+LABEL="$1"
+
+# ----------------------------------------------------------------------------
+# Output setup
+# ----------------------------------------------------------------------------
+TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+TS_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+START_EPOCH="$(date -u +%s)"
+
+if [[ ! -d /results ]]; then
+    echo "error: /results does not exist; mount a host directory with -v <host>:/results" >&2
+    exit 65
+fi
+if [[ ! -w /results ]]; then
+    echo "error: /results is not writable" >&2
+    exit 66
+fi
+
+OUT="/results/${LABEL}-${TS}.jsonl"
+: > "$OUT"
+
+emit() {
+    # emit <json-line>
+    printf '%s\n' "$1" >> "$OUT"
+}
+
+warn() {
+    local msg="$1"
+    local esc
+    esc=$(printf '%s' "$msg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    emit "{\"event\":\"warning\",\"message\":\"${esc}\"}"
+    echo "warning: ${msg}" >&2
+}
+
+# ----------------------------------------------------------------------------
+# Meta event
+# ----------------------------------------------------------------------------
+host="$(uname -n || echo unknown)"
+cpu_model="$(lscpu 2>/dev/null | awk -F: '/^Model name/ {sub(/^ +/, "", $2); print $2; exit}')"
+cpu_model="${cpu_model:-unknown}"
+numa_nodes="$(numactl --hardware 2>/dev/null | awk '/^available:/ {print $2; exit}')"
+numa_nodes="${numa_nodes:-0}"
+physical_cores="$(lscpu -p=Core,Socket 2>/dev/null | grep -v '^#' | sort -u | wc -l | tr -d ' ')"
+physical_cores="${physical_cores:-1}"
+total_threads="$(lscpu -p=CPU 2>/dev/null | grep -v '^#' | wc -l | tr -d ' ')"
+if [[ "$physical_cores" -gt 0 && "$total_threads" -gt 0 ]]; then
+    smt="$(( total_threads / physical_cores ))"
+else
+    smt=1
+fi
+thp_status="$(cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || echo unknown)"
+
+esc_field() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+emit "{\"event\":\"meta\",\"label\":\"$(esc_field "$LABEL")\",\"ts\":\"${TS_ISO}\",\"host\":\"$(esc_field "$host")\",\"cpu\":\"$(esc_field "$cpu_model")\",\"numa_nodes\":${numa_nodes},\"physical_cores\":${physical_cores},\"smt_threads_per_core\":${smt},\"thp\":\"$(esc_field "$thp_status")\"}"
+
+# ----------------------------------------------------------------------------
+# STREAM
+# ----------------------------------------------------------------------------
+run_stream() {
+    local run_idx="$1"
+    local tmp
+    tmp="$(mktemp)"
+    if ! OMP_NUM_THREADS="${physical_cores}" \
+         OMP_PROC_BIND=close \
+         OMP_PLACES=cores \
+         numactl --cpunodebind=0 --membind=0 /usr/local/bin/stream > "$tmp" 2>&1; then
+        warn "STREAM run ${run_idx} failed (exit $?)"
+        rm -f "$tmp"
+        return 0
+    fi
+
+    # STREAM emits a block like:
+    # Function    Best Rate MB/s  Avg time     Min time     Max time
+    # Copy:          12345.6      0.123456     0.123456     0.123456
+    # Scale:         ...
+    # Add:           ...
+    # Triad:         ...
+    local kernel
+    for kernel in Copy Scale Add Triad; do
+        local line rate avg min_t max_t
+        line="$(grep -E "^${kernel}:" "$tmp" | head -n 1 || true)"
+        if [[ -z "$line" ]]; then
+            warn "STREAM run ${run_idx}: kernel ${kernel} not parsed"
+            emit "{\"event\":\"stream_run\",\"run\":${run_idx},\"kernel\":\"${kernel}\",\"rate_mb_per_s\":null,\"avg_time_s\":null,\"min_time_s\":null,\"max_time_s\":null}"
+            continue
+        fi
+        # Strip the leading "Copy:" etc.
+        rate=$(awk '{print $2}' <<<"$line")
+        avg=$(awk '{print $3}' <<<"$line")
+        min_t=$(awk '{print $4}' <<<"$line")
+        max_t=$(awk '{print $5}' <<<"$line")
+        emit "{\"event\":\"stream_run\",\"run\":${run_idx},\"kernel\":\"${kernel}\",\"rate_mb_per_s\":${rate:-null},\"avg_time_s\":${avg:-null},\"min_time_s\":${min_t:-null},\"max_time_s\":${max_t:-null}}"
+    done
+    rm -f "$tmp"
+}
+
+for i in 1 2 3 4 5; do
+    run_stream "$i"
+    if [[ "$i" -lt 5 ]]; then
+        sleep 5
+    fi
+done
+
+# ----------------------------------------------------------------------------
+# Intel MLC
+# ----------------------------------------------------------------------------
+
+mlc_run() {
+    # mlc_run <flag>; echoes output to stdout, returns mlc exit code.
+    local flag="$1"
+    numactl --cpunodebind=0 --membind=0 /usr/local/bin/mlc "$flag" 2>&1
+}
+
+# --- Idle latency -----------------------------------------------------------
+{
+    if out="$(mlc_run --idle_latency)"; then
+        # MLC prints lines like:
+        #   Each iteration took ...
+        #   Using small pages for ...
+        # and ultimately:
+        #   Idle latency = NNN.N ns          (random)
+        # On some builds:
+        #   Random idle latency: NNN.N ns
+        #   Sequential idle latency: NNN.N ns
+        random_ns="$(echo "$out" | grep -iE 'random.*latency' | grep -oE '[0-9]+\.[0-9]+' | head -n 1)"
+        seq_ns="$(echo "$out" | grep -iE 'sequential.*latency' | grep -oE '[0-9]+\.[0-9]+' | head -n 1)"
+        # Fallback: the unlabeled "Each iteration took N.N base cycles ( = N.N ns)" line is the random latency.
+        if [[ -z "${random_ns}" ]]; then
+            random_ns="$(echo "$out" | grep -iE 'idle latency' | grep -oE '[0-9]+\.[0-9]+' | head -n 1)"
+        fi
+        emit "{\"event\":\"mlc_idle_latency\",\"random_ns\":${random_ns:-null},\"sequential_ns\":${seq_ns:-null}}"
+    else
+        warn "mlc --idle_latency failed"
+    fi
+} || true
+
+# --- Loaded latency ---------------------------------------------------------
+{
+    if out="$(mlc_run --loaded_latency)"; then
+        # Output table looks like:
+        #  Inject  Latency Bandwidth
+        #  Delay   (ns)    MB/sec
+        # ==========================
+        #  00000   123.45   45678.90
+        #  00002    ...
+        echo "$out" | awk '
+            BEGIN { in_table=0 }
+            /^=+/ { in_table=1; next }
+            in_table && NF>=3 && $1 ~ /^[0-9]+$/ {
+                printf "{\"event\":\"mlc_loaded_latency\",\"inject_delay\":%d,\"latency_ns\":%s,\"bandwidth_mb_per_s\":%s}\n", $1+0, $2, $3
+            }
+        ' >> "$OUT"
+    else
+        warn "mlc --loaded_latency failed"
+    fi
+} || true
+
+# --- Max bandwidth ----------------------------------------------------------
+normalize_pattern() {
+    # ALL Reads -> all_reads
+    # 3:1 Reads-Writes -> 3_1_reads_writes
+    # Stream-triad like -> stream_triad_like
+    local s="$1"
+    s="${s,,}"
+    s="${s//:/ _ }"
+    s="${s//-/ _ }"
+    s="$(echo "$s" | tr -s ' ' '_' | sed 's/^_//; s/_$//; s/__*/_/g')"
+    printf '%s' "$s"
+}
+
+{
+    if out="$(mlc_run --max_bandwidth)"; then
+        # Output looks like:
+        #   ALL Reads        :  123456.78
+        #   3:1 Reads-Writes :  111111.11
+        #   2:1 Reads-Writes :  ...
+        #   1:1 Reads-Writes :  ...
+        #   Stream-triad like:  ...
+        echo "$out" | grep -E ':[[:space:]]+[0-9]+\.[0-9]+' | while IFS= read -r line; do
+            pattern="$(echo "$line" | sed 's/[[:space:]]*:[[:space:]]*[0-9.]\+.*$//' | sed 's/[[:space:]]*$//; s/^[[:space:]]*//')"
+            bw="$(echo "$line" | grep -oE '[0-9]+\.[0-9]+' | tail -n 1)"
+            norm="$(normalize_pattern "$pattern")"
+            if [[ -z "$norm" || -z "$bw" ]]; then
+                continue
+            fi
+            emit "{\"event\":\"mlc_max_bandwidth\",\"pattern\":\"${norm}\",\"bandwidth_mb_per_s\":${bw}}"
+        done
+    else
+        warn "mlc --max_bandwidth failed"
+    fi
+} || true
+
+# --- Bandwidth matrix -------------------------------------------------------
+{
+    if out="$(mlc_run --bandwidth_matrix)"; then
+        # Output looks like:
+        # Numa node
+        # Numa node     0
+        #        0   123456.7
+        # On multi-node: a NxN grid with column header row then per-from-node rows.
+        # Parse: find the header row of node indices, then each subsequent data row.
+        echo "$out" | awk '
+            BEGIN { header_seen=0; n=0 }
+            /^[[:space:]]*Numa node[[:space:]]+[0-9]/ {
+                # header row: "Numa node   0   1   2 ..."
+                n = NF - 2
+                for (i=0; i<n; i++) col[i] = $(i+3)
+                header_seen=1
+                next
+            }
+            header_seen && NF >= 2 && $1 ~ /^[0-9]+$/ {
+                from = $1
+                for (i=0; i<n; i++) {
+                    val = $(i+2)
+                    if (val ~ /^[0-9]+(\.[0-9]+)?$/) {
+                        printf "{\"event\":\"mlc_bandwidth_matrix\",\"from_node\":%d,\"to_node\":%d,\"bandwidth_mb_per_s\":%s}\n", from+0, col[i]+0, val
+                    }
+                }
+            }
+        ' >> "$OUT"
+    else
+        warn "mlc --bandwidth_matrix failed"
+    fi
+} || true
+
+# ----------------------------------------------------------------------------
+# Done
+# ----------------------------------------------------------------------------
+END_EPOCH="$(date -u +%s)"
+TS_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DURATION=$(( END_EPOCH - START_EPOCH ))
+emit "{\"event\":\"done\",\"ts\":\"${TS_END}\",\"duration_s\":${DURATION}}"
+
+echo "JSONL written: ${OUT}" >&2

--- a/hosts/hestia/bench/memory/entrypoint.sh
+++ b/hosts/hestia/bench/memory/entrypoint.sh
@@ -23,6 +23,9 @@ LABEL="$1"
 # ----------------------------------------------------------------------------
 # Output setup
 # ----------------------------------------------------------------------------
+# Two formats on purpose:
+#   - TS uses dashes (path-safe; colons break Windows + several CLI tools).
+#   - TS_ISO is strict ISO 8601 with colons (for the JSONL `ts` field).
 TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
 TS_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 START_EPOCH="$(date -u +%s)"
@@ -79,6 +82,8 @@ emit "{\"event\":\"meta\",\"label\":\"$(esc_field "$LABEL")\",\"ts\":\"${TS_ISO}
 # ----------------------------------------------------------------------------
 # STREAM
 # ----------------------------------------------------------------------------
+STREAM_FAILURES=0
+
 run_stream() {
     local run_idx="$1"
     local tmp
@@ -88,7 +93,15 @@ run_stream() {
          OMP_PLACES=cores \
          numactl --cpunodebind=0 --membind=0 /usr/local/bin/stream > "$tmp" 2>&1; then
         warn "STREAM run ${run_idx} failed (exit $?)"
+        # Emit null events for all 4 kernels so the JSONL is complete and the
+        # aggregator can surface the partial-failure clearly, then mark this
+        # run as failed for the post-loop exit check.
+        local k
+        for k in Copy Scale Add Triad; do
+            emit "{\"event\":\"stream_run\",\"run\":${run_idx},\"kernel\":\"${k}\",\"rate_mb_per_s\":null,\"avg_time_s\":null,\"min_time_s\":null,\"max_time_s\":null}"
+        done
         rm -f "$tmp"
+        STREAM_FAILURES=$(( STREAM_FAILURES + 1 ))
         return 0
     fi
 
@@ -123,6 +136,14 @@ for i in 1 2 3 4 5; do
         sleep 5
     fi
 done
+
+# More than half the STREAM runs failing means the bandwidth tables are
+# unusable; fail loudly so the operator re-runs instead of aggregating noise.
+if [[ "$STREAM_FAILURES" -ge 3 ]]; then
+    warn "STREAM failed in $STREAM_FAILURES/5 runs; aborting before MLC"
+    emit "{\"event\":\"done\",\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"duration_s\":$(( $(date -u +%s) - START_EPOCH )),\"status\":\"stream_failed\"}"
+    exit 70
+fi
 
 # ----------------------------------------------------------------------------
 # Intel MLC

--- a/hosts/hestia/bench/memory/run.sh
+++ b/hosts/hestia/bench/memory/run.sh
@@ -107,9 +107,13 @@ restore_governor() {
     if command -v cpupower >/dev/null 2>&1; then
         cpupower frequency-set -g "$target" >/dev/null 2>&1 || true
     else
+        # nullglob: if cpufreq isn't present, expand to nothing instead of
+        # silently iterating over the literal glob string.
+        shopt -s nullglob
         for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
             [[ -w "$f" ]] && echo "$target" > "$f" 2>/dev/null || true
         done
+        shopt -u nullglob
     fi
 }
 trap restore_governor EXIT
@@ -121,9 +125,14 @@ echo "info: setting CPU governor to performance" >&2
 if command -v cpupower >/dev/null 2>&1; then
     cpupower frequency-set -g performance >/dev/null 2>&1 || {
         echo "warning: cpupower failed; falling back to sysfs writes" >&2
+        # nullglob: if cpufreq isn't present, expand to nothing instead of
+        # silently iterating over the literal glob string.
+        shopt -s nullglob
+        shopt -s nullglob
         for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
             [[ -w "$f" ]] && echo performance > "$f"
         done
+        shopt -u nullglob
     }
 else
     echo "warning: cpupower not installed; using sysfs fallback" >&2

--- a/hosts/hestia/bench/memory/run.sh
+++ b/hosts/hestia/bench/memory/run.sh
@@ -128,7 +128,6 @@ if command -v cpupower >/dev/null 2>&1; then
         # nullglob: if cpufreq isn't present, expand to nothing instead of
         # silently iterating over the literal glob string.
         shopt -s nullglob
-        shopt -s nullglob
         for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
             [[ -w "$f" ]] && echo performance > "$f"
         done
@@ -136,9 +135,11 @@ if command -v cpupower >/dev/null 2>&1; then
     }
 else
     echo "warning: cpupower not installed; using sysfs fallback" >&2
+    shopt -s nullglob
     for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
         [[ -w "$f" ]] && echo performance > "$f"
     done
+    shopt -u nullglob
 fi
 
 echo "info: enabling transparent hugepages (always/always)" >&2

--- a/hosts/hestia/bench/memory/run.sh
+++ b/hosts/hestia/bench/memory/run.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# hestia memory benchmark host wrapper.
+#
+# Purpose:
+#   Apply host-level performance controls (CPU governor, transparent huge
+#   pages, page-cache drop) and run the containerized STREAM + Intel MLC
+#   benchmark. Intended for comparing 6-DIMM vs 8-DIMM populated configs
+#   on hestia (EPYC 8004 / Siena, 6-channel DDR5, TrueNAS SCALE host).
+#
+# Prerequisites:
+#   - Run as root (touches /sys, /proc/sys).
+#   - vLLM (or any GPU inference workload) must be stopped: the script
+#     verifies via midclt if available; if it reports RUNNING, the script
+#     refuses to continue.
+#   - Docker image hestia-memory-bench:1 already built locally.
+#   - $RESULTS_DIR (default /mnt/tank/bench/memory) writable.
+#
+# Usage:
+#   sudo ./run.sh 6dimm
+#   sudo RESULTS_DIR=/mnt/data/bench/memory ./run.sh 8dimm
+#
+# Output:
+#   ${RESULTS_DIR}/<label>-<utc-ts>.preflight.json   (host state snapshot)
+#   ${RESULTS_DIR}/<label>-<utc-ts>.jsonl            (STREAM + MLC events)
+#
+# Note: if your TrueNAS pool isn't named 'tank', override RESULTS_DIR.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Args
+# ----------------------------------------------------------------------------
+usage() {
+    cat >&2 <<EOF
+usage: $0 <label>
+  label: identifier for the run, e.g. 6dimm, 8dimm
+  env RESULTS_DIR: output directory (default: /mnt/tank/bench/memory)
+EOF
+}
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+    usage
+    exit 64
+fi
+LABEL="$1"
+
+RESULTS_DIR="${RESULTS_DIR:-/mnt/tank/bench/memory}"
+IMAGE="${IMAGE:-hestia-memory-bench:1}"
+
+# ----------------------------------------------------------------------------
+# Pre-checks
+# ----------------------------------------------------------------------------
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "error: must run as root (touches /sys and /proc/sys)" >&2
+    exit 77
+fi
+
+mkdir -p "${RESULTS_DIR}"
+TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+PREFLIGHT="${RESULTS_DIR}/${LABEL}-${TS}.preflight.json"
+
+# --- Verify vLLM is stopped ---
+if command -v midclt >/dev/null 2>&1; then
+    state="$(midclt call app.query '[["name","=","vllm"]]' 2>/dev/null \
+        | python3 -c 'import sys,json
+apps=json.load(sys.stdin)
+print(apps[0]["state"] if apps else "absent")' 2>/dev/null || echo "unknown")"
+    case "$state" in
+        RUNNING)
+            cat >&2 <<EOF
+error: vLLM app is RUNNING on hestia. Memory benchmark must not contend
+with GPU inference workloads for the host memory bus.
+
+Stop it first:
+    midclt call app.stop vllm
+    nvidia-smi   # verify GPU idle / no python processes attached
+
+Then re-run this script.
+EOF
+            exit 2
+            ;;
+        absent|STOPPED|CRASHED|DEPLOYING|"")
+            echo "info: vllm state=${state}; proceeding." >&2
+            ;;
+        *)
+            echo "warning: unrecognized vllm state '${state}'; proceeding anyway." >&2
+            ;;
+    esac
+else
+    echo "warning: midclt not found; skipping vLLM check (non-TrueNAS host?)." >&2
+fi
+
+# ----------------------------------------------------------------------------
+# Capture prior governor (for restoration on exit)
+# ----------------------------------------------------------------------------
+PRIOR_GOV=""
+if [[ -r /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ]]; then
+    PRIOR_GOV="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || true)"
+fi
+
+restore_governor() {
+    local target="${PRIOR_GOV:-ondemand}"
+    if [[ -z "$target" ]]; then
+        target="ondemand"
+    fi
+    echo "info: restoring CPU governor to ${target}" >&2
+    if command -v cpupower >/dev/null 2>&1; then
+        cpupower frequency-set -g "$target" >/dev/null 2>&1 || true
+    else
+        for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+            [[ -w "$f" ]] && echo "$target" > "$f" 2>/dev/null || true
+        done
+    fi
+}
+trap restore_governor EXIT
+
+# ----------------------------------------------------------------------------
+# Apply host controls
+# ----------------------------------------------------------------------------
+echo "info: setting CPU governor to performance" >&2
+if command -v cpupower >/dev/null 2>&1; then
+    cpupower frequency-set -g performance >/dev/null 2>&1 || {
+        echo "warning: cpupower failed; falling back to sysfs writes" >&2
+        for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+            [[ -w "$f" ]] && echo performance > "$f"
+        done
+    }
+else
+    echo "warning: cpupower not installed; using sysfs fallback" >&2
+    for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+        [[ -w "$f" ]] && echo performance > "$f"
+    done
+fi
+
+echo "info: enabling transparent hugepages (always/always)" >&2
+[[ -w /sys/kernel/mm/transparent_hugepage/enabled ]] \
+    && echo always > /sys/kernel/mm/transparent_hugepage/enabled || true
+[[ -w /sys/kernel/mm/transparent_hugepage/defrag ]] \
+    && echo always > /sys/kernel/mm/transparent_hugepage/defrag || true
+
+echo "info: dropping page caches" >&2
+sync
+[[ -w /proc/sys/vm/drop_caches ]] && echo 3 > /proc/sys/vm/drop_caches || true
+
+# ----------------------------------------------------------------------------
+# Preflight snapshot
+# ----------------------------------------------------------------------------
+echo "info: writing preflight snapshot to ${PREFLIGHT}" >&2
+
+dmidecode_mem=""
+if command -v dmidecode >/dev/null 2>&1; then
+    dmidecode_mem="$(dmidecode -t memory 2>/dev/null \
+        | grep -E "Locator|Size|Speed|Configured|Manufacturer|Part Number" || true)"
+else
+    dmidecode_mem="dmidecode not available"
+fi
+
+lscpu_out="$(lscpu 2>/dev/null || echo "lscpu not available")"
+numactl_out="$(numactl --hardware 2>/dev/null || echo "numactl not available")"
+cmdline_out="$(cat /proc/cmdline 2>/dev/null || echo "")"
+gov_out="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)"
+thp_out="$(cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || echo unknown)"
+thp_defrag_out="$(cat /sys/kernel/mm/transparent_hugepage/defrag 2>/dev/null || echo unknown)"
+
+nvidia_smi_out=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia_smi_out="$(nvidia-smi --query-gpu=name,utilization.gpu,memory.used --format=csv 2>/dev/null || echo "nvidia-smi failed")"
+else
+    nvidia_smi_out="nvidia-smi not available"
+fi
+
+# Build JSON via python3 to avoid hand-rolled escaping.
+export LABEL TS PRIOR_GOV GOV_OUT="$gov_out" THP_OUT="$thp_out" \
+    THP_DEFRAG_OUT="$thp_defrag_out" CMDLINE_OUT="$cmdline_out" \
+    DMIDECODE_MEM="$dmidecode_mem" LSCPU_OUT="$lscpu_out" \
+    NUMACTL_OUT="$numactl_out" NVIDIA_SMI_OUT="$nvidia_smi_out"
+
+python3 - "$PREFLIGHT" <<'PYEOF'
+import json, sys, os
+path = sys.argv[1]
+doc = {
+    "label": os.environ.get("LABEL", ""),
+    "ts": os.environ.get("TS", ""),
+    "prior_governor": os.environ.get("PRIOR_GOV", ""),
+    "applied": {
+        "governor": os.environ.get("GOV_OUT", ""),
+        "thp_enabled": os.environ.get("THP_OUT", ""),
+        "thp_defrag": os.environ.get("THP_DEFRAG_OUT", ""),
+    },
+    "cmdline": os.environ.get("CMDLINE_OUT", ""),
+    "dmidecode_memory": os.environ.get("DMIDECODE_MEM", "").splitlines(),
+    "lscpu": os.environ.get("LSCPU_OUT", "").splitlines(),
+    "numactl_hardware": os.environ.get("NUMACTL_OUT", "").splitlines(),
+    "nvidia_smi": os.environ.get("NVIDIA_SMI_OUT", "").splitlines(),
+}
+with open(path, "w") as f:
+    json.dump(doc, f, indent=2)
+PYEOF
+
+# ----------------------------------------------------------------------------
+# Run the container
+# ----------------------------------------------------------------------------
+echo "info: launching container ${IMAGE} for label=${LABEL}" >&2
+docker run --rm \
+    --privileged \
+    --network=host \
+    --ipc=host \
+    --pid=host \
+    -v "${RESULTS_DIR}:/results" \
+    "${IMAGE}" "${LABEL}"
+
+# ----------------------------------------------------------------------------
+# Report
+# ----------------------------------------------------------------------------
+latest="$(ls -1t "${RESULTS_DIR}/${LABEL}-"*.jsonl 2>/dev/null | head -n 1 || true)"
+if [[ -n "$latest" && -f "$latest" ]]; then
+    size="$(stat -c '%s' "$latest" 2>/dev/null || wc -c < "$latest")"
+    echo "result: ${latest} (${size} bytes)" >&2
+else
+    echo "warning: no JSONL file matching ${RESULTS_DIR}/${LABEL}-*.jsonl was produced" >&2
+fi


### PR DESCRIPTION
## Summary

Adds a containerized memory bandwidth + latency benchmark for hestia (ASRock SIENAD8-2L2T, EPYC 8004 / Siena, 6-channel DDR5 over 8 DIMM slots). Single-shot operator workflow to objectively compare **6 DIMM (1DPC × 6, full speed)** vs **8 DIMM (2 channels at 2DPC, derated speed)** configs and quantify the bandwidth-vs-capacity tradeoff.

- **STREAM** (McCalpin, compiled from source) for sustained bandwidth (Copy / Scale / Add / Triad)
- **Intel MLC v3.11a** for idle/loaded latency curve, max-bandwidth per access pattern
- Stdlib-only Python aggregator emits a markdown comparison table; headline is STREAM Triad Δ%
- Host wrapper applies and restores governor, THP, drop_caches; verifies vLLM is stopped first
- Methodology mirrors `scripts/llama-cpp-bench.py` (5 runs, mean ± stddev, JSONL)

No Flux / kustomize impact — operator-run scripts only, no manifests.

## Files

- `hosts/hestia/bench/memory/Dockerfile` — debian:bookworm-slim, compiles STREAM in-image; expects `mlc_v3.11a.tgz` in build context (gitignored)
- `hosts/hestia/bench/memory/entrypoint.sh` — in-container runner, structured JSONL output
- `hosts/hestia/bench/memory/run.sh` — host wrapper with preflight + control restoration
- `hosts/hestia/bench/memory/aggregate.py` — JSONL → markdown comparator
- `hosts/hestia/bench/memory/README.md` — operator runbook
- `hosts/hestia/bench/memory/.gitignore` — keeps the Intel binary tarball out of git
- `docs/plans/2026-05-15-hestia-memory-benchmark.md` — archived plan with hypothesis + verification checks

## Hypothesis (from the plan)

- 8 DIMM costs ~17–25% bandwidth vs 6 DIMM (the JEDEC speed-grade ratio)
- 8 DIMM may also raise idle latency by 2–5 ns from extra rank pressure
- Loaded-latency curve "knee" moves left for 8 DIMM (saturates earlier, lower peak)

## Test plan

- [x] All shell scripts pass `bash -n`
- [x] `aggregate.py` passes `python3 -m py_compile`
- [x] Aggregator smoke-tested with synthetic JSONL fixtures (24% Δ correctly computed)
- [x] `docker buildx build --check` clean
- [x] JSONL schema cross-verified: producer (`entrypoint.sh`) emits exactly the events the consumer (`aggregate.py`) reads
- [x] No plaintext secrets in diff
- [ ] Operator: download Intel MLC `mlc_v3.11a.tgz` and place in build context
- [ ] Operator: build the image on hestia (`docker build -t hestia-memory-bench:1 hosts/hestia/bench/memory/`)
- [ ] Operator: stop vLLM, run with current 6-DIMM config (`sudo ./run.sh 6dimm`), wall time ~45 min
- [ ] Operator: power down, add 2 DIMMs, verify BIOS-reported speed grade
- [ ] Operator: run with 8-DIMM config (`sudo ./run.sh 8dimm`)
- [ ] Operator: aggregate (`python3 aggregate.py ... > docs/research/2026-05-15-hestia-memory-bandwidth.md`)
- [ ] Operator: restart vLLM, smoke-test `curl http://10.42.2.10:8000/v1/models`
- [ ] Results writeup landed via follow-up PR

## Verification checks (after both runs)

1. STREAM Triad — 6 DIMM ≥ 8 DIMM by ≥10%
2. MLC idle latency — 8 DIMM higher by 2–5 ns
3. MLC loaded-latency curve — 8 DIMM knee moves left
4. Run-to-run stddev < 2% of mean (otherwise a control leaked)
5. BIOS-reported speed grade matches the JEDEC table for the platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)