### PR TITLE
deploy(netscope): bump to 7f774e4 — BPF probe_read#4 fix

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36"
+          image: "ghcr.io/gjcourt/netscope:7f774e4@sha256:5c5c9bbac4ae9066ad94c77e7343026c54cbc5d4caec8c4ddbf6b8ebcbd7ec6d"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
Re-deploys the per-domain DNS latency feature (netscope#14) after the BPF verifier fix in [netscope#15](https://github.com/gjcourt/netscope/pull/15).

## Context
- #918 deployed `61d5a15` → crashlooped on Talos 6.18.9 (`record_dns_query: cannot use helper bpf_probe_read#4`) → reverted in #919.
- netscope#15 fixed it: the fentry DNS programs now read the iovec via `bpf_probe_read_kernel` instead of the generic `bpf_probe_read#4`. Root cause was clang-14 (bookworm builder) lowering a struct-field-loaded iovec pointer to the generic helper.
- `kernel-smoke` CI was hardened to compile with the **real bookworm clang-14** and load on a 6.18 kernel — so its green status is now meaningful evidence the fix loads.

## This PR
- `ghcr.io/gjcourt/netscope:2e20747` → `7f774e4@sha256:5c5c9bb…`
- `kustomize build apps/staging/netscope` passes.
- After merge + rollout, will **verify the BPF program actually loads on the Talos nodes** (the deploy-verify step CI can't fully cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)