### PR TITLE
fix(thermalscope): mount /sys/class/powercap for RAPL collector

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -69,6 +69,9 @@ spec:
             - name: thermal
               mountPath: /sys/class/thermal
               readOnly: true
+            - name: powercap
+              mountPath: /sys/class/powercap
+              readOnly: true
           resources:
             requests:
               cpu: 10m
@@ -100,3 +103,9 @@ spec:
           hostPath:
             path: /sys/class/thermal
             type: Directory
+        # No `type: Directory` check: RAPL/powercap is CPU+kernel dependent.
+        # Verified present on talos-18u-ski; omitting the existence check so a
+        # node lacking powercap loses only power metrics, not all thermalscope.
+        - name: powercap
+          hostPath:
+            path: /sys/class/powercap


### PR DESCRIPTION
Deploy-verify of #923 caught a missing mount: `thermalscope_power_up=1` and `power_watts{amdgpu}` (7–17 W) populated on all 6 nodes, but `thermalscope_rapl_energy_microjoules_total` had **no data** — the RAPL collector reads `/sys/class/powercap`, which the DaemonSet never mounted (only `hwmon` + `thermal`). Adds the mount (no `type` existence-check so a node lacking powercap loses only power metrics, not all thermalscope). Verified RAPL present on talos-18u-ski.

🤖 Generated with [Claude Code](https://claude.com/claude-code)