### PR TITLE
feat(thermalscope): promote NVMe SMART smart-agent to production

### DIFF
--- a/apps/base/thermalscope-smart/daemonset.yaml
+++ b/apps/base/thermalscope-smart/daemonset.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: thermalscope-smart-agent
+  namespace: thermalscope
+  labels:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: smart-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/component: smart-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thermalscope
+        app.kubernetes.io/component: smart-agent
+    spec:
+      serviceAccountName: thermalscope-smart-agent
+      hostNetwork: true
+      hostPID: false
+      dnsPolicy: ClusterFirstWithHostNet
+      # Same scheduling intent as the production thermalscope-agent: run on
+      # every node (3 CP + 3 worker). NVMe wear/health is per-drive and we
+      # want it visible on all six. `operator: Exists` with no key tolerates
+      # every taint, including the control-plane NoSchedule taint.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: agent
+          # thermalscope PR #7 — NVMe SMART wear/health collector, opt-in via
+          # THERMALSCOPE_NVME_HEALTH. Pinned to the multi-arch index digest
+          # per the homelab image-discipline rule.
+          image: "ghcr.io/gjcourt/thermalscope:fe29fe5@sha256:ef85dd996cb042024388565eadd356bf5b225fb87a9970c89b49055148043019"
+          imagePullPolicy: IfNotPresent
+          env:
+            # Turn ON the SMART health collector (off by default in the agent).
+            - name: THERMALSCOPE_NVME_HEALTH
+              value: "1"
+            # Bind to :9103 so this DaemonSet never collides with the
+            # production thermalscope-agent on hostPort 9102. Staging and
+            # production share the same physical Talos nodes — two DaemonSets
+            # on the same hostPort wedge prod pods Pending (see incident
+            # PR #676). 9103 is bound by at most one DaemonSet per node, and
+            # this smart-agent exists ONLY in staging (thermalscope-stage).
+            - name: THERMALSCOPE_LISTEN_ADDR
+              value: ":9103"
+            # Host /dev is bind-mounted read-only at /host/dev (NOT /dev) so
+            # the container keeps its own writable /dev — otherwise the default
+            # terminationMessagePath (/dev/termination-log) is unwritable and
+            # the pod crashloops. Point the NVMe collector at the host devices.
+            - name: THERMALSCOPE_NVME_DEV_ROOT
+              value: "/host/dev"
+            # info for production. debug was used only during the staging
+            # errno hunt (to surface the per-device open/ioctl EPERM); at the
+            # 5-minute scrape cadence it is too noisy for steady-state prod.
+            - name: THERMALSCOPE_LOG_LEVEL
+              value: "info"
+          ports:
+            - name: metrics
+              containerPort: 9103
+              hostPort: 9103
+              protocol: TCP
+          securityContext:
+            # privileged is REQUIRED here. NVMe SMART/health is read via the
+            # NVMe admin passthrough ioctl (NVME_IOCTL_ADMIN_CMD, Get Log Page
+            # 0x02) on /dev/nvmeN, which needs an open handle on the char
+            # device. With privileged:false the staging run confirmed (debug
+            # log, all 4 nodes) `open /host/dev/nvme0: operation not
+            # permitted` (EPERM): the Kubernetes device cgroup denies access
+            # to host /dev/nvme* char devices for non-privileged pods EVEN
+            # WITH CAP_SYS_ADMIN and the /dev bind mount. privileged:true
+            # opens the device cgroup so the open() (and the admin ioctl)
+            # succeed. CAP_SYS_ADMIN below is retained (harmless/redundant
+            # under privileged) to document the ioctl's capability need.
+            # Required: the k8s device cgroup denies /dev/nvme* to non-privileged pods even with CAP_SYS_ADMIN (confirmed EPERM in staging).
+            privileged: true
+            runAsUser: 0
+            # allowPrivilegeEscalation is intentionally omitted: the API
+            # server rejects privileged:true together with
+            # allowPrivilegeEscalation:false ("cannot set
+            # allowPrivilegeEscalation to false and privileged to true").
+            # privileged already implies escalation is allowed.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - SYS_ADMIN
+          volumeMounts:
+            # ONLY host /dev (read-only) — the NVMe admin ioctl needs an open
+            # handle on /dev/nvmeN. Mounted at /host/dev (NOT /dev) so the
+            # container's own writable /dev (and /dev/termination-log) survive;
+            # the collector is pointed here via THERMALSCOPE_NVME_DEV_ROOT.
+            # Deliberately NO /sys/* mounts: without hwmon/thermal/powercap the
+            # temp/RAPL/GPU collectors stay inert, so this agent emits ONLY the
+            # NVMe-health series and does not duplicate the production agent's
+            # temperature series.
+            - name: dev
+              mountPath: /host/dev
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9103
+              host: 127.0.0.1
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # No livenessProbe: stateless Go HTTP server; readiness recovery
+          # plus the up{job="thermalscope-smart"} alert is sufficient — a
+          # liveness restart would not unstick anything readiness wouldn't.
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory

