### PR TITLE
chore(immich-photos-backup): pin digest after source-path fix

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-01@sha256:789e14ff577420541736877232c789f1a823397a59dfd22b8fb5644f0059cf32
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-01@sha256:de2b01973ed3111dca56ef0af7bdd0f2f29df68db6c2213fedf31d3ea119fd86
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
Pins the image built from #850.

| Field | Value |
|---|---|
| Tag | `2026-06-01` |
| Digest | `sha256:de2b01973ed3111dca56ef0af7bdd0f2f29df68db6c2213fedf31d3ea119fd86` |
| Replaces | `sha256:789e14ff…` (the #849 pin for the family-path repoint) |

## Test plan
- [x] `build-immich-photos-backup` succeeded (run 26737953336)
- [ ] After merge, `deploy-hestia` rolls the container; tomorrow's 04:00 cron logs `--- sync george ---` and `--- sync mara ---` with both exit 0 and the textfile metric written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)