### PR TITLE
fix(immich-photos-backup): repoint to /mnt/main/family/images/photos

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -1,5 +1,7 @@
 # Daily rsync of /volume1/family/images/photos on alcatraz (Synology DSM,
-# 10.42.2.11) into the local ZFS dataset main/backups/immich-photos.
+# 10.42.2.11) into the local ZFS dataset main/family/images/photos.
+# (Renamed from main/backups/immich-photos in the 2026-06-01 hestia-SOT plan
+#  — see docs/plans/2026-06-01-hestia-photos-sot.md.)
 #
 # Always-running container; busybox crond fires the script at 04:00 local
 # (TZ honored via the image's tzdata + the TZ env var below). Snapshots
@@ -10,7 +12,7 @@
 #   1. SSH key at /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz
 #      (private key, mode 600, owned by root). The matching public key
 #      lives in truenas-backup@10.42.2.11:~/.ssh/authorized_keys.
-#   2. ZFS dataset main/backups/immich-photos (created by midclt
+#   2. ZFS dataset main/family/images/photos (created by midclt
 #      pool.dataset.create — see README for the exact command).
 #   3. node-exporter textfile collector at /var/lib/node-exporter/textfile
 #      so the Prometheus metric the script writes is scraped.
@@ -38,8 +40,11 @@ services:
       # container restarts. Operator must pre-create the file (touch is
       # enough — accept-new will fill it in).
       - /mnt/main/apps/immich-photos-backup/ssh/known_hosts:/root/.ssh/known_hosts
-      # Backup destination: ZFS dataset with 8 TiB quota.
-      - /mnt/main/backups/immich-photos:/mnt/main/backups/immich-photos
+      # Backup destination — bind-mounted the whole main/family parent so the
+      # same container can later extend to sync other family/ subdirs (audio,
+      # literature, documents, etc.) without a compose change. Today the script
+      # only writes to family/images/photos.
+      - /mnt/main/family:/mnt/main/family
       # Prometheus textfile collector dir — script writes
       # immich-backup.prom on each successful run for the
       # ImmichPhotoBackupStale alert to key off of.

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 SRC="truenas-backup@10.42.2.11:/volume1/family/images/photos/"
-DST="/mnt/main/backups/immich-photos/"
+DST="/mnt/main/family/images/photos/"
 SSH_KEY="/root/.ssh/id_ed25519_alcatraz"
 # Bind-mounted from host so first-run host-key acceptance survives
 # container restarts; see docker-compose.yml.


### PR DESCRIPTION
## Summary
Phase 4 of [docs/plans/2026-06-01-hestia-photos-sot.md](https://github.com/gjcourt/homelab/blob/master/docs/plans/2026-06-01-hestia-photos-sot.md). The ZFS dataset `main/backups/immich-photos` was renamed to `main/family/images/photos` earlier today as Phase 2 (zero-copy ZFS rename — preserved the 201 GiB of seeded photos). Without this PR, the next 04:00 cron fails because the script's `DST` and the compose bind mount both point at the now-gone path.

## Changes
- `images/immich-photos-backup/immich-photos-backup.sh`: `DST` → `/mnt/main/family/images/photos/`
- `hosts/hestia/immich-photos-backup/docker-compose.yml`: bind `/mnt/main/family:/mnt/main/family` (widened from the old leaf-bind so the same container can extend to sync other `family/` subdirs in a future PR without another compose change)

## Time pressure
Next cron fires at 04:00 local. Currently ~21:00 local = ~7h runway. PR + build + digest-pin sequence needs to land before then.

## Test plan
- [x] `bash -n` passes
- [x] `yaml.safe_load` passes
- [ ] After merge: build workflow publishes new image
- [ ] Follow-up PR pins digest
- [ ] deploy-hestia auto-applies → container restarts with new mount
- [ ] Manual kickstart: `docker exec ... /usr/local/bin/immich-photos-backup.sh` → completes successfully + writes textfile metric