### PR TITLE
chore(renovate): enable automerge for non-major updates + dial cron to @daily

### DIFF
--- a/infra/controllers/renovate/cronjob.yaml
+++ b/infra/controllers/renovate/cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: renovate
   namespace: renovate
 spec:
-  schedule: "@hourly"
+  schedule: "@daily"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,19 @@
     "fileMatch": [
       "\\.yaml$"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "patch",
+        "minor",
+        "major"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": false
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,7 @@
         "digest",
         "pin",
         "patch",
-        "minor",
-        "major"
+        "minor"
       ],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Why

Two related Renovate behaviors to fix:

1. **No automerge** — 7 `chore(deps)` PRs are currently sitting `MERGEABLE/CLEAN` with all checks `SUCCESS`. Renovate opens them and walks away. Oldest is #785 from 2026-05-26.
2. **Hourly cron is overkill** — `@hourly` runs 24×/day. Dependency sweeps don't need that cadence.

## Changes

### `renovate.json`
Adds a packageRules entry that opts **non-major** update types (digest, pin, patch, minor) into automerge. CI is the sole gate — if `validate-kustomize`, `yaml-lint`, or `sync-staging` fails, the PR stays open for review.

Major updates also stay open. Semver-major is the right signal for "operator should look" — version-scheme changes (linuxserver tag conventions, vendor reflows) often hide here even when CI is green.

`automergeType: pr` (Renovate merges via API) because GitHub's native auto-merge is disabled at the repo level.

### `infra/controllers/renovate/cronjob.yaml`
`@hourly` → `@daily`. Catches everything Renovate would have caught anyway, less noise.

## Effect on the current backlog

| PR | Package | Type | Auto under new scope? |
|---|---|---|---|
| #860 | renovate/renovate digest | digest | ✅ |
| #859 | hermes-agent digest | digest | ✅ |
| #858 | zigbee2mqtt digest | digest | ✅ |
| #837 | alpine 3.20 → 3.23 | minor | ✅ |
| #816 | vllm v0.21.0 → v0.22.0 | minor | ✅ |
| #796 | memos 0.28.0 → 0.29.0 | minor | ✅ |
| #785 | qbittorrent 5.2.1 → 20.04.1 | **major** | ❌ stays open |

6 of 7 clear immediately on the next Renovate run. #785 stays open for human review (the linuxserver tag-scheme jump from `v5` to `v20` is exactly the kind of thing worth a look).

## Test plan
- [x] `kustomize build infra/controllers/renovate` passes
- [ ] After merge, next daily Renovate run picks up the 6 eligible backlog PRs and merges them
- [ ] #785 stays open
- [ ] No regression in tomorrow's deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)