### PR TITLE
revert(netscope): roll back to 2e20747 — 61d5a15 fails BPF verifier on Talos

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:61d5a15@sha256:538cbdf39c257cb6ef3797a160aa1922cdde06f0582918b1a01789195bc2b211"
+          image: "ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
Explicit, intentional rollback of #918 (per AGENTS rollback policy).

## Why
The `61d5a15` build (netscope#14 — per-domain DNS latency) **crashloops on the Talos kernel**:

```
program record_dns_query: load program: invalid argument:
program of this type cannot use helper bpf_probe_read#4
```

The new `fentry/udp_sendmsg` DNS program (`record_dns_query`) emits the generic `bpf_probe_read` (helper #4), which **tracing/fentry programs are forbidden from using** on this kernel — the verifier rejects the whole BPF collection. The `bpf_probe_read#4` is sneaking in via a `BPF_CORE_READ` expansion despite the source intending `bpf_probe_read_user`/`_kernel`.

netscope's `kernel-smoke` CI passed because it loads on a **different kernel** than Talos — classic passed-CI-failed-on-real-hardware.

## Impact
None. The DaemonSet rolling update **halted at 1/6** (5/6 stayed on `2e20747`), so no observability outage. This returns all nodes to the known-good image.

## Follow-up (netscope repo, separate)
- Force `bpf_probe_read_kernel`/`_user` in the DNS fentry programs (audit `BPF_CORE_READ` sites in `record_dns_query`/`record_dns_response`).
- Pin `kernel-smoke` to the Talos kernel version so this is caught in CI.
- Then rebuild + redeploy.

`2e20747` ← `61d5a15`. `kustomize build apps/staging/netscope` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)