### PR TITLE
chore(storage): repoint jellyfin + navidrome NFS PVs to hestia

### DIFF
--- a/apps/base/jellyfin/media/nfs-media.yaml
+++ b/apps/base/jellyfin/media/nfs-media.yaml
@@ -14,8 +14,8 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/video/movies
+    server: 10.42.2.10
+    path: /mnt/main/media/movies
     readOnly: true
   mountOptions:
     - nfsvers=3
@@ -57,8 +57,8 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/video/tv-shows
+    server: 10.42.2.10
+    path: /mnt/main/media/tv-shows
     readOnly: true
   mountOptions:
     - nfsvers=3
@@ -100,8 +100,8 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/video/tv-anime
+    server: 10.42.2.10
+    path: /mnt/main/media/tv-anime
     readOnly: true
   mountOptions:
     - nfsvers=3

--- a/apps/production/navidrome/nfs-music.yaml
+++ b/apps/production/navidrome/nfs-music.yaml
@@ -30,8 +30,8 @@ spec:
     - retrans=2
     - nolock
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/audio/music
+    server: 10.42.2.10
+    path: /mnt/main/media/music
     readOnly: true
 ---
 apiVersion: v1

--- a/apps/staging/navidrome/nfs-music.yaml
+++ b/apps/staging/navidrome/nfs-music.yaml
@@ -30,8 +30,8 @@ spec:
     - retrans=2
     - nolock
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/audio/music
+    server: 10.42.2.10
+    path: /mnt/main/media/music
     readOnly: true
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary

Phase 1.1 step 4 of the [alcatraz → hestia migration](../blob/master/docs/plans/2026-05-20-alcatraz-to-hestia-migration.md). Repoints 10 static NFS PVs (jellyfin movies/tv-shows/tv-anime × both envs + navidrome music × both envs) from alcatraz (`10.42.2.11`) to hestia (`10.42.2.10`).

Data was rsync'd to hestia datasets `main/media/{movies,tv-shows,tv-anime,music}` over the past two days. Final delta-sync today:
- **movies**: +3.87 GB new files, 1.15 TiB total on hestia
- **tv-anime**: ~0 deltas (68 GiB stable)
- **music**: ~0 deltas (35 GiB stable)
- **tv-shows**: empty on source (no data)

| PV | Old NFS source | New NFS source |
|---|---|---|
| jellyfin-movies-pv-{prod,staging} | alcatraz:/volume1/family/video/movies | hestia:/mnt/main/media/movies |
| jellyfin-tvshows-pv-{prod,staging} | alcatraz:.../tv-shows | hestia:.../tv-shows |
| jellyfin-tvanime-pv-{prod,staging} | alcatraz:.../tv-anime | hestia:.../tv-anime |
| navidrome-music-pv-{prod,stage} | alcatraz:.../audio/music | hestia:.../music |

`immich-photos-pv-{prod,staging}` is **intentionally NOT touched** — photos stay on alcatraz as the primary source; Phase 2 of the plan handles photo backup separately.

## Post-merge runbook

`nfs.server` and `nfs.path` are immutable on existing PVs. Manifest change alone is a no-op until we destroy-and-recreate the PVs.

```bash
# 1. Suspend Flux (per feedback_flux_suspend_during_cluster_ops memory)
flux suspend kustomization apps-staging -n flux-system
flux suspend kustomization apps-production -n flux-system

# 2. Scale jellyfin + navidrome down in both envs
for env in stage prod; do
  kubectl scale deploy/jellyfin -n jellyfin-$env --replicas=0
  kubectl scale deploy/navidrome -n navidrome-$env --replicas=0
done

# 3. Delete 10 PVCs + 10 PVs
for env in stage prod; do
  kubectl delete pvc -n jellyfin-$env jellyfin-movies-pvc jellyfin-tvshows-pvc jellyfin-tvanime-pvc
  kubectl delete pvc -n navidrome-$env navidrome-music-pvc
done
kubectl delete pv jellyfin-movies-pv-prod jellyfin-movies-pv-staging \
                  jellyfin-tvshows-pv-prod jellyfin-tvshows-pv-staging \
                  jellyfin-tvanime-pv-prod jellyfin-tvanime-pv-staging \
                  navidrome-music-pv-prod navidrome-music-pv-stage

# 4. Resume Flux (recreates PVs + PVCs on hestia)
flux resume kustomization apps-staging -n flux-system
flux resume kustomization apps-production -n flux-system

# 5. Scale up + verify
for env in stage prod; do
  kubectl scale deploy/jellyfin -n jellyfin-$env --replicas=1
  kubectl scale deploy/navidrome -n navidrome-$env --replicas=1
done
```

## Test plan

- [x] `kustomize build` passes for 4 overlays (jellyfin {stage,prod}, navidrome {stage,prod})
- [x] `nfs.server: 10.42.2.10` in all changed manifests; no remaining `10.42.2.11` in changed files
- [x] immich-photos-pv-* untouched (verified via `git diff`)
- [ ] **Post-merge**: Jellyfin library scan completes without I/O errors on prod
- [ ] **Post-merge**: Navidrome music library reachable, playback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)