### PR TITLE
chore: pin finance-dashboard image to 2026-06-18

### DIFF
--- a/apps/base/finance-dashboard/deployment.yaml
+++ b/apps/base/finance-dashboard/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           # Private code-only image, pulled via the ghcr-secret
           # (secret-ghcr.yaml, operator-encrypted). Pin to the date tag CI
           # produces (build-finance-dashboard.yml) once the first image is built.
-          image: ghcr.io/gjcourt/finance-dashboard:latest
+          image: ghcr.io/gjcourt/finance-dashboard:2026-06-18
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Follow-up to #934. Pins the deployment from `:latest` to the immutable date tag `2026-06-18` the first build produced, per the strictly-increasing image-tag convention. Renovate manages it from here. No behavior change (same image `:latest` already points to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)