### PR TITLE
deploy(changes): jazz chord progression app at changes.burntbytes.com

### DIFF
--- a/apps/base/changes/deployment.yaml
+++ b/apps/base/changes/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: changes
+  namespace: changes
+  labels:
+    app: changes
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: changes
+  template:
+    metadata:
+      labels:
+        app: changes
+    spec:
+      serviceAccountName: changes
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: changes
+          # Public image (ghcr package set to public); no imagePullSecret needed.
+          image: ghcr.io/gjcourt/changes:2026-06-25
+          ports:
+            - containerPort: 8080
+          # No env: WEB_DIR=/web is baked into the image; the corpus is embedded
+          # in the binary, so there is no database or external dependency.
+          resources:
+            requests:
+              cpu: 10m
+              memory: 24Mi
+            limits:
+              cpu: 100m
+              memory: 96Mi
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true

--- a/apps/base/changes/deployment.yaml
+++ b/apps/base/changes/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     spec:
       serviceAccountName: changes
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ghcr-secret
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -27,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: changes
-          # Public image (ghcr package set to public); no imagePullSecret needed.
+          # Private ghcr image; pulled via the shared ghcr-secret (above).
           image: ghcr.io/gjcourt/changes:2026-06-25
           ports:
             - containerPort: 8080

--- a/apps/base/changes/kustomization.yaml
+++ b/apps/base/changes/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - networkpolicy.yaml
   - pdb.yaml
+  - secret-ghcr.yaml
   - service.yaml
   - serviceaccount.yaml
 labels:

--- a/apps/base/changes/kustomization.yaml
+++ b/apps/base/changes/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - namespace.yaml
+  - networkpolicy.yaml
+  - pdb.yaml
+  - service.yaml
+  - serviceaccount.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: changes
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/changes/namespace.yaml
+++ b/apps/base/changes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: changes
+  labels:
+    http-ingress: "true"

--- a/apps/base/changes/networkpolicy.yaml
+++ b/apps/base/changes/networkpolicy.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: changes
+  namespace: changes
+  labels:
+    app.kubernetes.io/name: changes
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: Gateway ingress on 8080; egress DNS only (corpus is embedded, no DB).
+  endpointSelector:
+    matchLabels:
+      app: changes
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/base/changes/pdb.yaml
+++ b/apps/base/changes/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: changes
+  namespace: changes
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: changes

