### PR TITLE
feat(backup): immich-photos daily rsync from alcatraz → hestia

### DIFF
--- a/hosts/hestia/backup/README.md
+++ b/hosts/hestia/backup/README.md
@@ -1,0 +1,91 @@
+# hestia backup scripts
+
+Source of truth for daily backup jobs that run on hestia (TrueNAS Scale) and
+pull data from external hosts into local ZFS datasets.
+
+## immich-photos-backup.sh
+
+Daily rsync of the Immich photo library (`/volume1/family/images/photos` on
+alcatraz, ~5 TiB) into the local ZFS dataset `main/backups/immich-photos`.
+
+### Architecture
+
+```
+alcatraz (Synology, 10.42.2.11)            hestia (TrueNAS, 10.42.2.10)
+  /volume1/family/images/photos   ─SSH→     /mnt/main/backups/immich-photos/
+        (primary, RW)                              (mirror, RO via snapshots)
+```
+
+- **Primary** stays on alcatraz; Immich keeps mounting alcatraz NFS for live access.
+- **Backup** on hestia is pull-only — alcatraz never reaches into hestia.
+- **Snapshots** are managed by a TrueNAS periodic-snapshot task on the dataset, not by the rsync script. Snapshot retention: daily/14, weekly/8, monthly/12.
+
+### Manual deploy (operator-only)
+
+The deploy-hestia GitHub Actions workflow only auto-deploys docker-compose
+files. Shell scripts are copied manually.
+
+```bash
+# 1. As truenas_admin on hestia
+sudo install -m 0755 -o root -g root \
+  /tmp/immich-photos-backup.sh /usr/local/bin/immich-photos-backup.sh
+
+# 2. Add a cron entry. Pick 04:00 — after the 02:00 CNPG S3 backup window
+#    so they don't contend for the WAN uplink.
+sudo crontab -e
+# 0 4 * * *  /usr/local/bin/immich-photos-backup.sh
+
+# 3. First run is the 5 TiB initial seed. Run it manually inside a `tmux` or
+#    `screen` session — it'll take ~12 hours over gigabit. After the seed,
+#    daily incremental runs typically finish in <30 minutes.
+tmux new -s immich-seed
+/usr/local/bin/immich-photos-backup.sh
+```
+
+### Prerequisites the operator must set up before the script can run
+
+1. **ZFS dataset on hestia:**
+   - Name: `main/backups/immich-photos`
+   - Compression: `lz4` (default)
+   - `recordsize=1M`
+   - `atime=off`
+   - Quota: `8T`
+
+2. **TrueNAS periodic snapshot task** on the dataset:
+   - Daily snapshot, retain 14 days
+   - Weekly snapshot, retain 8 weeks
+   - Monthly snapshot, retain 12 months
+   - Schedule **after** the cron-driven rsync (e.g. `05:00` if rsync starts at `04:00` and finishes within an hour).
+
+3. **SSH key from hestia → alcatraz:**
+   ```bash
+   # On hestia:
+   sudo -u root ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519_alcatraz -N ""
+   cat /root/.ssh/id_ed25519_alcatraz.pub
+   # Add the public key to alcatraz's authorized_keys for DSM admin user
+   # (DSM → Control Panel → Terminal & SNMP → enable SSH → DSM admin keys).
+   # Optionally pin the key to rsync only with `command="rsync ..."` prefix.
+   #
+   # Then verify (from hestia):
+   ssh -i /root/.ssh/id_ed25519_alcatraz truenas_admin@10.42.2.11 'ls /volume1/family/images/photos | head'
+   ```
+
+4. **node-exporter textfile collector** must be running on hestia with
+   `--collector.textfile.directory=/var/lib/node-exporter/textfile`. The script
+   writes `immich-backup.prom` there.
+
+### Monitoring
+
+The script writes two Prometheus textfile metrics on success:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `immich_photos_backup_last_success_seconds` | gauge | Unix timestamp of last successful rsync |
+| `immich_photos_backup_duration_seconds` | gauge | Wall-clock duration of last successful rsync |
+
+The `ImmichPhotoBackupStale` alert in
+`infra/configs/alerts/prometheus-rules.yaml` fires if the timestamp is older
+than 36 hours (one missed daily run + buffer).
+
+Logs land in `/var/log/immich-photos-backup.log`. The script tees stdout/stderr,
+so `tail -F` works for live observation.

