### PR TITLE
fix(netscope): label hestia static target with nodename

### DIFF
--- a/infra/configs/netscope/scrapeconfig.yaml
+++ b/infra/configs/netscope/scrapeconfig.yaml
@@ -11,6 +11,11 @@ spec:
         - 10.42.2.10:9101
       labels:
         instance: hestia
+        # The netscope dashboard panels are `sum by (nodename)` /
+        # legendFormat {{nodename}} — cluster agents get nodename from k8s SD,
+        # but this static target has none, so hestia rendered as "Value".
+        # Set it explicitly so hestia shows by name alongside the talos-* nodes.
+        nodename: hestia
   # Force the job label to "netscope-agent" so hestia joins the SAME job as
   # the cluster DaemonSet targets (scraped via the netscope ServiceMonitor,
   # apps/base/netscope/servicemonitor.yaml) and the PrometheusRule alerts


### PR DESCRIPTION
## Summary
hestia is reporting in netscope (`up=1`) but rendered as **"Value"** in the per-node Grafana panels instead of "hestia". The panels are `sum by (nodename)` / `legendFormat {{nodename}}`; cluster agents get `nodename` from Kubernetes SD, but the hestia static scrape target (added in #993) had only `instance`/`job` labels — no `nodename` — so Grafana fell back to the default series name "Value".

Adds `nodename: hestia` to the static target labels so hestia appears by name alongside the `talos-*` nodes.

## Test plan
- [x] Confirmed via Prometheus: hestia series has `{instance,job}` only, cluster series carry `nodename`
- [ ] After deploy: the "Per-Node Receive Rate" / DNS / retransmit panels show **hestia** instead of "Value"

🤖 Generated with [Claude Code](https://claude.com/claude-code)