### PR TITLE
fix(cilium): point k8sServiceHost at Talos KubePrism (remove control-plane SPOF)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,14 +5,14 @@
 > this page links out. **Update this file in the same PR whenever** a plan's
 > status changes, an incident postmortem lands, or hardware/topology changes.
 >
-> Last updated: 2026-06-19
+> Last updated: 2026-06-24
 
 ## Cluster at a glance
 
 | | |
 |---|---|
 | Cluster | `melodic-muse` |
-| Nodes | 4 — 3 control-plane (`.20`/`.21`/`.23`) + 1 worker (`.25`); `.22`/`.24` physically out (see Known issues) |
+| Nodes | 4 — 3 control-plane (`.20`/`.21`/`.23`) + 1 worker (`.25`); **`.20` hung since 2026-06-21** (etcd at 2/3) and `.22`/`.24` physically out (see Known issues) |
 | Platform | Talos v1.12.4 · Kubernetes v1.35.0 |
 | CNI / ingress | Cilium 1.19 (VXLAN) + Gateway API |
 | GitOps | Flux CD, reconciling from `master` |
@@ -57,5 +57,6 @@ Planned, not yet started:
 - **No on-prem LLM inference.** The 2× RTX 4090 were sold 2026-05-16. The `llms/` and GPU-`monitoring/` Custom Apps on hestia are archived. Restoring inference needs new GPU hardware or a hosted-API backend.
 - **`hermes` / `hermes-callee` (Signal bots) and `signal-cli` decommissioned 2026-06-17.** Removed from `apps/{base,production,staging}/` and garbage-collected by Flux (`prune: true`). They had no model backend after the GPUs were sold and were already scaled to 0. Signal-based critical-alert routing is dead as a result — see the obsoleted Phase 2 in [plans/2026-05-09-monitoring-enhancement.md](plans/2026-05-09-monitoring-enhancement.md).
 - **`.22` (talos-v2l-hng) decommissioned 2026-06-19** — bad DIMM (reads 30.6 GiB vs ~62), did not return after the 2026-06-18 maintenance. Removed from etcd and the cluster; **`.23` was promoted to control-plane in its place**, restoring fault-tolerant 3-member etcd (now a 4-node cluster). See the [control-plane promotion runbook](operations/2026-06-19-talos-controlplane-promotion.md) and [plan/execution record](plans/2026-06-19-promote-talos-25-to-controlplane.md). `.22` hardware verdict (DIMM/board/RMA) and `.24` re-entry still pending. **Topology (verified 2026-06-19):** all 4 nodes share one **Rack Switch (USWED42)** and one **USP PDU Pro** (separate outlets) — so the switch + PDU are **accepted single points of failure** (a 3-member etcd survives a node/outlet loss, not a whole-switch/PDU loss). Highest-value mitigation: put the Rack Switch + PDU on a UPS.
+- **`.20` (talos-ykb-uir) hung 2026-06-21 21:16 UTC → cluster-wide DNS outage via a Cilium `k8sServiceHost` SPOF** (diagnosed/mitigated 2026-06-24). The node pings but `apid`/`kubelet` are stuck (no TLS handshake), so `talosctl` can't reach it — recovery needs a **physical power-cycle** (no BMC; mind the `.20/.21` shared switch/PDU). Cilium had `k8sServiceHost: 10.42.2.20` pinned, so losing that node killed cilium-operator → CoreDNS → every DNS-dependent service. **Mitigated live:** Cilium HelmRelease **suspended** and operator/agent `KUBERNETES_SERVICE_HOST` repointed to `.21`. Permanent fix (Talos KubePrism, `localhost:7445`) is in an open PR — **do not resume the suspended Cilium HelmRelease until it merges**, or Flux will re-apply the SPOF. Full postmortem: [incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md](operations/incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md).
 - **CNPG WAL archiving** broken on several staging clusters (stale system-ID in S3) — base backups succeed, but no PITR until fixed.
 - **LB pool / Lab-VLAN `/24` sharing** is the root cause of the 2026-05-05 wired-device incident; the dedicated LB subnet migration is tracked in the network-resilience plan (Phase D).

