### PR TITLE
fix(qbittorrent): revert from linuxserver 20.04.x → 5.2.1 (real latest)

### DIFF
--- a/hosts/hestia/qbittorrent/docker-compose.yml
+++ b/hosts/hestia/qbittorrent/docker-compose.yml
@@ -29,7 +29,13 @@
 
 services:
   qbittorrent:
-    image: lscr.io/linuxserver/qbittorrent:20.04.1@sha256:fc98c8af048936d0070dc5e5992feab08664f8a61a860d91be02f782f8721485
+    # Pin to the linuxserver 5.x version-tag family — that's the actively
+    # maintained qbit line. The earlier 20.04.x tag (briefly merged via
+    # #785) is the Ubuntu-20.04-base build, frozen on qbit 4.3.9. The
+    # version string "20.04.1" lexically looks newer than "5.2.1" but
+    # semantically refers to a different (older) qbit. This is the
+    # canonical example of the linuxserver tag-scheme trap.
+    image: lscr.io/linuxserver/qbittorrent:5.2.1@sha256:715d2bfbcf1cd3d734cbbd4fbd599eb7ea0642eaa079a372dd0d343f59516700
     container_name: qbittorrent
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Why

PR #785 (merged 2026-06-02) bumped the qbit image tag from \`5.2.1\` → \`20.04.1\` thinking it was a forward bump. The linuxserver/qbittorrent registry actually publishes two parallel tag schemes:

- \`5.x.x\` — the actively-maintained current qbit (5.2.1 latest)
- \`20.04.x\` — the Ubuntu-20.04-base build, **frozen on qbit 4.3.9**

The "20" prefix is the base OS version. Tag-string ordering ("20.04.1" > "5.2.1") is a lexical illusion that hides what's really a qbit **downgrade** from 5.x → 4.3.9.

## Observed regression

Confirmed via WebUI API on hestia tonight (2026-06-02 post #785 deploy):
- qbit version dropped from 5.x to **v4.3.9** (libtorrent 1.2.14)
- 5.x API endpoints (\`/torrents/start\`, \`/torrents/stop\`) replaced with 4.x names (\`/torrents/resume\`, \`/torrents/pause\`)

Library + 70 torrents continued to function, so this wasn't catastrophic — but it's an unintentional downgrade.

## Change

Repin to \`lscr.io/linuxserver/qbittorrent:5.2.1@sha256:715d2bfb…\` (multi-arch index digest, multi-arch supports the linux/amd64 hestia host). Adds a 5-line inline comment explaining the tag-scheme trap so this doesn't repeat.

## Tag rule exception

Tag is lexically lower (\`5.2.1\` < \`20.04.1\`), which would normally violate AGENTS.md's "strictly increasing" rule. That rule exists to prevent **silent** rollbacks — this PR is an explicit, intentional revert of an upgrade-that-was-actually-a-downgrade. Explicit-intent exception per the rule's own wording: "never roll back to an earlier tag *without explicit intent*."

## Follow-up
Configure Renovate to ignore the \`20.04.x\` tag family for this image so it never offers another "upgrade" in that direction. Best left for a separate PR.

## Test plan
- [x] linuxserver/qbittorrent:5.2.1 image manifest exists on lscr.io / ghcr.io
- [x] Digest verified via \`docker-content-digest\` header
- [ ] After merge → deploy-hestia rolls → \`midclt call app.query\` shows new image; WebUI \`/api/v2/app/version\` returns v5.x
- [ ] All 70 torrents restored from BT_backup cleanly (this verified successfully on the 4.3.9 path; 5.x is forward-compat for BT_backup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)