--- a/apps/base/thermalscope-smart/kustomization.yaml
+++ b/apps/base/thermalscope-smart/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Separate base from apps/base/thermalscope — that base stamps
+# `app.kubernetes.io/component: agent` onto ALL its resources, which would
+# clobber the smart-agent's component label and break the Service selector.
+# The smart-agent's `component: smart-agent` label lives directly in each
+# manifest (DaemonSet/Service/SM/SA), so the labels block below only adds the
+# shared identity labels with includeSelectors:false — it never touches the
+# selector labels.
+resources:
+  - serviceaccount.yaml
+  - daemonset.yaml
+  - service.yaml
+  - servicemonitor.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/thermalscope-smart/service.yaml
+++ b/apps/base/thermalscope-smart/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thermalscope-smart-agent
+  namespace: thermalscope
+  labels:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: smart-agent
+spec:
+  type: ClusterIP
+  # Headless: Endpoints carry the host IPs (the agent runs hostNetwork)
+  # rather than ephemeral pod IPs — per-node scrape targets for the
+  # ServiceMonitor below.
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: smart-agent
+  ports:
+    - name: metrics
+      port: 9103
+      targetPort: metrics
+      protocol: TCP

--- a/apps/base/thermalscope-smart/serviceaccount.yaml
+++ b/apps/base/thermalscope-smart/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thermalscope-smart-agent
+  namespace: thermalscope

--- a/apps/base/thermalscope-smart/servicemonitor.yaml
+++ b/apps/base/thermalscope-smart/servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thermalscope-smart-agent
+  namespace: thermalscope
+  labels:
+    # kube-prometheus-stack's Prometheus instance selects ServiceMonitors by
+    # helm-default release label. Without this label the SM is invisible.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: thermalscope
+    app.kubernetes.io/component: smart-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thermalscope
+      app.kubernetes.io/component: smart-agent
+  # No namespaceSelector — defaults to the SM's own namespace, which the
+  # staging overlay rewrites to thermalscope-stage.
+  endpoints:
+    - port: metrics
+      path: /metrics
+      # SMART health changes slowly (wear, power-on hours, error counters);
+      # a 5-minute scrape interval is plenty and keeps the NVMe admin ioctl
+      # cost negligible.
+      interval: 300s
+      scrapeTimeout: 30s
+      relabelings:
+        # Promote the pod's node name to `instance` so each Talos node is a
+        # distinct target (e.g. instance="talos-ykb-uir").
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: instance
+          action: replace
+        # Distinct job from the production agent's job="thermalscope" so the
+        # two never share an up{} series and the NVMe-health alerts can scope
+        # cleanly if needed.
+        - targetLabel: job
+          replacement: thermalscope-smart
+      metricRelabelings:
+        # Keep ONLY the NVMe wear/health series this agent is responsible for
+        # (plus `up`). The previous `thermalscope_nvme.*` wildcard also let the
+        # NVMe *temperature* series through, duplicating the production agent's
+        # temps; this explicit allow-list excludes _temperature_ entirely.
+        - sourceLabels: [__name__]
+          regex: ^(thermalscope_nvme_(percentage_used_ratio|available_spare_ratio|available_spare_threshold_ratio|critical_warning|media_errors_total|error_log_entries_total|power_on_hours_total|power_cycles_total|unsafe_shutdowns_total|data_units_written_total|data_units_read_total)|thermalscope_nvmehealth_up|up)$
+          action: keep
+        # Drop the per-pod label: under hostNetwork the pod identity is the
+        # node, and pod names churn on restart — cardinality without signal.
+        - action: labeldrop
+          regex: pod

--- a/apps/base/thermalscope/daemonset.yaml
+++ b/apps/base/thermalscope/daemonset.yaml
@@ -34,10 +34,15 @@ spec:
       containers:
         - name: agent
           # Pin to a digest per the homelab image-discipline rule.
-          # `b7e057a` reads RAPL energy from the powercap device tree
-          # (thermalscope PR #5) instead of the /sys/class symlinks,
-          # which containerd masks — see the powercap volume note below.
-          image: "ghcr.io/gjcourt/thermalscope:096a780@sha256:e609b6626f8e3fb47f17c8dd4e7df69be7d389d04397b2cc5ab7deeaaf832cc3"
+          # `fe29fe5` adds the opt-in NVMe SMART health collector
+          # (thermalscope PR #7) on top of the powercap RAPL device-tree
+          # reads from PR #5 (the /sys/class symlinks are masked by
+          # containerd — see the powercap volume note below). This bump is a
+          # pure superset for THIS agent: nvmehealth is off unless
+          # THERMALSCOPE_NVME_HEALTH is set (it is not here), so behavior is
+          # identical to the prior `096a780` digest. The collector is enabled
+          # only on the separate privileged thermalscope-smart DaemonSet.
+          image: "ghcr.io/gjcourt/thermalscope:fe29fe5@sha256:ef85dd996cb042024388565eadd356bf5b225fb87a9970c89b49055148043019"
           imagePullPolicy: IfNotPresent
           env:
             # The default powercap root (/sys/devices/virtual/powercap) is

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -25,5 +25,6 @@ resources:
   - overture
   - snapcast
   - thermalscope
