### PR TITLE
fix(snapcast): allow egress to Spotify access-point on 4070

### DIFF
--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -48,12 +48,17 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
-    # go-librespot (Spotify Connect) connects to Spotify's servers over HTTPS.
+    # go-librespot (Spotify Connect) reaches Spotify over HTTPS (443) for OAuth +
+    # apresolve, and the access-point on 4070 (apresolve hands out :4070 hosts).
+    # Without 4070 the interactive login completes the token exchange but fails the
+    # AP connect, exits, and never persists credentials → the device never appears.
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
+              protocol: TCP
+            - port: "4070"
               protocol: TCP
     # mopidy sidecar pulls the library from Navidrome's in-cluster Subsonic
     # API (only the blog is exposed via the tunnel, so no hairpin).


### PR DESCRIPTION
## Summary
- The snapcast NetworkPolicy allowed go-librespot egress to Spotify on **443 only**. go-librespot completes the interactive-auth OAuth exchange over 443, then connects to the Spotify **access-point on 4070** (apresolve hands out `:4070` hosts). With 4070 blocked, the AP connect failed, go-librespot exited (code 1), and credentials were never persisted — so the whole-home **"Snapcast"** device never showed up in Spotify.
- Verified from the pod: `ap.spotify.com:4070` BLOCKED, `:443` OPEN; `state.json` had `credentials.data: null` with no AP connection going back to Jun 19.
- Adds `4070/TCP` to the `world` egress block.

## Test plan
- [x] `kustomize build` passes for base + prod/stage overlays
- [ ] After deploy: re-run go-librespot interactive auth → token persists → "Snapcast" appears in Spotify Connect and plays to living-room + kitchen

🤖 Generated with [Claude Code](https://claude.com/claude-code)