### PR TITLE
fix(immich-photos-backup): chmod source before rsync to handle 0700 uploads

### DIFF
--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -45,6 +45,34 @@ ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
     truenas-backup@10.42.2.11 'ls /volume1/homes/george/Photos | head; ls /volume1/homes/mara/Photos | head'
 ```
 
+### 3a. Sudoers entry on alcatraz (one-time, required)
+
+Synology DSM Photos uploads new files with POSIX mode `0700`. The owning group is `users` (gid 100) — which `truenas-backup` is also in, so the group bit's `---` denies before POSIX falls through to "other". rsync hits `send_files Permission denied (13)` on every new file and the run fails partially-but-silently (zero bytes transferred for new content; no metric update; the `ImmichPhotoBackupStale` alert eventually fires).
+
+The script's per-user rsync runs a `sudo chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod:
+
+```bash
+# As a DSM admin (currently: manager) on alcatraz:
+sudo tee /etc/sudoers.d/immich-photos-backup <<'EOF'
+truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos
+EOF
+sudo chmod 0440 /etc/sudoers.d/immich-photos-backup
+sudo visudo -cf /etc/sudoers.d/immich-photos-backup   # syntax check
+```
+
+Notes:
+- Commas inside the command args must be escaped (`g+rX\,o+rX`); unescaped commas separate multiple commands in sudoers.
+- Adding a third user (e.g. `kid1`) requires extending this file with another comma-separated command — same pattern.
+- DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 04:00 cron will fail loudly (chmod returns non-zero, `&&` aborts, rsync exits with `12` or `14`). Re-add the file post-upgrade.
+
+Verify after adding:
+```bash
+ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
+    truenas-backup@10.42.2.11 \
+    'sudo -n /bin/chmod -R g+rX,o+rX /volume1/homes/george/Photos && echo ok'
+```
+Should print `ok` with no password prompt.
+
 ### 4. node-exporter textfile collector
 If not already running, node-exporter on hestia must be invoked with `--collector.textfile.directory=/var/lib/node-exporter/textfile`. The container writes `immich-backup.prom` there on each successful run, which Prometheus scrapes for the `ImmichPhotoBackupStale` alert in `infra/configs/alerts/prometheus-rules.yaml`.
 

--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -53,19 +53,33 @@ The script's per-user rsync runs a `sudo chmod -R g+rX,o+rX` on the source via r
 
 ```bash
 # As a DSM admin (currently: manager) on alcatraz:
-sudo tee /etc/sudoers.d/immich-photos-backup <<'EOF'
+# Write to /tmp first and validate BEFORE moving into sudoers.d/ — a
+# syntax error in any file under /etc/sudoers.d/ makes sudo refuse to
+# operate at all on most versions, which would lock the operator out
+# of fixing it.
+cat > /tmp/immich-photos-backup.sudoers <<'EOF'
 truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos
 EOF
-sudo chmod 0440 /etc/sudoers.d/immich-photos-backup
-sudo visudo -cf /etc/sudoers.d/immich-photos-backup   # syntax check
+sudo visudo -cf /tmp/immich-photos-backup.sudoers   # MUST pass before next step
+sudo install -m 0440 -o root -g root \
+    /tmp/immich-photos-backup.sudoers \
+    /etc/sudoers.d/immich-photos-backup
+rm /tmp/immich-photos-backup.sudoers
 ```
+
+Sanity check the paths exist on your DSM (paths differ between Synology firmware versions):
+```bash
+ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
+    truenas-backup@10.42.2.11 'command -v sudo chmod'
+```
+Should print `/usr/bin/sudo` (or `/bin/sudo`) and `/bin/chmod`. If `chmod` resolves elsewhere on your DSM, update the script and sudoers line to match.
 
 Notes:
 - Commas inside the command args must be escaped (`g+rX\,o+rX`); unescaped commas separate multiple commands in sudoers.
 - Adding a third user (e.g. `kid1`) requires extending this file with another comma-separated command — same pattern.
-- DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 04:00 cron will fail loudly (chmod returns non-zero, `&&` aborts, rsync exits with `12` or `14`). Re-add the file post-upgrade.
+- DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 04:00 cron will fail loudly: `sudo -n` exits immediately, `&&` short-circuits, rsync exits with code `12` (protocol data stream error). Re-add the file post-upgrade.
 
