### PR TITLE
fix(monitoring): Flux readiness via kube-state-metrics (Phase 3 fix)

### DIFF
--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -225,42 +225,48 @@ spec:
     # -------------------------------------------------------------------------
     # Flux reconciliation health
     #
-    # gotk_reconcile_condition is emitted by every Flux controller for each
-    # managed object. A Ready=False condition that persists means GitOps has
+    # gotk_resource_info is an Info gauge (always 1) emitted by kube-state-metrics
+    # for each Flux object, carrying a `ready` label sourced from the object's
+    # Ready condition. A series with ready="False" that persists means GitOps has
     # stopped converging that object: a Kustomization stuck on a build error, a
     # HelmRelease failing to upgrade, or a GitRepository that can't fetch. Left
     # silent, the cluster drifts from Git until something else breaks loudly.
     #
-    # `for: 15m` rides out normal in-flight reconciles (a HelmRelease upgrade,
-    # a transient source fetch) — only a genuinely stuck object fires. Metrics
-    # are scraped via the flux-system PodMonitor in infra/configs/flux-monitoring.
+    # NOTE: GA Flux controllers (helm/kustomize-controller v1) no longer expose
+    # the old gotk_reconcile_condition gauge — readiness now comes from the
+    # kube-state-metrics customResourceState config in
+    # infra/controllers/kube-prometheus-stack/values.yaml. The namespace label is
+    # `exported_namespace` (the object's namespace); `customresource_kind`
+    # distinguishes the Flux kind. `for: 15m` rides out normal in-flight
+    # reconciles (a HelmRelease upgrade, a transient source fetch) so only a
+    # genuinely stuck object fires.
     # -------------------------------------------------------------------------
     - name: flux-reconciliation
       rules:
         - alert: FluxKustomizationNotReady
-          expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="Kustomization"}) == 1
+          expr: max by (name, exported_namespace) (gotk_resource_info{customresource_kind="Kustomization", ready="False"}) == 1
           for: 15m
           labels:
             severity: critical
           annotations:
-            summary: "Flux Kustomization {{ $labels.namespace }}/{{ $labels.name }} not ready"
+            summary: "Flux Kustomization {{ $labels.exported_namespace }}/{{ $labels.name }} not ready"
             description: >
-              Kustomization {{ $labels.namespace }}/{{ $labels.name }} has been Ready=False for >15m — Flux is no longer converging it to Git. Run `flux get kustomization {{ $labels.name }} -n {{ $labels.namespace }}` and check the status message for the build/apply error.
+              Kustomization {{ $labels.exported_namespace }}/{{ $labels.name }} has been Ready=False for >15m — Flux is no longer converging it to Git. Run `flux get kustomization {{ $labels.name }} -n {{ $labels.exported_namespace }}` and check the status message for the build/apply error.
         - alert: FluxHelmReleaseNotReady
-          expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="HelmRelease"}) == 1
+          expr: max by (name, exported_namespace) (gotk_resource_info{customresource_kind="HelmRelease", ready="False"}) == 1
           for: 15m
           labels:
             severity: critical
           annotations:
-            summary: "Flux HelmRelease {{ $labels.namespace }}/{{ $labels.name }} not ready"
+            summary: "Flux HelmRelease {{ $labels.exported_namespace }}/{{ $labels.name }} not ready"
             description: >
-              HelmRelease {{ $labels.namespace }}/{{ $labels.name }} has been Ready=False for >15m. Run `kubectl describe helmrelease {{ $labels.name }} -n {{ $labels.namespace }}`; a `flux reconcile helmrelease … --reset` clears a stalled upgrade.
+              HelmRelease {{ $labels.exported_namespace }}/{{ $labels.name }} has been Ready=False for >15m. Run `kubectl describe helmrelease {{ $labels.name }} -n {{ $labels.exported_namespace }}`; a `flux reconcile helmrelease … --reset` clears a stalled upgrade.
         - alert: FluxGitRepositoryNotReady
-          expr: max by (name, namespace) (gotk_reconcile_condition{type="Ready",status="False",kind="GitRepository"}) == 1
+          expr: max by (name, exported_namespace) (gotk_resource_info{customresource_kind="GitRepository", ready="False"}) == 1
           for: 15m
           labels:
             severity: critical
           annotations:
-            summary: "Flux GitRepository {{ $labels.namespace }}/{{ $labels.name }} not ready"
+            summary: "Flux GitRepository {{ $labels.exported_namespace }}/{{ $labels.name }} not ready"
             description: >
-              GitRepository {{ $labels.namespace }}/{{ $labels.name }} has been Ready=False for >15m — Flux can't fetch the source, so every Kustomization downstream is frozen at its last-applied revision. Check credentials and connectivity to the Git remote.
+              GitRepository {{ $labels.exported_namespace }}/{{ $labels.name }} has been Ready=False for >15m — Flux can't fetch the source, so every Kustomization downstream is frozen at its last-applied revision. Check credentials and connectivity to the Git remote.

