### PR TITLE
fix(mosquitto): mount auth secret keys via subPath, not directory

### DIFF
--- a/infra/controllers/mosquitto/deployment.yaml
+++ b/infra/controllers/mosquitto/deployment.yaml
@@ -44,8 +44,18 @@ spec:
             - name: config
               mountPath: /mosquitto/config/mosquitto.conf
               subPath: mosquitto.conf
+            # Mount each secret key as a real file via subPath, NOT the whole
+            # secret as a directory. A directory mount projects each key as a
+            # symlink (passwordfile -> ..data/passwordfile); mosquitto 2.1.2
+            # refuses to open the symlinked password_file ("Unable to open
+            # pwfile") and crashloops. subPath yields a real file it can open.
             - name: auth
-              mountPath: /mosquitto/auth
+              mountPath: /mosquitto/auth/passwordfile
+              subPath: passwordfile
+              readOnly: true
+            - name: auth
+              mountPath: /mosquitto/auth/acl
+              subPath: acl
               readOnly: true
             - name: data
               mountPath: /mosquitto/data


### PR DESCRIPTION
## Summary
Hotfix for a production outage: after #976 merged, the mosquitto broker
went **CrashLoopBackOff** with `password-file: Error: Unable to open pwfile
"/mosquitto/auth/passwordfile"`, taking down MQTT for **zigbee2mqtt** and
**Home Assistant**.

Root cause: the `auth` secret was mounted as a whole directory at
`/mosquitto/auth`. Kubernetes projects each secret key as a **symlink**
(`passwordfile -> ..data/passwordfile`). mosquitto 2.1.2 will not open the
symlinked `password_file` — the file is readable (confirmed as uid 1883),
but mosquitto's open fails on the symlink. Mounting each key via `subPath`
yields a **real file** mosquitto opens cleanly.

## Validation
- Reproduced and confirmed: read test as uid 1883 succeeds, yet mosquitto
  fails — isolating the symlink as the cause.
- **Live-patched the running deployment to subPath → mosquitto came up
  `1/1 Running`, log `mosquitto version 2.1.2 running`, no pwfile error.**
  z2m/HA MQTT restored. This PR codifies that live fix so Flux doesn't
  revert it.

## Test plan
- [x] `kustomize build infra/controllers` passes
- [x] mosquitto pod Ready with the subPath mount (validated live)
- [ ] Flux reconcile matches the live state (no rollout churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)