-Verify after adding:
+Verify after install:
 ```bash
 ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
     truenas-backup@10.42.2.11 \
@@ -92,6 +106,8 @@ First run pulls ~425 GB over gigabit (~30-60 min). Detach-safe via `docker logs 
 ## Subsequent updates
 
 Every change to `images/immich-photos-backup/**` on `master` triggers `.github/workflows/build-immich-photos-backup.yml` → publishes `ghcr.io/gjcourt/immich-photos-backup:YYYY-MM-DD` (with `:latest` mirror). Bump the digest in `docker-compose.yml` in a follow-up PR; `.github/workflows/deploy-hestia.yml` then auto-applies via `truenas-update-app.sh`.
+
+The sudoers entry in section 3a is a **prerequisite** for any image whose script invokes `sudo -n /bin/chmod` (currently: all images since 2026-06-09). If the entry was wiped by a DSM upgrade and the script is updated in the meantime, the next 04:00 cron will fail until the entry is restored — verify before each digest bump if alcatraz had recent firmware updates.
 
 To roll back: revert the digest in `docker-compose.yml` and merge; auto-deploy applies the prior image.
 

--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -49,7 +49,7 @@ ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
 
 Synology DSM Photos uploads new files with POSIX mode `0700`. The owning group is `users` (gid 100) — which `truenas-backup` is also in, so the group bit's `---` denies before POSIX falls through to "other". rsync hits `send_files Permission denied (13)` on every new file and the run fails partially-but-silently (zero bytes transferred for new content; no metric update; the `ImmichPhotoBackupStale` alert eventually fires).
 
-The script's per-user rsync runs a `sudo chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod:
+The script's per-user rsync runs a `sudo -n chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod (and no `requiretty` constraint — see Notes below):
 
 ```bash
 # As a DSM admin (currently: manager) on alcatraz:
@@ -78,6 +78,7 @@ Notes:
 - Commas inside the command args must be escaped (`g+rX\,o+rX`); unescaped commas separate multiple commands in sudoers.
 - Adding a third user (e.g. `kid1`) requires extending this file with another comma-separated command — same pattern.
 - DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 04:00 cron will fail loudly: `sudo -n` exits immediately, `&&` short-circuits, rsync exits with code `12` (protocol data stream error). Re-add the file post-upgrade.
+- If a future DSM update sets `Defaults requiretty` in `/etc/sudoers`, NOPASSWD alone won't be enough — sudo will reject all non-tty invocations including this one. Confirm `sudo -l` from a non-interactive ssh continues to work after any DSM upgrade.
 
 Verify after install:
 ```bash

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -12,6 +12,17 @@
 # so we sync from the homes path directly, mapping into the canonical hestia
 # layout family/images/photos/<user>/.
 #
+# Mode-fix note: Synology DSM Photos uploads new files with POSIX mode 0700
+# (owner-only). truenas-backup is in gid=100(users), which matches the file
+# group, so POSIX checks the group bit (`---`) and denies before falling
+# through to "other" — rsync hits send_files Permission denied (13) on every
+# new file. The fix runs a recursive chmod on the source via --rsync-path
+# before each rsync. See docs in hosts/hestia/immich-photos-backup/README.md
+# (section "Sudoers entry on alcatraz") for the required NOPASSWD sudoers
+# entry on alcatraz — without it the chmod fails, rsync doesn't run, and
+# the run fails loudly (intentional — silent perm-denied was the original
+# bug).
+#
 # Deployed as a TrueNAS Custom App; cron at 04:00 daily is fired by the
 # container's busybox crond (see hosts/hestia/immich-photos-backup/).
 #
@@ -70,11 +81,17 @@ for user in "${USERS[@]}"; do
   dst="${DST_BASE}/${user}/"
   mkdir -p "${dst}"
   echo "--- $(date -u +%FT%TZ) sync ${user}: ${src} -> ${dst} ---"
+  # See "Mode-fix note" in the header. The chmod runs on the remote (alcatraz)
+  # before rsync's own server-side invocation, fixing 0700 uploads in-place so
+  # truenas-backup can read them. `&&` so a chmod failure aborts the run with
+  # a clear remote-command-exited error rather than silently degrading.
+  remote_rsync="sudo /bin/chmod -R g+rX,o+rX /volume1/homes/${user}/Photos && rsync"
   if ! rsync -avh --delete --delete-excluded \
         --exclude='@eaDir' \
         --exclude='.DS_Store' \
         --exclude='Thumbs.db' \
         --rsh="${RSYNC_RSH}" \
