### PR TITLE
revert(netscope): roll back to 2e20747 — 7f774e4 still fails BPF verifier

### DIFF
--- a/apps/base/netscope/daemonset.yaml
+++ b/apps/base/netscope/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - operator: Exists
       containers:
         - name: agent
-          image: "ghcr.io/gjcourt/netscope:7f774e4@sha256:5c5c9bbac4ae9066ad94c77e7343026c54cbc5d4caec8c4ddbf6b8ebcbd7ec6d"
+          image: "ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36"
           imagePullPolicy: IfNotPresent
           # NETSCOPE_IFACE intentionally unset — the agent discovers the
           # IPv4 default-route interface at startup from /proc/net/route.


### PR DESCRIPTION
Second revert. The netscope#15 fix (bpf_probe_read_kernel for the iovec) did **not** resolve the verifier rejection — `7f774e4` still crashloops on Talos 6.18.9 with the identical `record_dns_query: cannot use helper bpf_probe_read#4`. There's another #4 site (or a different root cause), and `kernel-smoke` gave a false green (CI kernel config ≠ Talos). Contained as before (5/6 stayed healthy). Returning to known-good `2e20747` while the real fix is developed off the full Talos verifier log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)