### PR TITLE
docs(plans): mark control-plane VIP plan complete (executed)

### DIFF
--- a/docs/plans/2026-06-24-control-plane-vip-stable-endpoint.md
+++ b/docs/plans/2026-06-24-control-plane-vip-stable-endpoint.md
@@ -1,12 +1,12 @@
 ---
-status: planned
+status: complete
 last_modified: 2026-06-24
-summary: "Add a Talos layer-2 control-plane VIP (10.42.2.26) so kubeconfig/talosconfig reference a floating endpoint instead of hardcoding a single node. talosconfig already fixed client-side (multi-endpoint); this plan covers the operator-led VIP for kubeconfig."
+summary: "EXECUTED 2026-06-24 — Talos layer-2 control-plane VIP 10.42.2.26 live on all 3 CP nodes (etcd-elected); apiserver cert regenerated to include all node IPs + the VIP; kubeconfig and talosconfig cut over to the VIP. Nodes were DHCP (not static as drafted); applied per-node in try-mode with no reboots, etcd 3/3 throughout."
 ---
 
 # Plan: Control-plane VIP for a stable, node-independent API endpoint
 
-**Status:** Planned
+**Status:** ✅ **Executed 2026-06-24.** See the [Execution record](#execution-record-2026-06-24) at the bottom.
 **Date:** 2026-06-24
 **Author:** George (with Claude)
 
@@ -142,3 +142,52 @@ cluster:
 - Confirm `eno1` is the active NIC on `.20` and `.23` too (it is on `.21`; `bond0` is
   down). If any node differs, adjust the `interface:` in the patch for that node.
 - Requires Talos ≥ 1.5 for `machine.network.interfaces[].vip` (cluster is on 1.12 ✓).
+
+## Execution record (2026-06-24)
+
+Executed the same day the plan was written. **VIP `10.42.2.26` is live** on all three
+control-plane nodes, kubeconfig + talosconfig cut over.
+
+### Deviation from the draft
+The draft assumed a **static** `eno1` config to merge the VIP into. In reality
+`machine.network` was **empty `{}`** — the nodes get their IPs via **DHCP**, and
+`apiServer.certSANs` was unset (auto-generated). So the applied patch created the eno1
+entry with `dhcp: true` preserved:
+
+```yaml
+machine:
+  network:
+    interfaces:
+      - interface: eno1
+        dhcp: true
+        vip:
+          ip: 10.42.2.26
+cluster:
+  controlPlane:
+    endpoint: https://10.42.2.26:6443
+  apiServer:
+    certSANs: [10.42.2.26, 10.42.2.20, 10.42.2.21, 10.42.2.23]
+```
+
+### Method actually used
+1. **Network-only VIP patch, per node, in `--mode=try --timeout=5m`** (auto-revert). After
+   each, confirmed the node kept its DHCP IP, stayed reachable, VIP answered ARP, and etcd
+   stayed **3/3**. Order: `.23` → `.20` → `.21` (`.21` kept untouched until `.23`/`.20`
+   were confirmed).
+2. Then applied the **full patch** (VIP + endpoint + certSANs) per node in `--mode=no-reboot`.
+   Because the endpoint/certSANs is a real delta, this committed permanently and cancelled
+   any pending try-revert (verified by the apiserver cert actually regenerating with the
+   new SANs). No reboots; no quorum dip.
+
+### Verification
+- VIP held by `.23` (etcd-elected); configured on all three so it floats.
+- apiserver cert via `10.42.2.26:6443` now lists `IP:10.42.2.20/.21/.23/.26` (+ standard) —
+  also closed the prior gap where `.23` was absent from the cert.
+- `kubectl --server=https://10.42.2.26:6443 get nodes` → all 4 Ready.
+- kubeconfig regenerated to `https://10.42.2.26:6443` (backup at `~/.kube/config.pre-vip.bak`).
+- talosconfig endpoints: `10.42.2.26, .20, .21, .23`.
+
+### Not done / follow-up
+- **No disruptive failover test** (cordon/reboot the VIP holder) was run — the mechanism is
+  proven via the cert/kubectl path, but a hard float test can be done at a convenient window.
+- `~/.kube/config.pre-vip.bak` can be deleted once confident.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -74,11 +74,10 @@ see `scripts/plans-index/`).
 | [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | 2026-05-04 | IaC hardening — close the 22 findings from the 2026-05-02 critique |
 | [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | 2026-06-10 | Navidrome → Mopidy → Snapcast → HifiBerry audio pipeline — draft PR #426 open, not yet on master |
 
-### Planned (8)
+### Planned (7)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
-| [2026-06-24-control-plane-vip-stable-endpoint.md](2026-06-24-control-plane-vip-stable-endpoint.md) | 2026-06-24 | Add a Talos layer-2 control-plane VIP (10.42.2.26) so kubeconfig/talosconfig reference a floating endpoint instead of hardcoding a single node. talosconfig already fixed client-side (multi-endpoint); this plan covers the operator-led VIP for kubeconfig. |
 | [2026-06-21-bluetooth-presence-system.md](2026-06-21-bluetooth-presence-system.md) | 2026-06-21 | BLE beacon presence/occupancy system (ESPresense → HA → Grafana) for who/how-many is home, per-room |
 | [2026-06-16-burntbytes-mailserver.md](2026-06-16-burntbytes-mailserver.md) | 2026-06-16 | Self-hosted mail for burntbytes.com (<10 accounts): Mailu on the cluster + VPS SMTP gateway + SES smarthost |
 | [2026-06-02-immich-vectorchord-migration.md](2026-06-02-immich-vectorchord-migration.md) | 2026-06-10 | Migrate Immich CNPG from pgvecto.rs to VectorChord |
@@ -87,10 +86,11 @@ see `scripts/plans-index/`).
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | 2026-05-03 | Cardboard drawer insert design (75×32×12 cm) — physical project, no repo artifacts |
 | [2026-02-21-linkding-db-restore-plan.md](2026-02-21-linkding-db-restore-plan.md) | 2026-05-03 | Live DR drill: destroy and restore Linkding staging DB (never executed) |
 
-### Complete (18)
+### Complete (19)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-06-24-control-plane-vip-stable-endpoint.md](2026-06-24-control-plane-vip-stable-endpoint.md) | 2026-06-24 | EXECUTED 2026-06-24 — Talos layer-2 control-plane VIP 10.42.2.26 live on all 3 CP nodes (etcd-elected); apiserver cert regenerated to include all node IPs + the VIP; kubeconfig and talosconfig cut over to the VIP. Nodes were DHCP (not static as drafted); applied per-node in try-mode with no reboots, etcd 3/3 throughout. |
 | [2026-06-19-promote-talos-25-to-controlplane.md](2026-06-19-promote-talos-25-to-controlplane.md) | 2026-06-19 | EXECUTED 2026-06-19 — promoted .23 (not .25) to control-plane and removed dead .22, restoring 3-member etcd; cluster now 4 nodes (3 CP + 1 worker) |
 | [2026-06-18-finance-dashboard-multipage.md](2026-06-18-finance-dashboard-multipage.md) | 2026-06-18 | finance.burntbytes.com expanded from one balance-sheet page to a 4-page static site (balance sheet, cash flow, STR model, retirement runway) with encrypted-YAML data + interactive client-side charts |
 | [2026-06-10-docs-reorg-status-dashboard.md](2026-06-10-docs-reorg-status-dashboard.md) | 2026-06-10 | Docs status legibility: plan frontmatter cleanup, generated index, STATUS.md dashboard, HOMELAB.md migration |


### PR DESCRIPTION
Flips `docs/plans/2026-06-24-control-plane-vip-stable-endpoint.md` from `planned` → `complete` and adds an execution record.

The VIP (`10.42.2.26`) was executed the same day: live on all 3 CP nodes (etcd-elected), apiserver cert regenerated to include all node IPs + the VIP, kubeconfig/talosconfig cut over. The record documents the deviation from the draft (nodes were **DHCP**, not static) and the safe per-node **try-mode** method (no reboots, etcd 3/3 throughout).

## Test plan
- [x] `make plans-index-check` passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)