### PR TITLE
feat(homeassistant): add ESPresense mqtt_room presence sensor

### DIFF
--- a/apps/base/homeassistant/files/configuration.yaml
+++ b/apps/base/homeassistant/files/configuration.yaml
@@ -120,6 +120,25 @@ script: !include scripts.yaml
 scene: !include scenes.yaml
 binary_sensor: !include binary_sensors.yaml
 
+# Room-level BLE presence via ESPresense nodes (MQTT broker mosquitto-lb).
+# Each mqtt_room sensor reports which room the tracked device is closest to.
+# Device identity is enrolled on the ESPresense node itself (IRK-based, so it
+# survives iOS BLE MAC rotation); the enrolled name becomes BOTH the device_id
+# and the final segment of the device topic. ESPresense publishes per-room to
+# `espresense/devices/<name>/<room>`; mqtt_room subscribes to `<state_topic>/+`
+# and matches the payload `id` against device_id, reporting the closest room.
+#
+# To add a device: enroll it on a node (http://<node>/ui/ -> Name -> Enroll ->
+# accept the iOS Bluetooth pairing), confirm `espresense/devices/<name>/...`
+# starts publishing, then add an entry below with a matching device_id.
+sensor:
+  - platform: mqtt_room
+    name: "George iPhone Room"
+    device_id: "georgeiphone"
+    state_topic: "espresense/devices/georgeiphone"
+    timeout: 5
+    away_timeout: 180
+
 http:
   use_x_forwarded_for: true
   trusted_proxies:


### PR DESCRIPTION
## Summary
Wires the ESPresense BLE presence node into Home Assistant with a
room-level `mqtt_room` sensor (`sensor.george_iphone_room`). It subscribes
to `espresense/devices/georgeiphone/+` on the mosquitto broker and reports
which room the device is closest to.

The node itself (`espresense_5cf500` / "ESPresense office-presence") already
auto-appears in HA via MQTT discovery — connectivity, uptime, free-mem,
Restart/Update/Enroll buttons. This PR adds the per-device room tracking.

## Device identity
Tracking uses ESPresense's **v3 Enroll flow** (IRK), so it survives iOS BLE
MAC rotation. The IRK is captured on the node via a one-time Bluetooth
pairing and synced node-to-node over MQTT — it is **never stored in this
repo**. The enrolled name (`georgeiphone`) is the only thing referenced here,
as both `device_id` and the device topic segment.

## Test plan
- [x] `kustomize build apps/production/homeassistant` passes
- [x] `kustomize build apps/staging/homeassistant` passes
- [x] `mqtt_room` block renders into the homeassistant-config ConfigMap
- [x] No secrets/IRK in the diff
- [ ] After enroll: `sensor.george_iphone_room` reports `office_presence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)