### PR TITLE
feat(finance): RE 2nd-home+rental on one tab, runway 300yr/zoom fixes, nav + slider tweaks

### DIFF
--- a/images/finance-dashboard/cashflow.py
+++ b/images/finance-dashboard/cashflow.py
@@ -44,8 +44,8 @@ RSU_Q = (3, 6, 9, 12)
 
 # (id, label, min, max, step, fmt) — the live sliders. Everything else is baked.
 SLIDERS = [
-    ("base", "Base salary", 200_000, 500_000, 5_000, "money"),
-    ("rsu_annual", "RSU / stock per yr", 0, 800_000, 10_000, "money"),
+    ("base", "Base salary", 200_000, 1_000_000, 5_000, "money"),
+    ("rsu_annual", "RSU / stock per yr", 0, 5_000_000, 25_000, "money"),
     ("bonus", "Bonus", 0, 150_000, 5_000, "money"),
     ("mortgage_pi", "Mortgage P&I (monthly)", 4_000, 20_000, 250, "money"),
     ("living", "Living (monthly)", 5_000, 25_000, 500, "money"),

--- a/images/finance-dashboard/realestate.py
+++ b/images/finance-dashboard/realestate.py
@@ -25,7 +25,7 @@ import webcommon as wc
 SLIDERS = [
     ("price", "Purchase price", 1_000_000, 5_000_000, 50_000, "money"),
     ("down_pct", "Down payment", 0.05, 0.30, 0.005, "pct1"),
-    ("rate", "Mortgage rate", 0.04, 0.085, 0.00125, "pct1"),
+    ("rate", "Mortgage rate", 0.0375, 0.10, 0.00125, "pct1"),
     ("nightly", "Nightly rate", 300, 2000, 25, "money"),
     ("occupancy", "Occupancy", 0.25, 0.80, 0.01, "pct0"),
     ("insurance_pct", "Insurance (fire-zone)", 0.005, 0.03, 0.0005, "pct1"),
@@ -45,14 +45,18 @@ function proforma(p){
   const loan=p.price*(1-p.down_pct), pi=annual_pi(loan,p.rate,p.term), y1i=loan*p.rate;
   const ptax=p.price*p.prop_tax_rate, ins=p.price*p.insurance_pct, maint=p.price*p.maint_pct;
   const revenue=p.nightly*365*p.occupancy, strop=revenue*p.str_op_pct;
-  const net_cash=pi+ptax+ins+maint+strop-revenue;
+  const carry=pi+ptax+ins+maint;                  // full annual carrying cost (no STR opex / no income)
+  const net_cash=carry+strop-revenue;
+  const ownerCost=(1-p.rental_share)*carry;       // the structure you live in (non-rental)
+  const rentalCost=p.rental_share*carry+strop;    // rented structure's share + STR operating costs
+  const rentalNet=rentalCost-revenue;             // rental side net of STR income (negative = throws off cash)
   const rb=(1-p.land_frac)*p.rental_share*p.price;
   const dep_y1=rb*p.costseg_pct*p.bonus_pct + rb*(1-p.costseg_pct)/27.5;
   const dep_steady=rb*(1-p.costseg_pct)/27.5;
   const rce=p.rental_share*(y1i+ptax+ins+maint)+strop;
   const at=(dep)=> net_cash - (-(revenue-rce-dep)*p.marginal);
-  return {revenue, net_cash, nat_y1:at(dep_y1), nat_steady:at(dep_steady),
-          down:p.price*p.down_pct};
+  return {revenue, net_cash, nat_y1:at(dep_y1), nat_steady:at(dep_steady), down:p.price*p.down_pct,
+          secondHome:carry, secondHomeMo:carry/12, ownerCost, rentalCost, rentalNet};
 }
 function recompute(){
   const p=Object.assign({}, FIXED);
@@ -66,6 +70,14 @@ function recompute(){
   document.getElementById('r_y1').textContent=money(r.nat_y1);
   document.getElementById('r_steady').textContent=money(r.nat_steady);
   document.getElementById('r_down').textContent='Down: '+money(r.down);
+  // 2nd-home (non-rental) view
+  document.getElementById('r_2h').textContent=money(r.secondHome);
+  document.getElementById('r_2h_mo').textContent=money(r.secondHomeMo)+'/mo';
+  document.getElementById('r_down2').textContent=money(r.down);
+  // explicit rental vs non-rental cost split
+  document.getElementById('r_break').textContent=
+    'Cost split — owner-occupied side '+money(r.ownerCost)+'/yr · rental side '+money(r.rentalCost)
+    +'/yr offset by '+money(r.revenue)+' STR income (rental net '+money(r.rentalNet)+'). Net cash cost combines both.';
 }
 function setPrice(row){ const el=document.getElementById('price');
   el.value=Math.max(el.min, Math.min(el.max, parseFloat(row.dataset.price))); recompute();
@@ -125,19 +137,28 @@ def render_html(cfg: dict, cands: dict) -> str:
                  f'<td class=num>{c.get("dom","")}</td></tr>')
 
     body = f"""
-<h1>Wine-Country STR — Dual-Structure Model</h1>
-<div class=sublede>Live pro-forma for a 2-structure property (rent one, live in the other). Drag the sliders;
-click a candidate below to load its price. Fixed: {cfg['rental_share']*100:.0f}% rental share, {cfg['land_frac']*100:.0f}% land,
+<h1>Wine-Country Property — 2nd Home vs STR Rental</h1>
+<div class=sublede>One property, two ways to hold it — modeled side by side off the same sliders. Click a candidate below to load
+its price. Fixed: {cfg['rental_share']*100:.0f}% rental share, {cfg['land_frac']*100:.0f}% land,
 {cfg['prop_tax_rate']*100:.2f}% prop-tax, 100% bonus depreciation. <b>Not tax advice.</b></div>
 
+<div class=note id=modeling>Click a candidate below to load it into the model.</div>
+
+<h2>As a second home (personal use &middot; no rental)</h2>
+<div class=results>
+ <div class=card><div class=label>Annual carrying cost</div><div class="value big" id=r_2h></div><div class=sub>mortgage + tax + insurance + upkeep</div></div>
+ <div class=card><div class=label>Monthly cost</div><div class="value big" id=r_2h_mo></div></div>
+ <div class=card><div class=label>Cash to close</div><div class="value big" id=r_down2></div><div class=sub>down payment</div></div>
+</div>
+
+<h2>As a dual-structure STR rental (rent one &middot; live in the other)</h2>
 <div class=results>
  <div class=card><div class=label>Annual STR revenue</div><div class="value big pos" id=r_revenue></div></div>
  <div class=card><div class=label>Net cash cost / yr</div><div class="value big" id=r_netcash></div></div>
  <div class=card><div class=label>Year-1 after-tax</div><div class="value big" id=r_y1></div><div class=sub id=r_down></div></div>
  <div class=card><div class=label>Steady-state / yr</div><div class="value big" id=r_steady></div><div class=sub>yr 2+ (shield spent)</div></div>
 </div>
-
-<div class=note id=modeling>Click a candidate below to load it into the model.</div>
+<p class=note id=r_break></p>
 
 <div class=controls>
  {sliders}

--- a/images/finance-dashboard/runway.py
+++ b/images/finance-dashboard/runway.py
@@ -23,13 +23,14 @@ import webcommon as wc
 
 JS = r"""
 const R = RUNWAY;
+const MAXAGE = 300;            // project the lines all the way out so zooming out keeps rendering
 const fmtM = x => (x<0?'−$':'$') + Math.abs(x/1e6).toFixed(2) + 'M';
 const fmtK = x => '$' + Math.round(x).toLocaleString();
 
 function project(rate, retireAge, spend0, sav0, infl){
   let bal=R.current_investable, spend=spend0, sav=sav0;
   const pts=[{x:R.current_age, y:bal}];
-  for(let age=R.current_age; age<R.end_age; age++){
+  for(let age=R.current_age; age<MAXAGE; age++){
     bal = (age<retireAge) ? bal*(1+rate)+sav : bal*(1+rate)-spend;
     spend*=(1+infl); sav*=(1+infl);
     pts.push({x:age+1, y:bal});   // allow negative — shows how far underwater you'd go
@@ -37,6 +38,17 @@ function project(rate, retireAge, spend0, sav0, infl){
   return pts;
 }
 function depletion(pts){ for(const p of pts) if(p.y<=0) return p.x; return null; }
+
+function rescaleY(){   // fit y to whatever x-range is visible, so the default + zoomed-to-300 views both read well
+  const xs=chart.scales.x;
+  const x0=(xs&&xs.min!=null)?xs.min:R.current_age, x1=(xs&&xs.max!=null)?xs.max:R.end_age;
+  let lo=Infinity, hi=-Infinity;
+  for(const ds of chart.data.datasets) for(const p of ds.data)
+    if(p.x>=x0 && p.x<=x1){ if(p.y<lo)lo=p.y; if(p.y>hi)hi=p.y; }
+  if(lo===Infinity){ lo=0; hi=1; }
+  const pad=(hi-lo)*0.08 || Math.abs(hi)*0.08 || 1;
+  chart.options.scales.y.min=lo-pad; chart.options.scales.y.max=hi+pad;
+}
 
 function gauss(){ let u=0,v=0; while(!u)u=Math.random(); while(!v)v=Math.random();
   return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }
@@ -73,6 +85,7 @@ function recompute(){
   chart.data.datasets[0].data = lo;
   chart.data.datasets[1].data = mid;
   chart.data.datasets[2].data = hi;
+  rescaleY();
   chart.update('none');
 
   const dep = depletion(mid);
@@ -81,7 +94,7 @@ function recompute(){
 
   const setT = (id, txt, cls) => { const e=document.getElementById(id);
     e.textContent=txt; e.className='value big '+(cls||''); };
-  setT('t_dep', dep ? ('age '+dep) : (R.end_age+'+'), dep ? (dep<80?'bad':'warn') : 'pos');
+  setT('t_dep', dep ? ('age '+dep) : 'never', dep ? (dep<80?'bad':'warn') : 'pos');
   setT('t_succ', (success*100).toFixed(0)+'%', success>=0.9?'pos':success>=0.75?'warn':'bad');
   setT('t_term', fmtM(term), term>0?'pos':'bad');
   setT('t_verdict', success>=0.9?'Work-optional':success>=0.75?'Borderline':'Keep earning',
@@ -95,29 +108,35 @@ function init(){
   chart = new Chart(ctx, {
     type:'line',
     data:{ datasets:[
-      {label:'Conservative', data:[], borderColor:'#d97706', pointRadius:0, borderWidth:1.5, tension:.1},
+      {label:'Conservative', data:[], borderColor:'#d97706', pointRadius:0, borderWidth:1.5, tension:.1,
+       fill:{target:{value:0}, above:'transparent', below:'rgba(248,113,113,0.18)'}},
       {label:'Expected', data:[], borderColor:'#2f6fed', pointRadius:0, borderWidth:2.5, tension:.1,
        fill:{target:{value:0}, above:'transparent', below:'rgba(248,113,113,0.22)'}},
-      {label:'Optimistic', data:[], borderColor:'#16a34a', pointRadius:0, borderWidth:1.5, tension:.1},
+      {label:'Optimistic', data:[], borderColor:'#16a34a', pointRadius:0, borderWidth:1.5, tension:.1,
+       fill:{target:{value:0}, above:'transparent', below:'rgba(248,113,113,0.18)'}},
     ]},
     options:{ animation:false, parsing:false, responsive:true, maintainAspectRatio:false,
       interaction:{mode:'index', intersect:false},
       scales:{
         x:{type:'linear', title:{display:true,text:'Age'}, min:R.current_age, max:R.end_age,
-           ticks:{stepSize:5}, grid:{color:'#1c222b'}},
+           ticks:{maxTicksLimit:16}, grid:{color:'#1c222b'}},
         y:{title:{display:true,text:'Balance'},
            ticks:{callback:v=>(v<0?'−$':'$')+Math.abs(v/1e6).toFixed(1)+'M'},
            grid:{color:'#1c222b'}}
       },
       plugins:{ legend:{labels:{usePointStyle:true, boxWidth:8}},
         tooltip:{callbacks:{label:c=>c.dataset.label+': '+fmtM(c.parsed.y)+' @ '+c.parsed.x}},
-        zoom:{ zoom:{ wheel:{enabled:true},
-          drag:{enabled:true, backgroundColor:'rgba(47,111,237,0.12)', borderColor:'#2f6fed', borderWidth:1},
-          mode:'x' } } }
+        zoom:{
+          limits:{ x:{min:R.current_age, max:MAXAGE} },     // never pan/zoom into negative ages; cap at 300
+          zoom:{ wheel:{enabled:true},
+            drag:{enabled:true, backgroundColor:'rgba(47,111,237,0.12)', borderColor:'#2f6fed', borderWidth:1},
+            mode:'x', onZoomComplete:()=>{ rescaleY(); chart.update('none'); } },
+          pan:{ enabled:true, mode:'x', onPanComplete:()=>{ rescaleY(); chart.update('none'); } } } }
     }
   });
-  ctx.ondblclick = ()=>chart.resetZoom();
-  document.getElementById('zoomreset').addEventListener('click', ()=>chart.resetZoom());
+  function resetView(){ chart.resetZoom(); rescaleY(); chart.update('none'); }
+  ctx.ondblclick = resetView;
+  document.getElementById('zoomreset').addEventListener('click', resetView);
   document.querySelectorAll('input[type=range]').forEach(el=>el.addEventListener('input', recompute));
   recompute();
 }

--- a/images/finance-dashboard/webcommon.py
+++ b/images/finance-dashboard/webcommon.py
@@ -14,8 +14,8 @@ import html
 NAV = [
     ("index.html", "Balance Sheet"),
     ("cashflow.html", "Cash Flow"),
-    ("realestate.html", "Real Estate"),
     ("runway.html", "Runway"),
+    ("realestate.html", "Real Estate"),
 ]
 
 


### PR DESCRIPTION
Batch of finance-dashboard feedback:
1. **Nav** — Runway now sits before Real Estate.
2. **Runway renders to age 300** — lines project all the way out, so zooming out keeps drawing.
3. **Red underwater fill** — now on all three lines (was only on Expected, which stays positive at default params, so no red showed).
4. **Zoom can't go negative on x** — pan/zoom limited to [current age, 300].
5. **Real estate accounts for both rental + non-rental costs** — explicit owner-occupied vs rental split.
6. **Cash-flow sliders** — base to $1M, RSU/stock to $5M.
7. **Mortgage rate adjustable** — already a slider; range widened to 3.75-10%.

Plus: **2nd-home and dual-structure rental now live on one Real Estate tab** (your follow-up), modeled side-by-side off the same sliders. Y-axis auto-rescales to the visible range so the default 38-95 runway view stays readable even with data out to 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)