--- a/infra/configs/flux-monitoring/podmonitor.yaml
+++ b/infra/configs/flux-monitoring/podmonitor.yaml
@@ -1,6 +1,11 @@
-# Scrapes the Flux controllers' Prometheus metrics (gotk_reconcile_condition,
-# etc.) so the Flux reconciliation alerts in
-# infra/configs/alerts/prometheus-rules.yaml have data to evaluate against.
+# Scrapes the Flux controllers' own Prometheus metrics: reconcile durations
+# (gotk_reconcile_duration_seconds), controller-runtime reconcile/error
+# counters, and work-queue depth — useful for dashboards and controller-health
+# debugging. Per-object readiness for the Flux alerts in
+# infra/configs/alerts/prometheus-rules.yaml does NOT come from here: GA Flux
+# controllers no longer expose the gotk_reconcile_condition gauge, so that
+# signal (gotk_resource_info) is produced by the kube-state-metrics
+# customResourceState config in infra/controllers/kube-prometheus-stack.
 #
 # A PodMonitor (not ServiceMonitor) is required: helm-controller and
 # kustomize-controller expose http-prom:8080 but have no Service. The

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -2444,7 +2444,85 @@ kube-state-metrics:
   namespaceOverride: ""
   rbac:
     create: true
+    # Allow kube-state-metrics to list/watch Flux custom resources so the
+    # customResourceState config below can emit gotk_resource_info. GA Flux
+    # controllers (helm/kustomize-controller v1) no longer expose the
+    # gotk_reconcile_condition gauge, so per-object readiness for the Flux
+    # alerts in infra/configs/alerts/prometheus-rules.yaml comes from here.
+    extraRules:
+      - apiGroups:
+          - source.toolkit.fluxcd.io
+          - kustomize.toolkit.fluxcd.io
+          - helm.toolkit.fluxcd.io
+          - notification.toolkit.fluxcd.io
+        resources: ["*"]
+        verbs: ["list", "watch"]
   releaseLabel: true
+
+  # Emit gotk_resource_info{customresource_kind, exported_namespace, name,
+  # ready, suspended, revision} for Flux objects, mirroring the upstream
+  # flux2-monitoring-example. This is the replacement for the removed
+  # gotk_reconcile_condition gauge. Served CRD versions on this cluster:
+  # Kustomization v1, HelmRelease v2, GitRepository v1.
+  customResourceState:
+    enabled: true
+    config:
+      kind: CustomResourceStateMetrics
+      spec:
+        resources:
+          - groupVersionKind:
+              group: kustomize.toolkit.fluxcd.io
+              kind: Kustomization
+              version: v1
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: "The current state of a Flux Kustomization."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=Ready]", status]
+                  suspended: [spec, suspend]
+                  revision: [status, lastAppliedRevision]
+          - groupVersionKind:
+              group: helm.toolkit.fluxcd.io
+              kind: HelmRelease
+              version: v2
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: "The current state of a Flux HelmRelease."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=Ready]", status]
+                  suspended: [spec, suspend]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              kind: GitRepository
+              version: v1
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: "The current state of a Flux GitRepository."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=Ready]", status]
+                  suspended: [spec, suspend]
+                  revision: [status, artifact, revision]
 
   ## Enable scraping via kubernetes-service-endpoints
   ## Disabled by default as we service monitor is enabled below


### PR DESCRIPTION
## Summary

Follow-up to #937. The three Flux reconciliation alerts merged there referenced **`gotk_reconcile_condition`**, which **GA Flux controllers no longer expose** — verified live against the deployed controllers (helm-controller v1.5.5, kustomize-controller v1.8.5): they emit `gotk_reconcile_duration_seconds` and `controller_runtime_*`, but no per-object Ready gauge. The rules were inert and would never have fired. The 2026-05-09 plan's metric assumption predated this Flux version.

This PR moves to the upstream **`flux2-monitoring-example`** pattern: have **kube-state-metrics** emit `gotk_resource_info{ready, ...}` for Flux objects via a CustomResourceState config, and alert on `ready="False"`.

- **`kube-prometheus-stack/values.yaml`** — `kube-state-metrics.customResourceState` config for `Kustomization` (v1), `HelmRelease` (v2), `GitRepository` (v1), plus `rbac.extraRules` granting `list`/`watch` on the Flux API groups. Served CRD versions confirmed on-cluster before pinning.
- **`prometheus-rules.yaml`** — rewrite the 3 rules to `gotk_resource_info{customresource_kind=..., ready="False"} == 1`. Namespace label is now `exported_namespace`.
- **`flux-monitoring/podmonitor.yaml`** — comment fix only: the PodMonitor scrapes controller-level metrics (reconcile durations, error counters), not readiness. It stays — still the source for Flux controller-health metrics.

## Test plan

- [x] `kustomize build infra/controllers` and `infra/configs` pass
- [x] CRS config serializes correctly into the helm-values ConfigMap (3 kinds, served versions, `ready` condition path)
- [x] Rules reference `gotk_resource_info`, zero `gotk_reconcile_condition`; no plaintext secrets
- [ ] Post-merge: kube-state-metrics rolls out with the new RBAC + config; `gotk_resource_info{customresource_kind="Kustomization"}` becomes non-empty in Prometheus
- [ ] Post-merge: the 3 rules go from "no data" to evaluating against real series

## Note on delivery

As with #937: with signal-cli + hermes decommissioned (#936), these critical alerts route to the **null receiver** — visible in Alertmanager/Grafana, not pushed anywhere. A new delivery channel is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)