### PR TITLE
chore(thermalscope): backfill canonical compose into git

### DIFF
--- a/hosts/hestia/thermalscope/README.md
+++ b/hosts/hestia/thermalscope/README.md
@@ -1,0 +1,41 @@
+# thermalscope
+
+Hestia thermal + power telemetry agent. Reads `/sys/class/{hwmon,thermal}` and exposes Prometheus metrics over host networking. Already running on hestia as a TrueNAS Custom App — this directory just backfills the canonical compose into git so `deploy-hestia.yml` can manage updates instead of the operator hand-editing the SCALE UI.
+
+| Attribute | Value |
+|---|---|
+| Image | `ghcr.io/gjcourt/thermalscope` (built from [`gjcourt/thermalscope`](https://github.com/gjcourt/thermalscope), Go + distroless) |
+| Tag scheme | git short SHA from the source repo (NOT the homelab YYYY-MM-DD convention — the image is owned by a different repo) |
+| Network | `host` (Prometheus scrapes hestia directly) |
+| Privileges | `privileged: true` — required to read kernel sysfs sensors |
+| Bind mounts | `/sys/class/hwmon`, `/sys/class/thermal`, `/usr/bin/nvidia-smi` (all RO) |
+
+## Provenance
+
+This compose was extracted from the live SCALE Custom App `thermalscope` via:
+```bash
+ssh truenas_admin@10.42.2.10 'midclt call app.config thermalscope' \
+  | jq '.services'
+```
+
+After this PR merges, `deploy-hestia.yml` auto-discovers the new directory and any future digest bumps in this compose flow through the workflow.
+
+## Updating
+
+When a new image is published from the [`gjcourt/thermalscope`](https://github.com/gjcourt/thermalscope) repo:
+
+```bash
+# Pick the new tag (git short SHA) and fetch its digest:
+TAG=<new-short-sha>
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:gjcourt/thermalscope:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json" \
+  "https://ghcr.io/v2/gjcourt/thermalscope/manifests/$TAG" \
+  | grep -i 'docker-content-digest'
+```
+
+Then bump the `image:` line in `docker-compose.yml` to `:${TAG}@sha256:${digest}`. Merge the PR; `deploy-hestia.yml` will roll it out via `truenas-update-app.sh`.
+
+## Notes
+
+- `nvidia-smi` bind mount is legacy from the 4090 era. The binary is a no-op now (no GPUs on the box); agent code handles its absence gracefully. Leave the mount in place — removing it requires either the agent to drop the dependency or a coordinated change with [`gjcourt/thermalscope`](https://github.com/gjcourt/thermalscope).

--- a/hosts/hestia/thermalscope/docker-compose.yml
+++ b/hosts/hestia/thermalscope/docker-compose.yml
@@ -1,0 +1,28 @@
+# thermalscope — hestia thermal + power telemetry agent.
+#
+# Image is built from https://github.com/gjcourt/thermalscope (Go agent,
+# distroless static base). Tags are git short SHAs from that repo; bump
+# the digest + tag here when a new agent build is published.
+#
+# Runs with host networking and CAP-PRIVILEGED because it reads:
+#   - /sys/class/hwmon          CPU + chassis sensors
+#   - /sys/class/thermal        thermal zones (per-core + package)
+#   - /usr/bin/nvidia-smi       (bind-mounted ro from host; legacy from
+#                               the 4090 era — leave in place; the
+#                               binary is a no-op without GPUs and
+#                               agent code already handles its absence)
+#
+# Metrics are exposed via host networking; Prometheus scrapes hestia
+# directly.
+
+services:
+  thermalscope:
+    image: ghcr.io/gjcourt/thermalscope:d470623@sha256:af1c2d64a54ffb4168ab8424a704a3b9b49efe8d1b4cdb9f4f64f18cdd70b0c3
+    container_name: thermalscope
+    network_mode: host
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - /sys/class/hwmon:/sys/class/hwmon:ro
+      - /sys/class/thermal:/sys/class/thermal:ro
+      - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro


### PR DESCRIPTION
## Summary
`thermalscope` has been running on hestia for a while but only existed in SCALE's UI — never committed to the repo. Backfilling the live compose so deploy-hestia.yml owns it now.

## Provenance
Compose extracted from `midclt call app.config thermalscope` on hestia. Image + digest pinned to `ghcr.io/gjcourt/thermalscope:d470623@sha256:af1c2d6...` (currently running).

## What changes
- New `hosts/hestia/thermalscope/docker-compose.yml` (mirrors live compose exactly)
- New `hosts/hestia/thermalscope/README.md` (update flow + provenance + nvidia-smi-bind-mount caveat)

## After merge
- `deploy-hestia.yml` auto-discovers the new app (matrix entry derived from directory name)
- Future image bumps from the [`gjcourt/thermalscope`](https://github.com/gjcourt/thermalscope) repo are applied by bumping the digest + tag in this compose and merging
- No more drift between SCALE UI and the repo

## Test plan
- [x] YAML parses
- [x] `deploy-hestia` discover-step picks up `thermalscope` (verified locally)
- [x] Compose matches live app exactly (no spec change — pure GitOps backfill)
- [ ] After merge: deploy-hestia run succeeds with a no-op apply (image + spec already match)