### PR TITLE
feat: sortable real-estate columns + interactive cash flow + initial highlight

### DIFF
--- a/images/finance-dashboard/cashflow.py
+++ b/images/finance-dashboard/cashflow.py
@@ -5,18 +5,19 @@ Annual totals hide the shape that matters month-to-month: front-loaded 401(k),
 lumpy bonus + quarterly RSU vests, CA property tax in two installments (Apr+Dec),
 and the April tax true-up from RSU/bonus supplemental under-withholding.
 
-Inputs come from cashflow.yaml (DEFAULTS below is the schema + fallback). Render
-the HTML page, or print the text table, or override any field on the CLI:
-  python3 cashflow.py                                  # text table (defaults)
-  python3 cashflow.py --file cashflow.yaml --html --out cashflow.html
-  python3 cashflow.py --living 14000 --rsu-annual 0    # scenario override
+The HTML page is interactive — sliders for base / RSU / bonus / mortgage /
+living / 401(k) recompute the monthly table + summary live (client-side JS).
+Inputs default from cashflow.yaml; the CLI text mode and overrides still work.
 
-NOT tax advice — withholding rates are planning approximations; the exact April
-true-up is a CPA item.
+  python3 cashflow.py                                  # text table
+  python3 cashflow.py --file cashflow.yaml --html --out cashflow.html
+
+NOT tax advice — withholding rates are planning approximations.
 """
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import yaml
@@ -27,24 +28,82 @@ MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
 DEFAULTS = dict(
-    base=298_700.0, bonus=59_740.0, bonus_month=3,      # 20% bonus, paid March
-    rsu_annual=450_000.0,                               # vests quarterly (Mar/Jun/Sep/Dec)
+    base=298_700.0, bonus=59_740.0, bonus_month=3,
+    rsu_annual=450_000.0,
     pretax_pct=0.10, deferral_cap=24_500.0,
     aftertax_pct=0.13, total_415c=72_000.0, match=10_800.0,
-    salary_wh=0.35,                                     # blended fed+CA withholding on salary
-    supp_wh=0.3223,                                     # 22% fed + 10.23% CA supplemental (bonus/RSU)
+    salary_wh=0.35, supp_wh=0.3223,
     mortgage_pi=12_865.0,
-    prop_tax=45_000.0,                                  # CA: 2 installments (Apr + Dec)
+    prop_tax=45_000.0,
     hoa=500.0, insurance=1_000.0, insurance_month=1,
     living=12_500.0,
-    april_trueup=40_000.0,                              # ESTIMATE — CPA item
+    april_trueup=40_000.0,
     start_cash=50_000.0,
 )
 RSU_Q = (3, 6, 9, 12)
 
+# (id, label, min, max, step, fmt) — the live sliders. Everything else is baked.
+SLIDERS = [
+    ("base", "Base salary", 200_000, 500_000, 5_000, "money"),
+    ("rsu_annual", "RSU / stock per yr", 0, 800_000, 10_000, "money"),
+    ("bonus", "Bonus", 0, 150_000, 5_000, "money"),
+    ("mortgage_pi", "Mortgage P&I (monthly)", 4_000, 20_000, 250, "money"),
+    ("living", "Living (monthly)", 5_000, 25_000, 500, "money"),
+    ("pretax_pct", "401k pre-tax %", 0, 0.20, 0.01, "pct"),
+    ("aftertax_pct", "401k after-tax %", 0, 0.20, 0.01, "pct"),
+]
+FIXED_KEYS = ["bonus_month", "deferral_cap", "total_415c", "match", "salary_wh",
+              "supp_wh", "prop_tax", "hoa", "insurance", "insurance_month",
+              "april_trueup", "start_cash"]
+
+JS = r"""
+const MONTHS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const money=x=>(x<0?'−$':'$')+Math.abs(Math.round(x)).toLocaleString();
+const fmtV=(v,f)=>f==='pct'?(v*100).toFixed(0)+'%':'$'+Math.round(v).toLocaleString();
+function build(p){
+  const gm=p.base/12, rv=p.rsu_annual/4, atroom=p.total_415c-p.deferral_cap-p.match;
+  let pd=0, ad=0, cum=p.start_cash, rows=[], tin=0, tout=0, t401k=0;
+  for(let i=0;i<12;i++){ const m=i+1;
+    const pre=Math.max(0,Math.min(p.pretax_pct*gm, p.deferral_cap-pd)); pd+=pre;
+    const at=Math.max(0,Math.min(p.aftertax_pct*gm, atroom-ad)); ad+=at;
+    const ns=(gm-pre)*(1-p.salary_wh)-at;
+    const nb=(m===p.bonus_month?p.bonus:0)*(1-p.supp_wh);
+    const nr=([3,6,9,12].indexOf(m)>=0?rv:0)*(1-p.supp_wh);
+    const inf=ns+nb+nr;
+    const ptax=(m===4||m===12)?p.prop_tax/2:0, ins=(m===p.insurance_month)?p.insurance:0, tu=(m===4)?p.april_trueup:0;
+    const out=p.mortgage_pi+ptax+p.hoa+ins+p.living+tu;
+    const net=inf-out; cum+=net;
+    rows.push([MONTHS[i],ns,nb,nr,inf,out,net,cum]); tin+=inf; tout+=out; t401k+=pre+at;
+  }
+  return {rows,tin,tout,t401k,surplus:tin-tout,min:Math.min(...rows.map(r=>r[7]))};
+}
+function recompute(){
+  const p=Object.assign({},FIXED);
+  document.querySelectorAll('input[type=range]').forEach(el=>{ p[el.id]=parseFloat(el.value);
+    document.getElementById(el.id+'_v').textContent=fmtV(p[el.id], el.dataset.fmt); });
+  const r=build(p);
+  document.getElementById('t_surplus').textContent=money(r.surplus);
+  document.getElementById('t_takehome').textContent=money(r.tin);
+  document.getElementById('t_spend').textContent=money(r.tout);
+  document.getElementById('t_401k').textContent=money(r.t401k+p.match);
+  let h='';
+  for(const x of r.rows){ const net=x[6], ncls=net<0?'num neg':'num';
+    h+='<tr><td>'+x[0]+'</td><td class=num>'+money(x[1])+'</td><td class=num>'+(x[2]?money(x[2]):'—')
+      +'</td><td class=num>'+(x[3]?money(x[3]):'—')+'</td><td class=num>'+money(x[4])+'</td><td class=num>'
+      +money(x[5])+'</td><td class="'+ncls+'">'+money(net)+'</td><td class=num>'+money(x[7])+'</td></tr>'; }
+  h+='<tr class=grp><td>Year</td><td></td><td></td><td></td><td class=num>'+money(r.tin)+'</td><td class=num>'
+    +money(r.tout)+'</td><td class=num>'+money(r.surplus)+'</td><td class=num>'+money(r.rows[11][7])+'</td></tr>';
+  document.getElementById('cfbody').innerHTML=h;
+  document.getElementById('lowcash').textContent=money(r.min);
+}
+window.addEventListener('load', function(){
+  document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
+  recompute();
+});
+"""
+
 
 def load_params(path: str | None) -> dict:
-    """Merge cashflow.yaml over DEFAULTS (yaml supplies values; DEFAULTS fills gaps)."""
     p = dict(DEFAULTS)
     if path and Path(path).exists():
         loaded = yaml.safe_load(Path(path).read_text()) or {}
@@ -63,81 +122,68 @@ def build(p):
     pre_done = at_done = 0.0
     cum = p["start_cash"]
     rows, tot_in, tot_out, tot_401k = [], 0.0, 0.0, 0.0
-
     for i in range(12):
         m = i + 1
         pre = max(0.0, min(p["pretax_pct"] * gross_m, p["deferral_cap"] - pre_done))
         pre_done += pre
         at = max(0.0, min(p["aftertax_pct"] * gross_m, aftertax_room - at_done))
         at_done += at
-
         net_sal = (gross_m - pre) * (1 - p["salary_wh"]) - at
         net_bonus = (p["bonus"] if m == p["bonus_month"] else 0.0) * (1 - p["supp_wh"])
         net_rsu = (rsu_vest if m in RSU_Q else 0.0) * (1 - p["supp_wh"])
         inflow = net_sal + net_bonus + net_rsu
-
         ptax = p["prop_tax"] / 2 if m in (4, 12) else 0.0
         ins = p["insurance"] if m == p["insurance_month"] else 0.0
         trueup = p["april_trueup"] if m == 4 else 0.0
         outflow = p["mortgage_pi"] + ptax + p["hoa"] + ins + p["living"] + trueup
-
         net = inflow - outflow
         cum += net
         rows.append((MONTHS[i], net_sal, net_bonus, net_rsu, inflow, outflow, net, cum))
         tot_in += inflow
         tot_out += outflow
         tot_401k += pre + at
-
     return rows, tot_in, tot_out, tot_401k, pre_done, at_done
 
 
 def render_html(p: dict) -> str:
-    rows, tin, tout, t401k, pre_done, at_done = build(p)
-    u = wc.usd
-    surplus = tin - tout
-    min_cum = min(r[7] for r in rows)
-    min_mo = min(rows, key=lambda r: r[7])[0]
+    fixed = {k: p[k] for k in FIXED_KEYS}
+    sliders = ""
+    for sid, label, lo, hi, step, fmt in SLIDERS:
+        sliders += (f'<div class=ctrl><label>{label} <b id="{sid}_v"></b></label>'
+                    f'<input type=range id="{sid}" min="{lo}" max="{hi}" step="{step}" '
+                    f'value="{p[sid]}" data-fmt="{fmt}"></div>')
 
-    def card(label, value, sub=""):
+    def card(label, vid, sub=""):
         return (f'<div class=card><div class=label>{label}</div>'
-                f'<div class=value>{value}</div><div class=sub>{sub}</div></div>')
-
-    trows = ""
-    for mo, ns, nb, nr, inflow, outflow, net, cum in rows:
-        ncls = ' class="num neg"' if net < 0 else " class=num"
-        trows += (f'<tr><td>{mo}</td><td class=num>{u(ns)}</td>'
-                  f'<td class=num>{u(nb) if nb else "—"}</td>'
-                  f'<td class=num>{u(nr) if nr else "—"}</td>'
-                  f'<td class=num>{u(inflow)}</td><td class=num>{u(outflow)}</td>'
-                  f'<td{ncls}>{u(net)}</td><td class=num>{u(cum)}</td></tr>')
+                f'<div class="value big" id={vid}></div><div class=sub>{sub}</div></div>')
 
     body = f"""
 <h1>Monthly Cash Flow</h1>
