### PR TITLE
docs(plans): mark burntbytes self-host complete

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -35,7 +35,6 @@ Active plans (see [docs/plans/](plans/README.md) for the full status-grouped ind
 
 - [Alcatraz → hestia migration](plans/2026-05-20-alcatraz-to-hestia-migration.md) — non-photo data off alcatraz onto hestia ZFS; Phase 1 mostly done, Phase 2 backup pipeline live.
 - [Hestia as photos source-of-truth](plans/2026-06-01-hestia-photos-sot.md) — Immich NFS PV repointed to hestia; soak/verification underway.
-- [burntbytes blog self-host](plans/2026-06-10-burntbytes-self-host.md) — hidden-origin live; apex listeners + Cloudflare DNS swing pending.
 - [Snapcast / HifiBerry rollout](plans/2026-05-03-snapcast-hifiberry-rollout.md) — server + LB IP live; per-device client setup remaining.
 - [Navidrome → Mopidy → Snapcast audio source](plans/2026-03-14-navidrome-snapcast-mopidy.md) — Mopidy sidecar in draft PR #426; not yet on master.
 - [Hestia memory benchmark](plans/2026-05-15-hestia-memory-benchmark.md) — 6-DIMM baseline captured; 8-DIMM comparison pending a physical DIMM swap.
@@ -51,7 +50,7 @@ Planned, not yet started:
 
 ## Recently completed (last ~60 days)
 
-- Guest VLAN DNS + HifiBerry access · AdGuard HA + DNS rollout · Authelia SMTP notifier · hestia GHA auto-deploy runner · critique remediation phases 2–5.
+- burntbytes.com self-hosted (off GitHub Pages → cluster via Cloudflare tunnel) · Guest VLAN DNS + HifiBerry access · AdGuard HA + DNS rollout · Authelia SMTP notifier · hestia GHA auto-deploy runner · critique remediation phases 2–5.
 
 ## Known issues / blocked
 

--- a/docs/plans/2026-06-10-burntbytes-self-host.md
+++ b/docs/plans/2026-06-10-burntbytes-self-host.md
@@ -1,7 +1,7 @@
 ---
-status: in-progress
+status: complete
 last_modified: 2026-06-10
-summary: "Self-host the burntbytes.com blog; hidden-origin live, apex + Cloudflare swing pending"
+summary: "burntbytes.com self-hosted on the cluster via Cloudflare tunnel; apex cutover live, GitHub Pages retired"
 ---
 
 # Self-host burntbytes.com on the Talos homelab
@@ -34,13 +34,39 @@ AdGuard wildcard rewrite. So:
   only be a single isolated revert (it cannot ride along with the app deploy).
 
 ```
-P0 (operator)   Lower apex Cloudflare TTL; capture tunnel UUID + original apex records
-P1 (source)     ✅ DONE — Dockerfile + nginx.conf + image.yml → ghcr image
-P2 (homelab)    App + hidden-hostname HTTPRoute + hidden tunnel entry (no gateway change)
-P3 (homelab)    Apex gateway listeners + apex hostname + apex tunnel entry (dark)
-P4 (Cloudflare) Apex DNS swing A → CNAME cfargotunnel (operator)
-P5 (cleanup)    Decommission Pages publish; runbook; plan → complete
+P1 (source)     ✅ Dockerfile + nginx.conf + image.yml → ghcr image (burntbytes #1)
+P2 (homelab)    ✅ App + hidden-hostname HTTPRoute + tunnel entry (#887)
+P3 (homelab)    ✅ Apex gateway listeners + apex hostname + apex tunnel entry (#888)
+P4 (Cloudflare) ✅ Apex route to the tunnel + Access removed (operator)
+P5 (cleanup)    ✅ Runbook (#890), source README (burntbytes #2), plan → complete
 ```
+
+## Outcome (2026-06-10)
+
+`https://burntbytes.com` is live, served from the cluster through the
+Cloudflare tunnel (visitor → CF edge → cloudflared → gateway → nginx). Verified
+public off-LAN: HTTP/2 200, Hugo content byte-identical to the in-cluster
+origin, Hugo `/404.html` on misses. GitHub Pages (`gjcourt.github.io`) is
+retired as the publish target but kept as a rollback parachute.
+
+### Gotchas hit during execution (worth remembering)
+
+- **Apex CNAME-to-`cfargotunnel` fails with Cloudflare error 1016.** A manually
+  created CNAME at the zone apex gets flattened, and `<uuid>.cfargotunnel.com`
+  has no public IP, so the tunnel route isn't registered. Fix:
+  `cloudflared tunnel route dns <tunnel> burntbytes.com` (registers the route
+  via the API). Subdomains don't hit this — only the apex.
+- **`cloudflared` does not hot-reload ingress on ConfigMap change.** After
+  editing `apps/production/cloudflare-tunnel/configmap.yaml`, the pods must be
+  restarted (`kubectl -n cloudflare-tunnel rollout restart deploy/cloudflared`)
+  — there's no config-hash annotation to auto-roll them. Follow-up: add one.
+- **A Cloudflare Access app was gating `burntbytes.com`** (and
+  `flashcards.burntbytes.com`) — a pre-existing Zero Trust login wall, deleted
+  during cutover so the public blog is reachable.
+- **Latent Hugo build breakage** surfaced on modern Hugo (0.163): the
+  `security.allowContent` default (0.158+) blocked the raw-HTML beerbuilder
+  lab, and `network-streamers.md` used a nonexistent `{{< fig >}}` shortcode.
+  Both fixed in burntbytes #1.
 
 ## P1 — source repo (DONE)
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,11 +60,10 @@ see `scripts/plans-index/`).
 
 <!-- BEGIN PLANS INDEX -->
 
