### PR TITLE
chore(immich-photos-backup): pin initial image digest

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:latest
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-05-31@sha256:34862abc66c6c6324b494f90f2dac9511a37efe55bba8f6941959a2803349fc6
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
Pin `ghcr.io/gjcourt/immich-photos-backup:latest` → `:2026-05-31@sha256:34862abc66c6c6324b494f90f2dac9511a37efe55bba8f6941959a2803349fc6` (the first published build from #835).

## Test plan
- [x] Digest fetched from `ghcr.io/v2/gjcourt/immich-photos-backup/manifests/2026-05-31` via the registry API
- [ ] After merge: `deploy-hestia` auto-apply succeeds (assumes operator has already created the Custom App per #835 README)