### PR TITLE
feat(thermalscope): Degradation & Fans observability (Phase 3)

### DIFF
--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -734,6 +734,147 @@ data:
         {
           "collapsed": false,
           "gridPos": {"h": 1, "w": 24, "x": 0, "y": 82},
+          "id": 500,
+          "title": "Degradation & Fans — temp-vs-load (cooling drift) + fan curve",
+          "type": "row",
+          "panels": []
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Cooling-degradation scatter: CPU Tctl (Y) vs CPU utilization (X), per host. A host that over time drifts UP-and-LEFT (hotter at the same load) is losing cooling capacity (dust, dried paste, weak fan). Utilization is the instance:node_cpu_utilization:rate5m recording rule, re-keyed to the thermalscope instance label via node_uname_info. node-exporter covers the 6 Talos nodes only — hestia (bare host, no DaemonSet) has no utilization series and does not appear here.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"pointSize": {"fixed": 8}},
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 83},
+          "id": 501,
+          "options": {
+            "seriesMapping": "auto",
+            "tooltip": {"mode": "single"},
+            "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_cpu_temperature_celsius{instance=~\"$instance\", sensor=\"Tctl\"} and on(instance) instance:node_cpu_utilization:rate5m",
+              "format": "time_series",
+              "legendFormat": "{{instance}} Tctl"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "instance:node_cpu_utilization:rate5m{instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "{{instance}} util"
+            }
+          ],
+          "title": "CPU temp vs CPU load (degradation scatter)",
+          "type": "xychart"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Secondary degradation scatter: CPU Tctl (Y) vs busy disk fraction (X), per host. Backed by instance:node_disk_busy:rate5m (hottest device per node, re-keyed to the thermalscope instance label). Useful when a host's heat tracks storage I/O rather than CPU. Talos nodes only (no hestia node-exporter series).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"pointSize": {"fixed": 8}},
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 83},
+          "id": 502,
+          "options": {
+            "seriesMapping": "auto",
+            "tooltip": {"mode": "single"},
+            "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_cpu_temperature_celsius{instance=~\"$instance\", sensor=\"Tctl\"} and on(instance) instance:node_disk_busy:rate5m",
+              "format": "time_series",
+              "legendFormat": "{{instance}} Tctl"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "instance:node_disk_busy:rate5m{instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "{{instance}} disk busy"
+            }
+          ],
+          "title": "CPU temp vs disk busy (degradation scatter)",
+          "type": "xychart"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Cooling-drift trend: current CPU Tctl minus Tctl 7 days ago, per host. Persistent positive drift = the host runs hotter than a week ago (cooling degradation). Retention is 10d so the offset window is 7d, NOT 30d — this signal DEEPENS as history accumulates and a longer baseline becomes possible. Compares wall-clock-aligned samples (not same-load), so read it alongside the scatter panels. Orange ≥2°C hotter, red ≥5°C.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "custom": {"lineWidth": 2, "spanNulls": false},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "orange", "value": 2},
+                  {"color": "red", "value": 5}
+                ]
+              },
+              "unit": "celsius"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 91},
+          "id": 503,
+          "options": {"tooltip": {"mode": "multi"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "thermalscope_cpu_temperature_celsius{instance=~\"$instance\", sensor=\"Tctl\"} - thermalscope_cpu_temperature_celsius{instance=~\"$instance\", sensor=\"Tctl\"} offset 7d",
+              "legendFormat": "{{instance}} Δ vs 7d ago"
+            }
+          ],
+          "title": "CPU temp drift vs 7d ago (deepens as history grows)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "hestia fan curve: chassis fan RPM (Y) vs CPU Tctl (X). Shows whether the BMC fan curve ramps sensibly with CPU heat. Fan RPM and temp join on instance=\"hestia\" (ipmi-exporter and thermalscope both label this host literally — no node_uname_info re-key needed). Visualization only; backs the ThermalScopeFanFailing alert qualitatively.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"pointSize": {"fixed": 8}},
+              "unit": "rotrpm"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 91},
+          "id": 504,
+          "options": {
+            "seriesMapping": "auto",
+            "tooltip": {"mode": "single"},
+            "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "ipmi_fan_speed_rpm{instance=\"hestia\"}",
+              "format": "time_series",
+              "legendFormat": "{{name}} rpm"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "max by(instance)(thermalscope_cpu_temperature_celsius{instance=\"hestia\", sensor=\"Tctl\"})",
+              "format": "time_series",
+              "legendFormat": "hestia Tctl"
+            }
+          ],
+          "title": "hestia fan curve (RPM vs CPU Tctl)",
+          "type": "xychart"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 99},
           "id": 105,
           "title": "AMD iGPU Thermals (Talos APUs)",
           "type": "row",
