### PR TITLE
fix(thermalscope): cost_per_kwh = 0.45 (real PG&E rate)

### DIFF
--- a/infra/configs/dashboards/thermalscope-cm.yaml
+++ b/infra/configs/dashboards/thermalscope-cm.yaml
@@ -1178,11 +1178,11 @@ data:
             "type": "query"
           },
           {
-            "current": {"selected": false, "text": "0.20", "value": "0.20"},
+            "current": {"selected": false, "text": "0.45", "value": "0.45"},
             "hide": 0,
-            "label": "Electricity rate ($/kWh) — set to your actual rate",
+            "label": "Electricity rate ($/kWh) — PG&E blended, all-in (bill 5/2026)",
             "name": "cost_per_kwh",
-            "query": "0.20",
+            "query": "0.45",
             "skipUrlSync": false,
             "type": "constant"
           },


### PR DESCRIPTION
Set the cost dashboard's `cost_per_kwh` from the $0.20 placeholder to George's **actual PG&E blended rate: $0.45/kWh** (from the 5/2026 bill: $327.36 / 726.5 kWh, E-1 Tiered + CleanPowerSF, deep in Tier 2). The monthly-cost panel was understating by ~2.25x. (Still CPU-package-only, so it remains a floor on whole-system cost.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)