### PR TITLE
feat: add Power & Energy observability to thermalscope

### DIFF
--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -768,6 +768,135 @@ data:
           ],
           "title": "Scrape Duration",
           "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 64},
+          "id": 300,
+          "title": "Power & Energy — CPU RAPL + SoC; cost is an estimate (set $cost_per_kwh)",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "Per-node CPU package power from the RAPL energy counter (rate over 5m). Backed by the instance:thermalscope_cpu_package_watts:rate5m recording rule.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "palette-classic"},
+                  "custom": {"lineWidth": 2, "spanNulls": false},
+                  "unit": "watt",
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 8, "w": 12, "x": 0, "y": 65},
+              "id": 301,
+              "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "instance:thermalscope_cpu_package_watts:rate5m{instance=~\"$instance\"}",
+                  "legendFormat": "{{instance}}"
+                }
+              ],
+              "title": "CPU Package Power (RAPL)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "Per-node SoC rail power reported by the amdgpu chip sensor.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "palette-classic"},
+                  "custom": {"lineWidth": 2, "spanNulls": false},
+                  "unit": "watt",
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 8, "w": 12, "x": 12, "y": 65},
+              "id": 302,
+              "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "thermalscope_power_watts{instance=~\"$instance\", chip=\"amdgpu\"}",
+                  "legendFormat": "{{instance}}"
+                }
+              ],
+              "title": "SoC Power (amdgpu)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "Total CPU package energy across all nodes over the trailing 24h. Backed by the instance:thermalscope_cpu_package_kwh:increase1d recording rule.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "thresholds"},
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "green", "value": null}
+                    ]
+                  },
+                  "unit": "kwatth",
+                  "decimals": 3,
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 5, "w": 12, "x": 0, "y": 73},
+              "id": 303,
+              "options": {
+                "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+                "orientation": "auto",
+                "colorMode": "value",
+                "graphMode": "area",
+                "textMode": "value_and_name"
+              },
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "sum(instance:thermalscope_cpu_package_kwh:increase1d{instance=~\"$instance\"})",
+                  "legendFormat": "Total CPU energy / day"
+                }
+              ],
+              "title": "Energy per day (kWh)",
+              "type": "stat"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "Estimated monthly CPU-package electricity cost: daily kWh × 30 × $cost_per_kwh. This is an ESTIMATE driven by the editable cost_per_kwh template variable — set it to your actual rate. Covers CPU package (RAPL) only, not whole-system draw.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "thresholds"},
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "green", "value": null}
+                    ]
+                  },
+                  "unit": "currencyUSD",
+                  "decimals": 2,
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 5, "w": 12, "x": 12, "y": 73},
+              "id": 304,
+              "options": {
+                "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+                "orientation": "auto",
+                "colorMode": "value",
+                "graphMode": "none",
+                "textMode": "value_and_name"
+              },
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "sum(instance:thermalscope_cpu_package_kwh:increase1d{instance=~\"$instance\"}) * 30 * $cost_per_kwh",
+                  "legendFormat": "Est. CPU cost / month"
+                }
+              ],
+              "title": "Estimated cost / month ($) — estimate, see $cost_per_kwh",
+              "type": "stat"
+            }
+          ]
         }
       ],
       "refresh": "30s",
@@ -805,6 +934,15 @@ data:
             "skipUrlSync": false,
             "sort": 1,
             "type": "query"
+          },
+          {
+            "current": {"selected": false, "text": "0.20", "value": "0.20"},
+            "hide": 0,
+            "label": "Electricity rate ($/kWh) — set to your actual rate",
+            "name": "cost_per_kwh",
+            "query": "0.20",
+            "skipUrlSync": false,
+            "type": "constant"
           }
         ]
       },
@@ -813,5 +951,5 @@ data:
       "timezone": "browser",
       "title": "ThermalScope — Rack",
       "uid": null,
-      "version": 3
+      "version": 4
     }

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -7,6 +7,22 @@ metadata:
     release: kube-prometheus-stack
 spec:
   groups:
