### PR TITLE
feat(monitoring): Phase 1 ServiceMonitor coverage — fix authelia + signal-cli discovery

### DIFF
--- a/apps/base/authelia/networkpolicy.yaml
+++ b/apps/base/authelia/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: authelia
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Gateway ingress on 9091; egress DNS + SMTP (port 465) for email notifications.
+  description: Gateway ingress on 9091; Prometheus scrape on 9959; egress DNS + SMTP (port 465) for email notifications.
   endpointSelector:
     matchLabels:
       app: authelia
@@ -20,6 +20,16 @@ spec:
       toPorts:
         - ports:
             - port: "9091"
+              protocol: TCP
+    # Prometheus scrapes the metrics endpoint (port 9959). Without this rule the
+    # ServiceMonitor target stays up=0 — the default-deny CNP drops the scrape.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9959"
               protocol: TCP
   egress:
     - toEndpoints:

--- a/apps/base/authelia/servicemonitor.yaml
+++ b/apps/base/authelia/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: authelia
   labels:
     app: authelia
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/apps/base/signal-cli/networkpolicy.yaml
+++ b/apps/base/signal-cli/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: signal-cli
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Ingress from hermes only; egress DNS + HTTPS for Signal servers.
+  description: Ingress from hermes + Prometheus scrape on 8080; egress DNS + HTTPS for Signal servers.
   endpointSelector:
     matchLabels:
       app: signal-cli
@@ -29,6 +29,17 @@ spec:
         - matchLabels:
             app: hermes
             k8s:io.kubernetes.pod.namespace: hermes-callee-stage
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Prometheus scrapes /metrics on the same bridge port (8080). Without this
+    # rule the ServiceMonitor target stays up=0 — the default-deny CNP drops
+    # the scrape even after the SM is discovered.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
       toPorts:
         - ports:
             - port: "8080"

--- a/apps/base/signal-cli/servicemonitor.yaml
+++ b/apps/base/signal-cli/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: signal-cli
   labels:
     app: signal-cli
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Phase 1 — ServiceMonitor coverage (monitoring-enhancement plan §1.1–§1.5)

Implements **Phase 1 only** of `docs/plans/2026-05-09-monitoring-enhancement.md`. No alert rules, no Phase 2/3 work.

### Headline result
The §1.1 live-cluster audit found **no new apps that genuinely serve `/metrics`** beyond those already covered. So §1.3/§1.4 produce **zero new ServiceMonitors**. The actionable Phase-1 work is:

1. The two §1.2 label fixes (authelia, signal-cli) — each its own commit.
2. NetworkPolicy enablement so those two now-discovered SMs can actually be scraped (see "Net-policy finding").

### §1.1 Audit (verified against the live `melodic-muse` cluster)

Method: inspected each app's Service/Deployment for a named metrics port, then `kubectl exec`'d into the running pod and curled `http://127.0.0.1:<port>/metrics`, treating Prometheus exposition format as the decisive signal. Apps scaled to 0 / crashlooping were judged from manifest + image + upstream behavior and flagged as not-live-verified.

