### PR TITLE
deploy(immich-photos-backup): bump to 2026-06-09 (rsync-path chmod shim)

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-01@sha256:de2b01973ed3111dca56ef0af7bdd0f2f29df68db6c2213fedf31d3ea119fd86
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-09@sha256:93a52aa278f27777b320a8b135d54474fd9059c363c7bb8439ff08505c5eb1b3
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Bumps `hosts/hestia/immich-photos-backup/docker-compose.yml` to `ghcr.io/gjcourt/immich-photos-backup:2026-06-09@sha256:93a52aa2…`, built from #881 (squash-merged at `6f432263`).

Picks up the `--rsync-path` chmod shim that fixes the recurring Synology DSM 0700-on-new-uploads silent skip.

## Operator prerequisite

**Before this image runs**, the NOPASSWD sudoers entry for `truenas-backup` on alcatraz must be in place per `hosts/hestia/immich-photos-backup/README.md` section 3a. Without it, the next 04:00 cron will fail loudly (`sudo: a password is required` → rsync exit 12). The previous image (`2026-06-01`) didn't invoke sudo so this is a new prerequisite, not a regression.

Catch-up sync for the 7-day silent failure was already run tonight manually after a one-shot chmod; this image prevents the next recurrence.

## Test plan

- [ ] After deploy-hestia run: `docker logs immich-photos-backup` shows the new image tag in container metadata.
- [ ] Next 04:00 cron ends with `=== END (success ...)`; `/var/lib/node-exporter/textfile/immich-backup.prom` timestamp advances; `immich_photos_backup_last_success_seconds` series begins reporting in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)