+    # Recording rules backing the dashboard's Power & Energy row. RAPL
+    # exposes a microjoule counter per CPU package; rate() over it yields
+    # watts, and increase() over 24h converted to kWh drives the energy
+    # and cost panels.
+    - name: thermalscope.recording
+      rules:
+        # CPU package power (watts) per node — rate of the RAPL energy
+        # counter (µJ/s = µW) divided by 1e6 to convert to watts.
+        - record: instance:thermalscope_cpu_package_watts:rate5m
+          expr: rate(thermalscope_rapl_energy_microjoules_total{domain="package-0"}[5m]) / 1e6
+
+        # CPU package energy over the trailing 24h (kWh) per node.
+        # increase() yields µJ; 1 kWh = 3.6e12 µJ.
+        - record: instance:thermalscope_cpu_package_kwh:increase1d
+          expr: increase(thermalscope_rapl_energy_microjoules_total{domain="package-0"}[24h]) / 3.6e12
+
     - name: thermalscope
       rules:
         - alert: ThermalScopeScraperDown


### PR DESCRIPTION
## What

Builds out the **Power & Energy** observability for thermalscope now that RAPL power metrics are live in prod: two recording rules, a new collapsible dashboard row, and a \$/month cost estimate.

## Recording rules
New `thermalscope.recording` group in `infra/configs/thermalscope/prometheus-rule.yaml` (the 5 existing alerts are untouched):

| Rule | Expr |
|---|---|
| `instance:thermalscope_cpu_package_watts:rate5m` | `rate(thermalscope_rapl_energy_microjoules_total{domain="package-0"}[5m]) / 1e6` |
| `instance:thermalscope_cpu_package_kwh:increase1d` | `increase(thermalscope_rapl_energy_microjoules_total{domain="package-0"}[24h]) / 3.6e12` |

## Dashboard — new "Power & Energy" row (collapsible, panel ids 300–304)
1. **CPU Package Power (RAPL)** — timeseries, watts, `instance:thermalscope_cpu_package_watts:rate5m{instance=~"$instance"}`, legend by instance
2. **SoC Power (amdgpu)** — timeseries, watts, `thermalscope_power_watts{instance=~"$instance", chip="amdgpu"}`
3. **Energy per day (kWh)** — stat, `sum(instance:thermalscope_cpu_package_kwh:increase1d{instance=~"$instance"})`
4. **Estimated cost / month (\$)** — stat, `sum(instance:thermalscope_cpu_package_kwh:increase1d{instance=~"$instance"}) * 30 * $cost_per_kwh`

Existing panels, ids, and gridPos are unchanged. Appended at `y=64` to clear all existing rows; nested panels follow the existing collapsed-row style (ids 102/103/105). Dashboard `version` bumped 3→4. The `grafana_dashboard: "1"` sidecar label is preserved.

## Cost handling
New **constant** template variable `cost_per_kwh` (default `0.20`), labelled *"Electricity rate (\$/kWh) — set to your actual rate"*. It is the single source of truth for the rate. The cost is explicitly an **estimate** and covers **CPU package (RAPL) draw only**, not whole-system power — panel titles/descriptions say so.

## Validation
- **Embedded dashboard JSON parses** as valid JSON (validated separately from the YAML); no duplicate panel ids; 3 template vars present.
- **`kustomize build infra/configs`** passes (5933 lines).
- **PrometheusRule YAML** parses; 2 recording groups + 5 alerts intact.
- **Live PromQL against prod** (`kube-prometheus-stack-prometheus:9090`): all 4 panels' underlying expressions return data — CPU package ≈ 7–17 W/node (6 series), amdgpu ≈ 7–22 W/node (6 series), daily total ≈ 0.089 kWh, cost ≈ \$0.54/mo at \$0.20/kWh.
- The recording-rule **names** return 0 series today — expected; they don't exist in prod until this PR merges and Prometheus reloads the rules. Panels 1/3/4 reference the rules and will populate once reconciled (the dashboard and rules ship together in this PR). Their underlying expressions are confirmed working.

## Render gap (honest)
JSON validity + live-query checks give ~90% confidence, but the **visual Grafana render is not verified** (needs a running Grafana). Possible cosmetic issues (panel sizing, unit display, legend overflow) can only be confirmed in the UI after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)