### PR TITLE
docs(plans): correct mopidy status + close reorg plan

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -37,6 +37,7 @@ Active plans (see [docs/plans/](plans/README.md) for the full status-grouped ind
 - [Hestia as photos source-of-truth](plans/2026-06-01-hestia-photos-sot.md) — Immich NFS PV repointed to hestia; soak/verification underway.
 - [burntbytes blog self-host](plans/2026-06-10-burntbytes-self-host.md) — hidden-origin live; apex listeners + Cloudflare DNS swing pending.
 - [Snapcast / HifiBerry rollout](plans/2026-05-03-snapcast-hifiberry-rollout.md) — server + LB IP live; per-device client setup remaining.
+- [Navidrome → Mopidy → Snapcast audio source](plans/2026-03-14-navidrome-snapcast-mopidy.md) — Mopidy sidecar in draft PR #426; not yet on master.
 - [Hestia memory benchmark](plans/2026-05-15-hestia-memory-benchmark.md) — 6-DIMM baseline captured; 8-DIMM comparison pending a physical DIMM swap.
 
 ## Next up
@@ -50,7 +51,7 @@ Planned, not yet started:
 
 ## Recently completed (last ~60 days)
 
-- Guest VLAN DNS + HifiBerry access · Mopidy/Navidrome/Snapcast audio pipeline · AdGuard HA + DNS rollout · Authelia SMTP notifier · hestia GHA auto-deploy runner · critique remediation phases 2–5.
+- Guest VLAN DNS + HifiBerry access · AdGuard HA + DNS rollout · Authelia SMTP notifier · hestia GHA auto-deploy runner · critique remediation phases 2–5.
 
 ## Known issues / blocked
 

--- a/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
+++ b/docs/plans/2026-03-14-navidrome-snapcast-mopidy.md
@@ -1,7 +1,7 @@
 ---
-status: complete
+status: in-progress
 last_modified: 2026-06-10
-summary: "Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio pipeline"
+summary: "Navidrome → Mopidy → Snapcast → HifiBerry audio pipeline — draft PR #426 open, not yet on master"
 ---
 
 # Navidrome → Mopidy → Snapcast → HifiBerry Integration Plan

--- a/docs/plans/2026-06-10-docs-reorg-status-dashboard.md
+++ b/docs/plans/2026-06-10-docs-reorg-status-dashboard.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: complete
 last_modified: 2026-06-10
 summary: "Docs status legibility: plan frontmatter cleanup, generated index, STATUS.md dashboard, HOMELAB.md migration"
 ---

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -64,7 +64,6 @@ see `scripts/plans-index/`).
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
-| [2026-06-10-docs-reorg-status-dashboard.md](2026-06-10-docs-reorg-status-dashboard.md) | 2026-06-10 | Docs status legibility: plan frontmatter cleanup, generated index, STATUS.md dashboard, HOMELAB.md migration |
 | [2026-06-10-burntbytes-self-host.md](2026-06-10-burntbytes-self-host.md) | 2026-06-10 | Self-host the burntbytes.com blog; hidden-origin live, apex + Cloudflare swing pending |
 | [2026-06-01-hestia-photos-sot.md](2026-06-01-hestia-photos-sot.md) | 2026-06-10 | Make hestia the source of truth for family/ + homes/; repoint Immich NFS PV; alcatraz narrows to upload target |
 | [2026-05-20-alcatraz-to-hestia-migration.md](2026-05-20-alcatraz-to-hestia-migration.md) | 2026-05-21 | Migrate non-photo data (~870 GiB iSCSI + 3 TiB NFS media) off alcatraz onto hestia ZFS |
