### PR TITLE
chore(immich): repoint photos NFS PV from alcatraz to hestia

### DIFF
--- a/apps/production/immich/nfs-photos.yaml
+++ b/apps/production/immich/nfs-photos.yaml
@@ -1,4 +1,6 @@
-# Static PV for Synology NFS photos share (external library)
+# Static PV for the Immich external library NFS share.
+# Repointed alcatraz (10.42.2.11) -> hestia (10.42.2.10) in the 2026-06-01
+# hestia-SOT migration; see docs/plans/2026-06-01-hestia-photos-sot.md.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -14,8 +16,8 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   nfs:
-    server: 10.42.2.11
-    path: /volume1/family/images/photos
+    server: 10.42.2.10
+    path: /mnt/main/family/images/photos
     readOnly: false
   mountOptions:
     - nfsvers=3


### PR DESCRIPTION
## Summary
Phase 5 of the [hestia-SOT plan](../blob/master/docs/plans/2026-06-01-hestia-photos-sot.md). Repoints `immich-photos-pv-prod` from alcatraz NFS (`10.42.2.11:/volume1/family/images/photos`) to the hestia ZFS dataset (`10.42.2.10:/mnt/main/family/images/photos`). Same content — Phase 3's rsync chain has 308 GB of photos on the hestia path.

Same shape as #765 (jellyfin + navidrome NFS repoint). `nfs.server` and `nfs.path` are immutable on existing PVs, so post-merge ops require deleting the PVC + PV and letting Flux recreate them. `Retain` reclaim policy keeps the alcatraz NFS export untouched as a rollback parachute.

## Hestia prereq (already done)
- NFS export `id=5` created via `sharing.nfs.create` on `/mnt/main/family/images/photos` (networks `10.42.2.0/24`, maproot `root/wheel`) — matches the 4 existing media exports.

## Post-merge runbook
```bash
flux suspend kustomization apps-production -n flux-system
kubectl -n immich-prod scale deploy --replicas=0 --all
kubectl -n immich-prod delete pvc immich-photos-pvc
kubectl delete pv immich-photos-pv-prod
flux resume kustomization apps-production -n flux-system
flux reconcile kustomization apps-production -n flux-system
kubectl -n immich-prod scale deploy --replicas=1 --all
```
Then smoke test: open Immich web UI, browse a recent album, confirm files load.

## Rollback
Revert this PR + delete PVC/PV + reconcile. Alcatraz NFS export still serves the original content.

## Test plan
- [x] `kustomize build apps/production/immich` passes
- [ ] Post-merge: PVC binds to new PV, immich pods come up, smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)