### PR TITLE
feat(netscope): add hestia eBPF agent + scrape config

### DIFF
--- a/hosts/hestia/netscope/README.md
+++ b/hosts/hestia/netscope/README.md
@@ -1,0 +1,79 @@
+# netscope (hestia)
+
+Per-node network telemetry agent (eBPF / CO-RE / libbpf) for hestia, the
+standalone TrueNAS box at `10.42.2.10`. hestia is **not** a Kubernetes node,
+so it can't run the cluster `netscope-agent` DaemonSet — this compose runs the
+same agent image as a privileged, host-network Docker container instead, and
+Prometheus scrapes it directly (`infra/configs/netscope/scrapeconfig.yaml`).
+
+| Attribute | Value |
+|---|---|
+| Image | `ghcr.io/gjcourt/netscope` (built from [`gjcourt/netscope`](https://github.com/gjcourt/netscope)) |
+| Tag | pinned to the **same digest** the cluster DaemonSet uses (`apps/base/netscope/daemonset.yaml`) — bump both together |
+| Tag scheme | git short SHA from the source repo (NOT the homelab YYYY-MM-DD convention) |
+| Network | `host` (Prometheus scrapes hestia directly on `:9101`) |
+| Privileges | `privileged: true` — eBPF tcx attach + BPF map/program pinning |
+| Bind mounts | `/sys/fs/bpf` (rw, bpffs), `/sys/kernel/btf` (ro, CO-RE) |
+| Job label | `netscope-agent` (forced by the ScrapeConfig relabeling, same job as cluster nodes) |
+
+## Readiness (verified)
+
+hestia is CO-RE-ready: kernel **6.18.13**, BTF present at
+`/sys/kernel/btf/vmlinux`, Docker **29**. The libbpf agent will load and
+relocate against the running kernel without a prebuilt BTF blob.
+
+Unlike the cluster nodes, hestia runs **no Cilium** — there is no existing tcx
+chain to anchor against. The agent attaches at the default-route NIC and
+returns `TC_ACT_UNSPEC` (observe-only, never drops).
+
+## Interface selection (multiple NICs)
+
+The agent auto-discovers the IPv4 default-route interface from
+`/proc/net/route` at startup. hestia has **multiple NICs** (ASRock
+SIENAD8-2L2T). If discovery picks the wrong one, pin it explicitly via the
+`NETSCOPE_IFACE` env in `docker-compose.yml`:
+
+```yaml
+    environment:
+      NETSCOPE_IFACE: eno1
+```
+
+Find the right interface first:
+
+```bash
+ssh truenas_admin@10.42.2.10 'ip -o -4 route show default'
+```
+
+## Deploy
+
+**Automatic (preferred):** once this lands on `master`, `deploy-hestia.yml`
+auto-discovers `hosts/hestia/netscope/docker-compose.yml` and rolls it out to
+the TrueNAS Apps subsystem via the self-hosted runner on hestia.
+
+**Manual (operator, if deploying before/without the merge):**
+
+```bash
+ssh truenas_admin@10.42.2.10
+docker compose -f /path/to/homelab/hosts/hestia/netscope/docker-compose.yml up -d
+docker logs -f netscope    # confirm BTF load + chosen interface
+curl -s localhost:9101/metrics | head   # confirm metrics on :9101
+```
+
+The Prometheus `netscope-agent` target for `instance=hestia` stays **DOWN**
+until the container is running — that's expected, not a failure.
+
+## Updating
+
+When a new image is published from [`gjcourt/netscope`](https://github.com/gjcourt/netscope):
+
+```bash
+TAG=<new-short-sha>
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:gjcourt/netscope:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json" \
+  "https://ghcr.io/v2/gjcourt/netscope/manifests/$TAG" \
+  | grep -i 'docker-content-digest'
+```
+
+Bump the `image:` line here **and** `apps/base/netscope/daemonset.yaml` to the
+same `:${TAG}@sha256:${digest}` so cluster and hestia stay in lockstep.

--- a/hosts/hestia/netscope/docker-compose.yml
+++ b/hosts/hestia/netscope/docker-compose.yml
@@ -1,0 +1,42 @@
+# netscope — hestia per-node network telemetry agent (eBPF).
+#
+# Image is built from https://github.com/gjcourt/netscope. The tag here is
+# pinned to the SAME digest the cluster DaemonSet runs
+# (apps/base/netscope/daemonset.yaml) so hestia and the 6 Talos nodes report
+# from identical agent code. Bump both together.
+#
+# Runs with host networking and privileged because it is a CO-RE / libbpf
+# eBPF agent: it attaches tcx programs and reads kernel state.
+#   - /sys/fs/bpf      BPF filesystem (pinned maps/programs)
+#   - /sys/kernel/btf  kernel BTF for CO-RE relocation (vmlinux present on
+#                      hestia's 6.18.13 kernel — verified)
+#
+# Coexists with the host's existing networking (returns TC_ACT_UNSPEC, so it
+# observes without dropping). hestia runs no Cilium — it's a standalone
+# TrueNAS box, not a Kubernetes node — so the agent simply attaches at the
+# default-route NIC.
+#
+# Metrics are exposed on :9101 over host networking; Prometheus scrapes
+# hestia directly (infra/configs/netscope/scrapeconfig.yaml), joining the
+# same `netscope-agent` job as the cluster targets.
+#
+# Interface selection: the agent auto-discovers the IPv4 default-route NIC
+# from /proc/net/route at startup. hestia has MULTIPLE NICs — if discovery
+# picks the wrong one, pin it explicitly with the NETSCOPE_IFACE env below
+# (e.g. NETSCOPE_IFACE=eno1). See README.md.
+
+services:
+  netscope:
+    image: ghcr.io/gjcourt/netscope:2e20747@sha256:75d159d39a7e4498c537bd2e6739d4f722f63c880ab6bb91e8fd372d9ab6ce36
+    container_name: netscope
+    network_mode: host
+    privileged: true
+    restart: unless-stopped
+    # environment:
+    #   # Uncomment + set if default-route NIC auto-discovery picks the wrong
+    #   # interface on hestia (multiple NICs). Find the right one with:
+    #   #   ssh truenas_admin@10.42.2.10 'ip -o -4 route show default'
+    #   NETSCOPE_IFACE: eno1
+    volumes:
+      - /sys/fs/bpf:/sys/fs/bpf
+      - /sys/kernel/btf:/sys/kernel/btf:ro

--- a/infra/configs/kustomization.yaml
+++ b/infra/configs/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - flux-monitoring
   - gateway
   - ipmi-exporter
+  - netscope
   - network-policies
   - thermalscope
   - unpoller

--- a/infra/configs/netscope/kustomization.yaml
+++ b/infra/configs/netscope/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - scrapeconfig.yaml

--- a/infra/configs/netscope/scrapeconfig.yaml
+++ b/infra/configs/netscope/scrapeconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: hestia-netscope
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  staticConfigs:
+    - targets:
+        - 10.42.2.10:9101
+      labels:
+        instance: hestia
+  # Force the job label to "netscope-agent" so hestia joins the SAME job as
+  # the cluster DaemonSet targets (scraped via the netscope ServiceMonitor,
+  # apps/base/netscope/servicemonitor.yaml) and the PrometheusRule alerts
+  # (which match on job="netscope-agent"). The operator otherwise auto-names
+  # the job "scrapeConfig/monitoring/hestia-netscope".
+  relabelings:
+    - targetLabel: job
+      replacement: netscope-agent
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  metricsPath: /metrics


### PR DESCRIPTION
## Summary

Adds **netscope** to **hestia** (TrueNAS box at `10.42.2.10`), which is **not** a Kubernetes node and so can't run the cluster `netscope-agent` DaemonSet. Instead it runs the same agent image as a privileged, host-network Docker container (mirroring `thermalscope`) and Prometheus scrapes it directly, joining the same `netscope-agent` job as the 6 cluster nodes.

## Changes

- **`hosts/hestia/netscope/docker-compose.yml`** — mirrors the thermalscope compose. Image `ghcr.io/gjcourt/netscope` pinned to the **same digest** the cluster DaemonSet uses (`apps/base/netscope/daemonset.yaml` → `2e20747@sha256:75d159d…`). `network_mode: host`, `privileged: true`, mounts `/sys/fs/bpf` (rw — bpffs pinning) and `/sys/kernel/btf` (ro — CO-RE). `restart: unless-stopped`. Commented `NETSCOPE_IFACE` env override for hestia's multiple NICs.
- **`hosts/hestia/netscope/README.md`** — deploy + interface-selection + update runbook.
- **`infra/configs/netscope/scrapeconfig.yaml`** — static target `10.42.2.10:9101`, `instance: hestia`, relabel forces `job: netscope-agent`, `metricsPath: /metrics`. Mirrors `infra/configs/thermalscope/scrapeconfig.yaml`.
- **`infra/configs/netscope/kustomization.yaml`** + wired into `infra/configs/kustomization.yaml` (same pattern as thermalscope).

## Validation

- `kustomize build infra/configs` passes; the `hestia-netscope` ScrapeConfig renders.
- `yamllint -c .yamllint -s` clean on all changed files.

## Readiness / caveats

- hestia is CO-RE-ready: kernel **6.18.13**, BTF at `/sys/kernel/btf/vmlinux`, Docker **29** — libbpf agent loads without a prebuilt BTF blob.
- hestia runs **no Cilium** (standalone box) — agent attaches at the default-route NIC, observe-only (`TC_ACT_UNSPEC`).
- **The `netscope-agent`/`instance=hestia` Prometheus target stays DOWN until the container is running — expected, not a failure.**

## Deploy (post-merge)

`deploy-hestia.yml` auto-discovers `hosts/hestia/netscope/docker-compose.yml` and rolls it out via the self-hosted runner on merge to master. Manual fallback:

```bash
ssh truenas_admin@10.42.2.10
docker compose -f /path/to/homelab/hosts/hestia/netscope/docker-compose.yml up -d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)