-<div class=sublede>base {u(p['base'])} + {u(p['bonus'])} bonus + {u(p['rsu_annual'])} RSU/yr (quarterly) ·
-living {u(p['living'])}/mo · mortgage {u(p['mortgage_pi'])}/mo · 401k {p['pretax_pct']*100:.0f}% pre + {p['aftertax_pct']*100:.0f}% after-tax</div>
+<div class=sublede>Drag the sliders — base, RSU, bonus, mortgage, living, 401(k) — and the monthly table + totals
+update live. Salary alone runs short most months; the quarterly RSU vests + March bonus carry the year.</div>
 
-<div class=cards>
- {card("Cash surplus / yr", u(surplus), "after everything")}
- {card("Take-home / yr", u(tin), "net of tax + 401k")}
- {card("Total spend / yr", u(tout), "incl. mortgage + tax")}
- {card("401(k) saved", u(t401k + p['match']), f"{u(t401k)} you + {u(p['match'])} match")}
+<div class=results>
+ {card("Cash surplus / yr", "t_surplus", "after everything")}
+ {card("Take-home / yr", "t_takehome", "net of tax + 401k")}
+ {card("Total spend / yr", "t_spend", "incl. mortgage + tax")}
+ {card("401(k) saved", "t_401k", "you + employer match")}
 </div>
 
