### PR TITLE
deploy(netscope): bump image to 61d5a15 (per-domain DNS latency)

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36"
+          image: "ghcr.io/gjcourt/netscope:61d5a15@sha256:538cbdf39c257cb6ef3797a160aa1922cdde06f0582918b1a01789195bc2b211"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
Deploys [netscope#14](https://github.com/gjcourt/netscope/pull/14) — per-domain DNS query-latency breakdown (`netscope_dns_query_microseconds_by_suffix`, a per-suffix histogram alongside the cluster aggregate, with cardinality control).

- `ghcr.io/gjcourt/netscope:2e20747` → `61d5a15@sha256:538cbdf…`
- Built from netscope merge commit `61d5a15`; GHA build green.
- `kustomize build apps/staging/netscope` passes. netscope is staging-only (no prod overlay), so this lands in `netscope-stage` once CI merges to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)