### PR TITLE
deploy(thermalscope): bump to a561320 — RAPL power/energy

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
           # hwmon chip handling (thermalscope PR #3), exposing
           # `thermalscope_amdgpu_temperature_celsius` on nodes with
           # an AMD GPU present.
-          image: "ghcr.io/gjcourt/thermalscope:88170e1@sha256:df4839459c785db2e4988521be3448dc10a3a4baa0645bea93f8d3c777db11fe"
+          image: "ghcr.io/gjcourt/thermalscope:a561320@sha256:734a5a68d40ec780afd2916b039814999a05de6b8181122720d4ca56b4db8f6c"
           imagePullPolicy: IfNotPresent
           ports:
             - name: metrics


### PR DESCRIPTION
Phase 1 of the thermalscope power plan (#922). Deploys [thermalscope#4](https://github.com/gjcourt/thermalscope/pull/4): RAPL energy counters (read as root — node-exporter can't under lockdown), hwmon power_watts, power_up health. Additive only — existing temp/fan metrics unchanged.

After rollout: verify `rate(thermalscope_rapl_energy_microjoules_total[5m])/1e6` reads sane watts on a real node before wiring the Power/Energy dashboard row (per the plan's rollout — confirm on hardware first).

`88170e1` → `a561320`. kustomize build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)