### PR TITLE
feat(monitoring): route critical alerts to email via Gmail SMTP

### DIFF
--- a/docs/plans/2026-06-17-alertmanager-smtp-alerting.md
+++ b/docs/plans/2026-06-17-alertmanager-smtp-alerting.md
@@ -1,0 +1,102 @@
+---
+status: in-progress
+last_modified: 2026-06-17
+summary: "Route critical Alertmanager alerts to email via Gmail SMTP (replaces dead Signal channel)"
+---
+
+# Plan: Alertmanager critical-alert email delivery via Gmail SMTP
+
+## Context
+
+The homelab's critical alerts — the three Flux reconciliation alerts (#937/#940),
+plus `NodeFilesystemReadOnly` and `LokiPushErrors` — currently route to
+Alertmanager's **`null` receiver** and are pushed nowhere. They evaluate
+correctly and are visible in Alertmanager/Grafana, but no human is notified.
+This gap opened when signal-cli + hermes were decommissioned (#936), which
+obsoleted Phase 2 of [2026-05-09-monitoring-enhancement.md](2026-05-09-monitoring-enhancement.md)
+(Signal-based routing). That plan explicitly left "critical-alert delivery needs
+a real channel (email/ntfy), TBD."
+
+This restores delivery by reusing the **same Gmail SMTP relay Authelia already
+uses** (`apps/production/authelia/configuration.yaml` — `smtp.gmail.com`, auth
+`gjcourt@gmail.com`, a Gmail app password). Alertmanager has a native
+`email_configs` receiver, so this is not wiring *through* Authelia — both point
+at the same upstream relay. No new service to run (unlike ntfy). Credential
+pattern follows the precedent in
+[2026-02-17-authelia-smtp-notifier.md](2026-02-17-authelia-smtp-notifier.md).
+
+**Decisions:**
+- Deliver to **`gjcourt+alerts@gmail.com`** (Gmail plus-addressing → same inbox, one filter sorts it into a label).
+- **Critical severity only** for now; widen to warnings later if useful.
+
+## Changes
+
+### 1. SMTP credential secret (operator-encrypted)
+Secrets are namespace-scoped, so the Gmail app password must exist as a Secret
+in the **`monitoring`** namespace (Authelia's copy in `authelia-prod` can't be
+read cross-namespace). Same value as `AUTHELIA_NOTIFIER_SMTP_PASSWORD` in
+`apps/production/authelia/secret-authelia.yaml`.
+
+- Template `infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml.example`
+  (the `.example` suffix is outside the `.sops.yaml` `.*secret.*\.yaml$` rules)
+  ships in-tree; the real `secret-alertmanager-smtp.yaml` is wired into
+  `kustomization.yaml` `resources:`.
+- **Operator step:** copy the template, fill the password, `sops -e -i` it, commit.
+  The `.sops.yaml` rule `infra/.*secret.*\.yaml$` encrypts it; the
+  `infra-controllers` Flux Kustomization already has SOPS decryption enabled.
+- Until the encrypted secret exists, `kustomize build infra/controllers` / CI
+  **fails on the missing resource** — the intended gate.
+
+### 2. Mount the secret
+`infra/controllers/kube-prometheus-stack/values.yaml` —
+`alertmanager.alertmanagerSpec.secrets: [alertmanager-smtp]`. Mounted read-only
+at `/etc/alertmanager/secrets/alertmanager-smtp/password`, keeping the password
+out of the (plaintext) values ConfigMap.
+
+### 3. Routing + receiver
+Same `values.yaml`, `alertmanager.config` block — leaving the `null` default,
+Watchdog→null route, and inhibit_rules intact:
+- `config.global`: `smtp_smarthost: smtp.gmail.com:587`, `smtp_from`,
+  `smtp_auth_username`, `smtp_auth_password_file` (the mounted file),
+  `smtp_require_tls: true`.
+- New `email-critical` receiver → `to: gjcourt+alerts@gmail.com`, `send_resolved: true`.
+- New route `severity = "critical"` → `email-critical`, `repeat_interval: 4h`.
+
+### 4. Docs
+This plan doc; `docs/reference/monitoring.md` §7 (note the receiver/route/secret);
+regen `docs/plans/README.md` via `make plans-index`.
+
+## Files
+
+| File | Change |
+|---|---|
+| `infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml.example` | new — template |
+| `infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml` | new — **operator**, SOPS-encrypted |
+| `infra/controllers/kube-prometheus-stack/kustomization.yaml` | wire secret into `resources:` |
+| `infra/controllers/kube-prometheus-stack/values.yaml` | secrets mount + global SMTP + receiver + route |
+| `docs/reference/monitoring.md` | document the email receiver/route/secret |
+
+## Verification
+
+- `kubectl get secret alertmanager-smtp -n monitoring` exists; Alertmanager pod
+  rolls **clean** (a missing/mis-mounted secret blocks startup);
+  `kubectl exec -n monitoring alertmanager-... -- ls /etc/alertmanager/secrets/alertmanager-smtp/`.
+- Config loaded: `amtool config show` shows the `email-critical` receiver + route.
+- **Live test:** a real `severity=critical` delivers to `gjcourt+alerts@gmail.com`
+  within ~5 min, with a `[RESOLVED]` when cleared. (Watchdog routes to `null` —
+  not a valid test.)
+- No regressions: `flux get kustomizations -A` green.
+
+## Gotchas
+
+- **Port 587, not 465.** Authelia uses 465 (implicit TLS); Alertmanager's
+  supported path is 587 + STARTTLS. Same app password works on both.
+- **Gmail rewrites From** to the authenticated account → `smtp_from: gjcourt@gmail.com`.
+- **Password duplicated** across two SOPS secrets (a reflector for one value isn't worth it).
+- **Sequencing:** secret + values land in one merge so Flux applies the secret
+  before the Alertmanager StatefulSet rolls.
+
+## Out of scope
+- ntfy / push-to-phone (new service; revisit only if email proves insufficient).
+- Warnings to email (start critical-only).
+- Per-alert routing/grouping beyond the single critical route; Alertmanager HA.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,10 +60,11 @@ see `scripts/plans-index/`).
 
 <!-- BEGIN PLANS INDEX -->
 
-### In progress (8)
+### In progress (9)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-06-17-alertmanager-smtp-alerting.md](2026-06-17-alertmanager-smtp-alerting.md) | 2026-06-17 | Route critical Alertmanager alerts to email via Gmail SMTP (replaces dead Signal channel) |
 | [2026-06-16-thermalscope-power-and-headroom.md](2026-06-16-thermalscope-power-and-headroom.md) | 2026-06-17 | thermalscope: add power/energy/cost (RAPL), thermal headroom, and throttle/degradation signals — phases 1–3 live; phase 4 pending |
 | [2026-06-01-hestia-photos-sot.md](2026-06-01-hestia-photos-sot.md) | 2026-06-10 | Make hestia the source of truth for family/ + homes/; repoint Immich NFS PV; alcatraz narrows to upload target |
 | [2026-05-20-alcatraz-to-hestia-migration.md](2026-05-20-alcatraz-to-hestia-migration.md) | 2026-05-21 | Migrate non-photo data (~870 GiB iSCSI + 3 TiB NFS media) off alcatraz onto hestia ZFS |

--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -48,6 +48,7 @@ Access Grafana and verify that data is populating in the default dashboards.
 - **Kernel Logs**: Vector collects Talos kernel and service logs and sends them to Loki. See [Talos Kernel Log Shipping](kernel-log-shipping.md).
 - **Metric Alerts**: Alertmanager receives alerts from Prometheus via `PrometheusRule` resources. Custom rules are in `infra/configs/alerts/prometheus-rules.yaml`.
 - **Log Alerts**: Loki's built-in ruler evaluates LogQL rules from `infra/controllers/loki/alerting-rules.yaml` and forwards firing alerts to Alertmanager.
+- **Alert delivery**: Alertmanager config lives in `infra/controllers/kube-prometheus-stack/values.yaml` (`alertmanager.config`). `severity = "critical"` alerts route to the `email-critical` receiver, which emails `gjcourt+alerts@gmail.com` via Gmail SMTP (`smtp.gmail.com:587`, STARTTLS, auth `gjcourt@gmail.com`). The app password is the SOPS-encrypted `alertmanager-smtp` secret in the `monitoring` namespace, mounted at `/etc/alertmanager/secrets/alertmanager-smtp/password` via `alertmanagerSpec.secrets` and referenced by `smtp_auth_password_file`. Everything else (warnings, info, Watchdog) still routes to the `null` receiver. See [plans/2026-06-17-alertmanager-smtp-alerting.md](../plans/2026-06-17-alertmanager-smtp-alerting.md).
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:

--- a/infra/controllers/kube-prometheus-stack/kustomization.yaml
+++ b/infra/controllers/kube-prometheus-stack/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   - namespace.yaml
   - release.yaml
   - repository.yaml
+  # SOPS-encrypted; operator-created from secret-alertmanager-smtp.yaml.example.
+  # kustomize build fails until it exists — intended gate (see the .example header).
+  - secret-alertmanager-smtp.yaml
 
 configMapGenerator:
   - name: kube-prometheus-stack-helm-values

--- a/infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml
+++ b/infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml
@@ -1,0 +1,41 @@
+# TEMPLATE — operator action required.
+#
+# Alertmanager's email-critical receiver authenticates to Gmail SMTP with a
+# Gmail app password. Secrets are namespace-scoped, so this must live in the
+# `monitoring` namespace (Authelia's copy in authelia-prod can't be read
+# cross-namespace). The value is the SAME app password already stored in
+# apps/production/authelia/secret-authelia.yaml (AUTHELIA_NOTIFIER_SMTP_PASSWORD).
+#
+# To activate:
+#   cp secret-alertmanager-smtp.yaml.example secret-alertmanager-smtp.yaml
+#   # paste the Gmail app password into stringData.password
+#   sops -e -i secret-alertmanager-smtp.yaml      # .sops.yaml rule infra/.*secret.*\.yaml$ encrypts it
+#   git add secret-alertmanager-smtp.yaml && git commit
+#
+# secret-alertmanager-smtp.yaml is already wired into kustomization.yaml, so
+# `kustomize build` (and CI) fails until the encrypted file exists — that is
+# the intended gate. The infra-controllers Flux Kustomization has SOPS
+# decryption enabled, so no further wiring is needed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-smtp
+  namespace: monitoring
+type: Opaque
+stringData:
+  password: ENC[AES256_GCM,data:wR2oPyQM1n/9NLhlFaPA+g==,iv:Sl43z9r/zBkntQWRXm5oLpUF/j2DJRfKq6+0FvMNHnk=,tag:0A2e1ipcK2P0kOcjRwPnnA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHaG1OcFkvaGFwVkc0QXNG
+        OGZEMTBPTysrYzdPSy9BY1JLRWUva0I4KzBJCjFTL0ZuODFpdU00c0gyRFhPbGVp
+        YVMveitUMDQ5eVY1SUMvRFFaYzgvcUUKLS0tIFlXQ2NGK00yR0QzRUM1elhYdVR4
+        VCtEZ1did3c5RDNQS2hYUXgzaWN1SjQK6oyjHKwtlIAfp5EdwBlKJ9n7B3YlJCB1
+        eEnM73SPjYH3cWy/6njlLAAoxUGTCApQk84CF1u3oUteRj04wZCz9Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-24T15:47:44Z"
+  mac: ENC[AES256_GCM,data:EeZoT34doPc1F5eafB2gT+OhzVPcUBMTI5qIHgydcHkroXMz3ERMsJ/wto6HOgEgfqHuA/LmqeGaJO5XQj+DCkgxjXS9OTFVU5Y68SXOPka+cwC6pTvKKi40MFnD5B5lnbJ/zBEDKFseilQnp5HdoRCGmz9TjInT9NkNrGwOOF4=,iv:tFGpZ0zIoqmYGfXxs31DFGYO/2KBVpghYwFtCa8DXtI=,tag:3FWamiGChFRkvN7KwVg7Jg==,type:str]
+  version: 3.13.1

--- a/infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml.example
+++ b/infra/controllers/kube-prometheus-stack/secret-alertmanager-smtp.yaml.example
@@ -1,0 +1,26 @@
+# TEMPLATE — operator action required.
+#
+# Alertmanager's email-critical receiver authenticates to Gmail SMTP with a
+# Gmail app password. Secrets are namespace-scoped, so this must live in the
+# `monitoring` namespace (Authelia's copy in authelia-prod can't be read
+# cross-namespace). The value is the SAME app password already stored in
+# apps/production/authelia/secret-authelia.yaml (AUTHELIA_NOTIFIER_SMTP_PASSWORD).
+#
+# To activate:
+#   cp secret-alertmanager-smtp.yaml.example secret-alertmanager-smtp.yaml
+#   # paste the Gmail app password into stringData.password
+#   sops -e -i secret-alertmanager-smtp.yaml      # .sops.yaml rule infra/.*secret.*\.yaml$ encrypts it
+#   git add secret-alertmanager-smtp.yaml && git commit
+#
+# secret-alertmanager-smtp.yaml is already wired into kustomization.yaml, so
+# `kustomize build` (and CI) fails until the encrypted file exists — that is
+# the intended gate. The infra-controllers Flux Kustomization has SOPS
+# decryption enabled, so no further wiring is needed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-smtp
+  namespace: monitoring
+type: Opaque
+stringData:
+  password: "REPLACE_WITH_GMAIL_APP_PASSWORD"

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -508,6 +508,17 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
+      # Gmail SMTP relay (same upstream Authelia uses). Port 587 + STARTTLS is
+      # Alertmanager's supported path (Authelia uses 465/implicit TLS; the same
+      # app password works on both). Gmail rewrites From to the authenticated
+      # account, so smtp_from is the bare account; delivery goes to the
+      # plus-alias via the receiver's `to`. Password comes from the mounted
+      # alertmanager-smtp secret, never from this ConfigMap.
+      smtp_smarthost: 'smtp.gmail.com:587'
+      smtp_from: 'gjcourt@gmail.com'
+      smtp_auth_username: 'gjcourt@gmail.com'
+      smtp_auth_password_file: '/etc/alertmanager/secrets/alertmanager-smtp/password'
+      smtp_require_tls: true
     inhibit_rules:
       - source_matchers:
           - 'severity = critical'
@@ -541,8 +552,19 @@ alertmanager:
       - receiver: 'null'
         matchers:
           - alertname = "Watchdog"
+      # Critical alerts (Flux not-ready, NodeFilesystemReadOnly, LokiPushErrors)
+      # go to email. repeat_interval is shorter than the global default because
+      # email has no ack — re-nag every 4h while still firing.
+      - receiver: 'email-critical'
+        matchers:
+          - severity = "critical"
+        repeat_interval: 4h
     receivers:
     - name: 'null'
+    - name: 'email-critical'
+      email_configs:
+        - to: 'gjcourt+alerts@gmail.com'
+          send_resolved: true
     templates:
     - '/etc/alertmanager/config/*.tmpl'
 
@@ -925,7 +947,12 @@ alertmanager:
     ## Secrets is a list of Secrets in the same namespace as the Alertmanager object, which shall be mounted into the
     ## Alertmanager Pods. The Secrets are mounted into /etc/alertmanager/secrets/.
     ##
-    secrets: []
+    # alertmanager-smtp holds the Gmail app password; mounted at
+    # /etc/alertmanager/secrets/alertmanager-smtp/password and referenced by
+    # config.global.smtp_auth_password_file so the credential never enters the
+    # (plaintext) values ConfigMap.
+    secrets:
+      - alertmanager-smtp
 
     ## If false then the user will opt out of automounting API credentials.
     ##


### PR DESCRIPTION
## Summary

Restores delivery for critical alerts, which currently dead-end at Alertmanager's `null` receiver (no notifications since signal-cli/hermes were decommissioned in #936). Points Alertmanager's native `email_configs` at the **same Gmail SMTP relay Authelia already uses** — no new service. Closes the open Phase-2 delivery question in the monitoring-enhancement plan.

Plan: `docs/plans/2026-06-17-alertmanager-smtp-alerting.md`.

**Decisions:** deliver to `gjcourt+alerts@gmail.com` (plus-alias, filterable); **critical severity only** for now.

## Changes
- **`values.yaml`** — `alertmanagerSpec.secrets: [alertmanager-smtp]`; `config.global` Gmail SMTP (`smtp.gmail.com:587`, STARTTLS, `smtp_auth_password_file` → mounted secret); new `email-critical` receiver → `gjcourt+alerts@gmail.com`; new `severity = "critical"` route (4h repeat). The `null` default, Watchdog route, and inhibit rules are untouched.
- **`secret-alertmanager-smtp.yaml.example`** — template for the `monitoring`-namespace Gmail app-password secret (same value as `AUTHELIA_NOTIFIER_SMTP_PASSWORD`); wired into `kustomization.yaml`.
- **docs** — plan doc, `monitoring.md §7`, regenerated plans index.

## ⚠️ Operator step required (this is why it's a draft)
Secrets are operator-encrypted. On this branch:
```
cd infra/controllers/kube-prometheus-stack
cp secret-alertmanager-smtp.yaml.example secret-alertmanager-smtp.yaml
# paste the Gmail app password (same as Authelia's) into stringData.password
sops -e -i secret-alertmanager-smtp.yaml
git add secret-alertmanager-smtp.yaml && git commit && git push
```
Until that lands, **`kustomize build` / CI fails on the missing `secret-alertmanager-smtp.yaml`** — the intended gate. The `infra-controllers` Flux Kustomization already has SOPS decryption enabled.

## Test plan
- [x] `kustomize build infra/controllers` validated with a throwaway placeholder secret (config parses: receiver, route, secret mount all correct); placeholder not committed
- [x] No plaintext password in the diff
- [ ] Operator commits the encrypted secret → CI green
- [ ] Post-merge: `alertmanager-smtp` secret present; Alertmanager pod rolls clean with the mount
- [ ] Post-merge: a real `severity=critical` alert delivers to `gjcourt+alerts@gmail.com` (+ `[RESOLVED]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)