### PR TITLE
fix(kube-prometheus-stack): disable kubeProxy scraping (Cilium kube-proxy replacement)

### DIFF
--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -2369,9 +2369,15 @@ kubeScheduler:
     targetLabels: []
 
 ## Component scraping kube proxy
+## Disabled: this cluster uses Cilium kube-proxy replacement
+## (cilium-config kube-proxy-replacement=true), so no kube-proxy runs. Leaving
+## this enabled ships a scrape target (:10249) that can never have endpoints and
+## the KubeProxyDown rule, which then fires perpetually as a critical false
+## positive (re-armed on every Prometheus restart). Disabling removes both the
+## ServiceMonitor and the rule at the source. See the 2026-06-24 investigation.
 ##
 kubeProxy:
-  enabled: true
+  enabled: false
 
   ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
   ##


### PR DESCRIPTION
## Summary

`KubeProxyDown` (severity=critical) has been firing as a **false positive**. This cluster runs **Cilium kube-proxy replacement** (`cilium-config: kube-proxy-replacement=true`), so there is no kube-proxy — but kube-prometheus-stack's `kubeProxy` component was enabled, shipping:
- a Service/ServiceMonitor scraping kube-proxy's `:10249` (endpoints **never** populated — 111 days, `absent(up{job="kube-proxy"})==1` across the whole window), and
- the `KubeProxyDown` rule (`absent(up{job="kube-proxy"} == 1)`, `for: 15m`, critical).

It surfaced *today* only because the Helm upgrade recreated both Prometheus pods (~14:30 UTC), resetting the rule's `for:` timer → re-fired at 14:45. Now that critical alerts route to email, the long-standing false positive became noisy.

**Fix:** `kubeProxy.enabled: false` — removes both the scrape target **and** the `KubeProxyDown` rule at the source (not a silence). Safe: there is no kube-proxy to monitor, so nothing legitimate is lost. Standard fix for Cilium-replacement clusters.

## Test plan
- [x] `kustomize build infra/controllers` passes
- [x] Valid YAML, no secrets
- [ ] Post-merge: `KubeProxyDown` clears; `kube-prometheus-stack-kube-proxy` Service/ServiceMonitor and the `kubernetes-system-kube-proxy` PrometheusRule are pruned

🤖 Generated with [Claude Code](https://claude.com/claude-code)