### PR TITLE
chore(storage): pin mosquitto + zigbee2mqtt PVCs to truenas-iscsi

### DIFF
--- a/infra/controllers/mosquitto/storage.yaml
+++ b/infra/controllers/mosquitto/storage.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 1Gi

--- a/infra/controllers/zigbee2mqtt/storage.yaml
+++ b/infra/controllers/zigbee2mqtt/storage.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
## Summary
Pin `storageClassName: truenas-iscsi` on the two infra-controllers PVCs that previously had no SC (silently picking up the cluster default `synology-iscsi`).

## Background
Companion to #772 (which pinned the jellyfin prod PVCs). The mosquitto and zigbee2mqtt PVCs were data-migrated to truenas PVs in the same session, rebound via PV `claimRef` pre-binding. Pinning the manifest avoids any future drift between cluster spec and Git.

Cluster prep already done before this PR opened: live PVCs now show `storageClassName: truenas-iscsi` matching this manifest, so the merge will be a no-op for the cluster.

## Test plan
- [x] `kustomize build infra/controllers` renders both PVCs with `storageClassName: truenas-iscsi`
- [ ] After merge: `flux reconcile kustomization infra-controllers` returns READY=True (currently suspended — will be resumed after merge)