### PR TITLE
chore(storage): pin jellyfin prod PVCs to truenas-iscsi

### DIFF
--- a/apps/production/jellyfin/storage.yaml
+++ b/apps/production/jellyfin/storage.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       # Actual usage: ~227Mi. Jellyfin 10.11+ requires 2GiB free in /config/data;
@@ -27,7 +28,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synology-iscsi
+  storageClassName: truenas-iscsi
   resources:
     requests:
       # Actual usage: ~32Mi. Jellyfin 10.11+ requires 2GiB free in /cache;


### PR DESCRIPTION
## Summary
- Pin `jellyfin-config-pvc` and `jellyfin-cache-pvc` to `storageClassName: truenas-iscsi` (config was relying on cluster default = synology-iscsi; cache was explicitly synology-iscsi).
- Unblocks `apps-production` Flux Kustomization which is failing the strategic-merge dry-run for these two PVCs because the live cluster PVCs were rebound to truenas PVs but the manifests didn't pin the class.

## Background
Part of the alcatraz → hestia migration. The 13 preserve PVCs were data-migrated and rebound to truenas-iscsi PVs via claimRef pre-binding. For most apps the production overlay already pinned `storageClassName: truenas-iscsi` so Flux's reconcile matched cleanly; jellyfin's two PVCs were the outliers.

`immich-upload-pvc` and `immich-model-cache-pvc` are intentionally **not** changed here — they're still on synology and will get pinned in the PR that performs the actual data migration.

## Test plan
- [x] `kustomize build apps/production/jellyfin` renders both PVCs with `storageClassName: truenas-iscsi`
- [ ] After merge: `flux reconcile kustomization apps-production -n flux-system` returns READY=True
- [ ] After merge: `kubectl get pvc -n jellyfin-prod jellyfin-cache-pvc` shows it's been recreated on truenas-iscsi (manual cluster cleanup of the existing synology-bound jellyfin-cache PVC required after the manifest lands)