### PR TITLE
feat(burntbytes): self-host the blog on the hidden origin hostname

### DIFF
--- a/apps/base/burntbytes/deployment.yaml
+++ b/apps/base/burntbytes/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: burntbytes
+  namespace: burntbytes
+  labels:
+    app: burntbytes
+spec:
+  # Two replicas: this serves the public apex (burntbytes.com), so spread
+  # across nodes for zero-downtime rollouts and single-node resilience.
+  replicas: 2
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: burntbytes
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: burntbytes
+    spec:
+      serviceAccountName: burntbytes
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ghcr-secret
+      # Spread the two replicas across nodes where possible; ScheduleAnyway
+      # so a single-schedulable-node window doesn't block rollout.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: burntbytes
+      securityContext:
+        # nginx-unprivileged runs as uid 101 by default; match it here so the
+        # container's /tmp + cache emptyDirs are owned correctly.
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: burntbytes
+          image: ghcr.io/gjcourt/burntbytes:2026-06-10-29cc91a
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          # Probe pattern per docs/operations/2026-05-02-adding-an-app.md:
+          # readiness HTTP-tight, liveness tcpSocket-loose so the two can't
+          # co-restart the pod off a single flap.
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          # nginx-unprivileged writes its pid + temp paths under /tmp and
+          # caches under /var/cache/nginx; mount emptyDirs so
+          # readOnlyRootFilesystem doesn't break startup.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}

--- a/apps/base/burntbytes/kustomization.yaml
+++ b/apps/base/burntbytes/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - namespace.yaml
+  - networkpolicy.yaml
+  - pdb.yaml
+  - secret-ghcr.yaml
+  - service.yaml
+  - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: burntbytes
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/burntbytes/namespace.yaml
+++ b/apps/base/burntbytes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: burntbytes
+  labels:
+    http-ingress: "true"

--- a/apps/base/burntbytes/networkpolicy.yaml
+++ b/apps/base/burntbytes/networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: burntbytes
+  namespace: burntbytes
+  labels:
+    app.kubernetes.io/name: burntbytes
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    Static Hugo blog served by nginx; no DB, no external calls. Gateway
+    ingress on 8080 only.
+  endpointSelector:
+    matchLabels:
+      app: burntbytes
+  ingress:
+    # Cluster gateway proxy ingress. host + remote-node + ingress are all
+    # required — see feedback memory `feedback_cilium_gateway_netpol`.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # DNS only — nginx resolves hostnames for logging; the app never makes
+    # outbound calls. Reply traffic to the Gateway proxy is carried by
+    # Cilium conntrack on the established ingress flow, so no symmetric
+    # egress rule for host/remote-node/ingress is needed. Same pattern as
+    # apps/base/flashcards/networkpolicy.yaml.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/base/burntbytes/pdb.yaml
+++ b/apps/base/burntbytes/pdb.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: burntbytes
+  namespace: burntbytes
+spec:
+  # Two replicas; allow one to be evicted at a time so node drains can
+  # proceed while keeping the site up.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: burntbytes

