### PR TITLE
chore(qbittorrent): bind /downloads to media/movies for alcatraz parity

### DIFF
--- a/hosts/hestia/qbittorrent/docker-compose.yml
+++ b/hosts/hestia/qbittorrent/docker-compose.yml
@@ -11,11 +11,17 @@
 # Storage layout:
 #   /mnt/main/apps/qbittorrent/config   — qbit state (sqlite, .torrent files,
 #                                         settings, RSS feeds, categories)
-#   /mnt/main/downloads/incomplete      — in-progress .part files
-#   /mnt/main/downloads/complete        — finished torrents (operator moves
-#                                         to /mnt/main/media/{movies,tv-shows,
-#                                         tv-anime}/ when ready to expose
-#                                         to Jellyfin)
+#   /mnt/main/media/movies              — downloads land directly in the
+#                                         Jellyfin movies library. This matches
+#                                         the alcatraz qbit layout so migrated
+#                                         .fastresume files resolve without
+#                                         path rewrites. Trade-off: qbit's
+#                                         "Delete torrent and files" will
+#                                         reach into the library — don't use
+#                                         that right-click option casually.
+#                                         (For staging-then-move workflow, use
+#                                         qbit Categories to set a per-category
+#                                         save path.)
 #
 # Web UI: http://10.42.2.10:8080 — LAN-only. Default creds shown in container
 # startup logs (linuxserver image generates a random admin password on first
@@ -34,7 +40,7 @@ services:
       - TORRENTING_PORT=6881
     volumes:
       - /mnt/main/apps/qbittorrent/config:/config
-      - /mnt/main/downloads:/downloads
+      - /mnt/main/media/movies:/downloads
     ports:
       - "8080:8080"
       - "6881:6881/tcp"


### PR DESCRIPTION
## Summary
Re-bind hestia qbit's `/downloads` from `/mnt/main/downloads` → `/mnt/main/media/movies` so the layout matches the alcatraz qbit it's replacing.

## Why
Migrating from alcatraz qbit. Each torrent's `.fastresume` file references the in-container save path (`/downloads/...`). On alcatraz, `/downloads` was bind-mounted to `/volume1/family/video/movies`. With this PR, hestia's `/downloads` points at `/mnt/main/media/movies` which IS the post-migration copy of that exact tree. The `.fastresume` files transfer cleanly — no rewrites, no full re-hash on first start.

## Trade-off
qbit's "Delete torrent and files" right-click now reaches into the Jellyfin library. For staging-isolation on future downloads, use qbit's per-Category save path override.

## After merge
1. Deploy-hestia auto-applies → container restarts with the new mount
2. rsync alcatraz `BT_backup/` to hestia (separate operator step):
   ```bash
   sudo rsync -avh --info=progress2 \
     -e "ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz" \
     truenas-backup@10.42.2.11:/volume1/docker/qbittorrent/config/qBittorrent/BT_backup/ \
     /mnt/main/apps/qbittorrent/config/qBittorrent/BT_backup/
   ```
3. Restart qbit container — torrents auto-discover + resume to seeding
4. Verify in web UI: all torrents present, status = "Seeding" with peers

## Test plan
- [x] YAML parses
- [ ] After merge: deploy-hestia run succeeds
- [ ] After rsync + restart: qbit lists all migrated torrents in "Seeding" state