### PR TITLE
chore(immich-photos-backup): pin 2026-06-01 digest for family/ path

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-05-31@sha256:672e2d435758c60b589c740b743807202820afa3257826fd8dc95cd282419526
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-01@sha256:789e14ff577420541736877232c789f1a823397a59dfd22b8fb5644f0059cf32
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/gjcourt/immich-photos-backup` to the digest built from #848 (DST → `/mnt/main/family/images/photos`, bind widened to `/mnt/main/family`).
- Tag `2026-06-01` / digest `sha256:789e14ff…`.

## Test plan
- [x] `build-immich-photos-backup` succeeded (run 26734743335)
- [ ] After merge, `deploy-hestia` rolls the container; `docker logs immich-photos-backup` shows healthy crond + bind `/mnt/main/family` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)