### PR TITLE
fix(thermalscope): mount powercap device subtree so RAPL symlinks resolve

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -72,6 +72,12 @@ spec:
             - name: powercap
               mountPath: /sys/class/powercap
               readOnly: true
+            # /sys/class/powercap entries are symlinks into
+            # /sys/devices/virtual/powercap; the symlink targets must be
+            # mounted too or RAPL reads resolve to nothing (verified).
+            - name: powercap-devices
+              mountPath: /sys/devices/virtual/powercap
+              readOnly: true
           resources:
             requests:
               cpu: 10m
@@ -109,3 +115,7 @@ spec:
         - name: powercap
           hostPath:
             path: /sys/class/powercap
+        # Symlink targets for /sys/class/powercap (see volumeMount note).
+        - name: powercap-devices
+          hostPath:
+            path: /sys/devices/virtual/powercap


### PR DESCRIPTION
Follow-up to #924. Mounting `/sys/class/powercap` alone didn't surface RAPL — those entries are **symlinks into `/sys/devices/virtual/powercap`**, and the targets weren't in the container (the base sysfs exposes real PCI devices, which is why hwmon worked, but not the *virtual* powercap subtree). Adds the device-subtree mount.

**Verified on a node** before this PR: with both `/sys/class/powercap` + `/sys/devices/virtual/powercap` mounted, the collector's class-path glob resolves through the symlinks and reads `package-0` + `core` `energy_uj` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)