@@ -772,7 +913,7 @@ data:
         },
         {
           "collapsed": true,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 91},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 108},
           "id": 102,
           "title": "NVIDIA GPU Thermals & Power (hestia) — collapsed; expand when GPUs in use",
           "type": "row",
@@ -858,7 +999,7 @@ data:
         },
         {
           "collapsed": true,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 83},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 109},
           "id": 103,
           "title": "NVIDIA GPU Utilization & Clock (hestia) — collapsed",
           "type": "row",
@@ -937,7 +1078,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 85},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 110},
           "id": 104,
           "title": "Collector Health",
           "type": "row"
@@ -1061,5 +1202,5 @@ data:
       "timezone": "browser",
       "title": "ThermalScope — Rack",
       "uid": null,
-      "version": 6
+      "version": 7
     }

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -61,6 +61,43 @@ spec:
         - record: instance:thermalscope_cpu_headroom_celsius
           expr: 95 - thermalscope_cpu_temperature_celsius{sensor="Tctl"}
 
+        # --- Phase 3: Degradation & Fans ---
+
+        # Per-host CPU utilization (0–1) over 5m, re-keyed to the
+        # thermalscope instance="<nodename>" label so it joins cleanly with
+        # thermalscope_cpu_temperature_celsius for the temp-vs-load
+        # degradation analysis. node-exporter keys series by
+        # instance="<ip>:9100"; node_uname_info maps that to nodename. The
+        # outer sum by(instance) drops the temporary nodename label left by
+        # group_left so the result carries exactly the thermalscope label
+        # set (matches the dashboard's $instance variable). node-exporter
+        # covers the 6 Talos nodes only — hestia is a bare host outside the
+        # DaemonSet, so it has no utilization series here (its temps still
+        # appear, just without a load pairing).
+        - record: instance:node_cpu_utilization:rate5m
+          expr: |
+            sum by(instance) (
+              label_replace(
+                (1 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m])))
+                  * on(instance) group_left(nodename) node_uname_info,
+                "instance", "$1", "nodename", "(.+)"
+              )
+            )
+
+        # Per-host busy disk fraction (0–1) over 5m — the hottest device on
+        # each node. Same node-exporter → nodename re-key as the CPU
+        # utilization rule above, so it shares the thermalscope instance
+        # label. Used as a secondary load axis in the degradation row.
+        - record: instance:node_disk_busy:rate5m
+          expr: |
+            max by(instance) (
+              label_replace(
+                rate(node_disk_io_time_seconds_total[5m])
+                  * on(instance) group_left(nodename) node_uname_info,
+                "instance", "$1", "nodename", "(.+)"
+              )
+            )
+
     - name: thermalscope
       rules:
         - alert: ThermalScopeScraperDown
@@ -154,3 +191,36 @@ spec:
           annotations:
             summary: "CPU on {{ $labels.instance }} appears to be thermally throttling"
             description: "{{ $labels.instance }} worst-core frequency ratio is {{ $value }} (<0.85) while Tctl is above 80°C — likely thermal throttling."
