### PR TITLE
feat(deploy-hestia): x-deploy.archived frontmatter + dynamic discovery

### DIFF
--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -87,8 +87,17 @@ jobs:
                   print(f"skip (runner self-deploy): {path}", file=sys.stderr)
                   continue
 
-              with open(path) as f:
-                  doc = yaml.safe_load(f) or {}
+              try:
+                  with open(path) as f:
+                      doc = yaml.safe_load(f) or {}
+              except yaml.YAMLError as e:
+                  # GHA already marks the step red on non-zero exit (which then
+                  # blocks `apply` via the implicit needs-succeeded gate), but
+                  # a plain traceback is operator-hostile. Surface the file +
+                  # YAML error inline before exiting.
+                  print(f"FAIL (yaml parse error): {path}", file=sys.stderr)
+                  print(f"  {e}", file=sys.stderr)
+                  sys.exit(1)
 
               deploy_meta = doc.get("x-deploy") or {}
               archived = deploy_meta.get("archived")

--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -2,16 +2,32 @@ name: Deploy hestia Custom Apps
 
 # Push-based auto-deploy of TrueNAS Custom App compose files.
 #
-# When `hosts/hestia/<app>/docker-compose*.yml` changes on master, the matching
-# matrix entry runs on the self-hosted runner on hestia and applies the new
-# compose to the TrueNAS Apps subsystem via the WebSocket API.
+# When `hosts/hestia/<dir>/docker-compose*.yml` changes on master, the
+# `discover` job enumerates every compose file under `hosts/hestia/**/` and
+# emits a matrix of non-archived apps. Each matrix entry runs on the
+# self-hosted runner on hestia and applies the compose to the TrueNAS Apps
+# subsystem via the WebSocket API.
 #
-# Adding a new app: add a matrix entry and ensure `<app-name>` matches the
-# Custom App name in SCALE UI exactly.
+# Per-file opt-out: add a top-level `x-deploy.archived: true` block to the
+# compose file. `x-*` keys are docker-compose extensions — compose itself
+# ignores them; only this workflow reads them. Example:
 #
-# Excluded: actions-runner itself (chicken-and-egg — the runner can't reliably
-# deploy a compose change that recreates its own container). Runner upgrades
-# stay manual.
+#     x-deploy:
+#       archived: true
+#       archived-at: 2026-05-16
+#       archived-reason: GPUs sold from hestia
+#       # name: foo  # optional override; defaults to derive-from-filename
+#
+#     services:
+#       ...
+#
+# App name derivation: `docker-compose-<name>.yml` → `<name>` (e.g.
+# `docker-compose-llama-cpp.yml` → `llama-cpp`). For a plain `docker-compose.yml`,
+# the parent directory name is used. Override with `x-deploy.name`.
+#
+# Excluded unconditionally: `hosts/hestia/actions-runner/` (chicken-and-egg —
+# the runner can't reliably deploy a compose change that recreates its own
+# container). Runner upgrades stay manual.
 #
 # See: docs/plans/2026-05-02-hestia-gha-runner.md
 
@@ -20,18 +36,15 @@ on:
     branches: [master]
     paths:
       - 'hosts/hestia/**/docker-compose*.yml'
+      - '.github/workflows/deploy-hestia.yml'
+      - 'scripts/truenas-update-app.sh'
   workflow_dispatch:
     inputs:
       app:
-        description: 'Which app to redeploy (matches matrix entry name)'
+        description: 'Which app to redeploy (empty / "all" = every non-archived app)'
         required: false
-        type: choice
+        type: string
         default: all
-        options:
-          - all
-          - llama-cpp
-          - thermalscope
-          - ipmi-exporter
       dry_run:
         description: 'Connect, query, and diff without calling app.update'
         required: false
