### PR TITLE
feat(thermalscope): Headroom & Throttle observability (Phase 2)

### DIFF
--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -897,6 +897,109 @@ data:
               "type": "stat"
             }
           ]
+        },
+        {
+          "collapsed": true,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 78},
+          "id": 400,
+          "title": "Headroom & Throttle — °C to thermal limits + CPU clock throttle indicator",
+          "type": "row",
+          "panels": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "NVMe thermal headroom to the SMART crit threshold, per drive (crit − current). Backed by the instance:thermalscope_nvme_headroom_celsius recording rule. Red <5°C, orange <10°C.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "thresholds"},
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "red", "value": null},
+                      {"color": "orange", "value": 5},
+                      {"color": "green", "value": 10}
+                    ]
+                  },
+                  "unit": "celsius",
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 8, "w": 12, "x": 0, "y": 79},
+              "id": 401,
+              "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": ""}, "orientation": "horizontal", "displayMode": "gradient"},
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "instance:thermalscope_nvme_headroom_celsius{instance=~\"$instance\"}",
+                  "legendFormat": "{{instance}} {{device}}"
+                }
+              ],
+              "title": "NVMe headroom (°C to crit)",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "CPU thermal headroom to Tjmax, per host ($cpu_tjmax − Tctl). Tjmax is an advisory constant — these AMD APUs expose no crit sensor — set via the $cpu_tjmax template variable. Red <5°C, orange <10°C.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "thresholds"},
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "red", "value": null},
+                      {"color": "orange", "value": 5},
+                      {"color": "green", "value": 10}
+                    ]
+                  },
+                  "unit": "celsius",
+                  "min": 0
+                }
+              },
+              "gridPos": {"h": 8, "w": 12, "x": 12, "y": 79},
+              "id": 402,
+              "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": ""}, "orientation": "horizontal", "displayMode": "gradient"},
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "$cpu_tjmax - thermalscope_cpu_temperature_celsius{sensor=\"Tctl\", instance=~\"$instance\"}",
+                  "legendFormat": "{{instance}}"
+                }
+              ],
+              "title": "CPU headroom (°C to Tjmax)",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "description": "Worst-throttled-core CPU frequency ratio (current/max), per node. Backed by the instance:thermalscope_cpu_freq_ratio recording rule. NOTE: these APUs idle-park cores well below max, so the idle baseline is ~0.4–0.7, NOT ~1.0 — a low ratio is only concerning alongside high temperature (see the ThermalScopeCPUThrottling alert). node-exporter covers the 6 Talos nodes only (not hestia). Red <0.85.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {"mode": "thresholds"},
+                  "custom": {"lineWidth": 2, "spanNulls": false},
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "red", "value": null},
+                      {"color": "green", "value": 0.85}
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                }
+              },
+              "gridPos": {"h": 8, "w": 24, "x": 0, "y": 87},
+              "id": 403,
+              "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+              "targets": [
+                {
+                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "expr": "instance:thermalscope_cpu_freq_ratio{instance=~\"$instance\"}",
+                  "legendFormat": "{{instance}}"
+                }
+              ],
+              "title": "CPU frequency ratio (throttle indicator)",
+              "type": "timeseries"
+            }
+          ]
         }
       ],
       "refresh": "30s",
@@ -943,6 +1046,15 @@ data:
             "query": "0.20",
             "skipUrlSync": false,
             "type": "constant"
+          },
+          {
+            "current": {"selected": false, "text": "95", "value": "95"},
+            "hide": 0,
+            "label": "AMD APU Tjmax (°C) — advisory",
+            "name": "cpu_tjmax",
+            "query": "95",
+            "skipUrlSync": false,
+            "type": "constant"
           }
         ]
       },
@@ -951,5 +1063,5 @@ data:
       "timezone": "browser",
       "title": "ThermalScope — Rack",
       "uid": null,
-      "version": 4
+      "version": 5
     }

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -23,6 +23,44 @@ spec:
         - record: instance:thermalscope_cpu_package_kwh:increase1d
           expr: increase(thermalscope_rapl_energy_microjoules_total{domain="package-0"}[24h]) / 3.6e12
 
+        # --- Phase 2: Headroom & Throttle ---
+
+        # NVMe thermal headroom (°C) to the SMART crit threshold, per drive.
+        # Joins the threshold and current-temp series on their shared
+        # (instance,device,sensor) labels. Only temp1/Composite exposes a
+        # crit threshold, so headroom is defined exactly where crit exists.
+        - record: instance:thermalscope_nvme_headroom_celsius
+          expr: thermalscope_nvme_temperature_threshold_celsius{level="crit"} - on(instance,device,sensor) thermalscope_nvme_temperature_celsius
+
+        # CPU frequency ratio (current / max) for the worst-throttled core,
+        # per node. A throttle indicator: <1 means at least one core is
+        # below its max clock. Note these AMD APUs idle-park cores well
+        # below max, so the idle baseline is ~0.4–0.7, NOT ~1.0 — a low
+        # ratio is only meaningful when paired with high temperature (see
+        # ThermalScopeCPUThrottling). node-exporter keys series by
+        # instance="<ip>:9100"; we re-key to the thermalscope
+        # instance="<nodename>" via node_uname_info so this rule joins
+        # cleanly with thermalscope_cpu_temperature_celsius and matches the
+        # dashboard's $instance variable. node-exporter covers the 6 Talos
+        # nodes only (hestia is a bare host outside the DaemonSet).
+        - record: instance:thermalscope_cpu_freq_ratio
+          expr: |
+            min by(instance) (
+              label_replace(
+                (node_cpu_scaling_frequency_hertz / node_cpu_scaling_frequency_max_hertz)
+                  * on(instance) group_left(nodename) node_uname_info,
+                "instance", "$1", "nodename", "(.+)"
+              )
+            )
+
+        # CPU thermal headroom (°C) to Tjmax, per host. These AMD APUs
+        # expose no crit sensor in sysfs, so Tjmax is an advisory constant.
+        # Hardcoded 95 here; the dashboard panel single-sources the same
+        # value through the $cpu_tjmax constant template variable. Keep the
+        # two in sync if you change the assumption.
+        - record: instance:thermalscope_cpu_headroom_celsius
+          expr: 95 - thermalscope_cpu_temperature_celsius{sensor="Tctl"}
+
     - name: thermalscope
       rules:
         - alert: ThermalScopeScraperDown
