### PR TITLE
feat(snapcast): Mopidy sidecar for Navidrome streaming (rebased #426)

### DIFF
--- a/apps/base/navidrome/networkpolicy.yaml
+++ b/apps/base/navidrome/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: navidrome
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 4533; egress DNS + HTTPS for Last.fm and Deezer scrobbling.
+  description: Gateway ingress on 4533 + snapcast mopidy sidecar (Subsonic API); egress DNS + HTTPS for Last.fm and Deezer scrobbling.
   endpointSelector:
     matchLabels:
       app: navidrome
@@ -17,6 +17,20 @@ spec:
         - host
         - remote-node
         - ingress
+      toPorts:
+        - ports:
+            - port: "4533"
+              protocol: TCP
+    # Snapcast's mopidy sidecar fetches the library via the Subsonic API
+    # (pod-to-pod, in-cluster). Both prod and staging snapcast point at
+    # navidrome-prod, so allow both namespaces.
+    - fromEndpoints:
+        - matchLabels:
+            app: snapcast
+            k8s:io.kubernetes.pod.namespace: snapcast-prod
+        - matchLabels:
+            app: snapcast
+            k8s:io.kubernetes.pod.namespace: snapcast-stage
       toPorts:
         - ports:
             - port: "4533"

--- a/apps/base/snapcast/config/snapserver.conf
+++ b/apps/base/snapcast/config/snapserver.conf
@@ -8,6 +8,11 @@ source = pipe:///tmp/snapfifo?name=default&sampleformat=48000:16:2&codec=flac
 # Sample format matches Snapcast's librespot/go-librespot expectations (44.1kHz).
 source = pipe:///audio/spotify.fifo?name=spotify&sampleformat=44100:16:2&codec=flac&mode=read
 
+# Navidrome (via mopidy + mopidy-subidy sidecar). Mopidy writes raw PCM at
+# 44.1kHz / S16LE / stereo to this FIFO; snapserver reads it as a stream
+# and clients can subscribe via the Snapweb UI or Snapcast clients.
+source = pipe:///audio/navidrome.fifo?name=navidrome&sampleformat=44100:16:2&codec=flac&mode=read
+
 [http]
 # Serve Snapweb (built-in UI) via the snapserver http port (1780)
 doc_root = /usr/share/snapserver/snapweb/

--- a/apps/base/snapcast/configmap-mopidy.yaml
+++ b/apps/base/snapcast/configmap-mopidy.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mopidy-config
+  namespace: snapcast
+  labels:
+    app: snapcast
+data:
+  # Mounted at /etc/mopidy/mopidy.conf in the mopidy sidecar. The sidecar's
+  # entrypoint runs `envsubst` to expand the ${NAVIDROME_*} env vars from the
+  # navidrome-credentials Secret before invoking mopidy.
+  mopidy.conf: |
+    [core]
+    data_dir = /mopidy-state
+    cache_dir = /tmp/mopidy-cache
+
+    [logging]
+    verbosity = 0
+
+    [mpd]
+    enabled = true
+    # Listen on all interfaces inside the pod; the snapcast Service exposes
+    # port 6600 to LAN clients (Symfonium, MALP, ncmpcpp, etc.).
+    hostname = ::
+    port = 6600
+
+    [subidy]
+    url = ${NAVIDROME_URL}
+    username = ${NAVIDROME_USER}
+    password = ${NAVIDROME_PASSWORD}
+    # Navidrome implements OpenSubsonic — the 1.16.1 API surface is what
+    # mopidy-subidy targets.
+    api_version = 1.16.1
+
+    [file]
+    enabled = false
+
+    [local]
+    enabled = false
+
+    [audio]
+    # Pipe raw PCM into the shared FIFO that snapserver reads. The full
+    # GStreamer pipeline is required so the bytes on the wire are raw S16LE
+    # at 44.1kHz/stereo — `filesink` alone would emit a container format that
+    # snapserver cannot parse.
+    output = audioresample ! audioconvert ! audio/x-raw,rate=44100,channels=2,format=S16LE ! filesink location=/audio/navidrome.fifo

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -231,11 +231,11 @@ spec:
               memory: 512Mi
 
         - name: mopidy
-          # ghcr.io/gjcourt/mopidy:2026-05-04 — first-party image built by
-          # .github/workflows/build-mopidy.yml from images/mopidy/. Tag-only is
-          # acceptable per AGENTS.md (CI guarantees date-tag immutability for
-          # first-party gjcourt/* images).
-          image: ghcr.io/gjcourt/mopidy:2026-05-04
+          # ghcr.io/gjcourt/mopidy:2026-06-11 — first-party image built by
+          # .github/workflows/build-mopidy.yml from images/mopidy/. The
+          # 2026-05-04 build crashlooped on pkg_resources (Python 3.14); this
+          # tag is the Python 3.12 + setuptools fix (#898). Digest-pinned.
+          image: ghcr.io/gjcourt/mopidy:2026-06-11@sha256:233fa674aa61d1d04d3c6f1ef0825a50138c60f100a17ef3c8186f8bfb3cf390
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -232,10 +232,11 @@ spec:
 
         - name: mopidy
           # ghcr.io/gjcourt/mopidy:2026-06-11 — first-party image built by
-          # .github/workflows/build-mopidy.yml from images/mopidy/. The
-          # 2026-05-04 build crashlooped on pkg_resources (Python 3.14); this
-          # tag is the Python 3.12 + setuptools fix (#898). Digest-pinned.
-          image: ghcr.io/gjcourt/mopidy:2026-06-11@sha256:233fa674aa61d1d04d3c6f1ef0825a50138c60f100a17ef3c8186f8bfb3cf390
+          # .github/workflows/build-mopidy.yml from images/mopidy/. Digest-pinned
+          # to the Debian rebuild (#899) with system GStreamer/gi bindings; the
+          # earlier python:slim builds crashlooped on pkg_resources then on
+          # missing `gi`.
+          image: ghcr.io/gjcourt/mopidy:2026-06-11@sha256:9877833580604f8e123915f1a797bfd1188c1cd965953a85ec7d0af762d812bd
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -88,6 +88,33 @@ spec:
             - name: audio-pipes
               mountPath: /audio
 
+        - name: init-navidrome-fifo
+          # busybox 1.37
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              rm -f /audio/navidrome.fifo
+              mkfifo /audio/navidrome.fifo
+              chmod 666 /audio/navidrome.fifo
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: audio-pipes
+              mountPath: /audio
+
       containers:
         - name: snapserver
           image: gjcourt/snapcast:0.34.0-snapweb0.9.3
@@ -203,6 +230,70 @@ spec:
               cpu: 1000m
               memory: 512Mi
 
+        - name: mopidy
+          # gjcourt/mopidy:3.4.2-1 — first-party image built from images/mopidy/
+          # (Phase 1 of docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). After
+          # the first build, this should be digest-pinned per AGENTS.md image
+          # discipline; tag-only is acceptable while bootstrapping the image.
+          image: gjcourt/mopidy:3.4.2-1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: NAVIDROME_URL
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_URL
+            - name: NAVIDROME_USER
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_USER
+            - name: NAVIDROME_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: navidrome-credentials
+                  key: NAVIDROME_PASSWORD
+            - name: HOME
+              value: /mopidy-state
+          ports:
+            - name: mpd
+              containerPort: 6600
+          command:
+            - sh
+            - -c
+            - |
+              # Substitute env vars into the templated config before starting.
+              # gettext-base provides envsubst in the python:slim base image.
+              envsubst < /etc/mopidy/mopidy.conf > /tmp/mopidy.conf
+              exec mopidy --config /tmp/mopidy.conf
+          readinessProbe:
+            tcpSocket:
+              port: mpd
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 6
+          volumeMounts:
+            - name: mopidy-config
+              mountPath: /etc/mopidy/mopidy.conf
+              subPath: mopidy.conf
+              readOnly: true
+            - name: mopidy-state
+              mountPath: /mopidy-state
+            - name: audio-pipes
+              mountPath: /audio
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
       volumes:
         - name: snapserver-config
           configMap:
@@ -217,3 +308,9 @@ spec:
         - name: go-librespot-config
           configMap:
             name: go-librespot-config
+        - name: mopidy-config
+          configMap:
+            name: mopidy-config
+        - name: mopidy-state
+          persistentVolumeClaim:
+            claimName: snapcast-mopidy-state

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -231,11 +231,11 @@ spec:
               memory: 512Mi
 
         - name: mopidy
-          # gjcourt/mopidy:3.4.2-1 — first-party image built from images/mopidy/
-          # (Phase 1 of docs/plans/2026-03-14-navidrome-snapcast-mopidy.md). After
-          # the first build, this should be digest-pinned per AGENTS.md image
-          # discipline; tag-only is acceptable while bootstrapping the image.
-          image: gjcourt/mopidy:3.4.2-1
+          # ghcr.io/gjcourt/mopidy:2026-05-04 — first-party image built by
+          # .github/workflows/build-mopidy.yml from images/mopidy/. Tag-only is
+          # acceptable per AGENTS.md (CI guarantees date-tag immutability for
+          # first-party gjcourt/* images).
+          image: ghcr.io/gjcourt/mopidy:2026-05-04
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -242,11 +242,11 @@ spec:
               drop:
                 - ALL
           env:
+            # The Navidrome URL isn't a secret — keep it a plaintext literal so
+            # it's reviewable in git and can't drift inside the encrypted blob.
+            # In-cluster Subsonic API (only the blog is exposed via the tunnel).
             - name: NAVIDROME_URL
-              valueFrom:
-                secretKeyRef:
-                  name: navidrome-credentials
-                  key: NAVIDROME_URL
+              value: "http://navidrome.navidrome-prod.svc.cluster.local:4533"
             - name: NAVIDROME_USER
               valueFrom:
                 secretKeyRef:

--- a/apps/base/snapcast/kustomization.yaml
+++ b/apps/base/snapcast/kustomization.yaml
@@ -1,10 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - configmap-mopidy.yaml
   - deployment.yaml
   - namespace.yaml
   - networkpolicy.yaml
   - pdb.yaml
+  # secret-navidrome-credentials.yaml is created from the .yaml.example template
+  # and SOPS-encrypted by the operator before this PR can land. See PR body and
+  # docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
+  - secret-navidrome-credentials.yaml
   - service.yaml
   - serviceaccount.yaml
   - storage.yaml

--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: snapcast
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: LAN snapclients (world entity; SNAT prevents CIDR match) on 1704/1705/1780; egress DNS + Spotify HTTPS.
+  description: LAN snapclients (world entity; SNAT prevents CIDR match) on 1704/1705/1780 + MPD on 6600; egress DNS, Spotify HTTPS, and in-cluster Navidrome Subsonic (4533).
   endpointSelector:
     matchLabels:
       app: snapcast
@@ -29,6 +29,10 @@ spec:
               protocol: TCP
             - port: "1780"
               protocol: TCP
+            # MPD protocol — the mopidy sidecar serves LAN clients
+            # (Symfonium, MALP, ncmpcpp) on 6600 via the snapcast LB.
+            - port: "6600"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:
@@ -46,4 +50,14 @@ spec:
       toPorts:
         - ports:
             - port: "443"
+              protocol: TCP
+    # mopidy sidecar pulls the library from Navidrome's in-cluster Subsonic
+    # API (only the blog is exposed via the tunnel, so no hairpin).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: navidrome-prod
+            app: navidrome
+      toPorts:
+        - ports:
+            - port: "4533"
               protocol: TCP

--- a/apps/base/snapcast/secret-navidrome-credentials.yaml
+++ b/apps/base/snapcast/secret-navidrome-credentials.yaml
@@ -1,0 +1,46 @@
+# Template for the navidrome-credentials Secret consumed by the mopidy sidecar.
+#
+# The actual encrypted version lives at:
+#   apps/base/snapcast/secret-navidrome-credentials.yaml
+# and should NEVER be committed in plaintext.
+#
+# To create it for the first time:
+#
+#   cp apps/base/snapcast/secret-navidrome-credentials.yaml.example \
+#      apps/base/snapcast/secret-navidrome-credentials.yaml
+#   # Edit the .yaml file and replace the PLACEHOLDER values below with real
+#   # Navidrome Subsonic credentials.
+#   sops -e -i apps/base/snapcast/secret-navidrome-credentials.yaml
+#
+# Then add `secret-navidrome-credentials.yaml` to apps/base/snapcast/kustomization.yaml
+# and commit.
+#
+# .sops.yaml's fallback creation_rule already covers any `*secret*.yaml` under
+# apps/, so SOPS will encrypt with the homelab age key automatically.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: navidrome-credentials
+  namespace: snapcast
+  labels:
+    app: snapcast
+type: Opaque
+stringData:
+  NAVIDROME_URL: ENC[AES256_GCM,data:lWVtrHS14/3jpKYExeFHIrm+BK57dMzad6jWyQ==,iv:WxBPUwDYyr4U+KdXJ5OTvJiKOI6CXnTK4bmhjCOLBbc=,tag:rUcxXl9dbTEGru2omKAyvA==,type:str]
+  NAVIDROME_USER: ENC[AES256_GCM,data:G9YLoe07z9tPIgn7,iv:newhKqEyqFmJEBE1WQtrJ3XM1KDg7VwZ0iR9waA8HOg=,tag:PWf/p7kwWHm0HSlxBbMmZA==,type:str]
+  NAVIDROME_PASSWORD: ENC[AES256_GCM,data:ceFTJo6RfHWzLUomZqjbTVhXGA==,iv:5RXX97WaukO3MCGdw+5/WZTfyHboPpnFr92IYY1Yq4c=,tag:bm57f35JS6wvb0PXepEQDw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjVWYySHd3aVBvU3R5ZGtk
+        eTRyUDFnTkhpVGp0ZmhsSTJrL2YrZWEwYTNzCm1kYUZMQ1NUaTg2Z3FhUnF5cFE4
+        QkNjdHFYMVQzNG1OanBWRjFVZlhvVVkKLS0tIEc3Rm9yN25ydEpmQmt6VENXUmRH
+        djVlMXB4U0twbERsYXBQM0h3WUlVY0UKY9YiNdBl9yRvFoVe7OdkqeXR1TiCAZyd
+        0BxqGi7wj3BZzSwqowQRbwZX7upogGQANAKdQWBs2ypp1TgCn/8LEA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-11T00:21:30Z"
+  mac: ENC[AES256_GCM,data:jyLCQT3nKJE9byHdpGe/Ln8pyAAVpXvjVkTPHBLTtK8+6ljHO/ncbjjgAU5lds8Cc2EWj2MBtu2enPq6ZWX2pVI0TRrUYRa1iRbz0Qa5r2SkzZZ/9rpuPcfD/zC1jmmAILzgI7TBVY28BG34CViHX08/MocRdlIcyzHE09pHkSM=,iv:RQ6i0D34bCc42Ks8JnJvwC99t4FYuxSYSUnz3xAZzuA=,tag:EbzARMUr0nG5bfnGWxitkQ==,type:str]
+  version: 3.13.1

--- a/apps/base/snapcast/secret-navidrome-credentials.yaml.example
+++ b/apps/base/snapcast/secret-navidrome-credentials.yaml.example
@@ -1,0 +1,32 @@
+# Template for the navidrome-credentials Secret consumed by the mopidy sidecar.
+#
+# The actual encrypted version lives at:
+#   apps/base/snapcast/secret-navidrome-credentials.yaml
+# and should NEVER be committed in plaintext.
+#
+# To create it for the first time:
+#
+#   cp apps/base/snapcast/secret-navidrome-credentials.yaml.example \
+#      apps/base/snapcast/secret-navidrome-credentials.yaml
+#   # Edit the .yaml file and replace the PLACEHOLDER values below with real
+#   # Navidrome Subsonic credentials.
+#   sops -e -i apps/base/snapcast/secret-navidrome-credentials.yaml
+#
+# Then add `secret-navidrome-credentials.yaml` to apps/base/snapcast/kustomization.yaml
+# and commit.
+#
+# .sops.yaml's fallback creation_rule already covers any `*secret*.yaml` under
+# apps/, so SOPS will encrypt with the homelab age key automatically.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: navidrome-credentials
+  namespace: snapcast
+  labels:
+    app: snapcast
+type: Opaque
+stringData:
+  NAVIDROME_URL: "https://music.burntbytes.com"
+  NAVIDROME_USER: "PLACEHOLDER_REPLACE_BEFORE_SOPS"
+  NAVIDROME_PASSWORD: "PLACEHOLDER_REPLACE_BEFORE_SOPS"

--- a/apps/base/snapcast/secret-navidrome-credentials.yaml.example
+++ b/apps/base/snapcast/secret-navidrome-credentials.yaml.example
@@ -27,6 +27,11 @@ metadata:
     app: snapcast
 type: Opaque
 stringData:
-  NAVIDROME_URL: "https://music.burntbytes.com"
+  # In-cluster Navidrome Subsonic API — only the blog is exposed via the
+  # Cloudflare tunnel, so reach Navidrome by its ClusterIP service rather than
+  # hairpinning out through the public ingress. The snapcast CNP allows egress
+  # to navidrome-prod:4533 (see networkpolicy.yaml). The Subsonic plugin uses
+  # salted-token auth, so plain http in-cluster doesn't expose the password.
+  NAVIDROME_URL: "http://navidrome.navidrome-prod.svc.cluster.local:4533"
   NAVIDROME_USER: "PLACEHOLDER_REPLACE_BEFORE_SOPS"
   NAVIDROME_PASSWORD: "PLACEHOLDER_REPLACE_BEFORE_SOPS"

--- a/apps/base/snapcast/secret-navidrome-credentials.yaml.example
+++ b/apps/base/snapcast/secret-navidrome-credentials.yaml.example
@@ -27,11 +27,10 @@ metadata:
     app: snapcast
 type: Opaque
 stringData:
-  # In-cluster Navidrome Subsonic API — only the blog is exposed via the
-  # Cloudflare tunnel, so reach Navidrome by its ClusterIP service rather than
-  # hairpinning out through the public ingress. The snapcast CNP allows egress
-  # to navidrome-prod:4533 (see networkpolicy.yaml). The Subsonic plugin uses
-  # salted-token auth, so plain http in-cluster doesn't expose the password.
-  NAVIDROME_URL: "http://navidrome.navidrome-prod.svc.cluster.local:4533"
+  # Credentials for a dedicated low-privilege Navidrome user (create one in the
+  # Navidrome UI → Settings → Users). The Subsonic plugin uses salted-token
+  # auth, so the password isn't sent in cleartext even over the in-cluster http
+  # endpoint. The NAVIDROME_URL is NOT here — it's a plaintext literal in
+  # deployment.yaml (in-cluster service), since a URL isn't a secret.
   NAVIDROME_USER: "PLACEHOLDER_REPLACE_BEFORE_SOPS"
   NAVIDROME_PASSWORD: "PLACEHOLDER_REPLACE_BEFORE_SOPS"

--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -36,3 +36,11 @@ spec:
       port: 57622
       targetPort: 57622
       protocol: TCP
+
+    # MPD protocol — mopidy sidecar exposes port 6600 for clients
+    # (Symfonium, MALP, ncmpcpp). Browse the Navidrome library, queue
+    # tracks; audio streams into the snapcast `navidrome` source.
+    - name: mpd
+      port: 6600
+      targetPort: 6600
+      protocol: TCP

--- a/apps/base/snapcast/storage.yaml
+++ b/apps/base/snapcast/storage.yaml
@@ -23,6 +23,7 @@ metadata:
   labels:
     app: snapcast
 spec:
+  storageClassName: truenas-iscsi
   accessModes:
     - ReadWriteOnce
   resources:

--- a/apps/base/snapcast/storage.yaml
+++ b/apps/base/snapcast/storage.yaml
@@ -12,3 +12,19 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+# Mopidy sidecar state: Subsonic library cache (mopidy-subidy) and Mopidy
+# bookkeeping. ~10–50 MB in practice; 1Gi gives plenty of headroom.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapcast-mopidy-state
+  namespace: snapcast
+  labels:
+    app: snapcast
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## ⚠️ DRAFT — rebased supersession of #426, gated on operator action

Rebases #426 onto current master (it had gone `CONFLICTING` — snapcast picked up the go-librespot drop-in and other changes since). The snapcast manifests auto-merged cleanly; only the plan-doc/index conflicts needed resolving (master already had the plan at `status: in-progress`). The Mopidy image (Phase 1) now exists at `ghcr.io/gjcourt/mopidy:2026-05-04`, so the only remaining gate is the SOPS secret.

Stages Phases 2-7 of `docs/plans/2026-03-14-navidrome-snapcast-mopidy.md`. After merge, MPD clients (Symfonium, MALP, ncmpcpp) connect to the snapcast LB IP on TCP 6600 and stream the Navidrome library to any HifiBerry via the new `navidrome` snapcast source.

**CI fails until the operator creates the SOPS-encrypted credentials Secret — that failure is the gate.**

## Operator unblock (only remaining step)

```bash
cp apps/base/snapcast/secret-navidrome-credentials.yaml.example \
   apps/base/snapcast/secret-navidrome-credentials.yaml
# Edit: replace PLACEHOLDER with real Navidrome Subsonic creds
# (make a dedicated low-priv Navidrome user for the bot).
sops -e -i apps/base/snapcast/secret-navidrome-credentials.yaml
git add apps/base/snapcast/secret-navidrome-credentials.yaml
git commit -m "feat(snapcast): SOPS-encrypted navidrome credentials" && git push
```
Then mark ready + merge.

## What changed in this PR (7 files, +209)

| File | Change |
|---|---|
| `config/snapserver.conf` | adds the `navidrome` source (`pipe:///audio/navidrome.fifo`) |
| `configmap-mopidy.yaml` (new) | Mopidy config, envsubst-templated for Subsonic creds |
| `deployment.yaml` | `init-navidrome-fifo` initContainer (mkfifo) + Mopidy sidecar (envsubst entrypoint, MPD probe, `/mopidy-state` PVC) |
| `storage.yaml` | `snapcast-mopidy-state` PVC (1Gi) |
| `service.yaml` | exposes TCP 6600 (`mpd`) on the LB |
| `secret-navidrome-credentials.yaml.example` (new) | template the operator copies + SOPS-encrypts |
| `kustomization.yaml` | references the new ConfigMap + (operator-created) Secret |

## Validation

- Rebased cleanly onto current master; `git diff --stat origin/master` = only the 7 intended files.
- `kustomize build apps/base/snapcast` renders 11 resources cleanly with the secret reference temporarily commented (the live reference is the intended CI gate).
- Mopidy sidecar pins `ghcr.io/gjcourt/mopidy:2026-05-04`; snapserver + go-librespot are master's current versions.

Supersedes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)