@@ -43,18 +56,78 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      count: ${{ steps.gen.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enumerate non-archived compose files
+        id: gen
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import glob
+          import json
+          import os
+          import sys
+
+          try:
+              import yaml
+          except ImportError:
+              os.system("pip install --quiet pyyaml >&2")
+              import yaml
+
+          entries = []
+          for path in sorted(glob.glob("hosts/hestia/**/docker-compose*.yml", recursive=True)):
+              # actions-runner deploys itself — exclude unconditionally.
+              if path.startswith("hosts/hestia/actions-runner/"):
+                  print(f"skip (runner self-deploy): {path}", file=sys.stderr)
+                  continue
+
+              with open(path) as f:
+                  doc = yaml.safe_load(f) or {}
+
+              deploy_meta = doc.get("x-deploy") or {}
+              if deploy_meta.get("archived"):
+                  reason = deploy_meta.get("archived-reason", "no reason given")
+                  print(f"skip (archived): {path}  reason={reason}", file=sys.stderr)
+                  continue
+
+              fname = os.path.basename(path)
+              if fname.startswith("docker-compose-") and fname.endswith(".yml"):
+                  default_name = fname[len("docker-compose-"):-len(".yml")]
+              else:
+                  default_name = os.path.basename(os.path.dirname(path))
+              name = deploy_meta.get("name") or default_name
+
+              entries.append({"name": name, "file": path})
+              print(f"include: name={name}  file={path}", file=sys.stderr)
+
+          matrix = {"include": entries}
+          print(f"matrix={json.dumps(matrix)}")
+          print(f"count={len(entries)}")
+          PY
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Discovered apps"
+            echo ""
+            echo "- Count: \`${{ steps.gen.outputs.count }}\`"
+            echo "- Matrix: \`${{ steps.gen.outputs.matrix }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   apply:
+    needs: discover
+    if: needs.discover.outputs.count != '0'
     runs-on: [self-hosted, hestia]
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: llama-cpp
-            file: hosts/hestia/llms/docker-compose-llama-cpp.yml
-          - name: thermalscope
-            file: hosts/hestia/monitoring/docker-compose.yml
-          - name: ipmi-exporter
-            file: hosts/hestia/monitoring/docker-compose-ipmi-exporter.yml
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +135,7 @@ jobs:
       - name: Skip if workflow_dispatch targeted a different app
         if: |
           github.event_name == 'workflow_dispatch' &&
+          inputs.app != '' &&
           inputs.app != 'all' &&
           inputs.app != matrix.name
         run: |

--- a/.github/workflows/deploy-hestia.yml
+++ b/.github/workflows/deploy-hestia.yml
@@ -91,10 +91,21 @@ jobs:
                   doc = yaml.safe_load(f) or {}
 
               deploy_meta = doc.get("x-deploy") or {}
-              if deploy_meta.get("archived"):
+              archived = deploy_meta.get("archived")
+              # Strict `is True` so a string "false" (common YAML mistake — quoted
+              # bools become strings, and any non-empty string is truthy) doesn't
+              # silently skip an app. We require a YAML bool `true`.
+              if archived is True:
                   reason = deploy_meta.get("archived-reason", "no reason given")
                   print(f"skip (archived): {path}  reason={reason}", file=sys.stderr)
                   continue
+              if archived is not None and archived is not False:
+                  print(
+                      f"FAIL (bad x-deploy.archived value): {path}  got={archived!r}; "
+                      "must be a YAML bool (true / false), not a string or number.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
 
               fname = os.path.basename(path)
               if fname.startswith("docker-compose-") and fname.endswith(".yml"):

--- a/hosts/hestia/README.md
+++ b/hosts/hestia/README.md
@@ -31,7 +31,23 @@ edits to `hosts/hestia/<app>/docker-compose*.yml` are applied automatically:
 4. The self-hosted runner on hestia executes [`scripts/truenas-update-app.sh`](../../scripts/truenas-update-app.sh), which calls TrueNAS's WebSocket `app.update` API with the new compose. The corresponding container restarts.
 5. Verify via the workflow run in GitHub Actions and `docker ps` on hestia.
 
-**Adding a new app**: drop `hosts/hestia/<new-app>/docker-compose.yml` in this tree, then add a matrix entry in `.github/workflows/deploy-hestia.yml` whose `name:` matches the Custom App name in SCALE UI exactly. The first deploy of a brand-new app still needs the operator to paste the compose into SCALE UI once (chicken-and-egg — the runner can't create an app that doesn't yet exist, only update one). Subsequent edits flow through the runner.
+**Adding a new app**: drop `hosts/hestia/<new-app>/docker-compose-<new-app>.yml` in this tree — no workflow edit needed. The `discover` job in `.github/workflows/deploy-hestia.yml` enumerates `hosts/hestia/**/docker-compose*.yml` on every run and derives the SCALE app name from the filename suffix (`docker-compose-foo.yml` → `foo`). The first deploy of a brand-new app still needs the operator to paste the compose into SCALE UI once (chicken-and-egg — the runner can't create an app that doesn't yet exist, only update one). Subsequent edits flow through the runner automatically.
+
+**Optional `x-deploy:` block** (docker-compose extension key — compose itself ignores `x-*` keys) lets a compose file control deploy behavior:
+
+```yaml
+x-deploy:
+  archived: true              # bool — must be a YAML true/false, not a string. Skips deploy.
+  archived-at: 2026-05-16     # for posterity; surfaced in the workflow run log
+  archived-reason: GPUs sold from hestia
+  name: thermalscope          # optional — override the filename-derived app name
+                              # (needed when the file is plain docker-compose.yml)
+
+services:
+  ...
+```
+
+Toggle `archived: true` ↔ `false` to deactivate / re-activate an app without removing the compose file from the repo.
 
 **Excluded from the workflow**: the runner itself (`actions-runner/`). A compose change that recreates the runner's own container would kill the workflow mid-flight. Runner upgrades stay manual.
 

--- a/hosts/hestia/llms/docker-compose-llama-cpp.yml
+++ b/hosts/hestia/llms/docker-compose-llama-cpp.yml
@@ -11,6 +11,14 @@
 #   medium-workload TTFT 0.071 s, decode 173.9 t/s, VRAM peak 22.3 GiB
 # vLLM v0.20.1 measurement on the same model family beats this:
 #   TTFT 0.090 s, decode 194.3 t/s, plus 626 t/s aggregate at concurrency 8.
+x-deploy:
+  # Archived 2026-05-16 — GPUs removed from hestia. Already retired in favour
+  # of vLLM in May 2026, but the compose stayed in the matrix as a fallback.
+  # Now fully decommissioned; flip `archived: false` to re-activate.
+  archived: true
+  archived-at: 2026-05-16
+  archived-reason: GPUs sold from hestia
+
 services:
   llama:
     image: ghcr.io/gjcourt/llama-cpp-bench:2026-05-04

--- a/hosts/hestia/llms/docker-compose-vllm-experiment.yml
+++ b/hosts/hestia/llms/docker-compose-vllm-experiment.yml
@@ -33,6 +33,14 @@
 #   midclt call app.redeploy vllm   # prefer over app.start; avoids stuck DEPLOYING states
 #
 # Production llama-cpp on the same port 8000 must be stopped first.
+x-deploy:
+  # Archived 2026-05-16 — GPUs removed from hestia. Experiments compose is
+  # kept in place so future vLLM frontier-model tuning can resume by
+  # flipping `archived: false` once GPUs are back.
+  archived: true
+  archived-at: 2026-05-16
+  archived-reason: GPUs sold from hestia
+
 services:
   vllm:
     command:

--- a/hosts/hestia/llms/docker-compose-vllm.yml
+++ b/hosts/hestia/llms/docker-compose-vllm.yml
@@ -27,6 +27,15 @@
 # To deploy this compose: paste into the vllm SCALE app's custom_compose_config
 # via midclt or the Apps UI. The llama-cpp SCALE app must be stopped first
 # (port 8000 conflict).
+x-deploy:
+  # Archived 2026-05-16 — both RTX 4090s removed from hestia. The vLLM
+  # SCALE app has been deleted via `midclt call app.delete vllm`. This
+  # compose remains in place for fast re-activation if GPUs return: flip
+  # `archived: false` and the deploy workflow will pick it up again.
+  archived: true
+  archived-at: 2026-05-16
+  archived-reason: GPUs sold from hestia
+
 services:
   vllm:
     command:

--- a/hosts/hestia/monitoring/docker-compose-nvtop.yml
+++ b/hosts/hestia/monitoring/docker-compose-nvtop.yml
@@ -1,3 +1,10 @@
+x-deploy:
+  # Archived 2026-05-16 — GPUs removed from hestia. nvtop has nothing to
+  # report. Flip `archived: false` to re-activate when GPUs return.
+  archived: true
+  archived-at: 2026-05-16
+  archived-reason: GPUs sold from hestia
+
 services:
   nvtop:
     image: onmoon/nvtop

--- a/hosts/hestia/monitoring/docker-compose.yml
+++ b/hosts/hestia/monitoring/docker-compose.yml
@@ -12,6 +12,18 @@
 # (gcr.io/distroless/static-debian12) has no shell and no curl/wget — any
 # CMD-SHELL test would always fail. Prometheus's up{job="thermalscope"}
 # scrape success is the real health signal.
+x-deploy:
+  # Filename is `docker-compose.yml` (no app suffix), so the deploy
+  # workflow's default name would be the parent dir ("monitoring").
+  # Override explicitly to match the actual SCALE app name.
+  name: thermalscope
+  # Archived 2026-05-16 — thermalscope mounts /usr/bin/nvidia-smi from the
+  # host to scrape GPU temp/power; with GPUs removed, the binary is gone and
+  # the container will crash-loop. Flip `archived: false` once GPUs return.
+  archived: true
+  archived-at: 2026-05-16
+  archived-reason: GPUs sold from hestia (nvidia-smi unavailable)
+
 services:
   thermalscope:
     image: ghcr.io/gjcourt/thermalscope:d470623


### PR DESCRIPTION
## Summary

Two-part change so dead-but-not-deleted compose files can live in place, ready to re-activate:

1. **Per-file opt-out via `x-deploy.archived`** — docker-compose's standard `x-*` extension namespace is parsed by this workflow but ignored by compose itself.
2. **Dynamic matrix discovery** — replaces the hard-coded matrix in \`deploy-hestia.yml\` with a job that enumerates \`hosts/hestia/**/docker-compose*.yml\` and filters out anything archived.

Archives all 5 GPU-dependent compose files (vllm × 2, llama-cpp, nvtop, thermalscope) since the 4090s were sold from hestia today. Re-activation is a one-line flip (\`archived: true\` → \`archived: false\`) rather than a restore-from-history round-trip.

## How the frontmatter works

```yaml
x-deploy:
  archived: true
  archived-at: 2026-05-16
  archived-reason: GPUs sold from hestia
  # name: foo  # optional override; defaults to derive-from-filename

services:
  ...
```

App name derivation (when \`x-deploy.name\` is absent):
- \`docker-compose-<name>.yml\` → \`<name>\` (e.g. \`docker-compose-llama-cpp.yml\` → \`llama-cpp\`)
- \`docker-compose.yml\` → parent directory name (override usually needed; thermalscope uses this)

## Files

**Workflow**
- \`.github/workflows/deploy-hestia.yml\` — new \`discover\` job + dynamic matrix; \`workflow_dispatch.app\` changes from \`choice\` to \`string\` since the list can no longer be statically maintained; \`apply\` gated on \`count != '0'\` so an all-archived set doesn't fail the run

**Archived compose files** (all 5 archived, reason \"GPUs sold from hestia\")
- \`hosts/hestia/llms/docker-compose-vllm.yml\`
- \`hosts/hestia/llms/docker-compose-vllm-experiment.yml\`
- \`hosts/hestia/llms/docker-compose-llama-cpp.yml\`
- \`hosts/hestia/monitoring/docker-compose-nvtop.yml\`
- \`hosts/hestia/monitoring/docker-compose.yml\` (thermalscope — also gets \`name: thermalscope\` override since the filename has no app suffix)

## Test plan

- [x] All 7 YAMLs parse cleanly under \`yaml.safe_load\`
- [x] Local dry-run of the discover script: 1 included (\`ipmi-exporter\`), 1 runner skipped, 5 archived skipped — matches intent
- [ ] On merge: the \`discover\` job should fire from \`paths:\` filter and produce \`matrix={\"include\": [{\"name\": \"ipmi-exporter\", ...}]}\` with \`count=1\`
- [ ] \`apply\` job runs only \`ipmi-exporter\` (no behavior change for it)
- [ ] \`workflow_dispatch\` with \`app=ipmi-exporter\` works
- [ ] \`workflow_dispatch\` with \`app=all\` works (current behavior preserved)

## Re-activation

Just flip the flag:

\`\`\`yaml
x-deploy:
  archived: false   # was: true
\`\`\`

Next push to master picks it up automatically. No matrix edit required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)