### PR TITLE
chore(immich-photos-backup): pin digest for known_hosts fix

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-05-31@sha256:34862abc66c6c6324b494f90f2dac9511a37efe55bba8f6941959a2803349fc6
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-05-31@sha256:71864f84d6288996f9f6e393a2add0dedd6caf6221932e5d5114872e583ab168
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
Bump the immich-photos-backup image digest in compose so the known_hosts fix from #839 takes effect on hestia. Tag stays `:2026-05-31` (registry overwrote the same-day tag); digest changes from `34862ab...` → `71864f8...`.

## After merge
- `deploy-hestia.yml` auto-applies via `truenas-update-app.sh` → container restarts on the new image
- Cron-fired runs now pass `StrictHostKeyChecking=accept-new` + persistent `known_hosts` so no interactive stdin needed

Reminder: operator needs to `touch /mnt/main/apps/immich-photos-backup/ssh/known_hosts` (or pre-seed via `ssh-keyscan`) before the container restart — empty file is fine since `accept-new` will populate it on first run.