### PR TITLE
chore(storage): mark 7 preserve staging PVCs for truenas-iscsi (pv-migrate to follow)

### DIFF
--- a/apps/base/audiobookshelf/storage.yaml
+++ b/apps/base/audiobookshelf/storage.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: audiobookshelf
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:
@@ -22,6 +23,7 @@ metadata:
   labels:
     app: audiobookshelf
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/base/homeassistant/storage.yaml
+++ b/apps/base/homeassistant/storage.yaml
@@ -4,6 +4,7 @@ metadata:
   name: homeassistant-config-pvc
   namespace: homeassistant
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/base/mealie/storage.yaml
+++ b/apps/base/mealie/storage.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: mealie
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/base/signal-cli/storage.yaml
+++ b/apps/base/signal-cli/storage.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: signal-cli
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
-  storageClassName: synology-iscsi
   resources:
     requests:
       storage: 1Gi

--- a/apps/staging/immich/storage.yaml
+++ b/apps/staging/immich/storage.yaml
@@ -8,6 +8,7 @@ metadata:
     app: immich
     env: staging
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/staging/jellyfin/storage.yaml
+++ b/apps/staging/jellyfin/storage.yaml
@@ -8,6 +8,7 @@ metadata:
     app: jellyfin
     env: staging
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
## Summary

Phase 1.1 step 3b. Adds `storageClassName: truenas-iscsi` to the 7 staging PVC manifests whose contents must be preserved (versus the 13 lossy PVCs in PR #753 which got delete-and-recreate).

| PVC | Size | What's in it |
|---|---|---|
| audiobookshelf-data-pvc | 1 GiB | audiobook library scan cache (rescan takes hours) |
| audiobookshelf-meta-data-pvc | 1 GiB | per-book metadata (cover art, descriptions) |
| homeassistant-config-pvc | 1 GiB | automations, integrations, history DB |
| immich-upload-pvc (stage) | 100 GiB | active staging uploads |
| jellyfin-config-pvc (stage) | 5 GiB | library DB, watch history, user state |
| mealie-data-pvc | 1 GiB | uploaded recipe images |
| signal-cli-config (stage) | 1 GiB | Signal account auth state |

**Total**: ~109 GiB of data to copy. Largest single PVC is immich-upload at 100 GiB (~20–40 min on LAN).

## Post-merge runbook (per PVC)

```bash
# 1. Scale workload to 0
kubectl scale deploy/<dep> -n <ns> --replicas=0

# 2. pv-migrate to a temp PVC on truenas-iscsi
kubectl pv-migrate migrate <orig> <orig>-tmp \
  -n <ns> --dest-storage-class truenas-iscsi

# 3. Delete original (Retain PV preserves data briefly as safety net)
kubectl delete pvc <orig> -n <ns>

# 4. Force Flux reconcile — creates new <orig> on truenas-iscsi (EMPTY)
flux reconcile kustomization apps-staging -n flux-system

# 5. pv-migrate back: temp → new orig
kubectl pv-migrate migrate <orig>-tmp <orig> -n <ns>

# 6. Delete temp PVC
kubectl delete pvc <orig>-tmp -n <ns>

# 7. Scale workload back up
kubectl scale deploy/<dep> -n <ns> --replicas=1
```

For audiobookshelf which has 2 PVCs, both must be handled before the deployment is scaled back up.

## Test plan

- [x] `kustomize build` passes for all affected overlays
- [x] No duplicate `storageClassName` lines (cleaned up legacy synology line in signal-cli)
- [ ] **Post-merge**: each PVC migrated; original data intact; app working

🤖 Generated with [Claude Code](https://claude.com/claude-code)