+  - thermalscope-smart
   - truenas-iscsi-monitor
   - vitals

--- a/apps/production/thermalscope-smart/kustomization.yaml
+++ b/apps/production/thermalscope-smart/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# PRODUCTION overlay for the NVMe SMART smart-agent. There is intentionally
+# NO apps/staging/thermalscope-smart overlay in this branch: staging and
+# production share the same physical Talos nodes, so a second DaemonSet on
+# hostPort 9103 must exist on at most ONE DaemonSet per node. The staging
+# smart-agent (thermalscope-stage, PR #967) verified the privileged NVMe
+# ioctl; it must be torn down (close PR #967) at/before this merges, or a
+# staging + prod smart-agent both bind hostPort 9103 on the same nodes —
+# the #676 hostPort collision that wedges pods Pending.
+#
+# The `thermalscope` Namespace is owned by the existing
+# apps/production/thermalscope overlay (it pulls in base/thermalscope's
+# namespace.yaml, with PSA enforce=privileged). This smart-agent lands in
+# that SAME namespace, so it must NOT re-declare the Namespace object —
+# two overlays emitting Namespace/thermalscope collide in the
+# apps/production build. We only set the `namespace:` field here.
+namespace: thermalscope
+resources:
+  - ../../base/thermalscope-smart/

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -224,3 +224,72 @@ spec:
           annotations:
             summary: "hestia chassis fan {{ $labels.name }} may be failing"
             description: "Fan {{ $labels.name }} on hestia is stalled or in a non-OK state while CPU Tctl is above 70°C — possible fan failure under load."
