### PR TITLE
chore(storage): pin immich prod PVCs to truenas-iscsi

### DIFF
--- a/apps/production/immich/storage.yaml
+++ b/apps/production/immich/storage.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 500Gi
@@ -25,6 +26,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 20Gi


### PR DESCRIPTION
## Summary
Pin `storageClassName: truenas-iscsi` on `immich-upload-pvc` (500Gi) and `immich-model-cache-pvc` (20Gi).

## Coordination
This PR is paired with an in-flight cluster migration:
- `immich-upload-pvc` (500Gi): claimRef pre-binding to a new truenas PV after long rsync (~1-3 hours)
- `immich-model-cache-pvc` (20Gi): lossy destroy + recreate (model cache regenerates on next inference)

**Hold this PR open** until both PVCs are bound to truenas PVs in-cluster. Merging early triggers an immutable-spec error on the live synology-backed PVCs.

## Test plan
- [x] `kustomize build apps/production/immich` renders both PVCs with `storageClassName: truenas-iscsi`
- [ ] Cluster prep done: `kubectl get pvc -n immich-prod | grep -c synology-iscsi` returns 0
- [ ] After merge: `flux reconcile kustomization apps-production` returns READY=True