### PR TITLE
chore(storage): pin prod CNPG cluster storage to truenas-iscsi

### DIFF
--- a/apps/production/golinks/database.yaml
+++ b/apps/production/golinks/database.yaml
@@ -48,6 +48,7 @@ spec:
     # Actual usage: ~488Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 1Gi
+    storageClass: truenas-iscsi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -21,6 +21,7 @@ spec:
     # Actual usage: ~994Mi; target = 20% headroom → 2Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 2Gi
+    storageClass: truenas-iscsi
   postgresql:
     shared_preload_libraries:
       - "vectors.so"

--- a/apps/production/linkding/database.yaml
+++ b/apps/production/linkding/database.yaml
@@ -34,6 +34,7 @@ spec:
     # Actual usage: ~602Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 1Gi
+    storageClass: truenas-iscsi
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).

--- a/apps/production/memos/database.yaml
+++ b/apps/production/memos/database.yaml
@@ -34,6 +34,7 @@ spec:
     # Actual usage: ~633Mi; target = 20% headroom → 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 1Gi
+    storageClass: truenas-iscsi
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).

--- a/apps/production/vitals/database.yaml
+++ b/apps/production/vitals/database.yaml
@@ -28,6 +28,7 @@ spec:
     # Actual usage: ~178Mi; minimum LUN size on Synology iSCSI is 1Gi.
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 1Gi
+    storageClass: truenas-iscsi
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:


### PR DESCRIPTION
## Summary
Add `storageClass: truenas-iscsi` to `spec.storage` on the 5 production CNPG Cluster resources (golinks, linkding, memos, vitals, immich).

## Behavior
The field is **mutable** on a CNPG Cluster — applying this change does not modify the 15 existing instance PVCs (they stay on `synology-iscsi`). The operator only uses the new class for **new** PVCs (during a destroy/recreate, scale-up, or instance recovery).

## Follow-up (Phase 1.2b execution, not in this PR)
For each cluster, one at a time, after this lands:
1. Verify fresh base backup + ContinuousArchiving=True
2. Destroy a standby instance (e.g. `kubectl cnpg destroy -n <ns> <cluster> <N>`) — operator recreates the standby on truenas-iscsi
3. Wait for streaming replication to catch up
4. Repeat for each remaining standby
5. Switchover from old synology primary to a truenas standby
6. Destroy old primary instance → re-created as truenas standby

## Test plan
- [x] `kustomize build` passes for all 5 production overlays
- [ ] After merge: `flux reconcile kustomization apps-production` returns READY=True
- [ ] After merge: verify cluster status unchanged (existing PVCs remain synology, no in-place migration)
- [ ] Phase 1.2b follow-up: per-cluster manual rebootstrap operations