### PR TITLE
feat(snapcast): expose Mopidy-Iris web client at cast.burntbytes.com

### DIFF
--- a/apps/base/snapcast/configmap-mopidy.yaml
+++ b/apps/base/snapcast/configmap-mopidy.yaml
@@ -24,6 +24,17 @@ data:
     hostname = ::
     port = 6600
 
+    [http]
+    # Serves the Mopidy-Iris web client (browse Navidrome + play to the
+    # snapcast `navidrome` stream from a browser). Listen on all interfaces;
+    # the Service exposes 6680 and the cast.burntbytes.com route lands on /iris/.
+    enabled = true
+    hostname = ::
+    port = 6680
+
+    [iris]
+    enabled = true
+
     [subidy]
     url = ${NAVIDROME_URL}
     username = ${NAVIDROME_USER}

--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -232,11 +232,10 @@ spec:
 
         - name: mopidy
           # ghcr.io/gjcourt/mopidy:2026-06-11 — first-party image built by
-          # .github/workflows/build-mopidy.yml from images/mopidy/. Digest-pinned
-          # to the Debian rebuild (#899) with system GStreamer/gi bindings; the
-          # earlier python:slim builds crashlooped on pkg_resources then on
-          # missing `gi`.
-          image: ghcr.io/gjcourt/mopidy:2026-06-11@sha256:9877833580604f8e123915f1a797bfd1188c1cd965953a85ec7d0af762d812bd
+          # .github/workflows/build-mopidy.yml from images/mopidy/. Digest-pinned;
+          # this build adds Mopidy-Iris (#901) on top of the Debian + system
+          # GStreamer/gi base.
+          image: ghcr.io/gjcourt/mopidy:2026-06-11@sha256:bcbec138dc9c29a2ac56b5e265b825a82a93d57a7eece9349c8f2f5b18df6382
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -263,6 +262,8 @@ spec:
           ports:
             - name: mpd
               containerPort: 6600
+            - name: iris
+              containerPort: 6680
           command:
             - sh
             - -c

--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -33,6 +33,10 @@ spec:
             # (Symfonium, MALP, ncmpcpp) on 6600 via the snapcast LB.
             - port: "6600"
               protocol: TCP
+            # Mopidy HTTP — the Mopidy-Iris web client, via the gateway
+            # (cast.burntbytes.com) or the LB IP directly.
+            - port: "6680"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/apps/base/snapcast/service.yaml
+++ b/apps/base/snapcast/service.yaml
@@ -44,3 +44,10 @@ spec:
       port: 6600
       targetPort: 6600
       protocol: TCP
+    # Mopidy HTTP — serves the Mopidy-Iris web client (browse Navidrome +
+    # play to the `navidrome` stream). Reached via the cast.burntbytes.com
+    # gateway route (LAN only) or directly on the LB IP:6680.
+    - name: iris
+      port: 6680
+      targetPort: 6680
+      protocol: TCP

--- a/apps/production/snapcast/httproute.yaml
+++ b/apps/production/snapcast/httproute.yaml
@@ -33,3 +33,54 @@ spec:
     - backendRefs:
         - name: snapcast
           port: 1780
+---
+# Mopidy-Iris web client at cast.burntbytes.com. LAN-only — matches the
+# *.burntbytes.com wildcard gateway listener + AdGuard rewrite; NOT added to
+# the Cloudflare tunnel (only the blog is exposed off-LAN). The bare host
+# redirects to /iris/ since Mopidy's HTTP root only lists apps.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: cast-http
+  namespace: snapcast-prod
+spec:
+  hostnames:
+    - cast.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: cast-https
+  namespace: snapcast-prod
+spec:
+  hostnames:
+    - cast.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /iris/
+            statusCode: 302
+    - backendRefs:
+        - name: snapcast
+          port: 6680


### PR DESCRIPTION
## Summary

Wires up the Mopidy-Iris web UI (added to the image in #901) so the Navidrome library can be browsed + played onto the snapcast `navidrome` stream from a browser — a "music.burntbytes.com-style" player that actually drives the HifiBerries (Navidrome's own web player only plays locally in the browser).

- **configmap-mopidy** — enable Mopidy `[http]` on `:: 6680` + `[iris]`.
- **deployment** — `containerPort: 6680`; bump image digest to the Iris build.
- **service** — expose `6680` (iris) on the snapcast LB.
- **networkpolicy** — allow ingress on `6680`.
- **production httproute** — `cast.burntbytes.com` → `snapcast:6680`, bare `/` → `/iris/`. **LAN-only** (matches the `*.burntbytes.com` wildcard listener + AdGuard rewrite; not on the Cloudflare tunnel — only the blog is exposed off-LAN).

## Usage (after deploy)

Open **https://cast.burntbytes.com** on the LAN → Iris loads → search/browse Navidrome, queue + play. Assign a HifiBerry to the `navidrome` stream in Snapweb to hear it.

## Verification

- `kustomize build apps/production/snapcast` + staging both pass.
- Post-merge: validate on snapcast-stage (mopidy 3/3, Iris reachable on `:6680/iris/`), then prod; confirm `https://cast.burntbytes.com` loads Iris on the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)