-<p class=note>Salary alone runs short most months — the quarterly RSU vests + the March bonus carry the year.
-Cash bottoms at <b>{u(min_cum)}</b> in <b>{min_mo}</b> (property-tax installment + the ~{u(p['april_trueup'])} April tax true-up).
-Keep ~{u(max(0, -min_cum) + 60000)} buffer, or set up quarterly estimates to flatten April.</p>
+<div class=controls>
+ {sliders}
+</div>
+<p class=note>Cash bottoms at <b id=lowcash></b> (the April property-tax installment + the ~{wc.usd(p['april_trueup'])}
+tax true-up estimate). Withholding rates are approximations — a CPA item; quarterly estimates would smooth April.</p>
 
 <h2>Month by month</h2>
 <table>
- <tr><th>Mo</th><th class=num>Net Pay</th><th class=num>Bonus</th><th class=num>RSU</th>
-     <th class=num>In</th><th class=num>Out</th><th class=num>Net</th><th class=num>Cumulative</th></tr>
- {trows}
- <tr class=grp><td>Year</td><td class=num></td><td class=num></td><td class=num></td>
-     <td class=num>{u(tin)}</td><td class=num>{u(tout)}</td><td class=num>{u(surplus)}</td><td class=num>{u(rows[-1][7])}</td></tr>
+ <thead><tr><th>Mo</th><th class=num>Net Pay</th><th class=num>Bonus</th><th class=num>RSU</th>
+     <th class=num>In</th><th class=num>Out</th><th class=num>Net</th><th class=num>Cumulative</th></tr></thead>
+ <tbody id=cfbody></tbody>
 </table>