+
+    # NVMe SMART wear/health (thermalscope PR #7, opt-in smart-agent). These
+    # alerts are global and inactive until the metrics exist — they begin
+    # firing only once a thermalscope-smart DaemonSet is scraped. The staging
+    # smart-agent (job="thermalscope-smart") emits them first; the prod
+    # promotion is a gated follow-up. Wear/spare/error counters change
+    # slowly, so the `for:` windows are long and the scrape is every 5m.
+    - name: thermalscope.nvmehealth
+      rules:
+        # Percentage-used is the SMART endurance estimate (0–1 here; 1.0 =
+        # rated write endurance consumed). >80% is a plan-a-replacement
+        # warning; the drive is typically still healthy past 100%, but at
+        # >95% it is firmly end-of-life and should be swapped.
+        - alert: ThermalScopeNVMeWearHigh
+          expr: thermalscope_nvme_percentage_used_ratio > 0.8
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} is wearing out"
+            description: "{{ $labels.device }} on {{ $labels.instance }} reports {{ $value | humanizePercentage }} of rated write endurance used (>80%). Plan a replacement."
+
+        - alert: ThermalScopeNVMeWearCritical
+          expr: thermalscope_nvme_percentage_used_ratio > 0.95
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} is at end-of-life"
+            description: "{{ $labels.device }} on {{ $labels.instance }} reports {{ $value | humanizePercentage }} of rated write endurance used (>95%). Replace the drive."
+
+        # Available spare blocks have fallen below the drive's own SMART
+        # threshold — the drive is signalling that spare capacity is running
+        # out. Gated on threshold>0 so drives that don't report a threshold
+        # (threshold=0) never trip this.
+        - alert: ThermalScopeNVMeSpareLow
+          expr: |
+            thermalscope_nvme_available_spare_ratio < thermalscope_nvme_available_spare_threshold_ratio
+              and thermalscope_nvme_available_spare_threshold_ratio > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} is low on spare blocks"
+            description: "{{ $labels.device }} on {{ $labels.instance }} available spare {{ $value | humanizePercentage }} is below its SMART threshold. The drive is running out of spare capacity."
+
+        # The SMART critical-warning bitfield is non-zero — the drive is
+        # reporting at least one critical condition (spare below threshold,
+        # temperature out of range, reliability degraded, read-only, or
+        # volatile-memory backup failed). Any non-zero value pages.
+        - alert: ThermalScopeNVMeCriticalWarning
+          expr: thermalscope_nvme_critical_warning != 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} reports a SMART critical warning"
+            description: "{{ $labels.device }} on {{ $labels.instance }} critical_warning bitfield is {{ $value }} (non-zero). Inspect the drive's SMART status immediately."
+
+        # New media (uncorrectable) errors in the last 24h. Media errors are
+        # rare and cumulative; any increase is worth surfacing.
+        - alert: ThermalScopeNVMeMediaErrors
+          expr: increase(thermalscope_nvme_media_errors_total[24h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} logged new media errors"
+            description: "{{ $labels.device }} on {{ $labels.instance }} recorded {{ $value }} new media/uncorrectable error(s) in the last 24h."


### PR DESCRIPTION
## What

Promote the privileged **NVMe-SMART smart-agent** from staging (PR #967) to **production**.

- New base: `apps/base/thermalscope-smart/{daemonset,service,servicemonitor,serviceaccount,kustomization}.yaml` (brought over verbatim from `feat/thermalscope-smart-staging`, with `THERMALSCOPE_LOG_LEVEL` changed `debug → info`).
- New prod overlay: `apps/production/thermalscope-smart/` (`namespace: thermalscope` — the same namespace as the existing prod thermalscope-agent), wired into `apps/production/kustomization.yaml`.
- Alerts: `thermalscope.nvmehealth` group appended to `infra/configs/thermalscope/prometheus-rule.yaml`.
- Existing-agent digest bump: `apps/base/thermalscope/daemonset.yaml` `096a780@sha256:e609b66… → fe29fe5@sha256:ef85dd99…`.

**No staging overlay is added** (see warning below). **No dashboard change** (deferred).

## Staging verification (PR #967) — VERIFIED

With `privileged: true` the NVMe SMART admin ioctl reads correctly on every node. Example, node `talos-fpd-h0t`, `nvme0`:

- `percentage_used = 0`
- `available_spare = 1.0`
- `critical_warning = 0`
- `power_on_hours = 8475`
- ~8.6 TB written

## Why `privileged: true` (the EPERM rationale)

NVMe SMART/health is read via the NVMe admin passthrough ioctl (`NVME_IOCTL_ADMIN_CMD`, Get Log Page 0x02) on `/dev/nvmeN`, which needs an open handle on the char device. A non-privileged pod gets `EPERM` opening `/dev/nvme*`: the **Kubernetes device cgroup** denies access to host `/dev/nvme*` char devices for non-privileged pods **even with `CAP_SYS_ADMIN`** and the `/dev` bind mount. `CAP_SYS_ADMIN` is insufficient — `privileged: true` is required (confirmed EPERM across all nodes in staging). The agent keeps `runAsUser:0`, `readOnlyRootFilesystem:true`, mounts host `/dev` read-only at `/host/dev`, binds hostPort 9103, and the ServiceMonitor keep-regex drops the temperature series (no duplication of the prod thermal agent's temps).

## Existing-agent digest bump

`thermalscope-agent` (the non-privileged thermal/RAPL agent) is bumped to the same `fe29fe5` image. This is a **pure superset** for that agent: the NVMe-health collector is opt-in via `THERMALSCOPE_NVME_HEALTH`, which is **not** set on that DaemonSet, so its behavior is identical to `096a780`. It stays on hostPort 9102 (no collision with the smart-agent's 9103). Tag is strictly newer.

## Validation

`kustomize build` passes for:
- `apps/production/thermalscope-smart` ✅
- `apps/production` ✅
- `infra/configs` ✅

Rendered **prod** DaemonSet verified: `privileged: true`, host `/dev` → `/host/dev` (readOnly), `hostPort 9103`, image `fe29fe5@sha256:ef85dd99…`, namespace `thermalscope`, `THERMALSCOPE_LOG_LEVEL=info`. Label-clobber check passes — the smart base does **not** inherit the thermalscope base's `component: agent` label; pod/DS/Service all carry `component: smart-agent` and the Service selector matches the pod labels. No plaintext secrets in the diff.

> Note: the prod overlay deliberately does **not** re-declare the `thermalscope` Namespace — the existing `apps/production/thermalscope` overlay already owns it (PSA `enforce=privileged`). Two overlays emitting `Namespace/thermalscope` collide in the `apps/production` build; the smart overlay only sets the `namespace:` field.

## ⚠ Before merging

**Close PR #967 (the staging-verify PR) before/at merge** so the staging smart-agent is torn down. Otherwise a **staging** (`thermalscope-stage`) and **prod** (`thermalscope`) smart-agent would both bind **hostPort 9103 on the same physical Talos nodes** = the **#676 hostPort collision** that wedges pods Pending. This PR does not (and must not) touch PR #967 — the human closes it at merge time.

## Recommended follow-ups (NOT in this PR)

- A thermalscope **code change** to surface per-device NVMe read failures above Debug (or add a `thermalscope_nvme_read_errors_total` counter), so a future ioctl failure isn't invisible at the prod `info` log level.
- The **dashboard re-flow + NVMe wear row** (deferred from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
