### PR TITLE
fix(immich-photos-backup): exclude Synology @eaDir + OS metadata

### DIFF
--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -42,7 +42,20 @@ echo "=== $(date -u +%FT%TZ) START ==="
 # We point UserKnownHostsFile at a bind-mounted host path so the accepted
 # host key persists across container restarts (otherwise it lives only in
 # the container's writable layer and is lost on restart).
-if rsync -avh --delete \
+# Excludes:
+#   @eaDir         Synology indexer metadata + xattr backups
+#                  (@eaDir/<file>@SynoEAStream). Useless on hestia, bloats
+#                  the backup, and litters the tree with one dir per photo
+#                  dir. Synology recreates them on alcatraz as needed.
+#   .DS_Store      macOS Finder metadata; same deal.
+#   Thumbs.db      Windows thumbnail cache.
+# --delete-excluded ensures excludes also remove anything that landed in
+# the destination from earlier runs (e.g. the @eaDir noise transferred
+# before this exclude landed).
+if rsync -avh --delete --delete-excluded \
+    --exclude='@eaDir' \
+    --exclude='.DS_Store' \
+    --exclude='Thumbs.db' \
     --rsh="ssh -T -i ${SSH_KEY} \
            -o StrictHostKeyChecking=accept-new \
            -o UserKnownHostsFile=${KNOWN_HOSTS} \


### PR DESCRIPTION
## Summary
Strip Synology indexer cruft (`@eaDir/`, `*@SynoEAStream`) and the usual cross-OS metadata files (`.DS_Store`, `Thumbs.db`) from the rsync. Adds `--delete-excluded` so existing copies on hestia (left by today's initial seed) get cleaned up on next run.

## Why
Tonight's first seed showed the listing littered with `george/2019/10/@eaDir/IMG_3374.heic@SynoEAStream` etc. — Synology's media indexer + xattr backups. They're useless on hestia and meaningfully grow the backup tree (one dir per photo dir).

## Test plan
- [x] `bash -n` passes
- [ ] After merge + image rebuild + digest pin: next run logs no `@eaDir` transfers and `--delete-excluded` removes the existing ones from hestia