### PR TITLE
chore: pin finance-dashboard image to 2026-06-18-75ff25e

### DIFF
--- a/apps/base/finance-dashboard/deployment.yaml
+++ b/apps/base/finance-dashboard/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           # produces (build-finance-dashboard.yml) once the first image is built.
           # Bootstrap on :latest — the multi-page image only builds on merge.
           # Pin the immutable :YYYY-MM-DD-<sha> tag in a follow-up after the build.
-          image: ghcr.io/gjcourt/finance-dashboard:latest
+          image: ghcr.io/gjcourt/finance-dashboard:2026-06-18-75ff25e
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Follow-up to #946. Pins the deployment from `:latest` to the immutable `2026-06-18-75ff25e` tag the multi-page build produced, per the strictly-increasing image-tag convention. No behavior change (same image `:latest` points to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)