| app | exposes-metrics | port name | port number | sample metric | how-verified |
|-----|-----------------|-----------|-------------|---------------|--------------|
| authelia | **yes** | metrics | 9959 | `authelia_request` | exec+curl in pod → 200, Prometheus format. Has SM (label fixed here). |
| truenas-iscsi-monitor | **yes** | metrics | 8000 | `python_gc_objects_collected_total` | exec+curl → 200 Prometheus. **Already has discovered SM** (no change). |
| overture | yes (by design) | http | 8080 | n/a (scaled 0/0 on purpose) | **Already has discovered SM** wired in kustomization; pod intentionally down. No change. |
| signal-cli | assumed-yes (SM pre-exists) | http | 8080 | n/a | **Could not live-verify** — bridge scaled to 0 in prod & stage; no standalone source repo reachable. Plan §1.2 mandates the label fix regardless; applied. |
| adguard | no | — | — | — | exec+curl :8080/metrics → connection refused; AdGuard Home has no native Prometheus endpoint (needs external exporter, not deployed). |
| audiobookshelf | no | — | — | — | exec+wget :13378/metrics → 404. |
| excalidraw | no | — | — | — | exec+wget :80/metrics → 404. |
| golinks | no | — | — | — | exec+wget :8080/metrics → 404. |
| homeassistant | no | — | — | — | exec+curl :8123/metrics and /api/prometheus → both 404; prometheus integration not enabled in config. |
| homepage | no | — | — | — | exec+wget :3000/metrics → 404. |
| immich | no | — | — | — | exec+curl immich-server :2283/metrics → returns HTML (web app); no telemetry env, no 8081/8082 metrics ports. |
| jellyfin | no | — | — | — | exec+curl :8096/metrics → 404 (metrics are a community plugin, not enabled). |
| linkding | no | — | — | — | exec+curl :9090/metrics → 404 (Not Found page). |
| mealie | no | — | — | — | upstream has no native Prometheus endpoint; pod CrashLoopBackOff so not live-curled. |
| memos | no | — | — | — | exec+wget :5230/metrics → 200 but returns SPA HTML, not metrics. |
| navidrome | no | — | — | — | exec+wget :4533/metrics → 302 → login HTML. |
| openwebui | no | — | — | — | scaled 0/0; Open WebUI has no native Prometheus `/metrics`. |
| snapcast | no | — | — | — | exec+wget :1780/metrics → 404. |
| vitals | no | — | — | — | exec+wget :8080/metrics, /api/metrics, /healthz/metrics → 302→/login or 404. Custom app, no metrics endpoint. |
| cloudflare-tunnel | no | — | — | — | no in-cluster workload Service/pod in this repo's scope; infra bundle. |
| hermes | no | — | — | — | no Service and no container ports in the deployment — not scrapeable via a Service-based SM. |
| hermes-callee | no | — | — | — | overlay of hermes (same image/spec); same conclusion. |

> Note: the plan's "23 workload apps" list (dated 2026-05-09) has drifted. `synology-iscsi-monitor` no longer exists in the repo; `burntbytes`, `flashcards`, `flashcards-sync`, `thermalscope` are newer and outside the plan's named scope. The audit covered the plan's named 23 against current reality.

### §1.2 — Two broken SMs fixed (separate commits)
- `apps/base/authelia/servicemonitor.yaml` — added `release: kube-prometheus-stack`.
- `apps/base/signal-cli/servicemonitor.yaml` — added `release: kube-prometheus-stack` (previously only `{app: signal-cli}`).

Confirmed pre-fix that neither appeared in `kubectl get servicemonitor -A -l release=kube-prometheus-stack` (silently undiscovered), while overture and truenas-iscsi-exporter do.

### §1.3 / §1.4 — New SMs created
**None.** The audit confirms no remaining app serves `/metrics`, so per the plan's hard rule (no SM scraping a 404 → permanent `up=0` noise) nothing new is added.

### Net-policy finding (beyond the literal §1.2 text, required to hit the §1.5 goal)
Both authelia and signal-cli sit behind default-deny `CiliumNetworkPolicy`s that only allowed gateway / hermes traffic. The metrics ports (authelia 9959, signal-cli 8080) were **not** permitted from the monitoring namespace, so the label fix alone would leave the now-discovered SMs at `up=0` — exactly the noise the plan forbids. Added a `fromEndpoints` ingress rule for the monitoring-ns prometheus pod on each metrics port, mirroring the existing `apps/base/overture/networkpolicy.yaml` pattern. Landed as its own commit.

### §1.5 — Verification (honest about the pre-merge gap)
- `kustomize build` passes for every touched overlay: `apps/{production,staging}/authelia` and `apps/{production,staging}/signal-cli` all build clean.
- Diff is 4 files, no plaintext secrets.
- **`up==1` cannot be confirmed pre-merge** — `kubectl get servicemonitor -A -l release=kube-prometheus-stack` will only reflect these after merge + Flux reconcile. What is confirmed now: authelia genuinely serves Prometheus-format metrics on 9959 (curled live), and the netpol change opens the only path that was blocking the scrape — so post-deploy `up==1` for authelia is expected. signal-cli is scaled to 0, so its SM target will be down until the bridge is scaled up (independent of this PR); its label + netpol are correct for when it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
