### PR TITLE
fix(immich-photos-backup): sync from homes/<user>/Photos, not family/images/photos

### DIFF
--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -1,13 +1,15 @@
 # immich-photos-backup
 
-Daily incremental backup of the Immich photo library (`/volume1/family/images/photos` on alcatraz, ~425 GB today, 5 TiB headroom) into the local ZFS dataset `main/backups/immich-photos`. Always-running container; in-container busybox `crond` fires the rsync at 04:00 local time.
+Daily incremental backup of the Immich photo library from alcatraz (Synology, 10.42.2.11) into the local ZFS dataset `main/family/images/photos`. Always-running container; in-container busybox `crond` fires the rsync at 04:00 local time.
+
+Sources are per-user `homes/<user>/Photos/` paths, not `family/images/photos/<user>/`. On the Synology side those family paths are symlinks into each user's home, with per-file ACLs that deny `truenas-backup` file open via the family path — so we sync from the homes path directly and re-map into the canonical hestia `family/images/photos/<user>/` layout.
 
 | Attribute | Value |
 |---|---|
 | Image | `ghcr.io/gjcourt/immich-photos-backup` (built from `images/immich-photos-backup/`) |
 | Schedule | `0 4 * * *` (after CNPG S3 backups at 02:00) |
-| Source | `truenas-backup@10.42.2.11:/volume1/family/images/photos/` |
-| Destination | `/mnt/main/backups/immich-photos/` (ZFS, 8 TiB quota, lz4, recordsize=1M, atime=off) |
+| Sources | `truenas-backup@10.42.2.11:/volume1/homes/{george,mara}/Photos/` |
+| Destinations | `/mnt/main/family/images/photos/{george,mara}/` (ZFS, lz4, recordsize=1M, atime=off) |
 | SSH key | `/mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz` (mode 600, root) |
 | Metric | `immich_photos_backup_last_success_seconds` via node-exporter textfile collector |
 | Alert | `ImmichPhotoBackupStale` (fires after >36h) |
