### PR TITLE
fix(cilium): disable debug logging (was ~74 GB/day filling Loki)

### DIFF
--- a/infra/controllers/cilium/values.yaml
+++ b/infra/controllers/cilium/values.yaml
@@ -1,6 +1,9 @@
 # Helm values
+# debug logging (left on from the 2026-06 Talos recovery) spewed ~74 GB/day of
+# cilium-agent debug lines (envoy xDS + loadbalancer reconciler), which filled
+# the Loki PVC. Keep at info; flip to true only for active network debugging.
 debug:
-  enabled: true
+  enabled: false
 
 # Cluster-critical: Cilium agent is the network — eviction means everything dies.
 priorityClassName: system-node-critical


### PR DESCRIPTION
## Summary
The Loki PVC-full incident's root driver: **cilium-agent running at `level=debug`** (left on from the 2026-06 Talos recovery). Measured from Loki:
- `kube-system` = **~1 GB / 15 min** (~96 GB/day), **~99%** of all cluster log ingestion.
- Drilled down: 100% from **`cilium-agent`** (~1.1 GB/15min across the 4 DS pods) — every line `level=debug` (envoy xDS churn + loadbalancer reconciler `Update RevNat`/`Update master service`).

Sets `debug.enabled: false` (back to info). This drops Loki ingestion ~99%, so **7-day retention fits comfortably in the existing 40Gi** — no PVC expansion needed (which is doubly broken on Talos: controller SSH/sudo + node-side `resize2fs` EPERM).

## After merge
Flux updates the `cilium-config` ConfigMap, but agents read `debug` at startup — restart the DaemonSet to apply:
```
kubectl -n kube-system rollout restart ds/cilium
```
(rolling; Cilium is `system-node-critical` — restarts one node's agent at a time.)

## Test plan
- [x] values change is the documented Cilium `debug.enabled` toggle
- [ ] After deploy + DS restart: cilium-agent logs at `info`; Loki ingestion drops to a few GB/day; `storage-loki-0` stays well under 40Gi over 7d

🤖 Generated with [Claude Code](https://claude.com/claude-code)