### PR TITLE
docs(status): STATUS.md dashboard + HOMELAB.md migration + stale-claim fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,14 @@ See `docs/architecture/` for component-level architecture (DNS strategy, gateway
 4. New apps wired into the right `apps/{staging,production}/kustomization.yaml`
 5. Namespace follows the convention (production unsuffixed, staging `-stage`)
 6. New CNPG clusters: iSCSI PVC provisioned and StorageClass correct
-7. Docs updated if the change affects a runbook or architecture doc
+7. Docs updated if the change affects a runbook or architecture doc; `docs/STATUS.md` updated if the change flips a plan's status, lands an incident, or changes hardware/topology
 8. Every container has a `readinessProbe`; a `livenessProbe` is added only with a signal distinct from readiness (see `docs/operations/2026-05-02-adding-an-app.md#health-probes`)
 
 ## Documentation
 
-`docs/` taxonomy: `architecture/` · `design/` · `operations/` · `plans/` · `reference/` · `research/`. Each folder's `README.md` describes scope. Index: `docs/README.md`.
+**Current state, in-flight work, and known issues: `docs/STATUS.md`** — start here for "what's running / what's next".
+
+`docs/` taxonomy: `architecture/` · `design/` · `operations/` · `plans/` · `reference/` · `research/`. Each folder's `README.md` describes scope. Index: `docs/README.md`. The plans index (`docs/plans/README.md`) is generated from frontmatter by `scripts/plans-index` — edit a plan's frontmatter and run `make plans-index`, never hand-edit the index block.
 
 Per-app runbooks live under `docs/operations/apps/<app>.md`. Incident postmortems live under `docs/operations/incidents/<yyyy-mm-dd>-<topic>.md`. Per-doc content rewrites are tracked in `docs/plans/2026-02-21-documentation-rewrite-plan.md`.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ GitOps-managed Kubernetes cluster, powered by [Flux](https://fluxcd.io/) and [Ku
 
 This repository drives the state of the home infrastructure. It uses a **GitOps** workflow: changes are made in Git (via Pull Requests), and Flux reconciles the cluster to match this state.
 
-**Cluster**: `melodic-muse` (Single physical cluster)
-**Storage**: Synology NAS (iSCSI via CSI)
-**Networking**: Cilium (CNI + Gateway API)
+**Cluster**: `melodic-muse` — 6 Talos nodes (3 control-plane + 3 workers)
+**Storage**: Synology + hestia (TrueNAS) via democratic-csi iSCSI; hestia NFS backs the photo library
+**Networking**: Cilium (CNI + Gateway API), L2 + BGP load-balancer advertisement
+
+> **Current state, in-flight work, and known issues:** [`docs/STATUS.md`](docs/STATUS.md).
 
 ## 🏗 Architecture
 
@@ -47,10 +49,14 @@ The repository follows a **dry (Don't Repeat Yourself)** structure using Kustomi
     *   [`staging/`](apps/staging/) - Test overlays.
 *   [`clusters/`](clusters/) - Flux entrypoints.
 *   [`infra/`](infra/) - System-level controllers & configs.
+*   [`hosts/`](hosts/) - Non-Kubernetes host config (hestia TrueNAS Custom Apps, compose).
+*   [`images/`](images/) - Custom container image definitions.
 *   [`docs/`](docs/) - Runbooks and architecture notes.
 *   [`scripts/`](scripts/) - Automation & maintenance tools.
 
 ## 🔎 Status
 
+- **Current state / in-flight / known issues**: [docs/STATUS.md](docs/STATUS.md)
+- **Plans index** (status-grouped): [docs/plans/README.md](docs/plans/README.md)
 - **Applications Index**: [See apps/README.md](apps/README.md)
 - **Infrastructure Index**: [See infra/README.md](infra/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # Homelab Documentation
 
-GitOps repo for a single-node Talos Kubernetes cluster (`melodic-muse`). Documentation is organized into a fixed six-folder taxonomy.
+GitOps repo for a 6-node Talos Kubernetes cluster (`melodic-muse`, 3 control-plane + 3 workers). Documentation is organized into a fixed six-folder taxonomy.
+
+> **Current state at a glance:** [`STATUS.md`](STATUS.md) — cluster/hosts summary, in-flight work, known issues.
 
 ## Canonical taxonomy
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,59 @@
+# Status
+
+> **What this is.** A single-glance snapshot of the homelab: what's running,
+> what's in flight, what's next, and what's broken. Detail lives elsewhere —
+> this page links out. **Update this file in the same PR whenever** a plan's
+> status changes, an incident postmortem lands, or hardware/topology changes.
+>
+> Last updated: 2026-06-10
+
+## Cluster at a glance
+
+| | |
+|---|---|
+| Cluster | `melodic-muse` |
+| Nodes | 6 — 3 control-plane + 3 workers |
+| Platform | Talos v1.12.4 · Kubernetes v1.35.0 |
+| CNI / ingress | Cilium 1.19 (VXLAN) + Gateway API |
+| GitOps | Flux CD, reconciling from `master` |
+| Apps | ~14 self-hosted (see [apps/README.md](../apps/README.md)) |
+| LB advertisement | L2 announcements + BGP to the UCGF (AS 65010 ↔ 65100) |
+
+Full picture: [AGENTS.md](../AGENTS.md) · architecture in [docs/architecture/](architecture/README.md).
+
+## Hosts at a glance
+
+| Host | Role | Notes |
+|---|---|---|
+| 6× Talos nodes | Kubernetes cluster | `10.42.2.20–25` on the Lab VLAN |
+| hestia (`10.42.2.10`) | TrueNAS storage + compute | No GPUs since 2026-05-16. Runs the GHA deploy runner, Immich photo-backup rsync, qBittorrent, thermalscope telemetry, IPMI exporter. See [hosts/hestia/](../hosts/hestia/README.md). |
+| Synology / alcatraz (`10.42.2.11`) | Block + photo storage | iSCSI backing for CNPG PVCs; phone-photo upload target. Role narrowing — see the photos-SOT plan. |
+
+## In flight
+
+Active plans (see [docs/plans/](plans/README.md) for the full status-grouped index):
+
+- [Alcatraz → hestia migration](plans/2026-05-20-alcatraz-to-hestia-migration.md) — non-photo data off alcatraz onto hestia ZFS; Phase 1 mostly done, Phase 2 backup pipeline live.
+- [Hestia as photos source-of-truth](plans/2026-06-01-hestia-photos-sot.md) — Immich NFS PV repointed to hestia; soak/verification underway.
+- [burntbytes blog self-host](plans/2026-06-10-burntbytes-self-host.md) — hidden-origin live; apex listeners + Cloudflare DNS swing pending.
+- [Snapcast / HifiBerry rollout](plans/2026-05-03-snapcast-hifiberry-rollout.md) — server + LB IP live; per-device client setup remaining.
+- [Hestia memory benchmark](plans/2026-05-15-hestia-memory-benchmark.md) — 6-DIMM baseline captured; 8-DIMM comparison pending a physical DIMM swap.
+
+## Next up
+
+Planned, not yet started:
+
+- [Network resilience + BGP completion](plans/2026-05-06-network-resilience-and-bgp-completion.md) — the consolidated plan that supersedes the earlier BGP rollout.
+- [democratic-csi least-privilege key](plans/2026-05-09-democratic-csi-least-privilege-key.md).
+- [Monitoring enhancement](plans/2026-05-09-monitoring-enhancement.md) — ServiceMonitor coverage + critical-alert Signal routing.
+- [Immich pgvecto.rs → VectorChord](plans/2026-06-02-immich-vectorchord-migration.md).
+
+## Recently completed (last ~60 days)
+
+- Guest VLAN DNS + HifiBerry access · Mopidy/Navidrome/Snapcast audio pipeline · AdGuard HA + DNS rollout · Authelia SMTP notifier · hestia GHA auto-deploy runner · critique remediation phases 2–5.
+
+## Known issues / blocked
+
+- **No on-prem LLM inference.** The 2× RTX 4090 were sold 2026-05-16. `hermes` / `hermes-callee` (Signal bots) and `signal-cli` are deployed but **scaled to 0** — they have no model backend. The `llms/` and GPU-`monitoring/` Custom Apps on hestia are archived. Restoring inference needs new GPU hardware or a hosted-API backend. See [hermes runbook](operations/apps/hermes.md) and [plans/2026-05-02-hermes-bot-k8s.md](plans/2026-05-02-hermes-bot-k8s.md).
+- **CNPG WAL archiving** broken on several staging clusters (stale system-ID in S3) — base backups succeed, but no PITR until fixed.
+- **LB pool / Lab-VLAN `/24` sharing** is the root cause of the 2026-05-05 wired-device incident; the dedicated LB subnet migration is tracked in the network-resilience plan (Phase D).

--- a/docs/architecture/networking/addressing.md
+++ b/docs/architecture/networking/addressing.md
@@ -73,8 +73,9 @@ ssh root@10.42.2.1 'cat /run/dnsmasq.dhcp.conf.d/* 2>/dev/null | grep "dhcp-host
 | IP | Device / Role | Notes |
 |---|---|---|
 | `10.42.2.1` | UCGF (router/gateway) | DHCP server, FRR for BGP (AS 65100), bridge `br2` |
-| `10.42.2.10` | hestia (TrueNAS GPU server) | LLM inference, Signal-CLI, iSCSI provider via `democratic-csi` |
+| `10.42.2.10` | hestia (TrueNAS storage + compute) | iSCSI/NFS provider via `democratic-csi`, GHA deploy runner, Immich photo-backup, qBittorrent. **No GPUs since 2026-05-16.** See [hosts/hestia/](../../../hosts/hestia/README.md). |
 | `10.42.2.11` | Synology NAS | iSCSI target backing CNPG PVCs (`csi.san.synology.com`) |
+| `10.42.2.13` | hestia IPMI (ASRock Rack BMC) | Out-of-band management; switch port 48, DHCP on the Lab VLAN |
 | `10.42.2.19` | Apple TV | Wired |
 | `10.42.2.20` | `talos-ykb-uir` (CP) | `k8sServiceHost` SPOF |
 | `10.42.2.21` | `talos-2mz-rfj` (CP) | |

--- a/docs/architecture/networking/physical-topology.md
+++ b/docs/architecture/networking/physical-topology.md
@@ -47,7 +47,8 @@ last_modified: 2026-05-06
 
 | Device | IP | VLAN | Role |
 |---|---|---|---|
-| hestia (TrueNAS GPU server) | `10.42.2.10` | 2 | LLM inference (vLLM/llama.cpp), Signal-CLI bridge, iSCSI provider for non-Synology PVCs |
+| hestia (TrueNAS storage + compute) | `10.42.2.10` | 2 | iSCSI/NFS provider for non-Synology PVCs + photo library; GHA deploy runner, Immich photo-backup, qBittorrent. No GPUs since 2026-05-16. |
+| hestia IPMI (ASRock Rack BMC) | `10.42.2.13` | 2 | Out-of-band management; switch port 48 |
 | Synology NAS | `10.42.2.11` | 2 | iSCSI block storage backing CNPG PVCs; DSM at port 5000 |
 
 Both are kept on VLAN 2 with the cluster because they participate in iSCSI

--- a/docs/operations/2026-05-02-cnpg-backup-recovery.md
+++ b/docs/operations/2026-05-02-cnpg-backup-recovery.md
@@ -10,7 +10,7 @@ tags: [operations, cnpg, postgres, backup, recovery]
 # CNPG Backup & Disaster Recovery Guide
 
 > **Last tested:** 2026-04-18 — full wipe + S3 restore of `immich-stage` in ~5 minutes  
-> **Cluster:** Talos Kubernetes single-node (`talos-ykb-uir`)  
+> **Cluster:** Talos Kubernetes, 6 nodes (drill ran against CP `talos-ykb-uir`)  
 > **Backup method:** CloudNativePG + barman-cloud plugin v0.11.0 → AWS S3
 
 ---

--- a/docs/operations/apps/hermes.md
+++ b/docs/operations/apps/hermes.md
@@ -1,5 +1,13 @@
 # Hermes
 
+> **Status (2026-06-10): scaled to 0 — no backend.** Both bots are deployed but
+> have no LLM to talk to: the llama.cpp backend ran on hestia's GPUs, which were
+> sold 2026-05-16. The Signal account `+16179397251` and the in-cluster
+> `signal-cli` transport still exist (also scaled to 0). Restoring Hermes needs
+> a new inference backend — GPU hardware or a hosted-API endpoint in the bot
+> config. The architecture below documents the intended wiring, not the current
+> running state.
+
 ## 1. Overview
 
 Hermes is the [Hermes Agent](https://hermes-agent.nousresearch.com/) from NousResearch deployed in Signal-only mode. It runs as a long-lived gateway that listens for direct messages from allow-listed phone numbers, forwards each conversation to a local LLM, and replies back over Signal.

--- a/docs/research/2026-05-16-hestia-memory-bench-results.md
+++ b/docs/research/2026-05-16-hestia-memory-bench-results.md
@@ -1,0 +1,32 @@
+---
+status: Partial
+last_modified: 2026-06-10
+---
+
+# hestia memory bandwidth — 6-DIMM baseline
+
+Baseline run from the [memory benchmark harness](../../hosts/hestia/bench/memory/README.md)
+on hestia (ASRock Rack SIENAD8-2L2T, EPYC 8324P Siena, 6-channel DDR5). This
+captures the **6-DIMM, 1DPC × 6 channels** configuration only; the 8-DIMM
+comparison is pending a physical DIMM swap (see
+[plan](../plans/2026-05-15-hestia-memory-benchmark.md)).
+
+## 6-DIMM baseline (1DPC × 6 channels, full DDR5-4800)
+
+Run `6dimm-2026-05-16T04-00-00Z`:
+
+| Metric | Result |
+|---|---|
+| STREAM Triad | 131.2 GB/s |
+| Intel MLC all-reads | 186.1 GB/s |
+| Idle latency | ~115 ns |
+
+Raw JSONL: `/home/truenas_admin/bench/memory/6dimm-2026-05-16T04-00-00Z.jsonl`
+on hestia (mirrored locally at `/tmp/hestia-bench/` at capture time).
+
+## Pending
+
+- **8-DIMM run** — requires adding 2 DIMMs to the 2DPC-eligible slots, which
+  forces two channels into 2DPC and derates the bus. The point of the
+  benchmark is to measure that derate against the 4800 baseline above. Once
+  captured, run `aggregate.py` to produce the side-by-side Δ% comparison.

--- a/hosts/hestia/README.md
+++ b/hosts/hestia/README.md
@@ -2,23 +2,46 @@
 
 | Attribute | Value |
 |-----------|-------|
-| SSH | `truenas_admin@10.42.2.10` |
-| Role | NAS + GPU inference host |
+| SSH | `truenas_admin@10.42.2.10` (no passwordless sudo; `/home` is `noexec`) |
+| IPMI | ASRock Rack BMC at `10.42.2.13` (switch port 48) |
+| Role | TrueNAS storage + general-purpose compute (no GPUs since 2026-05-16) |
 | OS | TrueNAS SCALE |
 | Docker | 29.0.4 (managed by TrueNAS Apps) |
 | Arch | x86_64 |
+
+## Hardware
+
+| Component | Detail |
+|-----------|--------|
+| Board | ASRock Rack SIENAD8-2L2T (8 DIMM slots over 6 memory channels — 2 channels share slots) |
+| CPU | AMD EPYC 8324P (32-core Siena, Zen 4c), NPS1 (1 NUMA node) |
+| RAM | DDR5, populated 6× (1DPC × 6 channels = full speed); 8-DIMM mode forces 2 channels into 2DPC and derates the bus |
+| GPUs | **None** — 2× RTX 4090 sold 2026-05-16. `nvidia-smi` fails on the host; this is expected. |
+| Storage | pool `main` at `/mnt/main` (~21 TB) |
+
+### Network interfaces
+
+- **Management NIC** `enp201s0` — 1 GbE onboard, static `10.42.2.10/24` (active interface).
+- **25 GbE Mellanox NIC** — removed 2026-05-14 (overheating → PCIe BadTLP errors and instability); switch ports 51/52 LAG config preserved but inactive.
+- **IPMI NIC** — ASRock Rack BMC at `10.42.2.13` (switch port 48, DHCP on the Lab VLAN).
 
 ## Services
 
 All services on hestia run as **TrueNAS Custom Apps** (SCALE UI → Apps → Custom App).
 The compose YAML in each subdirectory is the canonical source.
 
-| Service | Directory | Port | Notes |
-|---------|-----------|------|-------|
-| signal | `signal/` | 8080 | signal-cli daemon + signal-bridge SSE relay |
-| llms | `llms/` | varies | llama.cpp / vLLM inference (GPU box) |
-| monitoring | `monitoring/` | varies | nvtop and GPU metrics |
-| gha-runner | `actions-runner/` | — | Self-hosted GitHub Actions runner; auto-deploys other hestia apps |
+| Service | Directory | Notes |
+|---------|-----------|-------|
+| gha-runner | `actions-runner/` | Self-hosted GitHub Actions runner; auto-deploys other hestia apps |
+| immich-photos-backup | `immich-photos-backup/` | Daily rsync of the Immich photo library from alcatraz into ZFS |
+| qbittorrent | `qbittorrent/` | P2P client, private-tracker downloads |
+| thermalscope | `thermalscope/` | Thermal + power telemetry, Prometheus metrics over host networking |
+| ipmi-exporter | `monitoring/` | IPMI metrics (`docker-compose-ipmi-exporter.yml`) |
+| memory bench | `bench/memory/` | On-demand STREAM + Intel MLC bandwidth benchmark (not a long-running app) |
+| llms | `llms/` | **Archived 2026-05-16** — llama.cpp / vLLM inference; GPUs sold |
+| monitoring (GPU) | `monitoring/` | **Archived** — `nvtop` + GPU metrics; GPUs sold |
+
+> signal-cli moved off hestia into the cluster (`apps/base/signal-cli/`, namespace `signal-cli`) — the old `signal/` Custom App was removed. Both it and the `hermes` bots are currently scaled to 0 (no LLM backend since the GPU sale).
 
 ## Deploying changes
 
@@ -72,8 +95,9 @@ Operator-owned datasets (survive App deletion):
 
 | Dataset | Mount | Used by |
 |---------|-------|---------|
-| `tank/apps/signal` | `/mnt/tank/apps/signal` | signal-cli identity data |
 | `main/apps/actions-runner` | `/mnt/main/apps/actions-runner` | runner registration + workspace |
+| `main/family/images/photos` | `/mnt/main/family/images/photos` | Immich photo-backup rsync target |
+| `tank/apps/signal` | `/mnt/tank/apps/signal` | Legacy — signal-cli identity data from the removed Custom App (signal-cli now runs in-cluster) |
 
 ## Common operations
 

--- a/hosts/hestia/bench/memory/README.md
+++ b/hosts/hestia/bench/memory/README.md
@@ -7,11 +7,6 @@ Measures memory bandwidth and latency on hestia (ASRock Rack SIENAD8-2L2T, EPYC 
 - Intel MLC tarball — download from <https://www.intel.com/content/www/us/en/developer/articles/tool/intelr-memory-latency-checker.html>, accept the EULA, and place `mlc_v3.12.tgz` in this directory before `docker build`.
 - Docker available on the host.
 - Root / `sudo` access (MLC and `numactl` pinning require it).
-- vLLM stoppable. Operator owns the recipe; recap:
-  ```bash
-  midclt call app.stop vllm
-  nvidia-smi   # confirm GPUs idle, no PIDs holding VRAM
-  ```
 - `cpupower` installed (`apt-get install linux-cpupower`) or fallback: write directly to `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`.
 - SIENAD8-2L2T board manual on hand for the DIMM-slot map: `~/Downloads/SIENAD8-2L2T.pdf` (slot layout on p. 12-13).
 
@@ -25,16 +20,12 @@ The build will fail loudly if `mlc_v3.12.tgz` is missing from the build context.
 
 ## Run
 
-### 1. Stop vLLM
+> hestia has no GPUs since 2026-05-16 — earlier revisions told you to stop
+> vLLM and check `nvidia-smi` first; there's no GPU workload to quiesce now.
+> For the cleanest numbers, still quiesce other heavy tenants (the rsync
+> backup, qBittorrent) before a run.
 
-```bash
-midclt call app.stop vllm
-nvidia-smi                      # both GPUs must show 0 MiB used and no PIDs
-```
-
-If vLLM does not stop cleanly within ~60s, see Troubleshooting.
-
-### 2. Apply controls and benchmark
+### Apply controls and benchmark
 
 ```bash
 # Optional: override results location (default lives on the boot pool)
@@ -75,13 +66,7 @@ Filenames are `<label>-<utc-ts>.jsonl` (e.g. `6dimm-2026-05-15T14-23-45Z.jsonl`)
 
 Diff the two JSONLs into a single markdown comparison under `docs/research/`. The aggregate script computes Δ% on STREAM Triad, idle latency delta, and a small loaded-latency table.
 
-## Restore service
-
-```bash
-midclt call app.start vllm
-# smoke test
-curl -sS http://10.42.2.10:8000/v1/models | jq '.data[].id'
-```
+The 6-DIMM baseline (2026-05-16) is captured in [`docs/research/2026-05-16-hestia-memory-bench-results.md`](../../../../docs/research/2026-05-16-hestia-memory-bench-results.md); the 8-DIMM comparison is still pending a physical DIMM swap.
 
 ## Interpreting results
 
@@ -97,7 +82,6 @@ curl -sS http://10.42.2.10:8000/v1/models | jq '.data[].id'
 | `mlc_v3.12.tgz not found` at build time | Tarball wasn't placed next to the Dockerfile | Download from Intel, accept EULA, drop in this directory, rebuild. |
 | 8DIMM didn't derate the bus | CPU silicon binning or BIOS auto-bump kept the bus at 4800 | Inspect the preflight JSON for `Configured Memory Speed` (from `dmidecode -t memory`). If it really is 4800 at 2DPC, document it — that's the answer. |
 | Run-to-run stddev > 2% | C-states or turbo bouncing leaked through | Check `/sys/devices/system/cpu/cpu0/cpuidle/state*/disable` — all non-C0/C1 should be `1`. Retry with `idle=poll` on the kernel cmdline. |
-| vLLM won't stop cleanly | Worker stuck on a CUDA op | Grace period 60s, then `midclt call app.kill vllm`. Confirm with `nvidia-smi`. |
 
 ## Related
 

--- a/hosts/hestia/llms/README.md
+++ b/hosts/hestia/llms/README.md
@@ -1,12 +1,21 @@
-# llms — GPU inference on hestia
+# llms — GPU inference on hestia (archived)
 
-> **Disabled 2026-05-10:** GPUs removed from hestia for sale. All compose
-> files in this directory are inactive — the SCALE Custom Apps (`llama`,
-> `vllm`) have been stopped and should not be restarted until GPU
-> hardware is restored. Downstream consumers (`openwebui`, `hermes`,
-> `hermes-callee`) are scaled to 0 in the apps overlays.
+> **Archived 2026-05-16:** the 2× RTX 4090 were **sold** — hestia has no GPUs.
+> Every compose file here is archived (`x-deploy.archived: true`) and the SCALE
+> Custom Apps have been deleted:
+>
+> ```bash
+> midclt call app.delete vllm
+> midclt call app.delete vllm-vision
+> midclt call app.delete ollama
+> ```
+>
+> Downstream consumers (`hermes`, `hermes-callee`, `signal-cli`) are scaled to 0
+> in the apps overlays. These files are kept for historical reference and as a
+> starting point if GPU hardware is ever re-added; they are **not** a
+> "restore when the GPUs come back" plan.
 
-LLM inference services for the GPU box on hestia (RTX 4090, 24 GB VRAM).
+LLM inference services from when hestia had a GPU box (RTX 4090, 24 GB VRAM).
 
 ## Services
 


### PR DESCRIPTION
## What

Phase B of the docs-reorg (Phase A = #889, merged). Two goals: a single glance-able "what's the state, where are we headed" page, and pulling the operator-side `~/.claude/HOMELAB.md` quick-reference into the repo so it's version-controlled and trustworthy.

### New: `docs/STATUS.md`
Cluster + hosts at a glance, **in-flight** plans (linked), **next up**, **recently completed**, and **known issues** (no LLM backend post-GPU-sale, CNPG WAL archiving, LB-pool/VLAN sharing). Pointers added from root `README.md`, `AGENTS.md` (+ a quality-gate item: flip a plan status → update STATUS.md), and `docs/README.md`. Update convention stated at the top of the file.

### HOMELAB.md content migrated into the repo
- **hestia hardware** (SIENAD8-2L2T / EPYC 8324P / 6× DDR5 / no GPUs / ~21 TB) + NIC history → new Hardware section in `hosts/hestia/README.md`.
- **hestia IPMI** `10.42.2.13` (switch port 48) → `addressing.md` + `physical-topology.md`.
- **6-DIMM memory-bench baseline** → `docs/research/2026-05-16-hestia-memory-bench-results.md`.

### Stale claims fixed (found while migrating)
- **"single-node" → 6-node**: `docs/README.md`, `cnpg-backup-recovery.md`.
- **hestia "GPU server / LLM inference" → storage+compute, no GPUs since 2026-05-16**: `addressing.md`, `physical-topology.md`, `hosts/hestia/README.md`.
- **hestia services table**: dropped the removed `signal/` Custom App, marked `llms/` + GPU-`monitoring/` archived, added the actually-running apps (immich-photos-backup, qbittorrent, thermalscope, ipmi-exporter, bench).
- **`llms/README.md`**: banner now says GPUs *sold* (with the `app.delete` cmds), not "restore when hardware returns."
- **`bench/memory/README.md`**: removed the vLLM/`nvidia-smi` quiesce steps (no GPUs to quiesce).
- **hermes runbook**: status banner — deployed but **scaled to 0**, no LLM backend; `signal-cli` likewise moved in-cluster and scaled to 0.

### Deliberately NOT migrated
HOMELAB.md's VLAN/IP **range table** — the repo's `addressing.md` is the newer, authoritative map (last_modified 2026-05-06) and the HOMELAB.md version had drifted (stale VLAN-name assignments). Rather than overwrite the good doc with the stale one, I kept addressing.md and added only the genuinely-missing IPMI row. Flagging for your eyes in case the HOMELAB.md table encodes intent I'm missing.

## Verification
- `make plans-index-check` → `ok: 34 plans, index up to date` (Phase A gate still green).
- No YAML changed; yamllint N/A.
- All new relative doc links verified to resolve on disk.

## Follow-up (operator-side, not in this PR)
Shrink `~/.claude/HOMELAB.md` to a pointer at `docs/STATUS.md` + access-only quirks (SSH user, no passwordless sudo, `noexec /home`, IPMI URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)