### PR TITLE
feat(homepage): use kitchen-music/living-music hostnames for HifiBerries

### DIFF
--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -16,14 +16,14 @@
         siteMonitor: https://music.burntbytes.com
     - Kitchen:
         icon: mdi-speaker
-        href: http://10.42.2.38
+        href: http://kitchen-music.burntbytes.com
         description: HifiBerry OS – Kitchen
-        siteMonitor: http://10.42.2.38
+        siteMonitor: http://kitchen-music.burntbytes.com
     - Living Room:
         icon: mdi-speaker
-        href: http://10.42.2.39
+        href: http://living-music.burntbytes.com
         description: HifiBerry OS – Living Room
-        siteMonitor: http://10.42.2.39
+        siteMonitor: http://living-music.burntbytes.com
     - Snapcast:
         icon: mdi-speaker-multiple
         href: https://snapcast.burntbytes.com


### PR DESCRIPTION
Switches the Kitchen/Living Room Homepage tiles from raw IPs (`10.42.2.38`/`.39`) to `kitchen-music.burntbytes.com` / `living-music.burntbytes.com`.

Backed by specific AdGuard DNS rewrites (kitchen-music→.38, living-music→.39) that override the `*.burntbytes.com` wildcard (which otherwise sends them to the gateway). Verified: both resolve to the HifiBerries on the primary + secondary resolvers, and the HifiBerry OS UI returns 200 via the hostname. Links stay `http://` since HifiBerry OS serves plain HTTP on :80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)