### PR TITLE
fix(immich-photos-backup): persist known_hosts + accept-new on first run

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -32,6 +32,12 @@ services:
       # SSH identity — single-file bind mount keeps the key isolated from
       # whatever else may live in /root/.ssh on the host.
       - /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz:/root/.ssh/id_ed25519_alcatraz:ro
+      # Persisted known_hosts — script's ssh runs with
+      # StrictHostKeyChecking=accept-new + UserKnownHostsFile=/root/.ssh/known_hosts.
+      # Bind-mounting from host means a first-run acceptance survives
+      # container restarts. Operator must pre-create the file (touch is
+      # enough — accept-new will fill it in).
+      - /mnt/main/apps/immich-photos-backup/ssh/known_hosts:/root/.ssh/known_hosts
       # Backup destination: ZFS dataset with 8 TiB quota.
       - /mnt/main/backups/immich-photos:/mnt/main/backups/immich-photos
       # Prometheus textfile collector dir — script writes

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 SRC="truenas-backup@10.42.2.11:/volume1/family/images/photos/"
 DST="/mnt/main/backups/immich-photos/"
 SSH_KEY="/root/.ssh/id_ed25519_alcatraz"
+# Bind-mounted from host so first-run host-key acceptance survives
+# container restarts; see docker-compose.yml.
+KNOWN_HOSTS="/root/.ssh/known_hosts"
 LOG="/var/log/immich-photos-backup.log"
 TEXTFILE_DIR="/var/lib/node-exporter/textfile"
 TEXTFILE="${TEXTFILE_DIR}/immich-backup.prom"
@@ -31,8 +34,19 @@ echo "=== $(date -u +%FT%TZ) START ==="
 
 # chacha20-poly1305 + no SSH compression matches the plan's high-throughput
 # configuration. --delete keeps the destination tight to the source.
+#
+# Host-key handling: when run from cron there's no stdin to answer a
+# `Are you sure you want to continue connecting?` prompt — without
+# StrictHostKeyChecking=accept-new the first run inside a fresh container
+# (no known_hosts) hangs forever and rsync eventually fails with code 12.
+# We point UserKnownHostsFile at a bind-mounted host path so the accepted
+# host key persists across container restarts (otherwise it lives only in
+# the container's writable layer and is lost on restart).
 if rsync -avh --delete \
-    --rsh="ssh -T -i ${SSH_KEY} -c chacha20-poly1305@openssh.com -o Compression=no -x" \
+    --rsh="ssh -T -i ${SSH_KEY} \
+           -o StrictHostKeyChecking=accept-new \
+           -o UserKnownHostsFile=${KNOWN_HOSTS} \
+           -c chacha20-poly1305@openssh.com -o Compression=no -x" \
     --stats \
     "${SRC}" "${DST}"; then
   END_TS=$(date +%s)


### PR DESCRIPTION
## Summary
Tonight's first kickstart of the containerized backup hit two related issues:

1. **Host key prompt blocks cron.** Container starts with no `known_hosts`; ssh prompts `Are you sure you want to continue connecting?`. Interactive shell can answer (yes). Cron runs can't — script would hang until ssh's timeout and rsync exits with code 12.
2. **Acceptance doesn't persist.** Even when accepted interactively, the entry lives only in the container's writable layer. Next container restart loses it and the next run repeats the prompt.

## Fix
- Script passes `-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=${KNOWN_HOSTS}` to ssh.
- Compose bind-mounts `/mnt/main/apps/immich-photos-backup/ssh/known_hosts` (read-write) so the accepted key persists across container restarts.

## Operator step after merge (one-time)
On hestia as root:
```bash
touch /mnt/main/apps/immich-photos-backup/ssh/known_hosts
chmod 644 /mnt/main/apps/immich-photos-backup/ssh/known_hosts
# Optional — pre-seed instead of waiting for accept-new on first run:
ssh-keyscan -t ed25519 10.42.2.11 \
  > /mnt/main/apps/immich-photos-backup/ssh/known_hosts
```

## What this triggers
- `images/immich-photos-backup/**` changed → `build-immich-photos-backup.yml` builds a new image
- Follow-up PR pins the new digest in compose
- `deploy-hestia.yml` auto-rolls

## Test plan
- [x] `bash -n` passes on the script
- [x] `yaml.safe_load` parses the compose
- [ ] After merge + image rebuild + digest pin: kickstart no longer prompts; container restart preserves host key