+
+        # --- Phase 3: Degradation & Fans ---
+
+        # A hestia chassis fan is stalled/degraded WHILE the CPU is hot.
+        # Two failure signals OR'd together:
+        #   - ipmi_fan_speed_state != 0 — the BMC's own per-fan assessment
+        #     (0 = "ok"/nominal; non-zero = warning/critical per IPMI SDR).
+        #   - ipmi_fan_speed_rpm < 500 — a hard RPM floor. Observed baseline
+        #     over 7d is ~1000–1400 rpm steady across all five fans, so 500
+        #     sits well below normal idle and only trips on a genuine stall
+        #     (a spun-down or seized fan), not on normal fan-curve dips.
+        # Gated on hestia Tctl > 70°C so a fan that idles low while the box
+        # is cool does not page — a degraded fan only matters under heat.
+        # Fan and temp series are joined on instance="hestia" (ipmi-exporter
+        # and thermalscope both label this host literally "hestia" — no
+        # node_uname_info re-key needed, unlike the node-exporter joins).
+        # The temp side is reduced with max by(instance) so a single high
+        # CPU sensor satisfies the gate for every fan on the host.
+        - alert: ThermalScopeFanFailing
+          expr: |
+            (
+              ipmi_fan_speed_state{instance="hestia"} != 0
+              or ipmi_fan_speed_rpm{instance="hestia"} < 500
+            )
+              and on(instance) max by(instance)(
+                thermalscope_cpu_temperature_celsius{instance="hestia", sensor="Tctl"}
+              ) > 70
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "hestia chassis fan {{ $labels.name }} may be failing"
+            description: "Fan {{ $labels.name }} on hestia is stalled or in a non-OK state while CPU Tctl is above 70°C — possible fan failure under load."


### PR DESCRIPTION
## What

Phase 3 (\"Degradation & Fans\") observability for thermalscope — pure homelab (recording rules + alert + dashboard), no collector/code/image change.

### Recording rules (`thermalscope.recording`)
- **`instance:node_cpu_utilization:rate5m`** — per-host CPU utilization over 5m. node-exporter keys series by `instance=<ip>:9100`; this re-keys to the thermalscope `instance=<nodename>` via `node_uname_info` (`sum by(instance)` drops the temporary `nodename` label) so it joins thermalscope temps.
- **`instance:node_disk_busy:rate5m`** — per-host hottest-device busy fraction, same re-key.
- Both cover the **6 Talos nodes only** — hestia is a bare host outside the node-exporter DaemonSet, so it has no load pairing (its temps still render).

### Alert (`thermalscope`)
- **`ThermalScopeFanFailing`** (warning, `for: 10m`) — a hestia chassis fan in a non-OK BMC state (`ipmi_fan_speed_state != 0`) **OR** below a 500 rpm stall floor, **gated on** hestia `Tctl > 70°C`. Fan and temp join on `instance="hestia"` — ipmi-exporter and thermalscope both label this host literally `hestia`, so no `node_uname_info` re-key is needed here.

### Dashboard — new collapsible **\"Degradation & Fans\"** row (ids 500–504), placed between Headroom & Throttle and the AMD iGPU row; `version` 6 → 7
- **501** CPU temp vs CPU load scatter (xychart) — cooling-drift detection
- **502** CPU temp vs disk busy scatter (xychart)
- **503** CPU temp drift vs 7d ago (timeseries) — retention is **10d**, so this uses `offset 7d` (not 30d) and is labeled to deepen as history accumulates
- **504** hestia fan curve, RPM vs Tctl (xychart)

## Cross-exporter joins (verified against live Prometheus)
| Join | Key | Why |
|---|---|---|
| temp × CPU/disk load | `instance` after re-keying node-exporter `<ip>:9100` → `<nodename>` via `node_uname_info` | thermalscope uses nodename; node-exporter uses ip:port |
| fan × temp | `instance="hestia"` directly | both exporters label hestia literally — no re-key |

## Validation
- `promtool check rules` → SUCCESS (15 rules)
- `kustomize build infra/configs` → passes
- Embedded JSON parses; 46 panels (41 + 5), no dup ids, all 4 template vars preserved, `grafana_dashboard: \"1\"` intact
- Every recording-rule / alert / panel expr returns series live; cross-exporter joins confirmed non-empty
- **Render gap:** Grafana visual render not verified (no Grafana access in this environment) — panel JSON is structurally valid but the xychart rendering is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)