### PR TITLE
fix: real-estate page — tiles/sliders blank + highlight selected candidate

### DIFF
--- a/images/finance-dashboard/realestate.py
+++ b/images/finance-dashboard/realestate.py
@@ -67,8 +67,12 @@ function recompute(){
   document.getElementById('r_steady').textContent=money(r.nat_steady);
   document.getElementById('r_down').textContent='Down: '+money(r.down);
 }
-function setPrice(v){ const el=document.getElementById('price');
-  el.value=Math.max(el.min, Math.min(el.max, v)); recompute();
+function setPrice(row){ const el=document.getElementById('price');
+  el.value=Math.max(el.min, Math.min(el.max, parseFloat(row.dataset.price))); recompute();
+  document.querySelectorAll('tr.sel').forEach(r=>r.classList.remove('sel'));
+  row.classList.add('sel');
+  const m=document.getElementById('modeling');
+  if(m) m.textContent='Modeling: '+(row.dataset.addr||'');
   window.scrollTo({top:0, behavior:'smooth'}); }
 window.addEventListener('load', function(){
   document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
@@ -94,7 +98,7 @@ def render_html(cfg: dict, cands: dict) -> str:
         if (c.get("freeway_mi") or 9) < 0.5:
             flags.append('<span class=off>freeway</span>')
         bdba = f'{c.get("beds","?")}/{c.get("baths","?")}'
-        rows += (f'<tr class=click onclick="setPrice({price})">'
+        rows += (f'<tr class=click data-price="{price}" data-addr="{html.escape(c.get("address",""))}" onclick="setPrice(this)">'
                  f'<td class=num>{c.get("fit","")}</td>'
                  f'<td><a href="{html.escape(c.get("url",""))}" onclick="event.stopPropagation()">{html.escape(c.get("address",""))}</a> {" ".join(flags)}</td>'
                  f'<td class=num>${price/1e6:.2f}M</td><td class=num>{c.get("acres","")}</td>'
@@ -113,6 +117,8 @@ click a candidate below to load its price. Fixed: {cfg['rental_share']*100:.0f}%
  <div class=card><div class=label>Year-1 after-tax</div><div class="value big" id=r_y1></div><div class=sub id=r_down></div></div>
  <div class=card><div class=label>Steady-state / yr</div><div class="value big" id=r_steady></div><div class=sub>yr 2+ (shield spent)</div></div>
 </div>
+
+<div class=note id=modeling>Click a candidate below to load it into the model.</div>
 
 <div class=controls>
  {sliders}

--- a/images/finance-dashboard/realestate.py
+++ b/images/finance-dashboard/realestate.py
@@ -70,8 +70,10 @@ function recompute(){
 function setPrice(v){ const el=document.getElementById('price');
   el.value=Math.max(el.min, Math.min(el.max, v)); recompute();
   window.scrollTo({top:0, behavior:'smooth'}); }
-document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
-recompute();
+window.addEventListener('load', function(){
+  document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
+  recompute();
+});
 """
 
 

--- a/images/finance-dashboard/static/style.css
+++ b/images/finance-dashboard/static/style.css
@@ -41,6 +41,8 @@ th { color:var(--muted); font-size:12px; font-weight:600; text-transform:upperca
 .ok { color:var(--green); } .off { color:var(--red); font-weight:600; }
 .drift.off { color:var(--red); } .drift { color:var(--green); }
 tr.click { cursor:pointer; } tr.click:hover td { background:#1d2530; }
+tr.sel td { background:#16314e; }
+tr.sel td:first-child { box-shadow:inset 3px 0 0 var(--blue); }
 
 /* ---- allocation / progress bars ---- */
 .bar { width:42%; }


### PR DESCRIPTION
Fixes two bugs + adds a usability touch on the Real Estate page:
- **Tiles + sliders did nothing** — the inline JS ran in `<head>` before the body existed, so `recompute()` found no elements and no slider listeners were attached. Defer to a `window 'load'` handler (matching runway.py). This fixes both the blank result tiles **and** the non-responsive sliders.
- **Highlight the selected candidate** — clicking a row now highlights it (blue tint + left accent) and shows a `Modeling: <address>` label above the controls, so it's obvious which property the pro-forma reflects.

Verified the ported pro-forma math is finite and the JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)