-<p class=note>April includes a ~{u(p['april_trueup'])} tax true-up <i>estimate</i> (RSU/bonus supplemental under-withholding) — a CPA item; quarterly estimates would smooth it.</p>
 """
-    return wc.page("Cash Flow", "cashflow.html", body)
+    head = "<script>\nconst FIXED = " + json.dumps(fixed) + ";\n" + JS + "\n</script>"
+    return wc.page("Cash Flow", "cashflow.html", body, head_extra=head)
 
 
 def print_text(p):
@@ -151,8 +197,7 @@ def print_text(p):
         print(f"  {mo:<4}{_txt(ns):>10}{_txt(nb):>10}{_txt(nr):>11}{_txt(i):>11}"
               f"{_txt(o):>11}{_txt(n):>11}{_txt(c):>12}{flag}")
     print("  " + "-" * 86)
-    print(f"  {'YR':<4}{'':>32}{_txt(tin):>11}{_txt(tout):>11}{_txt(tin-tout):>11}{_txt(rows[-1][7]):>12}")
-    print(f"\n  401(k) {_txt(t401k)} (pre {_txt(pre_done)} + after-tax {_txt(at_done)}) + match {_txt(p['match'])}\n")
+    print(f"  {'YR':<4}{'':>32}{_txt(tin):>11}{_txt(tout):>11}{_txt(tin-tout):>11}{_txt(rows[-1][7]):>12}\n")
 
 
 def main():
@@ -166,7 +211,7 @@ def main():
     args = ap.parse_args()
 
     p = load_params(args.file)
-    for k in DEFAULTS:  # CLI overrides win over the yaml
+    for k in DEFAULTS:
         v = getattr(args, k)
         if v is not None:
             p[k] = v

--- a/images/finance-dashboard/realestate.py
+++ b/images/finance-dashboard/realestate.py
@@ -74,9 +74,26 @@ function setPrice(row){ const el=document.getElementById('price');
   const m=document.getElementById('modeling');
   if(m) m.textContent='Modeling: '+(row.dataset.addr||'');
   window.scrollTo({top:0, behavior:'smooth'}); }
+function sortTable(th){
+  const tbl=th.closest('table'), tb=tbl.tBodies[0], rows=Array.from(tb.rows);
+  const key=th.dataset.key, type=th.dataset.type, asc=th.dataset.dir!=='asc';
+  tbl.querySelectorAll('th').forEach(h=>{h.dataset.dir=''; const a=h.querySelector('.arr'); if(a)a.remove();});
+  th.dataset.dir=asc?'asc':'desc';
+  rows.sort((a,b)=>{ let va=a.dataset[key], vb=b.dataset[key];
+    if(type==='num'){ va=parseFloat(va)||0; vb=parseFloat(vb)||0; return asc?va-vb:vb-va; }
+    return asc?(''+va).localeCompare(''+vb):(''+vb).localeCompare(''+va); });
+  rows.forEach(r=>tb.appendChild(r));
+  const s=document.createElement('span'); s.className='arr'; s.textContent=asc?' ▲':' ▼'; th.appendChild(s);
+}
 window.addEventListener('load', function(){
   document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
+  document.querySelectorAll('#cands th.sortable').forEach(th=>th.addEventListener('click', ()=>sortTable(th)));
   recompute();
+  const first=document.querySelector('#cands tbody tr');   // initial selection: top candidate, highlighted
+  if(first){ first.classList.add('sel');
+    const el=document.getElementById('price');
+    el.value=Math.max(el.min, Math.min(el.max, parseFloat(first.dataset.price))); recompute();
+    const m=document.getElementById('modeling'); if(m) m.textContent='Modeling: '+(first.dataset.addr||''); }
 });
 """
 
