### PR TITLE
chore(renovate-automerge): try squash → rebase → merge before update-branch

### DIFF
--- a/infra/controllers/renovate-automerge/script-configmap.yaml
+++ b/infra/controllers/renovate-automerge/script-configmap.yaml
@@ -122,27 +122,44 @@ data:
 
 
     def merge_pr(repo, pr):
-        """Returns (merged, rebased). When the merge fails with 405 (typically
-        because branch protection requires up-to-date branches), we attempt
-        update-branch so the next cron run can merge cleanly."""
+        """Returns (merged, rebased).
+
+        405 Method Not Allowed has two common causes that share the same
+        status code:
+          1. The repo's branch protection forbids the merge method we chose
+             (e.g. required_linear_history rejects 'merge' commits).
+          2. The PR is BEHIND and protection requires up-to-date branches.
+
+        So we try the merge methods in safest-first order — squash, rebase,
+        merge — and only after all three give 405 do we treat it as case 2
+        and trigger update-branch. CI re-runs on the new head; next cron
+        tick retries the merge.
+
+        Non-405 errors (409 conflict, 422 mergeability, etc.) won't be
+        helped by a different method, so we bail immediately."""
         number = pr["number"]
-        try:
-            gh(
-                f"/repos/{repo}/pulls/{number}/merge",
-                method="PUT",
-                body={"merge_method": "merge", "commit_title": pr["title"]},
-            )
-            return True, False
-        except urllib.error.HTTPError as exc:
-            print(f"    merge failed: {exc.code} {exc.reason}", flush=True)
-            # 405 Method Not Allowed is the GitHub response when branch
-            # protection requires the head be up-to-date and the PR is BEHIND.
-            # Trigger a rebase so the next run merges cleanly.
-            if exc.code == 405:
-                if update_branch(repo, pr):
-                    print(f"    -> rebased onto master; will retry next run", flush=True)
-                    return False, True
-            return False, False
+        last_405 = False
+        for method in ("squash", "rebase", "merge"):
+            body = {"merge_method": method}
+            if method in ("squash", "merge"):
+                body["commit_title"] = pr["title"]
+            try:
+                gh(f"/repos/{repo}/pulls/{number}/merge", method="PUT", body=body)
+                print(f"    -> merged via {method}", flush=True)
+                return True, False
+            except urllib.error.HTTPError as exc:
+                print(f"    merge_method={method} failed: {exc.code} {exc.reason}", flush=True)
+                last_405 = exc.code == 405
+                if not last_405:
+                    return False, False
+
+        # All three methods returned 405 — likely BEHIND master + branch
+        # protection requires up-to-date branches. Rebase and let the next
+        # cron run retry.
+        if last_405 and update_branch(repo, pr):
+            print(f"    -> rebased onto master; will retry next run", flush=True)
+            return False, True
+        return False, False
 
 
     def process_repo(repo):


### PR DESCRIPTION
## Why

PR #864 added an update-branch fallback for the BEHIND-master case (HTTP 405). But 405 has another common cause: **branch protection forbids the chosen merge method**. The script hardcoded \`merge_method=merge\`, so on repos with \`required_linear_history: true\` (which forbid merge commits), every PR returns 405 and update-branch returns 422 (would also create a merge commit). PRs sit stuck forever.

Caught today on gjcourt/drift #10 after the manual one-off automerge cron run:
\`\`\`
PR #10: chore(deps): update module modernc.org/sqlite to v1.51.0
  -> update type: minor, checking CI ...
  merge failed: 405 Method Not Allowed
  update-branch failed: 422 Unprocessable Entity
  -> held
\`\`\`

I merged #10 manually with \`--squash\`. This PR makes the script do the same dance.

## Change

\`merge_pr()\` now tries methods in safest-first order: \`squash → rebase → merge\`. Only after all three return 405 do we trust it's actually the BEHIND-master case and trigger update-branch. Non-405 errors (409 conflict, 422 mergeability) still short-circuit since a different method won't help them.

## Effect

| Repo trait | Before | After |
|---|---|---|
| Allows merge commits | merge ✓ | squash ✓ |
| \`required_linear_history\` (e.g. drift) | merge 405 → update-branch 422 → stuck | squash ✓ |
| BEHIND + up-to-date required | merge 405 → update-branch ✓ → retry next run | squash 405 → rebase 405 → merge 405 → update-branch ✓ → retry next run |
| Genuine conflict (409) | merge 409 → held | squash 409 → held (same outcome, no extra calls) |

Trade-off: repos that previously got merge commits will now get squash commits. For chore(deps) PRs (which are typically 1-2 commits anyway) this is a stylistic difference, not a functional one. If you'd rather preserve merge commits on specific repos, follow-up could read \`allow_merge_commit\` / \`allow_squash_merge\` / \`allow_rebase_merge\` from the repo settings API and skip disabled methods up front.

## Test plan
- [x] \`kustomize build infra/controllers/renovate-automerge\` passes
- [x] Embedded Python compiles cleanly
- [ ] After merge → trigger one-off Job → drift, Pingo, tempo-interview, homelab all merge minor PRs successfully via the right method per their protection
- [ ] No false-positive update-branch calls on repos that actually weren't BEHIND

🤖 Generated with [Claude Code](https://claude.com/claude-code)