--- a/docs/operations/incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md
+++ b/docs/operations/incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md
@@ -1,0 +1,109 @@
+# Incident: Control-Plane Node Hang Cascades to Cluster-Wide DNS Outage via Cilium `k8sServiceHost` SPOF
+
+**Date:** 2026-06-24 (trigger 2026-06-21)
+**Status:** Mitigated (live patch); permanent fix in this PR
+**Severity:** High — cluster-wide DNS down; storage, databases, and most apps unavailable
+**Duration:** ~2.5 days undetected (node hung 2026-06-21 21:16 UTC → diagnosed/mitigated 2026-06-24 ~05:00 UTC)
+**Environments affected:** Whole cluster (`melodic-muse`)
+**Authors:** George Courtois
+
+---
+
+## Summary
+
+Control-plane node `talos-ykb-uir` (`10.42.2.20`) hung at the OS level on
+**2026-06-21 21:16 UTC**. The node still answered ICMP and accepted TCP, but its
+`kubelet` stopped posting status and Talos `apid` could no longer complete a TLS
+handshake (even routed through a healthy node) — i.e. `machined`/`apid` were stuck,
+not just unreachable.
+
+A single dead node should be a non-event on a 3× control-plane cluster. Instead it
+took out cluster DNS and cascaded to storage, databases, and nearly every app —
+because **Cilium was pinned to that node's apiserver** (`k8sServiceHost: 10.42.2.20`).
+
+## Impact
+
+- `cilium-operator` crashlooping on every healthy node (dialing `https://10.42.2.20:6443`).
+- `CoreDNS` 0/2 ready — both new replicas failed readiness (`dial 10.96.0.1:443: i/o timeout`),
+  so `kube-dns` had **zero endpoints** → cluster DNS dead.
+- With no DNS backend, Cilium rejected traffic to `10.96.0.10:53`
+  (`connect: operation not permitted`), so everything that resolves a name failed:
+  democratic-csi (`getaddrinfo EAI_AGAIN truenas-api-proxy...`), cloudflared, the CNPG
+  operator, Flux `source-controller`, cert-manager, and all DB-backed apps (immich,
+  golinks, flashcards, linkding, home-assistant, …).
+- ~57 pods stuck `Terminating` on the dead node (kubelet gone, deletion unconfirmable).
+- etcd ran at **2/3 quorum** the entire window — healthy but fragile (losing `.21` or
+  `.23` would have been a full outage).
+
+## Root cause
+
+Two layers:
+
+1. **Trigger:** `.20` hung hard (resource/IO stall or kernel-level hang). Because
+   `apid` was unresponsive, `talosctl reboot/shutdown/reset` could not work — recovery
+   requires a physical power-cycle (the Talos nodes have no BMC/IPMI; only hestia does).
+
+2. **Why one node became a cluster-wide outage (the real bug):** Cilium runs *beneath*
+   Kubernetes Service networking, so it cannot reach the API via the `kubernetes`
+   ClusterIP (`10.96.0.1`) — it needs a direct apiserver address (`k8sServiceHost`).
+   That value was hardcoded to a single control-plane node, `10.42.2.20`, making that
+   node a single point of failure for the CNI, and therefore for DNS and everything
+   downstream. (`docs/architecture/networking/addressing.md` already annotated `.20` as
+   the "`k8sServiceHost` SPOF" — known risk, unmitigated.)
+
+## Mitigation (live, already applied)
+
+1. Suspended the Cilium HelmRelease so Flux would not revert the patch:
+   `kubectl -n kube-system patch helmrelease cilium --type merge -p '{"spec":{"suspend":true}}'`
+2. Repointed Cilium to a healthy apiserver:
+   `kubectl -n kube-system set env deploy/cilium-operator KUBERNETES_SERVICE_HOST=10.42.2.21`
+   `kubectl -n kube-system set env ds/cilium KUBERNETES_SERVICE_HOST=10.42.2.21`
+
+DNS recovered within ~1 minute (operator healthy, CoreDNS 2/2, kube-dns endpoints
+populated), and the cascade cleared (CSI 6/6, CNPG operator up, Flux/cloudflared up,
+databases back). `kubectl`/`talosctl` were also repointed to `.21` for the duration
+(both configs still target the dead `.20`).
+
+## Permanent fix (this PR)
+
+Point `k8sServiceHost` at **Talos KubePrism** instead of any node IP:
+
+```yaml
+k8sServiceHost: "localhost"
+k8sServicePort: "7445"
+```
+
+KubePrism runs on every node (loopback `127.0.0.1:7445`), load-balances across all
+control-plane apiservers, and health-checks dead ones out. Verified enabled and
+`healthy: true` on `.21` and `.23` at mitigation time
+(`talosctl get kubeprismstatus`), with all apiservers as upstreams — so no Talos
+machine-config change is required. After this merges and reconciles, any single
+control-plane node can hang without affecting Cilium, DNS, or apps.
+
+## Follow-up / restore checklist
+
+- [ ] Merge this PR; let Flux reconcile the Cilium HelmRelease values.
+- [ ] **Resume the Cilium HelmRelease** (`flux resume hr cilium -n kube-system` /
+      unset `spec.suspend`) — it is suspended right now; do not resume *before* this
+      merges or Flux will re-apply `k8sServiceHost: 10.42.2.20` and re-break the cluster.
+      The resume will roll the agents/operator onto the KubePrism value, superseding the
+      live `set env` patch.
+- [ ] Power-cycle `.20` (physical — no BMC). Mind the `.20/.21` shared switch/PSU path;
+      quorum is 2/3, so do not drop `.21` with it. On boot it rejoins etcd (→ 3/3) and
+      the ~57 `Terminating` zombie pods clear.
+- [ ] Repoint local `~/.kube/config` and `~/.talos/config` off `.20` (or to a VIP).
+- [ ] Investigate `.20`'s hang root cause on next boot: BMC/SEL log, BIOS/POST memory
+      training, dmesg — see `docs/operations/2026-06-17-talos-node-maintenance.md`.
+      (`.22` was previously decommissioned for a bad DIMM; watch for recurrence.)
+
+## Lessons
+
+- **Never pin a CNI's apiserver endpoint to a single node.** Use Talos KubePrism
+  (`localhost:7445`) or a control-plane VIP. A documented "SPOF" annotation is a bug to
+  fix, not a label to keep.
+- **`kubeconfig`/`talosconfig` pointing at a single node IP is its own fragility** —
+  losing that node looks like a total outage from the workstation even when the cluster
+  is up. Prefer a VIP / multiple endpoints.
+- A NotReady node whose `apid` won't handshake cannot be recovered via `talosctl`;
+  without a BMC, that means physical access. Out-of-band management for the cluster
+  nodes would have turned a 2.5-day outage into a remote reboot.

