### PR TITLE
feat(qbittorrent): add hestia Custom App for private-tracker P2P

### DIFF
--- a/hosts/hestia/qbittorrent/README.md
+++ b/hosts/hestia/qbittorrent/README.md
@@ -1,0 +1,75 @@
+# qbittorrent
+
+qBittorrent P2P client running as a TrueNAS Custom App on hestia. Used for private-tracker downloads only.
+
+| Attribute | Value |
+|-----------|-------|
+| Image | `lscr.io/linuxserver/qbittorrent` (digest-pinned in compose) |
+| Web UI | `http://10.42.2.10:8080` (LAN-only) |
+| Torrenting port | `6881/tcp` + `6881/udp` |
+| Config dataset | `/mnt/main/apps/qbittorrent/config` |
+| Downloads dataset | `/mnt/main/downloads` (subdirs: `incomplete/`, `complete/`) |
+| Network | host bridge, no VPN |
+
+## One-time bootstrap
+
+1. **Pre-create the persistence datasets on hestia** (one-time):
+   ```bash
+   ssh truenas_admin@10.42.2.10
+   sudo zfs list main/apps 2>/dev/null || sudo zfs create main/apps
+   sudo zfs create main/apps/qbittorrent
+   sudo mkdir -p /mnt/main/apps/qbittorrent/config
+   sudo zfs create main/downloads
+   sudo mkdir -p /mnt/main/downloads/{incomplete,complete}
+   sudo chown -R 950:950 /mnt/main/apps/qbittorrent /mnt/main/downloads
+   ```
+
+2. **Router port forward on UCGF** (one-time): forward inbound `WAN tcp/udp 6881` → `10.42.2.10:6881`. Without this, qBittorrent runs in passive mode (no inbound connections, no seeding, degraded download speeds).
+
+3. **Create the Custom App in SCALE UI** (one-time — auto-deploy can't do the initial create):
+   - Apps → Discover Apps → Custom App
+   - Name: `qbittorrent` (must match the matrix entry in `.github/workflows/deploy-hestia.yml`)
+   - Paste the contents of `docker-compose.yml` from this directory
+   - Install
+   - Wait for it to reach Running
+
+4. **Find the generated admin password**:
+   ```bash
+   ssh truenas_admin@10.42.2.10 'sudo docker logs qbittorrent 2>&1 | grep -E "temporary password|WebUI"' | head -10
+   ```
+   The linuxserver image generates a random admin password on first boot (5.0+). Log into the Web UI, change to a permanent password via Tools → Options → Web UI.
+
+## Recommended qBittorrent settings (set via Web UI on first login)
+
+- **Downloads**:
+  - Default save path: `/downloads/complete`
+  - Keep incomplete torrents in: `/downloads/incomplete` (toggle on, set path)
+  - Append `.!qB` to incomplete files: on
+- **Connection**:
+  - Port used for incoming connections: `6881`
+  - Use UPnP / NAT-PMP port forwarding: **off** (you're using a static router forward)
+- **Bittorrent**:
+  - Enable DHT: off (private trackers)
+  - Enable PeX: off (private trackers)
+  - Enable Local Peer Discovery: off
+  - Enable anonymous mode: off (private trackers usually require non-anonymous)
+- **Web UI**:
+  - Set a strong admin password
+  - Enable HTTPS: optional; LAN-only by default
+
+## Subsequent updates
+
+Once the Custom App is bootstrapped, every change to `docker-compose.yml` on `master` triggers `.github/workflows/deploy-hestia.yml`, which calls `scripts/truenas-update-app.sh qbittorrent ...` on the self-hosted runner and applies the new compose via the TrueNAS WebSocket API.
+
+To roll back: revert the offending commit and merge; auto-deploy applies the old compose. Or manually `midclt call app.update qbittorrent '{"custom_compose_config": "<old yaml>"}'` from a hestia shell.
+
+## Moving completed downloads to the Jellyfin library
+
+This stack intentionally does NOT mount `/mnt/main/media/` into qBittorrent. After a torrent finishes, manually move the contents:
+
+```bash
+# On hestia
+sudo mv /mnt/main/downloads/complete/'Some.Movie.2026.mkv' /mnt/main/media/movies/
+```
+
+Then Dashboard → Scheduled Tasks → "Scan Media Library" in Jellyfin (or wait for the automatic interval) to pick it up.

--- a/hosts/hestia/qbittorrent/docker-compose.yml
+++ b/hosts/hestia/qbittorrent/docker-compose.yml
@@ -1,0 +1,41 @@
+# qBittorrent — P2P client on hestia for private-tracker downloads.
+#
+# Network: bridge with explicit port maps. NO VPN — private trackers only,
+# raw home WAN IP exposed to peers. Do not point this at public trackers
+# without first wrapping in gluetun + a port-forwarding VPN.
+#
+# Inbound port: the router (UCGF) must forward WAN tcp/udp 6881 →
+# 10.42.2.10:6881. Without that forward qBittorrent runs in passive mode
+# (downloads only, can't seed, slower swarm participation).
+#
+# Storage layout:
+#   /mnt/main/apps/qbittorrent/config   — qbit state (sqlite, .torrent files,
+#                                         settings, RSS feeds, categories)
+#   /mnt/main/downloads/incomplete      — in-progress .part files
+#   /mnt/main/downloads/complete        — finished torrents (operator moves
+#                                         to /mnt/main/media/{movies,tv-shows,
+#                                         tv-anime}/ when ready to expose
+#                                         to Jellyfin)
+#
+# Web UI: http://10.42.2.10:8080 — LAN-only. Default creds shown in container
+# startup logs (linuxserver image generates a random admin password on first
+# boot since 5.0; check `docker logs qbittorrent` after first start).
+
+services:
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:5.2.1@sha256:1784d5a65d08d01de308c7d87ff2c1dba328379e180eeca41cc6b96bdf6a0ffc
+    container_name: qbittorrent
+    restart: unless-stopped
+    environment:
+      - PUID=950      # truenas_admin
+      - PGID=950
+      - TZ=America/New_York
+      - WEBUI_PORT=8080
+      - TORRENTING_PORT=6881
+    volumes:
+      - /mnt/main/apps/qbittorrent/config:/config
+      - /mnt/main/downloads:/downloads
+    ports:
+      - "8080:8080"
+      - "6881:6881/tcp"
+      - "6881:6881/udp"


### PR DESCRIPTION
## Summary
Last piece of Phase 1 of the alcatraz → hestia migration: move the qBittorrent client onto hestia as a TrueNAS Custom App.

- `hosts/hestia/qbittorrent/docker-compose.yml` — linuxserver/qbittorrent 5.2.1, digest-pinned
- `hosts/hestia/qbittorrent/README.md` — operator bootstrap runbook (datasets, router port-forward, SCALE UI Custom App create)

## Network posture
- **No VPN** — running with home WAN IP visible to peers. Acceptable trade-off because the operator uses **private trackers only** (no DMCA honeypot exposure). If public trackers are ever needed, wrap in gluetun first.
- **Router port forward** required: UCGF must forward inbound tcp/udp 6881 → 10.42.2.10:6881 for "connectable" status and proper seeding.

## Storage posture
- Config under `/mnt/main/apps/qbittorrent/config` (own dataset).
- Downloads under `/mnt/main/downloads/{incomplete,complete}` (own dataset).
- Intentionally **not** bind-mounted to `/mnt/main/media/` — operator moves finished torrents into the Jellyfin library by hand. Eliminates the risk of qBittorrent deleting indexed media when a user removes a torrent.

## Operator-only bootstrap (after merge)
1. Pre-create the ZFS datasets + chown to `truenas_admin` (full commands in `hosts/hestia/qbittorrent/README.md`)
2. UCGF router port forward WAN tcp/udp 6881 → 10.42.2.10:6881
3. One-time create Custom App `qbittorrent` in SCALE UI (paste compose contents)
4. After first start: grab the auto-generated admin password from `docker logs qbittorrent` and change it via Web UI

After bootstrap, every change to `docker-compose.yml` auto-deploys via the existing `.github/workflows/deploy-hestia.yml` (file is discovered by the glob; no workflow edit needed).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('hosts/hestia/qbittorrent/docker-compose.yml'))"` passes
- [x] Workflow auto-discovery picks up the new app (`name=qbittorrent`, `file=hosts/hestia/qbittorrent/docker-compose.yml`)
- [ ] After bootstrap: Web UI reachable at http://10.42.2.10:8080
- [ ] After router forward: qBittorrent shows "Connectable: Yes" under status
- [ ] First test torrent downloads + seeds successfully