### PR TITLE
fix(monitoring): durable + HA Loki & Prometheus (.20 incident remediation)

### DIFF
--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -3984,9 +3984,11 @@ prometheus:
     ## on scaling down and deleting statefulset, respectively.
     ## Requires Kubernetes version 1.27.0+.
     ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
-    persistentVolumeClaimRetentionPolicy: {}
-    #  whenDeleted: Retain
-    #  whenScaled: Retain
+    # Keep the TSDB PVC on scale-down/delete so metrics history survives pod
+    # churn (matches the Loki footgun fix in this PR).
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
 
     ## If true, pass --storage.tsdb.max-block-duration=2h to prometheus. This is already done if using Thanos
     ##
@@ -4333,8 +4335,10 @@ prometheus:
 
     ## Number of replicas of each shard to deploy for a Prometheus deployment.
     ## Number of replicas multiplied by shards is the total number of Pods created.
-    ##
-    replicas: 1
+    ## HA: 2 independent replicas so a single node hang (e.g. the 2026-06-21 .20
+    ## outage) can't strand the only Prometheus and black out all metrics. Each
+    ## replica is a full copy with its own PVC; Grafana queries via the Service.
+    replicas: 2
 
     ## EXPERIMENTAL: Number of shards to distribute targets onto.
     ## Number of replicas multiplied by shards is the total number of Pods created.
@@ -4416,8 +4420,17 @@ prometheus:
 
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/platform/storage.md
-    ##
-    storageSpec: {}
+    ## Durable TSDB: was emptyDir, so every restart wiped all history (the 10d
+    ## retention was never real) and a node hang lost the in-memory data. Each of
+    ## the 2 replicas gets its own 30Gi iSCSI PVC (sized for ~10d retention).
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: truenas-iscsi
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 30Gi
     ## Using PersistentVolumeClaim
     ##
     #  volumeClaimTemplate:

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -4316,9 +4316,11 @@ prometheus:
     ##
     retention: 10d
 
-    ## Maximum size of metrics
-    ##
-    retentionSize: ""
+    ## Maximum size of metrics. Backstop for the 20Gi PVC: TSDB self-trims at
+    ## 15GiB (~75% of the volume), leaving headroom for WAL + compaction so a
+    ## metrics spike can't fill the disk. Whichever of retention(10d)/15GiB hits
+    ## first wins.
+    retentionSize: "15GiB"
 
     ## Allow out-of-order/out-of-bounds samples ingested into Prometheus for a specified duration
     ## See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tsdb
@@ -4422,7 +4424,8 @@ prometheus:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/platform/storage.md
     ## Durable TSDB: was emptyDir, so every restart wiped all history (the 10d
     ## retention was never real) and a node hang lost the in-memory data. Each of
-    ## the 2 replicas gets its own 30Gi iSCSI PVC (sized for ~10d retention).
+    ## the 2 replicas gets its own 20Gi iSCSI PVC (40Gi total). retentionSize
+    ## below caps the TSDB at 15GiB so it self-trims before filling the volume.
     storageSpec:
       volumeClaimTemplate:
         spec:
@@ -4430,7 +4433,7 @@ prometheus:
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 30Gi
+              storage: 20Gi
     ## Using PersistentVolumeClaim
     ##
     #  volumeClaimTemplate:

--- a/infra/controllers/loki/values.yaml
+++ b/infra/controllers/loki/values.yaml
@@ -10,9 +10,12 @@ loki:
   limits_config:
     ingestion_rate_mb: 16
     ingestion_burst_size_mb: 32
-    # Retain logs for 30 days then delete via the compactor. Without this,
-    # chunks accumulate indefinitely and the PVC fills up.
-    retention_period: 30d
+    # Retain logs for 7 days then delete via the compactor. 30d did NOT fit the
+    # 40Gi filesystem PVC — it filled to 100%, which wedges Loki (a full disk
+    # means it can't start, so the compactor can't run to free space → permanent
+    # CrashLoop). 7d holds ~24Gi (~60%) in practice. With filesystem storage,
+    # retention MUST be sized to the PVC. See the 2026-06-24 incident doc.
+    retention_period: 7d
   commonConfig:
     replication_factor: 1
   storage:
@@ -56,6 +59,11 @@ singleBinary:
     enabled: true
     storageClass: truenas-iscsi
     size: 40Gi
+    # Do NOT auto-delete the data PVC when the StatefulSet is scaled down or
+    # deleted. The chart default deletes it (whenScaled/whenDeleted: Delete),
+    # so a routine `scale --replicas=0` destroys the log archive. The PV is
+    # Retain, so it's recoverable, but that's a footgun — keep the PVC.
+    enableStatefulSetAutoDeletePVC: false
   resources:
     limits:
       memory: 2Gi


### PR DESCRIPTION
## Summary

Two resilience gaps the 2026-06-21 `.20` control-plane hang exposed in the monitoring stack. Both are single-PVC/single-replica footguns.

### Loki (`infra/controllers/loki/values.yaml`)
- **`retention_period: 30d → 7d`** — Loki uses *filesystem* storage on one 40 Gi PVC. 30 d didn't fit; it filled to 100%, and a full disk **wedges** Loki (can't start → compactor can't run → can't free space → permanent CrashLoop). 7 d holds ~24 Gi (~60%). With filesystem storage, retention must be sized to the PVC.
- **`enableStatefulSetAutoDeletePVC: false`** — the chart default deletes the data PVC on scale-down/delete, so a routine `scale --replicas=0` destroys the log archive (hit this during cleanup; only recoverable because the PV is `Retain`).

### Prometheus (`infra/controllers/kube-prometheus-stack/values.yaml`)
- **`replicas: 1 → 2`** — it was a single replica on **emptyDir**, so it was a SPOF for *all* metrics: stranded on the hung `.20` it black-holed every dashboard for the whole outage (a StatefulSet pod can't reschedule off a `NotReady` node), and every restart wiped history (the 10 d retention was never real).
- **`storageSpec`: emptyDir → 20 Gi `truenas-iscsi` PVC per replica** — durable TSDB.
- **`retentionSize: 15GiB`** — backstop so the TSDB self-trims at ~75% of the 20 Gi volume before it can fill (same lesson as the Loki fill). Whichever of 10 d / 15 GiB hits first wins.
- **`persistentVolumeClaimRetentionPolicy: Retain`** — don't nuke the TSDB on scale/delete.

## ⚠️ Impact / things to know
- **Resource/storage:** Prometheus goes to **2 pods + 2× 20 Gi iSCSI PVCs (40 Gi total)**. Confirm the TrueNAS pool has room.
- **Rollout:** the kube-prometheus-stack HelmRelease upgrade recreates the Prometheus StatefulSet with the new storage — the current emptyDir history is discarded (expected; it's ephemeral anyway).
- **Not a missing alert:** the PVC-fill alert already exists (`KubePersistentVolumeFillingUp`) — it almost certainly fired for Loki. The real gap is **alert *delivery*** (routes to `null` since Signal was decommissioned). Restoring a notification channel is a separate decision and is **not** in this PR.

## Test plan
- [x] `kustomize build infra/controllers` passes
- [x] Both values files are valid YAML
- [x] No plaintext secrets
- [ ] Post-merge: Loki stays <80% on 7 d; Prometheus comes up `2/2` with bound 20Gi PVCs and survives a node drain without a metrics gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)