### PR TITLE
fix(mopidy): rebuild on Debian with system GStreamer (gi) bindings

### DIFF
--- a/images/mopidy/Dockerfile
+++ b/images/mopidy/Dockerfile
@@ -4,36 +4,46 @@
 # 6600, Mopidy fetches the library via mopidy-subidy, and the GStreamer audio
 # pipeline writes raw S16LE PCM into a shared FIFO that snapserver reads as the
 # `navidrome` source. See docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
+#
+# Built on Debian (NOT python:slim): Mopidy needs GStreamer's GObject
+# introspection bindings — the Python `gi` module — which cannot be installed
+# with pip (per Mopidy's docs). They come from the system python3-gi /
+# gir1.2-gst-* packages. Earlier python:3.x-slim builds crashed first on
+# `pkg_resources` (no setuptools) and then on `No module named 'gi'`.
+FROM debian:bookworm-slim
 
-# Python 3.12 — mopidy 3.4.2 predates 3.14 and imports the legacy
-# pkg_resources (from setuptools). On 3.14 the sidecar crashed at startup with
-# `ModuleNotFoundError: No module named 'pkg_resources'`. 3.12 is within mopidy
-# 3.4.x's supported range; setuptools is installed explicitly below since pip
-# no longer bundles it on 3.12+.
-FROM python:3.12-slim-bookworm
-
-# Runtime deps:
-#   - gstreamer1.0-plugins-{base,good} + tools — the audio pipeline (audioresample,
-#     audioconvert, filesink) and `gst-inspect-1.0` for debugging.
-#   - libcairo2 — pulled in by Mopidy's Pykka/dbus stack.
-#   - libgstreamer1.0-0 / libgstreamer-plugins-base1.0-0 — GStreamer core libs.
+# System deps:
+#   - python3 / python3-venv — interpreter + venv tooling.
+#   - python3-gi, python3-gi-cairo, gir1.2-glib-2.0, gir1.2-gstreamer-1.0,
+#     gir1.2-gst-plugins-base-1.0 — the GObject-introspection bindings + typelibs
+#     Mopidy imports as `gi` / `Gst`. NOT pip-installable.
+#   - gstreamer1.0-plugins-{base,good} + tools — audio pipeline elements
+#     (audioresample, audioconvert, filesink) + gst-inspect-1.0 for debugging.
+#   - libcairo2 — Mopidy's Pykka/dbus stack.
 #   - gettext-base — provides `envsubst`, which the snapcast pod's mopidy
 #     entrypoint runs to expand ${NAVIDROME_*} env vars from the Subsonic
-#     credentials Secret into /tmp/mopidy.conf before invoking mopidy. Without
-#     this the sidecar fails with `sh: envsubst: not found`.
+#     credentials Secret into /tmp/mopidy.conf before invoking mopidy.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gettext-base \
+        python3 \
+        python3-venv \
+        python3-gi \
+        python3-gi-cairo \
+        gir1.2-glib-2.0 \
+        gir1.2-gstreamer-1.0 \
+        gir1.2-gst-plugins-base-1.0 \
         gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good \
         gstreamer1.0-tools \
         libcairo2 \
-        libgstreamer-plugins-base1.0-0 \
-        libgstreamer1.0-0 \
+        gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
-# setuptools provides pkg_resources, which mopidy 3.4.2 imports at startup.
-# Pinned <81 to stay clear of the aggressive pkg_resources deprecation/removal
-# in newer setuptools while keeping Python 3.12 support.
+# Debian's system python3 is externally managed (PEP 668). Install Mopidy into
+# a venv created with --system-site-packages so the pip-installed Mopidy can
+# import the apt-provided gi + GStreamer bindings (a plain venv would hide
+# them). setuptools<81 provides the legacy pkg_resources Mopidy 3.4.2 imports.
+RUN python3 -m venv --system-site-packages /opt/mopidy-venv
+ENV PATH="/opt/mopidy-venv/bin:$PATH"
 RUN pip install --no-cache-dir \
         "setuptools<81" \
         mopidy==3.4.2 \
@@ -41,9 +51,9 @@ RUN pip install --no-cache-dir \
         mopidy-subidy==1.1.0 \
         mopidy-local==3.2.1
 
-# Match the snapcast pod's `runAsUser: 1000` / `fsGroup: 1000`. The sidecar
-# only writes to /tmp (cache) and the mopidy-state PVC mounted at /mopidy-state,
-# both writable by UID 1000 via fsGroup, so no extra chown is needed at build.
+# Match the snapcast pod's runAsUser: 1000 / fsGroup: 1000. The sidecar only
+# writes to /tmp (cache) and the mopidy-state PVC at /mopidy-state, both
+# writable by UID 1000 via fsGroup, so no build-time chown is needed.
 RUN groupadd --system --gid 1000 mopidy \
     && useradd --system --uid 1000 --gid 1000 --home-dir /mopidy-state --shell /usr/sbin/nologin mopidy
 
@@ -51,4 +61,6 @@ USER 1000:1000
 
 EXPOSE 6600
 
-ENTRYPOINT ["/usr/local/bin/mopidy"]
+# The snapcast deployment overrides this with an envsubst wrapper that execs
+# `mopidy` (on PATH via the venv); kept for standalone `docker run`.
+ENTRYPOINT ["mopidy"]


### PR DESCRIPTION
Root-cause fix for the never-functional mopidy image (caught shipping #895 on snapcast-stage). After #898 fixed `pkg_resources`, the sidecar still crashed with `No module named 'gi'` — Mopidy needs GStreamer's GObject-introspection bindings, which can't be pip-installed. Rebuild on `debian:bookworm-slim` with `python3-gi` + GStreamer typelibs and a `--system-site-packages` venv. Merging rebuilds the image; #895 will bump to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)