### PR TITLE
feat(mosquitto): MQTT broker auth + LAN LB for presence nodes (Commit A scaffold)

### DIFF
--- a/infra/controllers/mosquitto/configmap.yaml
+++ b/infra/controllers/mosquitto/configmap.yaml
@@ -8,6 +8,13 @@ data:
     persistence true
     persistence_location /mosquitto/data/
     listener 1883
-    # Allow anonymous for internal subnet, or user/pass.
-    # For simplicity in homelab internal cluster:
+    # --- Commit A (this PR): broker accepts authenticated clients, anonymous
+    # still allowed. Additive/safe — z2m + HA keep connecting anonymously while
+    # the new ESP32 nodes authenticate. (mounted from the mosquitto-auth Secret) ---
+    password_file /mosquitto/auth/passwordfile
     allow_anonymous true
+    # --- Commit B (LATER, flag-day — do via the two-commit interlock in the
+    # presence plan P2, after EVERY client has creds; enabling acl_file restricts
+    # anonymous clients, so this is NOT additive): ---
+    #   acl_file /mosquitto/auth/acl
+    #   allow_anonymous false

--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -44,12 +44,18 @@ spec:
             - name: config
               mountPath: /mosquitto/config/mosquitto.conf
               subPath: mosquitto.conf
+            - name: auth
+              mountPath: /mosquitto/auth
+              readOnly: true
             - name: data
               mountPath: /mosquitto/data
       volumes:
         - name: config
           configMap:
             name: mosquitto-config
+        - name: auth
+          secret:
+            secretName: mosquitto-auth
         - name: data
           persistentVolumeClaim:
             claimName: mosquitto-data-pvc

--- a/infra/controllers/mosquitto/kustomization.yaml
+++ b/infra/controllers/mosquitto/kustomization.yaml
@@ -5,4 +5,8 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - service.yaml
+  - service-lb.yaml
+  # SOPS-encrypted; operator-created from secret-mqtt-auth.yaml.example
+  # (validate-kustomize fails until it exists — the intended gate).
+  - secret-mqtt-auth.yaml
   - storage.yaml