--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -103,14 +103,19 @@ l2announcements:
 bgpControlPlane:
   enabled: true
 
-# -- (string) Kubernetes service host - use "auto" for automatic lookup from the cluster-info ConfigMap
-k8sServiceHost: "10.42.2.20"
+# -- (string) Kubernetes service host. Points at Talos KubePrism — the per-node API
+# load balancer listening on localhost:7445 that fans out to every control-plane
+# apiserver and health-checks dead ones out. This must NOT be a single control-plane
+# node IP: pinning "10.42.2.20" here made that node a SPOF — when it hung on
+# 2026-06-21 the cilium-operator/agents lost the apiserver cluster-wide, which took
+# down CoreDNS and cascaded to storage/DBs/apps. KubePrism survives any single CP loss.
+# See docs/operations/incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md
+k8sServiceHost: "localhost"
 # @schema
 # type: [string, integer]
 # @schema
-# -- (string) Kubernetes service port
-# k8sServicePort: "7445"
-k8sServicePort: "6443"
+# -- (string) Kubernetes service port — Talos KubePrism (machine.features.kubePrism.port)
+k8sServicePort: "7445"
 # @schema
 # type: [null, string]
 # @schema


### PR DESCRIPTION
## Summary

Removes the single point of failure that turned a hung control-plane node into a cluster-wide outage on 2026-06-21.

Cilium runs *beneath* Kubernetes Service networking, so it needs a direct apiserver address (`k8sServiceHost`) rather than the `kubernetes` ClusterIP. That value was hardcoded to one control-plane node (`10.42.2.20`). When `.20` hung, `cilium-operator` and the agents lost the apiserver on every node → CoreDNS went 0/2 → cluster DNS died → democratic-csi, CNPG, cloudflared, Flux, and ~all apps cascaded down. (`docs/architecture/networking/addressing.md` already flagged `.20` as the "`k8sServiceHost` SPOF".)

This points `k8sServiceHost` at **Talos KubePrism** (`localhost:7445`) — the per-node apiserver load balancer that fans out to all control-plane apiservers and health-checks dead ones out — so no single control-plane node can cause this again.

- `infra/controllers/cilium/values.yaml`: `k8sServiceHost: localhost`, `k8sServicePort: "7445"`
- `docs/operations/incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md`: full postmortem
- `docs/STATUS.md`: known-issue entry + node status

KubePrism verified **enabled and `healthy: true` on `.21`/`.23`** at mitigation time (`talosctl get kubeprismstatus`), with all apiservers as upstreams — so no Talos machine-config change is required.

## ⚠️ Merge / deploy ordering (important)

The Cilium HelmRelease is **currently suspended** in the live cluster (emergency mitigation: operator + agent `KUBERNETES_SERVICE_HOST` were `set env` to `10.42.2.21`). After this merges:
1. Let Flux reconcile the new values.
2. **Resume** the HelmRelease: `flux resume hr cilium -n kube-system` — this rolls Cilium onto the KubePrism value and supersedes the live patch.

Do **not** resume the HelmRelease before this merges, or Flux re-applies `k8sServiceHost: 10.42.2.20` and re-breaks DNS.

Node `.20` still needs a physical power-cycle (no BMC; mind the `.20/.21` shared switch/PDU) — tracked in the incident doc, independent of this PR.

## Test plan
- [x] `kustomize build infra/controllers` passes
- [x] KubePrism confirmed enabled + `healthy: true` on `.21`/`.23`
- [x] No plaintext secrets in diff
- [ ] Post-merge: Flux reconciles → resume HelmRelease → confirm `cilium-operator` + CoreDNS healthy on KubePrism, then power-cycle `.20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)