+        --rsync-path="${remote_rsync}" \
         --stats \
         "${src}" "${dst}"; then
     rc=$?

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -19,9 +19,11 @@
 # new file. The fix runs a recursive chmod on the source via --rsync-path
 # before each rsync. See docs in hosts/hestia/immich-photos-backup/README.md
 # (section "Sudoers entry on alcatraz") for the required NOPASSWD sudoers
-# entry on alcatraz — without it the chmod fails, rsync doesn't run, and
-# the run fails loudly (intentional — silent perm-denied was the original
-# bug).
+# entry on alcatraz — without it `sudo -n` fails immediately, rsync exits
+# with code 12 (protocol data stream error from remote command dying before
+# protocol start), the run is recorded FAILED in the log, and the metric
+# stays stale. Loud failure is intentional — silent perm-denied was the
+# original bug.
 #
 # Deployed as a TrueNAS Custom App; cron at 04:00 daily is fired by the
 # container's busybox crond (see hosts/hestia/immich-photos-backup/).
@@ -85,13 +87,19 @@ for user in "${USERS[@]}"; do
   # before rsync's own server-side invocation, fixing 0700 uploads in-place so
   # truenas-backup can read them. `&&` so a chmod failure aborts the run with
   # a clear remote-command-exited error rather than silently degrading.
-  remote_rsync="sudo /bin/chmod -R g+rX,o+rX /volume1/homes/${user}/Photos && rsync"
+  #
+  # `sudo -n` (non-interactive) is load-bearing: without it, an ssh session
+  # without a controlling tty will either fail with an opaque "no tty present"
+  # or hang trying to open /dev/tty if NOPASSWD isn't in effect — the inverse
+  # of the loud-failure mode we want. -n exits immediately with
+  # "sudo: a password is required", which surfaces in the cron log.
+  REMOTE_RSYNC="sudo -n /bin/chmod -R g+rX,o+rX /volume1/homes/${user}/Photos && rsync"
   if ! rsync -avh --delete --delete-excluded \
         --exclude='@eaDir' \
         --exclude='.DS_Store' \
         --exclude='Thumbs.db' \
         --rsh="${RSYNC_RSH}" \
-        --rsync-path="${remote_rsync}" \
+        --rsync-path="${REMOTE_RSYNC}" \
         --stats \
         "${src}" "${dst}"; then
     rc=$?


### PR DESCRIPTION
## Summary

- Adds `--rsync-path` shim that runs `sudo chmod -R g+rX,o+rX` on alcatraz before each rsync transfer, fixing the recurring 0700-on-new-uploads silent failure.
- Documents the one-time NOPASSWD sudoers entry required on alcatraz (`/etc/sudoers.d/immich-photos-backup`) in the host README — section 3a.
- Uses `&&` so a chmod failure aborts the rsync with a clear remote-command-exited error rather than silently degrading to the perm-denied skip we just fixed.

## Root cause

Synology DSM Photos uploads new files with POSIX mode `0700`. Owner is the user (e.g. `george:users`); group is `users` (gid 100). `truenas-backup` is in `users`, so POSIX checks the group bit (`---`) and denies access before falling through to "other" — silently skipping every new upload. Confirmed second time on 2026-06-09 (first surfaced 2026-06-02); manual one-shot chmod restored the missing 8 days of uploads tonight, and this PR prevents the next recurrence.

## Deploy sequence

1. Merge → CI builds `ghcr.io/gjcourt/immich-photos-backup:<YYYY-MM-DD>` with the new script.
2. Operator adds the sudoers entry on alcatraz per README section 3a (one-time). Verify with the `sudo -n chmod ... && echo ok` snippet.
3. Follow-up PR bumps the digest pin in `hosts/hestia/immich-photos-backup/docker-compose.yml`; auto-deploy applies.
4. Next 04:00 cron should end with `=== END (success ...)` and a non-zero transfer count for any user with new uploads since the previous run.

## Test plan

- [x] `bash -n images/immich-photos-backup/immich-photos-backup.sh` passes
- [ ] After image build + digest bump + sudoers entry: next 04:00 run completes with success line; `/var/lib/node-exporter/textfile/immich-backup.prom` timestamp advances; `immich_photos_backup_last_success_seconds` series exists in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)