--- a/infra/controllers/mosquitto/secret-mqtt-auth.yaml
+++ b/infra/controllers/mosquitto/secret-mqtt-auth.yaml
@@ -1,0 +1,43 @@
+# Template for the mosquitto auth Secret. OPERATOR-CREATED, SOPS-encrypted:
+#   1. cp secret-mqtt-auth.yaml.example secret-mqtt-auth.yaml
+#   2. generate the password hashes (mosquitto_passwd PBKDF2 format):
+#        docker run --rm -it eclipse-mosquitto sh -c '
+#          mosquitto_passwd -c -b /tmp/pw zigbee2mqtt  <pass> && \
+#          mosquitto_passwd    -b /tmp/pw homeassistant <pass> && \
+#          mosquitto_passwd    -b /tmp/pw espresense    <pass> && \
+#          mosquitto_passwd    -b /tmp/pw mmwave        <pass> && cat /tmp/pw'
+#      paste those 4 lines into `passwordfile` below.
+#   3. sops -e -i secret-mqtt-auth.yaml
+#   4. add `secret-mqtt-auth.yaml` to kustomization.yaml resources (it is already
+#      referenced there — CI/validate-kustomize fails until the real file exists,
+#      which is the intended gate).
+#
+# Four clients (see plan P2): zigbee2mqtt, homeassistant, espresense, mmwave.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mosquitto-auth
+  namespace: mosquitto
+type: Opaque
+stringData:
+  #ENC[AES256_GCM,data:2faMHrGMQTy0a9RlbBo1c++uEly+9Wy5IBI1XDEGIlbrtTeQYFwW+TjsqeHI+a6mLqHfmOf3kThaPzagzOpmyNFgiGOAdL9mccEamG7rxpXw,iv:8yVt0+NHNm+RvmxyJWxv9MU7jBe4Iw+JWU6yW66ajSM=,tag:AdCCbFa1dwYCkoN25Ct2Nw==,type:comment]
+  passwordfile: ENC[AES256_GCM,data:czkaguNMnI5B4eVNUnCtRDTeyJFm3dyl2XL161lUwOmpP5tvqhPlT3IzCCubBCdbm85B3WF7FcT4Uk37ThqbIDpx2wVx+wY4+3IRPl07a1T/o80EwOsj1ltvkHRuAY6q6OYymxDlNBgm4HC3YXXKXuzbiVv80SnL/6BZuj27Xs/uPrNJ2qWkJj8e4HZ54F1HRm8pD/dzbWeFMWe0XUluDCnk82/DptFGyOaHr5yjaQp8177/BTgHsq7tB4jSPHSfqsDCxfBg1mGvCmDOcOkRw99OSdZVys1ozeyNrnNgg0KyPVReDWdmGqOKcx+1YnJKdFjAYx32S6V9VDsaBQOC9evqYhpRBCR0J6g0CLsb/YoaL83kcbQbo7OomVJbLi2hPuKjAy8bIihE91yCKZhWqyx0S6v7ogd+GaZ2MScrYCo3A2aBSzf0z9zzBGs9pZytJyGGB7QEBPNWEorI++PRem8uwG7nTME0U24XEfX8tGrk/HKTchSpxqXYFiLovlLXSpBH7/V3j60zEuYWc3buh8OVfL1puY49szpyYnBUcQnWpU1wcPHhreUCaMMhIRyzTlgOpz5d0vU964av27a2Tklxa9uZojiBs57HcRqJEikwXf9lWGxuch+TF2duYKC1NVrmiDJgELzsXV4neYpWx4jG6zrfv6Uqcnj1vYANI1zAD3J5asLLP+OrxgkBcFHDAb4A4Ql22WxW39OgQbb4SP+buhuSVKYlZ9Ysqutnd9C1n6vF6P8yUdgBWU5G3B0ZVRDvdOICgJaD7H6+X494OA9B4uz51xUKEk0qq9K1on9xfZmXBWvyWJjBfuzjKt81Y/NlkXCI3emLnVhUM7RSs+LPIDsqbVa6Stb9dyGbHu0MwFwkL3bqL4vR4zG5ta5Nsf8q95SlP9MojwoqgZRHUp4QskjnvTIMSF8K+9uKuiMR9Thawrgu99l1uQ2dVtljSod513RwBM1e/4MD3zrBQgOXvDGOEf2jt8tHm6FUtKRC8sqW2ge5TyUkknOQLRst/qMocSDlANk4+pGaRTuUTFQvbss=,iv:luWirc8UpqYffjNg5V5Ob4Oo740syk7dHxX5UAwRbEI=,tag:MNVHM0pMx/z+IdfbUMLO1w==,type:str]
+  #ENC[AES256_GCM,data:WNy/WVwCOpoyB3xDoE2/y0JNL5FrYfItzcmD0xBMi5t+Z74/leBwHKxTS04rLtNP2LNYZ6+fDBaniyIHlF1ITUx2yg==,iv:XZIOnom40RWttkJVAYuzHYVBlpDxhs5pkFnYEzFPTk4=,tag:SHzmVJYVbi3H7/FzCAHu8w==,type:comment]
+  #ENC[AES256_GCM,data:UAawGqLqdt/ohtoNW2bEldcJK+cDZgE9O+Qi0tLC68ysSaZhNaLNhWLjDhHElVvdmBZs+/mlTyE8CQfAyGXeXsJY91WcYpGSlHVGfA==,iv:m0i5kT1Klh1l3gKAYmj8tWxoR6F4VOyd4mC6tJrGuTg=,tag:yUBEI2jGzD944lnW2DQYOw==,type:comment]
+  #ENC[AES256_GCM,data:q9TMCI93f47+/EHJAmqKxEnta89eWUleGxdiYzzjgYYggHHrKzG3MD8C8qdR/6Uu0lV/Fzgg95DfEZiSIg0qZeu13b/cnw==,iv:636q2Muo6MfwRcrKwvhA3HqUVpago4JkXMq9hIvedLI=,tag:SGIIMEtwggHnLgIW3BWmyQ==,type:comment]
+  acl: ENC[AES256_GCM,data:rArex3TYjjgXD8LNYHNqAWPK8leK/LR3fnbwyCFs5d2qK35WRxtS7u/BGmZdlZau2TcnYwQ8JTxP8P+lcMQ9KLUkf/zkZ5LMCbUS6/YsPQSqV2ahNm0a7IgkhUun+zvJZbt8IutGNRYI8vsGM9b4nIx0KFN+1/BlG+k85SFl4hfEAuylNgcPifF8sYqIf5B7tLg6auMRTcQ6B/helSizlw7FihsjlWHOhbxZFWUNBlbtmvCA4DebtrrJtJlExJKuAVLR5Eme3NhQgEg/gS5vLaZzM3VMxPfQtW4yaFnvEo0DulB8ofoQTtp7/TYmoFSHxjbFWeyzL2wQot3B0JfMcSgiOkYYxch93w==,iv:o5o4wLIgq/UTB+qXri7JUtTlR+KR//tbj006NhCdbvE=,tag:T7EVApAj62jcEQeH5j1Eww==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvaUx6RXR5NmVlaGkrMVBT
+        NW1EaG9jdDkvZEkrL3p5LzQxTXo4bTJ3QVFnCjQxM1dPZER1dmsvbk4zS2V6OHBT
+        M0xTUzg0MGF2TWdPdkVkMkdRZjF1bjAKLS0tIEVjTmZ0bmY1T1g5STAremMwVUNR
+        NnhNNHdPd3lueExDM2hoSHBPS08vd2sKC+2roLpZzZ3JvVGIVKzAtju2s8Gii+x3
+        GCLOyBkCuANMiAD2ZCbJ7WtQXeHk3IQKYHcqaNA6F8daCwvtNXwATA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-25T00:46:15Z"
+  mac: ENC[AES256_GCM,data:pljxBKO7facO36pRt0ykPZtd/lxbYBEYAZqV7nM0SsSqSy+sgPmTcksJZV12nZeebTuB1smZRuTOANuZNWjNUvtlHcOi08zEd9en2bt+kFwJoJjA9GoRgzftLtF3sKRC9J5sI4kI0r1i5nTbz8WtsmzlGZIZ99ho5K7h0pRXQPo=,iv:FZbaUfsG+e49kZKvvA6m9zW07v0d2NwXevqfeWlpndI=,tag:smQkmBFLGX111xTZWB5Bjg==,type:str]
+  version: 3.13.1

--- a/infra/controllers/mosquitto/secret-mqtt-auth.yaml.example
+++ b/infra/controllers/mosquitto/secret-mqtt-auth.yaml.example
@@ -1,0 +1,46 @@
+# Template for the mosquitto auth Secret. OPERATOR-CREATED, SOPS-encrypted:
+#   1. cp secret-mqtt-auth.yaml.example secret-mqtt-auth.yaml
+#   2. generate the password hashes (mosquitto_passwd PBKDF2 format):
+#        docker run --rm -it eclipse-mosquitto sh -c '
+#          mosquitto_passwd -c -b /tmp/pw zigbee2mqtt  <pass> && \
+#          mosquitto_passwd    -b /tmp/pw homeassistant <pass> && \
+#          mosquitto_passwd    -b /tmp/pw espresense    <pass> && \
+#          mosquitto_passwd    -b /tmp/pw mmwave        <pass> && cat /tmp/pw'
+#      paste those 4 lines into `passwordfile` below.
+#   3. sops -e -i secret-mqtt-auth.yaml
+#   4. add `secret-mqtt-auth.yaml` to kustomization.yaml resources (it is already
+#      referenced there — CI/validate-kustomize fails until the real file exists,
+#      which is the intended gate).
+#
+# Four clients (see plan P2): zigbee2mqtt, homeassistant, espresense, mmwave.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mosquitto-auth
+  namespace: mosquitto
+type: Opaque
+stringData:
+  # mosquitto password_file (used in Commit A — additive, anonymous still allowed)
+  passwordfile: |
+    zigbee2mqtt:$7$REPLACE_WITH_mosquitto_passwd_HASH
+    homeassistant:$7$REPLACE_WITH_mosquitto_passwd_HASH
+    espresense:$7$REPLACE_WITH_mosquitto_passwd_HASH
+    mmwave:$7$REPLACE_WITH_mosquitto_passwd_HASH
+  # mosquitto acl_file (used only in Commit B — the flag-day flip to
+  # allow_anonymous false; enabling acl_file restricts anonymous clients, so do
+  # it via the plan's two-commit interlock after every client has creds).
+  acl: |
+    user zigbee2mqtt
+    topic readwrite zigbee2mqtt/#
+    topic readwrite homeassistant/#
+
+    user homeassistant
+    topic readwrite #
+
+    user espresense
+    topic readwrite espresense/#
+    topic readwrite homeassistant/#
+
+    user mmwave
+    topic readwrite mmwave/#
+    topic readwrite homeassistant/#

--- a/infra/controllers/mosquitto/service-lb.yaml
+++ b/infra/controllers/mosquitto/service-lb.yaml
@@ -1,0 +1,26 @@
+# LoadBalancer Service exposing mosquitto's MQTT port to the LAN, for the
+# off-cluster ESP32 presence nodes (ESPresense scanners + ESPHome mmWave) on the
+# IoT VLAN. HA + zigbee2mqtt keep using the in-cluster ClusterIP `mosquitto`
+# Service (no change). A dedicated LB IP from home-c-pool; the worker BGP peering
+# to the UCGF makes the /32 routable from the IoT VLAN (a UCGF firewall allow
+# 10.42.7.0/24 -> <this IP>:1883 is still required — see the presence plan P2).
+#
+# NOTE: until the broker has auth (Commit B in the plan), keep the IoT->1883
+# firewall CLOSED — this LB IP must not expose an anonymous broker to the LAN.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto-lb
+  namespace: mosquitto
+  labels:
+    app: mosquitto
+  annotations:
+    lbipam.cilium.io/ip-pool: home-c-pool
+spec:
+  type: LoadBalancer
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: mqtt
+  selector:
+    app: mosquitto


### PR DESCRIPTION
**Draft** — critical-path infra prep for the BLE presence system (plan P2). Operator-gated; do not merge yet.

## What (additive, safe even when applied)
- **`service-lb.yaml`** — a dedicated LoadBalancer IP from `home-c-pool` exposing `:1883` for the off-cluster ESP32 nodes on the IoT VLAN. HA + zigbee2mqtt **keep** the in-cluster ClusterIP (no netpol change).
- **`secret-mqtt-auth.yaml.example`** — SOPS template for the **4 MQTT clients'** password file + ACL (`zigbee2mqtt`, `homeassistant`, `espresense`, `mmwave`), with the `mosquitto_passwd` generation steps.
- **configmap/deployment** — **Commit A** wiring: `password_file` + the mounted auth secret, **`allow_anonymous` still `true`** → z2m/HA unaffected, new nodes can authenticate. The `acl_file` + `allow_anonymous false` flip is left **commented as Commit B** (the flag-day — enabling `acl_file` restricts anonymous clients, so it's NOT additive and must go through the plan's two-commit interlock).

## Why it's a draft / red CI
`kustomize build infra/controllers` fails on the missing real `secret-mqtt-auth.yaml` — the intended gate (your #945 pattern). Verified: with the secret present, the LB service + `password_file` + auth mount render and `allow_anonymous` stays `true`.

## Operator steps before merge
1. Create + SOPS-encrypt `secret-mqtt-auth.yaml` from the `.example` (generate the 4 password hashes).
2. Keep the **IoT→:1883 firewall closed** until Commit B (don't expose an anonymous broker to the LAN).
3. Review, then merge. Commit B (acl + flip + wire all clients to creds) is a later, careful step — ideally rehearsed against a staging broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)