### PR TITLE
chore(cnpg): migrate 5 staging clusters to truenas-iscsi

### DIFF
--- a/apps/staging/golinks/database.yaml
+++ b/apps/staging/golinks/database.yaml
@@ -25,6 +25,7 @@ spec:
         matchLabels:
           policy-type: database
   storage:
+    storageClass: truenas-iscsi
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -24,6 +24,7 @@ spec:
 
   storage:
     # Expanded from 10Gi to 20Gi after filling up (pgdata ~9.5Gi as of 2026-04-17).
+    storageClass: truenas-iscsi
     size: 20Gi
 
   resources:

--- a/apps/staging/linkding/database.yaml
+++ b/apps/staging/linkding/database.yaml
@@ -31,6 +31,7 @@ spec:
           policy-type: database
 
   storage:
+    storageClass: truenas-iscsi
     size: 2Gi
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/staging/memos/database.yaml
+++ b/apps/staging/memos/database.yaml
@@ -33,6 +33,7 @@ spec:
   storage:
     # Actual usage: ~634Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
+    storageClass: truenas-iscsi
     size: 1Gi
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/staging/vitals/database.yaml
+++ b/apps/staging/vitals/database.yaml
@@ -25,6 +25,7 @@ spec:
         matchLabels:
           policy-type: database
   storage:
+    storageClass: truenas-iscsi
     size: 2Gi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).


### PR DESCRIPTION
## Summary

Phase 1.1 step 2 of the [alcatraz → hestia migration](../blob/master/docs/plans/2026-05-20-alcatraz-to-hestia-migration.md). Adds explicit `storageClass: truenas-iscsi` to the `.spec.storage` block of every staging CNPG Cluster CR.

| Cluster | Replicas | Size each | Total |
|---|---|---|---|
| golinks-db-staging-cnpg-v1 | 3 | 2 GiB | 6 GiB |
| linkding-db-staging-cnpg-v1 | 3 | 2 GiB | 6 GiB |
| memos-db-staging-cnpg-v1 | 3 | 1 GiB | 3 GiB |
| vitals-db-staging-cnpg-v1 | 3 | 2 GiB | 6 GiB |
| immich-db-staging-cnpg-v1 | 3 | 20 GiB | 60 GiB |
| **Total** | **15 PVCs** | | **~81 GiB** |

## Post-merge runbook

The manifest change alone doesn't migrate existing PVCs (storageClassName is immutable). Same pattern proven on flashcards-stage earlier this conversation:

```bash
# For each cluster, one replica at a time:
kubectl cnpg destroy <cluster> <id> -n <ns>
# Wait for the new instance to appear (cnpg-v1-N+1) and reach Ready
# Then destroy the next replica
# Finally, promote a new-SC replica and destroy the old primary
```

Order I'll execute: smallest → largest, so any operator surprises surface on cheap clusters first.
1. memos-stage (3 GiB) → 2. linkding-stage (6 GiB) → 3. golinks-stage (6 GiB) → 4. vitals-stage (6 GiB) → 5. immich-stage (60 GiB)

Per-cluster: ~3-5 min of operator time (basebackup from primary), brief 2/3 ready state per replica step.

## Test plan

- [x] `kustomize build apps/staging/{golinks,linkding,memos,vitals,immich}` all pass
- [x] No changes to production CNPG clusters (deferred to Phase 1.2)
- [ ] **Post-merge**: each cluster reports `readyInstances == 3` and all PVCs on `truenas-iscsi`
- [ ] **Post-merge**: each cluster's S3 backup (Barman Cloud Plugin) is still completing — verify `ContinuousArchiving=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)