### PR TITLE
feat(homepage): add Cast (Mopidy/Iris) to the Media group

### DIFF
--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -29,6 +29,11 @@
         href: https://snapcast.burntbytes.com
         description: Multi-room audio (Snapweb)
         siteMonitor: https://snapcast.burntbytes.com
+    - Cast:
+        icon: mdi-cast-audio
+        href: https://cast.burntbytes.com
+        description: Play Navidrome to the speakers (Mopidy / Iris)
+        siteMonitor: https://cast.burntbytes.com/iris/
     - Audiobookshelf:
         icon: audiobookshelf.png
         href: https://audiobooks.burntbytes.com


### PR DESCRIPTION
Adds the new `cast.burntbytes.com` Iris web player to the Homepage dashboard's Media group (right after Snapcast) — browse Navidrome + play to the HifiBerries from a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)