### PR TITLE
fix(immich-backup): correct ssh user + pin key path

### DIFF
--- a/hosts/hestia/backup/README.md
+++ b/hosts/hestia/backup/README.md
@@ -59,16 +59,20 @@ tmux new -s immich-seed
 
 3. **SSH key from hestia → alcatraz:**
    ```bash
-   # On hestia:
-   sudo -u root ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519_alcatraz -N ""
+   # On hestia (as root or via sudo):
+   ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519_alcatraz -N "" -C "immich-photos-backup@hestia"
    cat /root/.ssh/id_ed25519_alcatraz.pub
-   # Add the public key to alcatraz's authorized_keys for DSM admin user
-   # (DSM → Control Panel → Terminal & SNMP → enable SSH → DSM admin keys).
-   # Optionally pin the key to rsync only with `command="rsync ..."` prefix.
-   #
-   # Then verify (from hestia):
-   ssh -i /root/.ssh/id_ed25519_alcatraz truenas_admin@10.42.2.11 'ls /volume1/family/images/photos | head'
    ```
+   Then on alcatraz (DSM):
+   - Create a dedicated user `truenas-backup` (administrator group so it's allowed to SSH).
+   - Enable User Home Service (Control Panel → User & Group → Advanced).
+   - Paste the pubkey into `/var/services/homes/truenas-backup/.ssh/authorized_keys` (file must be owned by `truenas-backup`, mode 600; parent `.ssh` owned by user, mode 700).
+   - Grant `truenas-backup` Read access on the `family` shared folder (Control Panel → Shared Folder → family → Edit → Permissions).
+   - Verify from hestia:
+     ```bash
+     ssh -i /root/.ssh/id_ed25519_alcatraz truenas-backup@10.42.2.11 'ls /volume1/family/images/photos | head'
+     ```
+   Optional hardening: prefix the key entry with `command="rsync --server ..."` to restrict it to rsync only.
 
 4. **node-exporter textfile collector** must be running on hestia with
    `--collector.textfile.directory=/var/lib/node-exporter/textfile`. The script

--- a/hosts/hestia/backup/immich-photos-backup.sh
+++ b/hosts/hestia/backup/immich-photos-backup.sh
@@ -15,8 +15,9 @@
 
 set -euo pipefail
 
-SRC="truenas_admin@10.42.2.11:/volume1/family/images/photos/"
+SRC="truenas-backup@10.42.2.11:/volume1/family/images/photos/"
 DST="/mnt/main/backups/immich-photos/"
+SSH_KEY="/root/.ssh/id_ed25519_alcatraz"
 LOG="/var/log/immich-photos-backup.log"
 TEXTFILE_DIR="/var/lib/node-exporter/textfile"
 TEXTFILE="${TEXTFILE_DIR}/immich-backup.prom"
@@ -31,7 +32,7 @@ echo "=== $(date -u +%FT%TZ) START ==="
 # chacha20-poly1305 + no SSH compression matches the plan's high-throughput
 # configuration. --delete keeps the destination tight to the source.
 if rsync -avh --delete \
-    --rsh="ssh -T -c chacha20-poly1305@openssh.com -o Compression=no -x" \
+    --rsh="ssh -T -i ${SSH_KEY} -c chacha20-poly1305@openssh.com -o Compression=no -x" \
     --stats \
     "${SRC}" "${DST}"; then
   END_TS=$(date +%s)


### PR DESCRIPTION
## Summary
Two one-line fixes to `hosts/hestia/backup/immich-photos-backup.sh`:
1. `SRC` username `truenas_admin` → `truenas-backup` (the actual user provisioned on alcatraz; the original was a copy-paste placeholder from the plan doc)
2. Explicit `--rsh="ssh -T -i ${SSH_KEY} ..."` so the script uses the dedicated `/root/.ssh/id_ed25519_alcatraz` keypair regardless of what other keys exist on hestia

README rewritten for step 3 (SSH setup) to match the actual DSM flow — including the gotchas hit during the smoke test today (authorized_keys ownership, shared-folder ACL on `family`).

## Why this matters
Caught while running the live smoke test from hestia → alcatraz. The script as merged in PR #783 would have failed on first run with `Permission denied (publickey)` because of the wrong username + no explicit key.

## Test plan
- [x] `bash -n` passes
- [x] Manual `ssh -i ~/.ssh/id_ed25519_alcatraz truenas-backup@10.42.2.11 'ls /volume1/family/images/photos | head'` works from hestia
- [ ] After merge + operator install: first run logs `END (success, ...)` and writes `/var/lib/node-exporter/textfile/immich-backup.prom`