### PR TITLE
feat(pingo): sync WireGuard endpoint rewrite into AdGuard

### DIFF
--- a/apps/base/adguard/networkpolicy.yaml
+++ b/apps/base/adguard/networkpolicy.yaml
@@ -87,6 +87,18 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    # Pingo (DDNS) writes the WireGuard endpoint's DNS rewrite via the
+    # adguard-admin Service (port 8080 → pod port 80). Same DNAT note as above:
+    # match the pod port (80). Rewrites land on the primary and propagate to
+    # replicas via the adguardhome-sync CronJob.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: pingo
+            app.kubernetes.io/name: pingo
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
   egress:
     # kube-dns / CoreDNS for in-cluster Service resolution.
     - toEndpoints:

--- a/docs/reference/pingo.md
+++ b/docs/reference/pingo.md
@@ -24,7 +24,37 @@ type: Opaque
 stringData:
   CLOUDFLARE_API_TOKEN: "your-api-token"
   DOMAINS: "vpn.burntbytes.com"
+  # Optional — AdGuard Home rewrite sync (see below). Omit to disable.
+  ADGUARD_URLS: "http://adguard-admin.adguard-prod.svc.cluster.local:8080"
+  ADGUARD_USERNAME: "admin"
+  ADGUARD_PASSWORD: "your-adguard-password"
 ```
+
+## AdGuard rewrite sync
+
+Pingo also keeps a **DNS rewrite** for `vpn.burntbytes.com` on AdGuard, in sync
+with the public IP, so the WireGuard endpoint resolves correctly **from inside
+the LAN** too.
+
+**Why this is needed:** AdGuard serves a split-horizon wildcard
+`*.burntbytes.com → <k8s ingress>` that correctly routes every HTTP service. But
+`vpn.burntbytes.com` is a WireGuard UDP endpoint, not an HTTP service behind the
+ingress — on-LAN it must resolve to the **live public IP** (reached via the
+gateway's NAT hairpin), not the ingress. A more-specific AdGuard rewrite for
+`vpn.burntbytes.com` overrides the wildcard; Pingo updates that rewrite on every
+run alongside the Cloudflare record. Off-LAN, public DNS already returns the
+correct IP, so nothing changes there.
+
+- Pingo writes to the **primary** AdGuard admin Service (`adguard-admin`, port
+  8080). The `adguardhome-sync` CronJob propagates the rewrite to the replicas,
+  so a single `ADGUARD_URLS` entry suffices. (List multiple comma-separated URLs
+  only if instances stop replicating between themselves.)
+- Cross-namespace access is allowed by a dedicated ingress rule in
+  `apps/base/adguard/networkpolicy.yaml` (pingo namespace → admin port 80 after
+  DNAT), mirroring the homepage-widget rule.
+- The endpoint must stay **DNS-only** in Cloudflare (`PROXIED` unset/false): a
+  WireGuard handshake needs the real IP, and AdGuard rewrites have no proxy
+  concept.
 
 ## Operations
 

--- a/infra/controllers/pingo/cronjob.yaml
+++ b/infra/controllers/pingo/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: pingo
-              image: ghcr.io/gjcourt/pingo:2026-02-25
+              image: ghcr.io/gjcourt/pingo:2026-06-19
               imagePullPolicy: IfNotPresent
               envFrom:
                 - secretRef:

--- a/infra/controllers/pingo/cronjob.yaml
+++ b/infra/controllers/pingo/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: pingo
-              image: ghcr.io/gjcourt/pingo:2026-06-19
+              image: ghcr.io/gjcourt/pingo:2026-06-20
               imagePullPolicy: IfNotPresent
               envFrom:
                 - secretRef:

--- a/infra/controllers/pingo/secret.yaml
+++ b/infra/controllers/pingo/secret.yaml
@@ -5,21 +5,24 @@ metadata:
   namespace: pingo
 type: Opaque
 stringData:
-  #ENC[AES256_GCM,data:dH0HYZa7NaXTk4Woh4GQE9K+XjFDLnGNZyfVluEV93q61h12WZWaxSBSoLkxoAAsJSPn6EOlM7MiiVEWCXuH2Di0gX/OVhrxFGeS,iv:nxTIEwNIOJ5syKbVU5btdptVdr44Ytlb3k88OQL+50s=,tag:3O6gDJLkKL/o4UhwnCvnVw==,type:comment]
-  CLOUDFLARE_API_TOKEN: ENC[AES256_GCM,data:+8xJUpkbqzJ4CzwQbf9pv9HCHcvyC99uoNllTKeWqv4FxHOK1Azwfw==,iv:zWET3357WH11GO4zjqTuQYDux8zjQ8G9bcXRfzO/qqo=,tag:a5Iv6V3xEXdeZ6BFr+zxjA==,type:str]
-  DOMAINS: ENC[AES256_GCM,data:BCEK3973QeOUuR+bG3usasrq,iv:wlGthXw5+QXUqEZm8FTsNS7YB+ZB10lyLcsl2TpjL94=,tag:OA1j3XndX0mw2LxqUqZkEA==,type:str]
+  #ENC[AES256_GCM,data:ZdaGfLWZrAdg5Lvj7EQzYrn3hTSpHPYVchNjvvKK8R+9tluHL4vo5cSdY9fOYDZ6XwKRBC7CmAPLLG6UqEOXCXHjqWE/bthp4FVT,iv:NJhHJzme5U5lUOjsWd3kfqeP0nL1ISTGhj81kcEdaP4=,tag:mvhBgWAB7tmWBRil7clHPw==,type:comment]
+  CLOUDFLARE_API_TOKEN: ENC[AES256_GCM,data:Br7NoWo8HCo1ASDMbBKH2lz01cDGUmEWniEClghiGj88vIqlF6T+xA==,iv:eD56goe+XSE/pkq8+E9qAe6K96l0fP0Ze/PmLhuc2Jo=,tag:I6TIlCShL/BAMwpffRZ3Eg==,type:str]
+  DOMAINS: ENC[AES256_GCM,data:kBPbuLVvjdkSJlDAznPNF9WA,iv:RCvEVQp92QlK9xm3WIX/VwYVmLom6RJiRHunjFrvdVE=,tag:JgvLyqeiJCPtZ8Irc42deg==,type:str]
+  ADGUARD_URLS: ENC[AES256_GCM,data:+yAVED/MnjBDAUgANClyXBhQYPE/HQYfKsH2ZF9VW0fK8C3ss5MAN6hNBDMeeJxA8EK/Q8BG8xA=,iv:/d6L2ZNQGl9e9itH37nFZ0k9sR9TiPz/Y1KeqZ/KWlg=,tag:jDct39InmhBWiBwtoJSECA==,type:str]
+  ADGUARD_USERNAME: ENC[AES256_GCM,data:SjhWnM3A,iv:MOC2r1pZmKwPhtaM186Zze/+DlvJvujT5YPmlr+D9yI=,tag:isjjBh5s+bLQ+RgzEsIvNQ==,type:str]
+  ADGUARD_PASSWORD: ENC[AES256_GCM,data:8nqEMPrikrrp/DVnRHmeb08O2Q==,iv:bNSnxoX0HbgL0zM53pCd9ZbkyczkRAoDZHpQwkZhvHs=,tag:uJ0y/Zsx/hKCKWUl22AEAA==,type:str]
 sops:
   age:
-    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZy9RTVZPaGVkblB5aXFM
-        bFJxTWxqMlcwK0M5VlkzaEdraXlLejhsTldJCk9zR0EvNGlqeFpHQVhjTmZrQ1Ay
-        UnMzTFE1QjlGRTJ2Qi9ZK0lMRkFESlEKLS0tIFQ3K3ozWXlhM2xGZUJKT3k3NkUr
-        K3FYa3lLb0l1NjZmdU91NHlmbDA0QmsKCqteNk+ICFA7Ulq8iAIktZDKnUgn1X1X
-        rK11+eZ8pd0ncgPPK5+1d0ejq5wkSx6nfrE0fif9wGTJh5IU2NMIBA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHWnBnby8xZHlEVU15dGdJ
+        Z2x3bEZtemRRNUhVZlFmcWZOUEUwVXEwOFgwCkZ1eERhZ2JWTzEzazFnSUkwOXRK
+        ZDhjbDUwL1hqb1JPZ2ZmSE5FN21jU2sKLS0tIGNTeDJ3SHUxaWlyWlQzRVBqa2tT
+        VTlUMEQrTGtxZWFMckhobllEb3FScGMKBs+a9sd57RnngMTlO4/1Eb0Uwy6/Egag
+        StdnnOcGcaQnz7Jauwd4GTnWra3TLaN9ldcIyBmj+X2STz/NhJQUxg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-25T21:13:09Z"
-  mac: ENC[AES256_GCM,data:n7MU8NT9gpQq9Uj7PQmhHv9D0cQsRQEGcM5V5jVi9uenAG5nTVWrP4Qr9NwhsZVzpEjCN22sNGpFoObk9GR5usHAZsm/JIyXbfsgtdYripOgOwpShjAT5CE/AOvJ34prYknS2QCTVyR6zHUW2rbN+Cqq41py73iOUiTM/roZK3s=,iv:LSInol4PrHJAf6AHSOYScEIP5xDk6sUfX1W9OSU/17I=,tag:o3pQmav/hJ5FdBVq2ylICQ==,type:str]
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
   encrypted_regex: ^(data|stringData)$
-  version: 3.11.0
+  lastmodified: "2026-06-20T17:11:44Z"
+  mac: ENC[AES256_GCM,data:nWduTYiOYJoHLc4Lz8++XqB9tDaHUjnarf+q6Es8TZj+31PcxrRU3NGQZopWaaSf4lRzf+f3jHeP5FfxlEpYPUhxK6HwP2zjG5joHDJsswinfMv0EM+B6udEaRlG7pYNV6BBpM2gkgJ9WQ4X5noSwWCiSVl+2kzootsAlQz31o4=,iv:khiUyJGMe+WLHXG5Sj/gC1FAbivQd99QSKDTIfMF7A0=,tag:b7Nyu3ktbXA4v8a6KV7B0g==,type:str]
+  version: 3.13.1


### PR DESCRIPTION
**Draft** — gated on two operator-only steps (below). Merge only after both are done.

## What

Makes `vpn.burntbytes.com` resolve correctly **from inside the LAN** by having Pingo also maintain an AdGuard DNS rewrite for it, in sync with the public IP.

## Why

AdGuard serves a split-horizon wildcard `*.burntbytes.com → <k8s ingress>` — correct for every HTTP service, but it also catches the **WireGuard endpoint**, which is UDP and has no listener behind the ingress. On-LAN the WG handshake fails because the name resolves to the ingress instead of the public IP. A more-specific AdGuard rewrite (`vpn.burntbytes.com → public IP`) overrides the wildcard; the gateway's NAT hairpin then carries the handshake. Off-LAN already works via public DNS. Pingo keeps that rewrite current every run, so it survives dynamic-IP changes.

## Changes

- **`infra/controllers/pingo/cronjob.yaml`** — image `2026-02-25` → `2026-06-19` (the build adds AdGuard sync + concurrent multi-provider reconcile; code in gjcourt/Pingo#19). No structural change — new config rides the existing `envFrom: secretRef`.
- **`apps/base/adguard/networkpolicy.yaml`** — new ingress rule: pingo namespace → `adguard-admin` (port 80 after DNAT), mirroring the existing homepage-widget rule. Writes hit the primary; `adguardhome-sync` propagates to replicas.
- **`docs/reference/pingo.md`** — documents the rewrite sync, the split-horizon rationale, and the new `ADGUARD_*` secret keys.

## Validation

- `kustomize build` passes: `infra/controllers`, `apps/production/adguard`, `apps/staging/adguard`.
- Rendered prod netpol confirmed to include the `namespace: pingo` ingress rule.
- No plaintext secrets (doc shows placeholders only).

## Operator steps before merge (cannot be done in-PR)

1. **Build + push the image:** `scripts/build_and_push_image.sh` in the Pingo repo → `ghcr.io/gjcourt/pingo:2026-06-19`. (Merging this bump before the image exists = ImagePullBackOff.)
2. **Add the AdGuard secret keys:** `sops -e -i infra/controllers/pingo/secret.yaml` adding `ADGUARD_URLS` (`http://adguard-admin.adguard-prod.svc.cluster.local:8080`), `ADGUARD_USERNAME`, `ADGUARD_PASSWORD`.

Depends on: gjcourt/Pingo#19 (merge + image build first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)