-### In progress (8)
+### In progress (7)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
-| [2026-06-10-burntbytes-self-host.md](2026-06-10-burntbytes-self-host.md) | 2026-06-10 | Self-host the burntbytes.com blog; hidden-origin live, apex + Cloudflare swing pending |
 | [2026-06-01-hestia-photos-sot.md](2026-06-01-hestia-photos-sot.md) | 2026-06-10 | Make hestia the source of truth for family/ + homes/; repoint Immich NFS PV; alcatraz narrows to upload target |
 | [2026-05-20-alcatraz-to-hestia-migration.md](2026-05-20-alcatraz-to-hestia-migration.md) | 2026-05-21 | Migrate non-photo data (~870 GiB iSCSI + 3 TiB NFS media) off alcatraz onto hestia ZFS |
 | [2026-05-15-hestia-memory-benchmark.md](2026-05-15-hestia-memory-benchmark.md) | 2026-05-15 | STREAM + Intel MLC bandwidth benchmark: 6-DIMM baseline vs 8-DIMM comparison |
@@ -84,11 +83,12 @@ see `scripts/plans-index/`).
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | 2026-05-03 | Cardboard drawer insert design (75×32×12 cm) — physical project, no repo artifacts |
 | [2026-02-21-linkding-db-restore-plan.md](2026-02-21-linkding-db-restore-plan.md) | 2026-05-03 | Live DR drill: destroy and restore Linkding staging DB (never executed) |
 
-### Complete (14)
+### Complete (15)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
 | [2026-06-10-docs-reorg-status-dashboard.md](2026-06-10-docs-reorg-status-dashboard.md) | 2026-06-10 | Docs status legibility: plan frontmatter cleanup, generated index, STATUS.md dashboard, HOMELAB.md migration |
+| [2026-06-10-burntbytes-self-host.md](2026-06-10-burntbytes-self-host.md) | 2026-06-10 | burntbytes.com self-hosted on the cluster via Cloudflare tunnel; apex cutover live, GitHub Pages retired |
 | [2026-05-07-vllm-frontier-model-experiments.md](2026-05-07-vllm-frontier-model-experiments.md) | 2026-05-09 | Stability-first vLLM experiments on 2× 4090 — winner Qwen3.6-35B-A3B-AWQ TP=2 |
 | [2026-05-07-guest-vlan-dns-and-hifiberry-access.md](2026-05-07-guest-vlan-dns-and-hifiberry-access.md) | 2026-06-10 | Guest VLAN DNS + HifiBerry speaker access (firewall rules + mDNS reflector) |
 | [2026-05-04-phase2-5-completion.md](2026-05-04-phase2-5-completion.md) | 2026-06-10 | Close critique phases 2-5: probe coverage and liveness/readiness gaps (PRs A-D) |


### PR DESCRIPTION
Final phase of the burntbytes migration. burntbytes.com is live, served from the cluster through the Cloudflare tunnel — apex cutover done, GitHub Pages retired (kept as a rollback parachute).

- Plan → `status: complete` with an outcome section + the gotchas worth remembering (apex cfargotunnel 1016 → `cloudflared tunnel route dns`; cloudflared doesn't hot-reload ConfigMap ingress; a pre-existing Cloudflare Access wall on the apex; Hugo 0.163 build fixes).
- Regenerated `docs/plans/README.md` via `make plans-index`.
- STATUS.md: moved from In flight → Recently completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)