--- a/apps/base/burntbytes/secret-ghcr.yaml
+++ b/apps/base/burntbytes/secret-ghcr.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:sLQhw86/zZPCJ7VwyX1174YdYqVfjAbR9FxuSqhN/SeT7QWeaU3DdTKpysmjW6SgSfx1j5Bglc+/GGSM1Un/9bv8Uy0WRoLnupgScyCtZoE8usF8MaFRhRzibd3jh5JZOqu+F++/3nf99+ENwT7bM+3Q3S5OzSyDPLT4sTOAzfM5W4+j/e1XvsA4x2j1h4u2yLWLCHBY7ACs0jj1h2GVpvHl6+4/r+Wy76oBwOM8rFkXtGqa9ajD8WRSIQq6ZBDCTXc4xgozWNYIKv0+z85KJUeYXiSbrYWebkaHIoQQH6vARmUh3JITFCVHcwxSyPBDcE0CR0GocuUFkcO2RuyWzWrgSR5YeMFXQMd1Z91r3xkyEnXN1tLfqw==,iv:MEMr8N4V49VuhoLKXcUgP6NfX3CZ/H+/5yZ/SIvw53Q=,tag:H0g+V+gZlZaJO8ebVvrYjA==,type:str]
+kind: Secret
+metadata:
+  name: ghcr-secret
+type: kubernetes.io/dockerconfigjson
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmbFg3c25IM0xOWDlhV0dM
+        OG43WUpHUjBhV254eXBPVzVFOW5qUk1UUlh3CkJvTkl0cytLaDE4d3RWdTFyRHZ4
+        R0E2VVJwL3A5QStRakRBdlgvUXA2M0UKLS0tIGtOcUhNNlRXQlJKUGtSOGhJTU9Q
+        WmlIdUFEejE2d2ZPSFIzRWdVc1V2ZUEK97vJuo8Hj86xhgj7ndiP1hJfovptQdJW
+        tYHAMvx61BFm5uBV2AB0QQRODKpdJcgGlLDOcz+RjHChHpUTuur0yA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-15T23:56:20Z"
+  mac: ENC[AES256_GCM,data:O5RnqsvsHV41Ru1+O0iFFQ1BRMr9hawCqvS18KghHMggeSCAXA+JDQpU8XCSvvHPNbpwaOnGpnG5oa6UBaveKwssscTqsrebFhRVdlRoOq+AZEaeba2qKA+YYp7YKLfrYBU6iQvp3AVJjhUulkPwD+2r9w01CURHvm+KR8ZYyUA=,iv:2MT+ocn5KZdTlrxm01OBF0PDm/l4ZhlzdJsjMeL2UgQ=,tag:lkUwEuLq4KwTwiaILkXDzQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.11.0

--- a/apps/base/burntbytes/service.yaml
+++ b/apps/base/burntbytes/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: burntbytes
+  namespace: burntbytes
+  labels:
+    app: burntbytes
+spec:
+  type: ClusterIP
+  selector:
+    app: burntbytes
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/apps/base/burntbytes/serviceaccount.yaml
+++ b/apps/base/burntbytes/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: burntbytes
+  namespace: burntbytes
+automountServiceAccountToken: false

--- a/apps/production/burntbytes/httproute.yaml
+++ b/apps/production/burntbytes/httproute.yaml
@@ -1,0 +1,40 @@
+# P2 routes on the hidden hostname burntbytes-origin.burntbytes.com — a
+# subdomain already covered by the existing *.burntbytes.com wildcard cert and
+# the gateway's `http`/`https` wildcard listeners, so no shared-gateway change
+# is needed to validate the full path. P3 adds the apex (burntbytes.com)
+# hostname + dedicated apex listeners.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: burntbytes-http
+  namespace: burntbytes-prod
+spec:
+  hostnames:
+    - burntbytes-origin.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: burntbytes-https
+  namespace: burntbytes-prod
+spec:
+  hostnames:
+    - burntbytes-origin.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: burntbytes
+          port: 8080

--- a/apps/production/burntbytes/kustomization.yaml
+++ b/apps/production/burntbytes/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: burntbytes-prod
+resources:
+  - ../../base/burntbytes/
+  - httproute.yaml
+
+labels:
+  - pairs:
+      env: production
+      app.kubernetes.io/instance: production
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: burntbytes
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: burntbytes-prod

--- a/apps/production/cloudflare-tunnel/configmap.yaml
+++ b/apps/production/cloudflare-tunnel/configmap.yaml
@@ -34,5 +34,14 @@ data:
         originRequest:
           originServerName: overture.burntbytes.com
 
+      # burntbytes blog — hidden origin hostname for pre-cutover validation.
+      # Inert off-LAN until a Cloudflare DNS record points it at the tunnel;
+      # validated on-LAN via the *.burntbytes.com wildcard + AdGuard rewrite.
+      # The apex (burntbytes.com) entry is added in the apex-activation PR.
+      - hostname: burntbytes-origin.burntbytes.com
+        service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
+        originRequest:
+          originServerName: burntbytes-origin.burntbytes.com
+
       # Catch-all returns 404
       - service: http_status:404

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - adguard
   - audiobookshelf
   - authelia
+  - burntbytes
   - certificates
   - cloudflare-tunnel
   - excalidraw

--- a/docs/plans/2026-06-10-burntbytes-self-host.md
+++ b/docs/plans/2026-06-10-burntbytes-self-host.md
@@ -1,0 +1,116 @@
+---
+status: in_progress
+last_modified: 2026-06-10
+---
+
+# Self-host burntbytes.com on the Talos homelab
+
+## Context
+
+`burntbytes.com` is a Hugo + PaperMod blog (`gjcourt/burntbytes`, 4 published
+posts) previously published to `gjcourt/gjcourt.github.io` via a manual
+`hugo && git push` and served by GitHub Pages behind Cloudflare proxy. We're
+moving the origin into the `melodic-muse` cluster to retire the manual deploy
+and route apex traffic through the same path as every `*.burntbytes.com`
+subdomain. Pattern cloned: `apps/base/flashcards/` (static site → nginx-unprivileged
+image → ghcr → Renovate-bumped tag → Flux). Exposure path: Cloudflare proxy →
+`cloudflared` tunnel → `cilium-gateway-app-gateway-production` → HTTPRoute →
+`burntbytes` Service → nginx pod.
+
+## Sequencing (refined from the original draft for lower blast radius)
+
+The original draft bundled the apex gateway listeners into P2. During execution
+we found Cloudflare uses **per-subdomain** DNS records (no `*.burntbytes.com`
+CNAME to the tunnel), and that the hidden hostname `burntbytes-origin.burntbytes.com`
+is already covered by the existing wildcard cert + wildcard gateway listeners +
+AdGuard wildcard rewrite. So:
+
+- **P2 touches zero shared infra** — app + an HTTPRoute on the hidden hostname,
+  validated on-LAN via `curl --resolve` to the gateway IP. The tunnel hop is
+  app-agnostic and already proven for every other subdomain.
+- **P3 isolates the one risky change** — apex gateway listeners + apex hostname
+  + apex tunnel entry + operator AdGuard apex rewrite. A bad apex listener can
+  only be a single isolated revert (it cannot ride along with the app deploy).
+
+```
+P0 (operator)   Lower apex Cloudflare TTL; capture tunnel UUID + original apex records
+P1 (source)     ✅ DONE — Dockerfile + nginx.conf + image.yml → ghcr image
+P2 (homelab)    App + hidden-hostname HTTPRoute + hidden tunnel entry (no gateway change)
+P3 (homelab)    Apex gateway listeners + apex hostname + apex tunnel entry (dark)
+P4 (Cloudflare) Apex DNS swing A → CNAME cfargotunnel (operator)
+P5 (cleanup)    Decommission Pages publish; runbook; plan → complete
+```
+
+## P1 — source repo (DONE)
+
+`gjcourt/burntbytes` PR #1 (merged). Multi-stage `hugomods/hugo:0.163.0` →
+`nginxinc/nginx-unprivileged:1.27-alpine` on :8080; `nginx.conf` with gzip +
+fingerprinted-asset immutable cache + short HTML revalidate + Hugo 404 wiring;
+`image.yml` builds to `ghcr.io/gjcourt/burntbytes:{date, date-sha, latest}` and
+inits only the theme submodule (the `public/` submodule is an SSH Pages URL).
+
+Two latent build fixes surfaced on modern Hugo (0.163):
+
+- `config.yaml`: restored pre-0.158 `security.allowContent` so the raw-HTML
+  `labs/beerbuilder` lab builds.
+- `network-streamers.md`: `{{< fig >}}` → `{{< figure >}}` (the `fig` shortcode
+  never existed; this published post had never built).
+
+Published image: `ghcr.io/gjcourt/burntbytes:2026-06-10-29cc91a`
+(`sha256:d78b6f5be213a9f5816ef0fe691203f473214186346a3fe036652f92c08fc45f`).
+
+## P2 — homelab app on the hidden hostname (this PR)
+
+New: `apps/base/burntbytes/` (clone of flashcards — 2 replicas, PDB
+`maxUnavailable: 1`, topology spread, read-only rootfs, `/healthz` readiness,
+TCP liveness; portable SOPS ghcr-secret copied verbatim) and
+`apps/production/burntbytes/` (HTTPRoute on `burntbytes-origin.burntbytes.com`).
+Edits: wire `burntbytes` into `apps/production/kustomization.yaml`; add the
+hidden-host tunnel ingress entry. **No gateway / AdGuard / Cloudflare change.**
+
+Verification (post-merge):
+```bash
+flux reconcile kustomization apps-production -n flux-system
+kubectl -n burntbytes-prod get pods            # 2/2 Ready
+kubectl -n burntbytes-prod port-forward svc/burntbytes 18080:8080 &
+curl -fsS http://localhost:18080/healthz       # ok
+# Full path via the gateway (LAN), using the wildcard cert + listener:
+curl -fsSI --resolve burntbytes-origin.burntbytes.com:443:10.42.2.40 \
+  https://burntbytes-origin.burntbytes.com/
+curl -fsS  --resolve burntbytes-origin.burntbytes.com:443:10.42.2.40 \
+  https://burntbytes-origin.burntbytes.com/ | grep -i 'burnt\|papermod'
+```
+
+Rollback: revert PR; Flux removes the workload. Apex still on Pages.
+
+## P3 — apex activation (dark)
+
+- `infra/configs/gateway/gateway-production.yaml`: add `http-apex` + `https-apex`
+  listeners (hostname `burntbytes.com`, reusing `burntbytes-prod-wildcard-tls`
+  which already SANs the apex).
+- `apps/production/burntbytes/httproute.yaml`: add `burntbytes.com` to hostnames.
+- tunnel configmap: add `burntbytes.com` ingress entry.
+- **Operator**: AdGuard rewrite `burntbytes.com → 10.42.2.40` (wildcard doesn't
+  cover the bare apex).
+
+Verify on-LAN (`curl --resolve burntbytes.com:443:10.42.2.40`); off-LAN still
+serves Pages (DNS unchanged). If a new apex listener disrupts `*.burntbytes.com`,
+revert immediately (known-unknown: Cilium per-hostname listener coexistence).
+
+## P4 — Cloudflare DNS swing (operator)
+
+Lower apex TTL ahead of time (P0). Replace apex A/AAAA with a proxied CNAME `@`
+→ `<tunnel-uuid>.cfargotunnel.com`; purge cache. Verify off-LAN serves the
+self-hosted build (nginx ETag, not Pages) and `/404` renders Hugo's 404.
+Rollback: restore original apex A records + purge (≤5 min, TTL lowered).
+
+## P5 — cleanup
+
+Source PR: remove the Pages publish flow + README. Homelab PR: add
+`docs/operations/apps/burntbytes.md`; flip this plan to `status: complete`.
+Leave `gjcourt.github.io` intact 30 days as a rollback parachute.
+
+## Out of scope
+
+Analytics, comments, RSS validation, image pipeline, search, staging overlay,
+self-hosted CI runner, cluster-edge CDN, sitemap submission.


### PR DESCRIPTION
## Summary

Phase 2 of migrating **burntbytes.com** off GitHub Pages onto the cluster (plan: `docs/plans/2026-06-10-burntbytes-self-host.md`). Deploys the containerized Hugo blog from `gjcourt/burntbytes` PR #1 and exposes it at `burntbytes-origin.burntbytes.com` for pre-cutover validation.

**This PR changes no shared gateway / AdGuard / Cloudflare config.** The hidden hostname is a subdomain already covered by the `*.burntbytes.com` wildcard cert, the gateway's wildcard `http`/`https` listeners, and the AdGuard wildcard rewrite — so the full path can be validated without touching anything other apps depend on. Apex (`burntbytes.com`) listeners + hostname + DNS swing follow in isolated PRs.

## Changes

- `apps/base/burntbytes/` — clone of the `flashcards` static-site pattern: nginx-unprivileged on :8080, **2 replicas** + PDB(`maxUnavailable: 1`) + topology spread (public apex), read-only rootfs, `/healthz` readiness + TCP liveness, DNS-only CNP egress.
- `apps/production/burntbytes/httproute.yaml` — HTTPRoute on `burntbytes-origin.burntbytes.com`.
- `apps/production/kustomization.yaml` — wire in `burntbytes`.
- `apps/production/cloudflare-tunnel/configmap.yaml` — hidden-host ingress entry (inert off-LAN; on-LAN validated via the wildcard).
- `docs/plans/2026-06-10-burntbytes-self-host.md` — the plan.

## Notes

- **SOPS ghcr-secret copied verbatim** from `apps/base/flashcards/secret-ghcr.yaml` — it's encrypted with the cluster age key and namespace-portable (the overlay's `namespace:` directive places it in `burntbytes-prod`). No re-encryption performed (respects the operator-only SOPS rule).
- Image pinned to `ghcr.io/gjcourt/burntbytes:2026-06-10-29cc91a`.

## Verification

- `kustomize build apps/production/burntbytes`, `apps/production/cloudflare-tunnel`, and full `apps/production` all pass.
- Post-merge (LAN): `flux reconcile kustomization apps-production`; pods 2/2 Ready; `curl --resolve burntbytes-origin.burntbytes.com:443:10.42.2.40 https://burntbytes-origin.burntbytes.com/` serves the Hugo build over the wildcard cert.

## Test plan

- [ ] kustomize build green (CI)
- [ ] pods 2/2 Ready after reconcile
- [ ] hidden hostname serves the blog over HTTPS via the gateway (LAN curl --resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)