@@ -17,11 +19,11 @@ Daily incremental backup of the Immich photo library (`/volume1/family/images/ph
 Run on hestia as root (TrueNAS Web UI → System Settings → Shell).
 
 ### 1. ZFS datasets + snapshot tasks
-Already created in an earlier session via midclt (`main/backups/immich-photos` exists; daily/14, weekly/8, monthly/12 snapshot tasks scheduled at 05:00/05:30/06:00 — staggered after the 04:00 rsync). To verify:
+The destination dataset is `main/family/images/photos` (renamed from `main/backups/immich-photos` in the 2026-06-01 hestia-SOT migration — see `docs/plans/2026-06-01-hestia-photos-sot.md`). Snapshot tasks (daily/14, weekly/8, monthly/12) run on the `main/family` parent. To verify:
 ```bash
-midclt call pool.dataset.query '[["id", "=", "main/backups/immich-photos"]]' \
-  | jq '.[0] | {compression: .compression.value, recordsize: .recordsize.value, atime: .atime.value, quota: .quota.value, mountpoint}'
-midclt call pool.snapshottask.query '[["dataset", "=", "main/backups/immich-photos"]]' \
+midclt call pool.dataset.query '[["id", "=", "main/family/images/photos"]]' \
+  | jq '.[0] | {compression: .compression.value, recordsize: .recordsize.value, atime: .atime.value, mountpoint}'
+midclt call pool.snapshottask.query '[["dataset", "=", "main/family"]]' \
   | jq '.[] | {lifetime_value, lifetime_unit, schedule: .schedule | "\(.hour):\(.minute) dow=\(.dow) dom=\(.dom)"}'
 ```
 
@@ -37,10 +39,10 @@ chmod 644 /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz.pub
 ```
 
 ### 3. SSH key on alcatraz (already done)
-The matching public key is in `truenas-backup@10.42.2.11:/var/services/homes/truenas-backup/.ssh/authorized_keys`. The `truenas-backup` user has Read access on the `family` shared folder. Verify with:
+The matching public key is in `truenas-backup@10.42.2.11:/var/services/homes/truenas-backup/.ssh/authorized_keys`. The `truenas-backup` user needs Read access on the `homes` shared folder and on each user's `Photos/` subtree (verify per-user — DSM file-level ACLs override share-level grants; if needed, in DSM Control Panel → Shared Folder → homes → Edit → Permissions → tick "Apply to this folder, sub-folders and files"). Verify access:
 ```bash
 ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
-    truenas-backup@10.42.2.11 'ls /volume1/family/images/photos | head'
+    truenas-backup@10.42.2.11 'ls /volume1/homes/george/Photos | head; ls /volume1/homes/mara/Photos | head'
 ```
 
 ### 4. node-exporter textfile collector
@@ -69,5 +71,5 @@ To roll back: revert the digest in `docker-compose.yml` and merge; auto-deploy a
 
 - Container logs: `docker logs ix-immich-photos-backup-immich-photos-backup-1` (or via SCALE UI → Apps → immich-photos-backup → Logs)
 - Last successful run timestamp: `cat /var/lib/node-exporter/textfile/immich-backup.prom`
-- Snapshots: TrueNAS UI → Storage → Snapshots, filter by dataset `main/backups/immich-photos`
+- Snapshots: TrueNAS UI → Storage → Snapshots, filter by dataset `main/family`
 - Prometheus alert state: query `ALERTS{alertname="ImmichPhotoBackupStale"}`

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 # Daily incremental backup of the Immich photo library from alcatraz → hestia.
 #
-# Pulls /volume1/family/images/photos on alcatraz (Synology NAS, 10.42.2.11)
-# into the local ZFS dataset main/backups/immich-photos. Snapshots are managed
-# by a TrueNAS periodic-snapshot task scheduled after this rsync completes.
+# Pulls per-user Photos dirs from alcatraz (Synology NAS, 10.42.2.11) into the
+# local ZFS dataset main/family/images/photos. Snapshots are managed by a
+# TrueNAS periodic-snapshot task scheduled after this rsync completes.
 #
-# Deployed manually to /usr/local/bin/immich-photos-backup.sh on hestia and
-# scheduled via cron at 04:00 daily (after CNPG S3 backups at 02:00).
+# Source-path note: on alcatraz, /volume1/family/images/photos/<user> is a
+# symlink into /volume1/homes/<user>/Photos (the real bytes live in each
+# user's home). truenas-backup has share-level read on family/ but per-file
+# ACLs from each user's Synology account deny file open via the family path —
+# so we sync from the homes path directly, mapping into the canonical hestia
+# layout family/images/photos/<user>/.
+#
+# Deployed as a TrueNAS Custom App; cron at 04:00 daily is fired by the
+# container's busybox crond (see hosts/hestia/immich-photos-backup/).
 #
 # Reports backup freshness to node-exporter's textfile collector at
 # /var/lib/node-exporter/textfile/immich-backup.prom so the
@@ -15,8 +22,8 @@
 
 set -euo pipefail
 
-SRC="truenas-backup@10.42.2.11:/volume1/family/images/photos/"
-DST="/mnt/main/family/images/photos/"
+USERS=(george mara)
+DST_BASE="/mnt/main/family/images/photos"
 SSH_KEY="/root/.ssh/id_ed25519_alcatraz"
 # Bind-mounted from host so first-run host-key acceptance survives
 # container restarts; see docker-compose.yml.
@@ -33,7 +40,7 @@ START_TS=$(date +%s)
 echo "=== $(date -u +%FT%TZ) START ==="
 
 # chacha20-poly1305 + no SSH compression matches the plan's high-throughput
-# configuration. --delete keeps the destination tight to the source.
+# configuration. --delete keeps each user's destination tight to its source.
 #
 # Host-key handling: when run from cron there's no stdin to answer a
 # `Are you sure you want to continue connecting?` prompt — without
@@ -42,6 +49,7 @@ echo "=== $(date -u +%FT%TZ) START ==="
 # We point UserKnownHostsFile at a bind-mounted host path so the accepted
 # host key persists across container restarts (otherwise it lives only in
 # the container's writable layer and is lost on restart).
+#
 # Excludes:
 #   @eaDir         Synology indexer metadata + xattr backups
 #                  (@eaDir/<file>@SynoEAStream). Useless on hestia, bloats
@@ -50,22 +58,36 @@ echo "=== $(date -u +%FT%TZ) START ==="
 #   .DS_Store      macOS Finder metadata; same deal.
 #   Thumbs.db      Windows thumbnail cache.
 # --delete-excluded ensures excludes also remove anything that landed in
-# the destination from earlier runs (e.g. the @eaDir noise transferred
-# before this exclude landed).
-if rsync -avh --delete --delete-excluded \
-    --exclude='@eaDir' \
-    --exclude='.DS_Store' \
-    --exclude='Thumbs.db' \
-    --rsh="ssh -T -i ${SSH_KEY} \
+# the destination from earlier runs.
+RSYNC_RSH="ssh -T -i ${SSH_KEY} \
            -o StrictHostKeyChecking=accept-new \
            -o UserKnownHostsFile=${KNOWN_HOSTS} \
-           -c chacha20-poly1305@openssh.com -o Compression=no -x" \
-    --stats \
-    "${SRC}" "${DST}"; then
-  END_TS=$(date +%s)
-  DURATION=$((END_TS - START_TS))
-  echo "=== $(date -u +%FT%TZ) END (success, ${DURATION}s) ==="
+           -c chacha20-poly1305@openssh.com -o Compression=no -x"
 
+FAILED=0
+for user in "${USERS[@]}"; do
+  src="truenas-backup@10.42.2.11:/volume1/homes/${user}/Photos/"
+  dst="${DST_BASE}/${user}/"
+  mkdir -p "${dst}"
+  echo "--- $(date -u +%FT%TZ) sync ${user}: ${src} -> ${dst} ---"
+  if ! rsync -avh --delete --delete-excluded \
+        --exclude='@eaDir' \
+        --exclude='.DS_Store' \
+        --exclude='Thumbs.db' \
+        --rsh="${RSYNC_RSH}" \
+        --stats \
+        "${src}" "${dst}"; then
+    rc=$?
+    echo "!!! ${user} rsync failed rc=${rc}"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+END_TS=$(date +%s)
+DURATION=$((END_TS - START_TS))
+
+if [[ ${FAILED} -eq 0 ]]; then
+  echo "=== $(date -u +%FT%TZ) END (success, ${DURATION}s) ==="
   cat > "${TEXTFILE}.tmp" <<EOF
 # HELP immich_photos_backup_last_success_seconds Unix timestamp of last successful immich photos rsync
 # TYPE immich_photos_backup_last_success_seconds gauge
@@ -77,9 +99,8 @@ EOF
   mv "${TEXTFILE}.tmp" "${TEXTFILE}"
   exit 0
 else
-  RC=$?
-  echo "=== $(date -u +%FT%TZ) END (FAILED rc=${RC}) ==="
+  echo "=== $(date -u +%FT%TZ) END (FAILED, ${FAILED} of ${#USERS[@]} users, ${DURATION}s) ==="
   # Intentionally do NOT touch the textfile metric on failure — the alert
   # rule keys off staleness of the last *successful* run.
-  exit "${RC}"
+  exit 1
 fi


### PR DESCRIPTION
## Why

In the 2026-06-01 hestia-SOT migration (#847 plan, #848 path repoint, #849 digest pin), the daily backup was repointed at `/mnt/main/family/images/photos`. But the **source** still pointed at alcatraz `/volume1/family/images/photos`, which is where this PR lands: on Synology those `family/images/photos/<user>/` paths are symlinks into each user's home (`homes/<user>/Photos`), and per-file ACLs from each user's Synology account deny `truenas-backup` file open via the family path. The next 04:00 cron would have re-hit the same wall I just diagnosed during the bulk-seed.

## Change

- Script loops over `USERS=(george mara)` and runs one rsync per user from `homes/<user>/Photos/` → `family/images/photos/<user>/`. Accumulates per-user failures; metric only written when all succeed.
- README updated for new source paths, the dataset rename, and a DSM ACL "Apply to this folder, sub-folders and files" tip for the `homes` share.

## Test plan
- [x] Bulk-seed equivalent already verified by hand on hestia: rsync from `homes/george/Photos/` → `family/images/photos/george/` (125.89G) and `homes/mara/Photos/` → `family/images/photos/mara/` (182.03G) both exit 0 with high speedup (data already in place from prior daily syncs that worked).
- [ ] After merge: build kicks → digest pin PR → deploy-hestia rolls. Next 04:00 cron should log `--- sync george ---` then `--- sync mara ---` with both exits 0 and the textfile metric written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)