### PR TITLE
feat(burntbytes): activate apex hostname (dark until DNS cutover)

### DIFF
--- a/apps/production/burntbytes/httproute.yaml
+++ b/apps/production/burntbytes/httproute.yaml
@@ -1,8 +1,10 @@
-# P2 routes on the hidden hostname burntbytes-origin.burntbytes.com — a
-# subdomain already covered by the existing *.burntbytes.com wildcard cert and
-# the gateway's `http`/`https` wildcard listeners, so no shared-gateway change
-# is needed to validate the full path. P3 adds the apex (burntbytes.com)
-# hostname + dedicated apex listeners.
+# Serves both the apex (burntbytes.com, via the dedicated apex listeners) and
+# the hidden origin (burntbytes-origin.burntbytes.com, via the *.burntbytes.com
+# wildcard listeners). Each listener serves the intersection of its hostname
+# with this route's hostnames, so the apex listeners serve burntbytes.com and
+# the wildcard listeners serve burntbytes-origin. The origin hostname is kept
+# as a permanent smoke-test endpoint. DNS for the apex still points at GitHub
+# Pages until the Cloudflare cutover, so this is dark for off-LAN clients.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
@@ -10,11 +12,15 @@ metadata:
   namespace: burntbytes-prod
 spec:
   hostnames:
+    - burntbytes.com
     - burntbytes-origin.burntbytes.com
   parentRefs:
     - name: app-gateway-production
       namespace: default
       sectionName: http
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http-apex
   rules:
     - filters:
         - type: RequestRedirect
@@ -29,11 +35,15 @@ metadata:
   namespace: burntbytes-prod
 spec:
   hostnames:
+    - burntbytes.com
     - burntbytes-origin.burntbytes.com
   parentRefs:
     - name: app-gateway-production
       namespace: default
       sectionName: https
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https-apex
   rules:
     - backendRefs:
         - name: burntbytes

--- a/apps/production/cloudflare-tunnel/configmap.yaml
+++ b/apps/production/cloudflare-tunnel/configmap.yaml
@@ -37,11 +37,17 @@ data:
       # burntbytes blog — hidden origin hostname for pre-cutover validation.
       # Inert off-LAN until a Cloudflare DNS record points it at the tunnel;
       # validated on-LAN via the *.burntbytes.com wildcard + AdGuard rewrite.
-      # The apex (burntbytes.com) entry is added in the apex-activation PR.
       - hostname: burntbytes-origin.burntbytes.com
         service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
         originRequest:
           originServerName: burntbytes-origin.burntbytes.com
+
+      # burntbytes blog — apex. Inert until the Cloudflare apex DNS record is
+      # swung from GitHub Pages to <tunnel-uuid>.cfargotunnel.com (next phase).
+      - hostname: burntbytes.com
+        service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
+        originRequest:
+          originServerName: burntbytes.com
 
       # Catch-all returns 404
       - service: http_status:404

--- a/infra/configs/gateway/gateway-production.yaml
+++ b/infra/configs/gateway/gateway-production.yaml
@@ -51,4 +51,33 @@ spec:
           selector:
             matchLabels:
               http-ingress: "true"
+    # Apex (bare burntbytes.com) for the self-hosted blog. The
+    # *.burntbytes.com wildcard above does NOT match the apex, so it needs
+    # its own listeners. The wildcard cert already SANs burntbytes.com, so
+    # the same secret terminates TLS here.
+    - name: http-apex
+      port: 80
+      protocol: HTTP
+      hostname: "burntbytes.com"
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              http-ingress: "true"
+    - name: https-apex
+      port: 443
+      protocol: HTTPS
+      hostname: "burntbytes.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: burntbytes-prod-wildcard-tls
+            namespace: security
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              http-ingress: "true"
 


### PR DESCRIPTION
## Summary

Phase 3 of the burntbytes self-host migration (plan: `docs/plans/2026-06-10-burntbytes-self-host.md`). Adds the apex `burntbytes.com` path through the cluster. **Dark** until the Cloudflare apex DNS swing (next phase) — off-LAN clients still hit GitHub Pages.

This is the one PR that touches the shared production gateway, isolated on purpose. The gateway already runs a non-wildcard listener (`go`) alongside the `*.burntbytes.com` wildcard listeners, so adding apex listeners is proven territory — but it'll be validated carefully post-merge (gateway Programmed + an existing subdomain still serving + apex serving).

## Changes

- `infra/configs/gateway/gateway-production.yaml` — add `http-apex` + `https-apex` listeners (hostname `burntbytes.com`). Reuses `burntbytes-prod-wildcard-tls` (already SANs the apex).
- `apps/production/burntbytes/httproute.yaml` — add `burntbytes.com` to hostnames; bind routes to the apex listeners (`sectionName: http-apex`/`https-apex`). Each listener serves the intersection of its hostname with the route's hostnames, so apex listeners serve `burntbytes.com` and wildcard listeners keep serving `burntbytes-origin`.
- `apps/production/cloudflare-tunnel/configmap.yaml` — apex ingress entry (inert until DNS).

## Operator step (non-blocking, LAN-only)

Add AdGuard rewrite `burntbytes.com → 10.42.2.40` so LAN clients reach the apex directly instead of hairpinning through Cloudflare. Validation in this phase uses `curl --resolve`, which doesn't need the rewrite.

## Verification (post-merge)

```bash
flux reconcile kustomization apps-production -n flux-system --with-source
flux reconcile kustomization infra-configs -n flux-system --with-source
# Gateway healthy + all listeners programmed:
kubectl -n default get gateway app-gateway-production -o jsonpath='{.status.conditions[*].type}={.status.conditions[*].status}'
# Existing subdomain MUST still serve (no wildcard regression):
curl -fsSI --resolve overture.burntbytes.com:443:10.42.2.40 https://overture.burntbytes.com/ | head -1
# Apex now serves the blog via the cluster (dark — off-LAN still Pages):
curl -fsS --resolve burntbytes.com:443:10.42.2.40 https://burntbytes.com/ | grep -i 'burnt bytes'
# Sanity: off-LAN apex still GitHub Pages
curl -fsSI https://burntbytes.com/ | grep -i server
```

Rollback: revert PR; the apex listeners + hostname disappear on reconcile. Apex still on Pages throughout.

## Test plan

- [ ] kustomize build green (CI)
- [ ] gateway Programmed; existing subdomains unaffected
- [ ] apex serves the blog via LAN curl --resolve; off-LAN still Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)