--- a/apps/base/changes/secret-ghcr.yaml
+++ b/apps/base/changes/secret-ghcr.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:DIz2LgV7UQL/zYMUrXLWQevfEVFqUWNzM+41jeFLR2X69p+XPP1pLWMZeHBJ4jXWarbFoK8KzmJE5Oq+KvKZIGq4LiPjRa6lLCDuVGi0IVEBdvclqoG1cmHSvjKCHaBhiTyGkBgZsa6y+SGn8hPzeKAyGZ4CgaNShuILanfINKGTbQvqUJjaNJiG027S+OfsnKgbx4XJUGmYyJQFtRGvfj67BYSPwLhtjiwxAIf4x9z2s0/QQCHV2OIg9LP4oqa1FtDJ/k3FVv2SqUut6A7tjWU+Z1tnUqD/Etiv8jj/qOSZPwYObQtL4Vim8L+py9uizaEZmANQf2os24TUorKOpC+jj8q60a8W/bSerImRfhQ7iEu4/6r2OA==,iv:fXeaWJeTyKriHMENYywXwt6kssmt4Rc2Iz4/w8PsSm4=,tag:M2Am46wXSMJeCI82dNe7Qg==,type:str]
+kind: Secret
+metadata:
+  name: ghcr-secret
+type: kubernetes.io/dockerconfigjson
+sops:
+  age:
+    - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBMlA2bFNpVWlCSWRMT1h4
+        RVpXUFZUVWxYcFpLMHNFbTlDdndRdGRUTUFFCjRiTXlaN09iWmhFOU9LOUJDQzZh
+        N0VYZkRaZ2tPc1JPWURHVFhGUHJaWEEKLS0tIEdKVy8zVG5IOGE2dkYySkR3UnJl
+        S1NxNTdVRW1CakNPd0FIdC9WT1ZIbHMKKjSVxCPg/9vOwd4KbAEHBLvDvXo2ghsz
+        P7j5K3UuuM/pCP3GZfEC/raUbyQGO2WIls3VH6TRVMoeGJD8hGH99Q==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-15T23:56:02Z"
+  mac: ENC[AES256_GCM,data:yrn78+cS1/ikuIdh9LGyko7rLvC0vBdx9CLOIEoKTx3gTnl68Q6NO1SIbdjJS07yJTA4l6pE+m6S5vlyf+2wGXhPy7104vJeZ3QcMmdpFQyWasVkl2QlIfgy/kzAZz/o6kV4erkybkEMwbYkTgP+FU1ObapgqjTQSIoVsYulb2U=,iv:JP3ebV3f0SLQVHp6Df+wXjss9Q1ykt4kalk+1y5J0Jk=,tag:KBvZ2ZoGcoOiyuXkKy8tig==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.11.0

--- a/apps/base/changes/service.yaml
+++ b/apps/base/changes/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: changes
+  namespace: changes
+  labels:
+    app: changes
+spec:
+  type: ClusterIP
+  selector:
+    app: changes
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/apps/base/changes/serviceaccount.yaml
+++ b/apps/base/changes/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: changes
+  namespace: changes
+automountServiceAccountToken: false

--- a/apps/production/changes/httproute.yaml
+++ b/apps/production/changes/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: changes-http
+  namespace: changes-prod
+spec:
+  hostnames:
+    - changes.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: changes-https
+  namespace: changes-prod
+spec:
+  hostnames:
+    - changes.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: changes
+          port: 8080

--- a/apps/production/changes/kustomization.yaml
+++ b/apps/production/changes/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: changes-prod
+resources:
+  - ../../base/changes/
+  - httproute.yaml
+
+labels:
+  - pairs:
+      env: production
+      app.kubernetes.io/instance: production
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: changes
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: changes-prod

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - authelia
   - burntbytes
   - certificates
+  - changes
   - cloudflare-tunnel
   - excalidraw
   - external-services

--- a/apps/staging/changes/httproute.yaml
+++ b/apps/staging/changes/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: changes-http
+  namespace: changes-stage
+spec:
+  hostnames:
+    - changes.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: changes-https
+  namespace: changes-stage
+spec:
+  hostnames:
+    - changes.stage.burntbytes.com
+  parentRefs:
+    - name: app-gateway-staging
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: changes
+          port: 8080

--- a/apps/staging/changes/kustomization.yaml
+++ b/apps/staging/changes/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: changes-stage
+resources:
+  - ../../base/changes/
+  - httproute.yaml
+
+labels:
+  - pairs:
+      env: staging
+      app.kubernetes.io/instance: staging
+    includeSelectors: false
+
+patches:
+  - target:
+      kind: Namespace
+      name: changes
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: changes-stage

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - audiobookshelf
   - authelia
   - certificates
+  - changes
   - excalidraw
   - flashcards
   - flashcards-sync


### PR DESCRIPTION
## Summary
Deploys [`gjcourt/changes`](https://github.com/gjcourt/changes) — the jazz chord
progression database (transpose + Roman analysis) built from brainstorm 05-014.

- `apps/base/changes/` — deployment, service, namespace, CiliumNetworkPolicy, PDB, serviceaccount, **secret-ghcr**
- `apps/production/changes/` + `apps/staging/changes/` — overlays + HTTPRoutes
- Wired into the top-level production + staging kustomizations

Mirrors the **vitals** pattern, minus all Postgres bits — the corpus is **embedded
in the binary**, so there's no database, configmap, objectstore, or backups.

## Notes
- **Private** ghcr image (`ghcr.io/gjcourt/changes:2026-06-25`), pulled via the
  cluster's shared `ghcr-secret` (the base secret is namespace-agnostic; reused
  verbatim from the existing encrypted artifact — no new SOPS material).
- DNS is automatic via the `*.burntbytes.com` wildcard gateway listener + wildcard cert.
- NetworkPolicy: gateway ingress on 8080, DNS egress only (no outbound deps).
- Hardened: non-root 65534, readOnlyRootFilesystem, drop ALL caps, probes on `/api/health`.

## Test plan
- [x] `kustomize build apps/{staging,production}/changes` pass (9 objects each)
- [x] top-level `apps/production` + `apps/staging` build (wiring)
- [x] SOPS blocks intact/encrypted; no plaintext leak
- [ ] staging healthy at `changes.stage.burntbytes.com`
- [ ] prod healthy at `changes.burntbytes.com` (after staging verify + your OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)