### PR TITLE
deploy(thermalscope): bump to 096a780 — NVMe temp thresholds

### DIFF
--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
           # `b7e057a` reads RAPL energy from the powercap device tree
           # (thermalscope PR #5) instead of the /sys/class symlinks,
           # which containerd masks — see the powercap volume note below.
-          image: "ghcr.io/gjcourt/thermalscope:b7e057a@sha256:dbdee8e06a7a1c890b84ce0773b5c2706b5a59eabb1e7dcbab48ac88e0807957"
+          image: "ghcr.io/gjcourt/thermalscope:096a780@sha256:e609b6626f8e3fb47f17c8dd4e7df69be7d389d04397b2cc5ab7deeaaf832cc3"
           imagePullPolicy: IfNotPresent
           env:
             # The default powercap root (/sys/devices/virtual/powercap) is


### PR DESCRIPTION
Phase 2 enabler. Deploys thermalscope#6: `thermalscope_nvme_temperature_threshold_celsius{device,sensor,level}` (crit/max), label-parity with the current-temp series so headroom = threshold − current joins cleanly. Additive, no mount change (hwmon path already works). Recording rules + alerts + dashboard follow once the metric is confirmed live. b7e057a → 096a780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)