@@ -98,7 +115,9 @@ def render_html(cfg: dict, cands: dict) -> str:
         if (c.get("freeway_mi") or 9) < 0.5:
             flags.append('<span class=off>freeway</span>')
         bdba = f'{c.get("beds","?")}/{c.get("baths","?")}'
-        rows += (f'<tr class=click data-price="{price}" data-addr="{html.escape(c.get("address",""))}" onclick="setPrice(this)">'
+        rows += (f'<tr class=click data-price="{price}" data-addr="{html.escape(c.get("address",""))}" '
+                 f'data-fit="{c.get("fit",0)}" data-acres="{c.get("acres",0)}" data-beds="{c.get("beds",0) or 0}" '
+                 f'data-dist="{c.get("dist_mi",0)}" data-dom="{c.get("dom",0) or 0}" onclick="setPrice(this)">'
                  f'<td class=num>{c.get("fit","")}</td>'
                  f'<td><a href="{html.escape(c.get("url",""))}" onclick="event.stopPropagation()">{html.escape(c.get("address",""))}</a> {" ".join(flags)}</td>'
                  f'<td class=num>${price/1e6:.2f}M</td><td class=num>{c.get("acres","")}</td>'
@@ -127,10 +146,17 @@ click a candidate below to load its price. Fixed: {cfg['rental_share']*100:.0f}%
 cost-seg depreciation offsets W-2. Steady-state shows the carry once bonus depreciation is exhausted.</p>
 
 <h2>Candidates &nbsp;<span class=muted style="text-transform:none;font-weight:400">(from Redfin export · {cands.get("meta",{}).get("count","?")} hits · existing homes, by fit)</span></h2>
-<table>
- <tr><th class=num>Fit</th><th>Address</th><th class=num>Price</th><th class=num>Acres</th>
-     <th class=num>Bd/Ba</th><th class=num>Mi</th><th class=num>DOM</th></tr>
- {rows}
+<table id=cands>
+ <thead><tr>
+   <th class="num sortable" data-key=fit data-type=num>Fit</th>
+   <th class=sortable data-key=addr data-type=str>Address</th>
+   <th class="num sortable" data-key=price data-type=num>Price</th>
+   <th class="num sortable" data-key=acres data-type=num>Acres</th>
+   <th class="num sortable" data-key=beds data-type=num>Bd/Ba</th>
+   <th class="num sortable" data-key=dist data-type=num>Mi</th>
+   <th class="num sortable" data-key=dom data-type=num>DOM</th>
+ </tr></thead>
+ <tbody>{rows}</tbody>
 </table>
 <p class=note>Fit = composite (Plaza proximity · freeway distance · acreage · value · DOM-leverage). Click a row to model it.</p>
 """

--- a/images/finance-dashboard/static/style.css
+++ b/images/finance-dashboard/static/style.css
@@ -48,6 +48,8 @@ th { color:var(--muted); font-size:12px; font-weight:600; text-transform:upperca
 tr.click { cursor:pointer; } tr.click:hover td { background:#1d2530; }
 tr.sel td { background:#16314e; }
 tr.sel td:first-child { box-shadow:inset 3px 0 0 var(--blue); }
+th.sortable { cursor:pointer; user-select:none; } th.sortable:hover { color:var(--txt); }
+.arr { color:var(--blue); }
 
 /* ---- allocation / progress bars ---- */
 .bar { width:42%; }


### PR DESCRIPTION
- **Sortable candidates** — click any column header to sort (asc/desc, arrow indicator).
- **Initial highlight** — the top candidate is auto-selected + highlighted on load (and loaded into the pro-forma).
- **Interactive cash flow** — sliders for base / RSU / bonus / mortgage / living / 401(k) pre+after-tax recompute the monthly table + summary tiles live.

Single build from current master, so it also recovers #950's runway (negatives, red underwater fill, drag-zoom) + readable links — which a concurrent build had raced off `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)