### PR TITLE
chore(renovate-automerge): allow minor + handle BEHIND master via update-branch

### DIFF
--- a/infra/controllers/renovate-automerge/script-configmap.yaml
+++ b/infra/controllers/renovate-automerge/script-configmap.yaml
@@ -7,7 +7,8 @@ data:
   automerge.py: |
     #!/usr/bin/env python3
     """
-    Renovate automerge: merges digest/patch-only Renovate PRs with passing CI.
+    Renovate automerge: merges digest/pin/patch/minor Renovate PRs with passing
+    CI. Major updates and PRs with mixed update types stay open for review.
     Covers all repos listed in GITHUB_REPOS (comma-separated).
     Non-safe PRs are reported by email to EMAIL_TO.
     """
@@ -69,7 +70,7 @@ data:
         )
         if types:
             kinds = {t.lower() for t in types}
-            if kinds <= {"patch", "digest", "pin", "pindigest"}:
+            if kinds <= {"patch", "digest", "pin", "pindigest", "minor"}:
                 return True, "update type: " + ", ".join(sorted(kinds))
             return False, "update type: " + ", ".join(sorted(kinds))
 
@@ -85,7 +86,7 @@ data:
             if a[0] != b[0]:
                 return False, f"major bump ({versions[0]} -> {versions[-1]})"
             if a[1] != b[1]:
-                return False, f"minor bump ({versions[0]} -> {versions[-1]})"
+                return True, f"minor bump ({versions[0]} -> {versions[-1]})"
             return True, f"patch bump ({versions[0]} -> {versions[-1]})"
 
         return False, "cannot determine update type"
@@ -108,7 +109,22 @@ data:
             return False
 
 
+    def update_branch(repo, pr):
+        """Tell GitHub to merge master into the PR branch, clearing BEHIND
+        state. CI re-runs on the new head; next cron tick picks the PR up."""
+        number = pr["number"]
+        try:
+            gh(f"/repos/{repo}/pulls/{number}/update-branch", method="PUT", body={})
+            return True
+        except urllib.error.HTTPError as exc:
+            print(f"    update-branch failed: {exc.code} {exc.reason}", flush=True)
+            return False
+
+
     def merge_pr(repo, pr):
+        """Returns (merged, rebased). When the merge fails with 405 (typically
+        because branch protection requires up-to-date branches), we attempt
+        update-branch so the next cron run can merge cleanly."""
         number = pr["number"]
         try:
             gh(
@@ -116,10 +132,17 @@ data:
                 method="PUT",
                 body={"merge_method": "merge", "commit_title": pr["title"]},
             )
-            return True
+            return True, False
         except urllib.error.HTTPError as exc:
             print(f"    merge failed: {exc.code} {exc.reason}", flush=True)
-            return False
+            # 405 Method Not Allowed is the GitHub response when branch
+            # protection requires the head be up-to-date and the PR is BEHIND.
+            # Trigger a rebase so the next run merges cleanly.
+            if exc.code == 405:
+                if update_branch(repo, pr):
+                    print(f"    -> rebased onto master; will retry next run", flush=True)
+                    return False, True
+            return False, False
 
 
     def process_repo(repo):
@@ -143,9 +166,12 @@ data:
                 held.append({"pr": pr, "reason": reason})
                 continue
 
-            if merge_pr(repo, pr):
+            ok, rebased = merge_pr(repo, pr)
+            if ok:
                 print(f"    -> merged", flush=True)
                 merged.append({"pr": pr, "reason": reason})
+            elif rebased:
+                held.append({"pr": pr, "reason": reason + " (behind master — rebased; will merge next run)"})
             else:
                 held.append({"pr": pr, "reason": reason + " (merge failed)"})
 


### PR DESCRIPTION
## Diagnosis

After PR #861 enabled Renovate's own \`automerge: true\` for non-major updates, three digest PRs cleared (#858, #859, #860) but #837/#816/#796 (all minor) stayed open. The user was right that something else in homelab gates merges — the \`renovate-automerge\` CronJob (separate from the \`renovate\` CronJob) runs a custom Python script every 6h that's the **authoritative auto-merge policy**, and it covers all 9 repos.

Last run log:
\`\`\`
PR #837 alpine v3.23   → hold: update type: minor
PR #816 vllm v0.22.0   → hold: update type: minor
PR #796 memos v0.29.0  → hold: update type: minor
PR #785 qbit v20       → hold: update type: major
\`\`\`

The script's \`classify_pr()\` only accepted \`{patch, digest, pin, pinDigest}\` — minor and major both held. Plus the merge path didn't handle \`mergeStateStatus=BEHIND\` (the state these PRs were in), so even with \`minor\` allowed the merges would have 405'd.

## Changes

1. \`classify_pr()\` accepts \`minor\` in the safe set (matches the scope set in #861). Fallback version-string parser also flips minor bumps from False to True for consistency. Major still holds.
2. \`merge_pr()\` returns \`(merged, rebased)\`. On HTTP 405 (the response GitHub gives when branch protection requires up-to-date branches and the PR is BEHIND), the script triggers update-branch via the GitHub API. CI re-runs on the new head; next cron tick merges cleanly.

## Net effect on the current homelab backlog
| PR | Type | After this PR |
|---|---|---|
| #837 alpine 3.20 → 3.23 | minor (BEHIND) | rebase next run → merge run after |
| #816 vllm 0.21 → 0.22 | minor (BEHIND) | same |
| #796 memos 0.28 → 0.29 | minor (BEHIND) | same |
| #785 qbittorrent 5 → 20 | major | stays held (intended) |

Same shape applies across the other 8 repos the cron covers (Pingo, drift, tempo-interview, etc.).

## Test plan
- [x] \`kustomize build infra/controllers/renovate-automerge\` passes
- [x] Python compiles cleanly inside the ConfigMap
- [ ] After merge → next cron run (every 6h, or trigger \`kubectl create job --from=cronjob/renovate-automerge renovate-automerge-manual -n renovate\`) → email report should show #837/#816/#796 in "rebased; will merge next run", then merged on the following run
- [ ] #785 stays held with reason "major bump"

🤖 Generated with [Claude Code](https://claude.com/claude-code)