--- a/hosts/hestia/backup/immich-photos-backup.sh
+++ b/hosts/hestia/backup/immich-photos-backup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Daily incremental backup of the Immich photo library from alcatraz → hestia.
+#
+# Pulls /volume1/family/images/photos on alcatraz (Synology NAS, 10.42.2.11)
+# into the local ZFS dataset main/backups/immich-photos. Snapshots are managed
+# by a TrueNAS periodic-snapshot task scheduled after this rsync completes.
+#
+# Deployed manually to /usr/local/bin/immich-photos-backup.sh on hestia and
+# scheduled via cron at 04:00 daily (after CNPG S3 backups at 02:00).
+#
+# Reports backup freshness to node-exporter's textfile collector at
+# /var/lib/node-exporter/textfile/immich-backup.prom so the
+# `ImmichPhotoBackupStale` alert in infra/configs/alerts/prometheus-rules.yaml
+# can fire when daily runs stop landing.
+
+set -euo pipefail
+
+SRC="truenas_admin@10.42.2.11:/volume1/family/images/photos/"
+DST="/mnt/main/backups/immich-photos/"
+LOG="/var/log/immich-photos-backup.log"
+TEXTFILE_DIR="/var/lib/node-exporter/textfile"
+TEXTFILE="${TEXTFILE_DIR}/immich-backup.prom"
+
+mkdir -p "${TEXTFILE_DIR}"
+exec > >(tee -a "${LOG}")
+exec 2>&1
+
+START_TS=$(date +%s)
+echo "=== $(date -u +%FT%TZ) START ==="
+
+# chacha20-poly1305 + no SSH compression matches the plan's high-throughput
+# configuration. --delete keeps the destination tight to the source.
+if rsync -avh --delete \
+    --rsh="ssh -T -c chacha20-poly1305@openssh.com -o Compression=no -x" \
+    --stats \
+    "${SRC}" "${DST}"; then
+  END_TS=$(date +%s)
+  DURATION=$((END_TS - START_TS))
+  echo "=== $(date -u +%FT%TZ) END (success, ${DURATION}s) ==="
+
+  cat > "${TEXTFILE}.tmp" <<EOF
+# HELP immich_photos_backup_last_success_seconds Unix timestamp of last successful immich photos rsync
+# TYPE immich_photos_backup_last_success_seconds gauge
+immich_photos_backup_last_success_seconds ${END_TS}
+# HELP immich_photos_backup_duration_seconds Wall-clock duration of last successful rsync
+# TYPE immich_photos_backup_duration_seconds gauge
+immich_photos_backup_duration_seconds ${DURATION}
+EOF
+  mv "${TEXTFILE}.tmp" "${TEXTFILE}"
+  exit 0
+else
+  RC=$?
+  echo "=== $(date -u +%FT%TZ) END (FAILED rc=${RC}) ==="
+  # Intentionally do NOT touch the textfile metric on failure — the alert
+  # rule keys off staleness of the last *successful* run.
+  exit "${RC}"
+fi

--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -203,3 +203,22 @@ spec:
             summary: "Cilium has {{ $value }} BGP peers down — ECMP halved or worse"
             description: >
               {{ $value }} BGP peers are not Established. ECMP path count per LB IP has dropped from 3 to ≤1; one more failure is a total outage. Investigate before traffic is affected.
+    # -------------------------------------------------------------------------
+    # Backups: alcatraz → hestia immich photos
+    #
+    # The /usr/local/bin/immich-photos-backup.sh cron on hestia writes
+    # `immich_photos_backup_last_success_seconds` to the node-exporter
+    # textfile collector at the end of every successful run. Daily runs hit
+    # at ~04:00; 36h tolerates one full missed window before alerting.
+    # -------------------------------------------------------------------------
+    - name: immich-photos-backup
+      rules:
+        - alert: ImmichPhotoBackupStale
+          expr: time() - immich_photos_backup_last_success_seconds > 36 * 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Immich photo backup hasn't completed in >36h"
+            description: >
+              Last successful immich-photos-backup.sh run on hestia was {{ $value | humanizeDuration }} ago. Daily cron is at 04:00; >36h means at least one full day's backup was missed. Check /var/log/immich-photos-backup.log on hestia and verify the ssh key to alcatraz still works.


### PR DESCRIPTION
## Summary
Phase 2 of the alcatraz → hestia migration plan. Adds the daily incremental backup of the Immich photo library, with Prometheus alerting for staleness.

- `hosts/hestia/backup/immich-photos-backup.sh` — the rsync script, writes textfile-collector metrics on success
- `hosts/hestia/backup/README.md` — operator runbook (ZFS dataset setup, snapshot tasks, SSH key, initial seed, cron install)
- `ImmichPhotoBackupStale` alert in `infra/configs/alerts/prometheus-rules.yaml`

## Operator-only follow-ups (NOT in this PR)
1. Create ZFS dataset `main/backups/immich-photos` on hestia (lz4, recordsize=1M, atime=off, 8T quota).
2. Configure TrueNAS periodic-snapshot task: daily/14, weekly/8, monthly/12. Schedule after the 04:00 rsync.
3. Generate `id_ed25519_alcatraz` on hestia. Add the pub key to alcatraz's DSM authorized_keys.
4. Verify `ssh truenas_admin@10.42.2.11 'ls /volume1/family/images/photos | head'` works.
5. Copy script to `/usr/local/bin/immich-photos-backup.sh` and install cron.
6. Kick off the initial seed inside `tmux` (~12h over gigabit).

Full step-by-step in `hosts/hestia/backup/README.md`.

## Test plan
- [x] `bash -n hosts/hestia/backup/immich-photos-backup.sh` passes
- [x] PrometheusRule YAML valid
- [ ] First successful run produces `/var/lib/node-exporter/textfile/immich-backup.prom`
- [ ] `ImmichPhotoBackupStale` alert exists in Prometheus rule list after Flux reconcile
- [ ] After 36h with no run, alert fires (negative test, deferred)