@@ -82,3 +120,37 @@ spec:
           annotations:
             summary: "AMD iGPU on {{ $labels.instance }} is hot"
             description: "amdgpu {{ $labels.sensor }} on {{ $labels.instance }} is {{ $value }}°C (threshold 90°C)."
+
+        # --- Phase 2: Headroom & Throttle ---
+
+        # Fires per-instance per-device when an NVMe drive is within 5°C of
+        # its SMART crit threshold. This complements the fixed-65°C
+        # ThermalScopeNVMeTemperatureHigh alert by tracking the
+        # drive-reported limit directly, so it stays correct across drives
+        # with different crit points (currently 82–88°C).
+        - alert: ThermalScopeNVMeHeadroomLow
+          expr: instance:thermalscope_nvme_headroom_celsius < 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} has low thermal headroom"
+            description: "{{ $labels.device }} on {{ $labels.instance }} is only {{ $value }}°C from its crit threshold (<5°C headroom)."
+
+        # Real throttling = depressed clock WHILE hot. The freq ratio alone
+        # is meaningless on these APUs (idle cores park at ~0.4–0.7), so we
+        # gate on Tctl > 80°C. The join keys both sides on the thermalscope
+        # instance label (the recording rule re-keys node-exporter to
+        # nodename for exactly this reason). 0.85/80 chosen to sit below the
+        # 85°C ThermalScopeCPUTemperatureHigh threshold while still
+        # requiring genuinely high heat alongside the clock drop.
+        - alert: ThermalScopeCPUThrottling
+          expr: |
+            instance:thermalscope_cpu_freq_ratio < 0.85
+              and on(instance) max by(instance)(thermalscope_cpu_temperature_celsius{sensor="Tctl"}) > 80
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CPU on {{ $labels.instance }} appears to be thermally throttling"
+            description: "{{ $labels.instance }} worst-core frequency ratio is {{ $value }} (<0.85) while Tctl is above 80°C — likely thermal throttling."


### PR DESCRIPTION
## Phase 2 — Headroom & Throttle

Builds on the Phase 1 Power & Energy work. Adds thermal-headroom and CPU-throttle observability to thermalscope. Pure addition — all existing rules, alerts, and dashboard panels are untouched.

### Recording rules (`thermalscope.recording`)
| Rule | Expr | Live result |
|---|---|---|
| `instance:thermalscope_nvme_headroom_celsius` | `..._threshold{level="crit"} - on(instance,device,sensor) ..._temperature` | 6 series, 12–45°C |
| `instance:thermalscope_cpu_headroom_celsius` | `95 - ..._cpu_temperature{sensor="Tctl"}` | 7 series, 24–47°C |
| `instance:thermalscope_cpu_freq_ratio` | `min by(instance)(...)` re-keyed to nodename | 6 series, 0.42–0.69 |

**Label-scheme bridge:** `node_cpu_scaling_frequency_*` is keyed `instance="<ip>:9100"`, but thermalscope CPU/NVMe metrics are keyed `instance="<nodename>"`/`hestia`. The freq-ratio rule re-keys node-exporter to the thermalscope `instance` via `node_uname_info` so it (a) joins with thermalscope temps in the throttle alert and (b) matches the dashboard `$instance` variable. node-exporter covers the 6 Talos nodes only (hestia is a bare host outside the DaemonSet), so freq ratio has no hestia series — by design.

### Alerts (`thermalscope`)
- **ThermalScopeNVMeHeadroomLow** (warning) — `instance:thermalscope_nvme_headroom_celsius < 5` for 5m. Names device + instance. Firing now: 0 (lowest headroom 12°C).
- **ThermalScopeCPUThrottling** (warning) — `freq_ratio < 0.85 and on(instance) max by(instance)(Tctl) > 80` for 10m. The temp gate is load-bearing: these APUs idle-park cores at ~0.4–0.7, so a low ratio alone is not throttling. Firing now: 0.

### Dashboard
- New collapsible **Headroom & Throttle** row (id 400; panels 401 NVMe headroom bargauge, 402 CPU headroom bargauge, 403 CPU freq-ratio timeseries), matching the Phase 1 row conventions.
- New constant template var **`cpu_tjmax`** (default 95, label "AMD APU Tjmax (°C) — advisory") — single source for the Tjmax assumption; panel 402 uses `$cpu_tjmax`, the recording rule hardcodes 95 with a sync comment.
- Bumped dashboard `version` 4 → 5; `grafana_dashboard: "1"` label preserved.

### Validation
- `promtool check rules`: SUCCESS, 12 rules.
- `kustomize build infra/configs`: passes.
- Embedded dashboard JSON parses; 41 panel ids, no duplicates; all 4 template vars present.
- Every recording-rule expr returns live series (table above); panel 402 query (`$cpu_tjmax - Tctl`) returns 7 series live. Panels 401/403 read the new recording rules, so they return 0 until Flux applies this PR — their underlying expressions are validated live above.
- **Render gap:** the Grafana render (collapse behaviour, gradient/threshold coloring) cannot be verified from here — only JSON validity and query correctness were checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)