@@ -72,6 +71,7 @@ see `scripts/plans-index/`).
 | [2026-05-03-snapcast-hifiberry-rollout.md](2026-05-03-snapcast-hifiberry-rollout.md) | 2026-06-10 | Wire kitchen + living-room HifiBerries as snapclients of the in-cluster snapserver |
 | [2026-05-02-hermes-bot-k8s.md](2026-05-02-hermes-bot-k8s.md) | 2026-06-10 | Hermes agent (Signal mode) on melodic-muse so the bot is laptop-independent — **blocked:** LLM backend gone (RTX 4090s sold 2026-05-16); deployment scaled to 0 |
 | [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | 2026-05-04 | IaC hardening — close the 22 findings from the 2026-05-02 critique |
+| [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | 2026-06-10 | Navidrome → Mopidy → Snapcast → HifiBerry audio pipeline — draft PR #426 open, not yet on master |
 
 ### Planned (6)
 
@@ -88,11 +88,11 @@ see `scripts/plans-index/`).
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-06-10-docs-reorg-status-dashboard.md](2026-06-10-docs-reorg-status-dashboard.md) | 2026-06-10 | Docs status legibility: plan frontmatter cleanup, generated index, STATUS.md dashboard, HOMELAB.md migration |
 | [2026-05-07-vllm-frontier-model-experiments.md](2026-05-07-vllm-frontier-model-experiments.md) | 2026-05-09 | Stability-first vLLM experiments on 2× 4090 — winner Qwen3.6-35B-A3B-AWQ TP=2 |
 | [2026-05-07-guest-vlan-dns-and-hifiberry-access.md](2026-05-07-guest-vlan-dns-and-hifiberry-access.md) | 2026-06-10 | Guest VLAN DNS + HifiBerry speaker access (firewall rules + mDNS reflector) |
 | [2026-05-04-phase2-5-completion.md](2026-05-04-phase2-5-completion.md) | 2026-06-10 | Close critique phases 2-5: probe coverage and liveness/readiness gaps (PRs A-D) |
 | [2026-05-02-hestia-gha-runner.md](2026-05-02-hestia-gha-runner.md) | 2026-06-10 | Self-hosted GHA runner on hestia for auto-deploy of Custom App compose changes |
-| [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | 2026-06-10 | Navidrome → Mopidy → Snapcast → HifiBerry whole-house audio pipeline |
 | [2026-03-08-adguard-dns-rollout.md](2026-03-08-adguard-dns-rollout.md) | 2026-06-10 | Roll AdGuard Home out as the primary LAN DNS resolver |
 | [2026-02-28-network-migration-192-to-10-42-2.md](2026-02-28-network-migration-192-to-10-42-2.md) | 2026-03-06 | Migrate the LAN from 192.168.5.0/24 to 10.42.2.0/24 |
 | [2026-02-21-documentation-rewrite-plan.md](2026-02-21-documentation-rewrite-plan.md) | 2026-05-02 | Rewrite all app and infra documentation |


### PR DESCRIPTION
Follow-up to #889/#891 — fixes a status error I shipped and closes the reorg plan.

## The bug
PR #889's audit marked `2026-03-14-navidrome-snapcast-mopidy.md` **complete** based on a sub-agent claim that the Mopidy sidecar shipped 2026-05-03. That was wrong:
- Every checklist item in the plan is still `- [ ]` unchecked.
- No mopidy sidecar on `master` (`apps/base/navidrome|snapcast`).
- Draft **PR #426** (`feat/snapcast-mopidy`, updated 2026-05-16) is still open for exactly this work.

So it's **in-progress**, not complete. `docs/STATUS.md` moves it out of "recently completed" into "in flight" to match.

I re-verified the other five complete-flips from #889 against master and they're all correct (adguard-ha replicas:2 + sync CronJob, authelia SMTP in config, gha-runner + deploy workflow, adguard-dns in production, phase2-5 probe work). Only this one was wrong.

## Also
`2026-06-10-docs-reorg-status-dashboard.md` → **complete** (all three phases shipped: #889, #891, and the operator-side HOMELAB.md shrink).

Index regenerated; `plans-index -check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)