### PR TITLE
chore(storage): migrate Loki + immich-stage model-cache to truenas-iscsi

### DIFF
--- a/apps/staging/immich/storage.yaml
+++ b/apps/staging/immich/storage.yaml
@@ -25,6 +25,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 10Gi

--- a/infra/controllers/loki/values.yaml
+++ b/infra/controllers/loki/values.yaml
@@ -54,7 +54,7 @@ singleBinary:
   replicas: 1
   persistence:
     enabled: true
-    storageClass: synology-iscsi
+    storageClass: truenas-iscsi
     size: 40Gi
   resources:
     limits:


### PR DESCRIPTION
## Summary

Phase 1.1 step 1 of the alcatraz → hestia migration ([docs/plans/2026-05-20-alcatraz-to-hestia-migration.md](../blob/master/docs/plans/2026-05-20-alcatraz-to-hestia-migration.md)). Moves the two PVCs whose contents are **explicitly discardable** — no data copy required.

| PVC | Size | Old SC | New SC | Why safe to discard |
|---|---|---|---|---|
| `monitoring/storage-loki-0` | 40 GiB | synology-iscsi | truenas-iscsi | Log buffers regenerate from running workloads (~hours to backfill) |
| `immich-stage/immich-model-cache-pvc` | 10 GiB | synology-iscsi | truenas-iscsi | Model artifacts re-download from HuggingFace on immich-ml cold start (~minutes) |

Production immich model-cache (20 GiB) **intentionally not migrated here** — stays on synology-iscsi until Phase 1.2.

## Why post-merge ops are needed

Both PVCs are immutable on `storageClassName`. The manifest change alone won't trigger storage migration; Flux will report an "immutable field" error and keep using the old PVC. Post-merge, I'll:

1. **Loki** — `kubectl scale sts loki -n monitoring --replicas=0`, `kubectl delete sts loki -n monitoring --cascade=orphan`, `kubectl delete pvc storage-loki-0 -n monitoring`, `flux reconcile helmrelease loki -n monitoring`. New STS + PVC come up on truenas-iscsi.
2. **Immich-stage** — `kubectl scale deploy immich-machine-learning -n immich-stage --replicas=0`, `kubectl delete pvc immich-model-cache-pvc -n immich-stage`, `flux reconcile kustomization apps-staging -n flux-system`, `kubectl scale deploy immich-machine-learning -n immich-stage --replicas=1`.

## Test plan

- [x] `kustomize build infra/controllers` passes
- [x] `kustomize build apps/staging/immich` passes
- [x] Production immich storage.yaml unchanged (stays on synology-iscsi)
- [ ] **Post-merge**: PVCs reconciled on truenas-iscsi (verification commands in commit message)
- [ ] **Post-merge**: Loki accepting new log streams from promtail within 5 min
- [ ] **Post-merge**: immich-stage `/api/server-info/ping` returns OK + ML container ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)