### PR TITLE
feat: add xfs iSCSI StorageClasses for in-place PVC expansion

### DIFF
--- a/infra/controllers/democratic-csi/values.yaml
+++ b/infra/controllers/democratic-csi/values.yaml
@@ -53,6 +53,61 @@ storageClasses:
       node-publish-secret:
       controller-expand-secret:
 
+  # xfs variants of the iSCSI StorageClasses above.
+  # Rationale: online PVC *expansion* works on xfs but NOT on ext4 with this
+  # democratic-csi + Talos setup. ext4 node-side resize2fs fails the online
+  # EXT4_IOC_RESIZE_FS ioctl with EPERM against the host-mounted globalmount;
+  # xfs grows via `xfs_growfs <mountpoint>` (mountpoint-based, no block-device
+  # ioctl), which succeeds. Verified end-to-end on melodic-muse 2026-06-28
+  # (1Gi -> 2Gi, df confirmed 2Gi, data preserved).
+  # These are *additive* — existing ext4 volumes keep their fsType and still
+  # require recreate-to-grow. Use the xfs classes for NEW volumes that may
+  # need to expand in place.
+  - name: truenas-iscsi-xfs
+    defaultClass: false
+    reclaimPolicy: Retain
+    volumeBindingMode: Immediate
+    allowVolumeExpansion: true
+    parameters:
+      fsType: xfs
+    mountOptions: []
+    secrets:
+      provisioner-secret:
+      controller-publish-secret:
+      node-stage-secret:
+      node-publish-secret:
+      controller-expand-secret:
+
+  - name: truenas-iscsi-ssd-xfs
+    defaultClass: false
+    reclaimPolicy: Retain
+    volumeBindingMode: Immediate
+    allowVolumeExpansion: true
+    parameters:
+      fsType: xfs
+    mountOptions: []
+    secrets:
+      provisioner-secret:
+      controller-publish-secret:
+      node-stage-secret:
+      node-publish-secret:
+      controller-expand-secret:
+
+  - name: truenas-iscsi-ephemeral-xfs
+    defaultClass: false
+    reclaimPolicy: Delete
+    volumeBindingMode: Immediate
+    allowVolumeExpansion: true
+    parameters:
+      fsType: xfs
+    mountOptions: []
+    secrets:
+      provisioner-secret:
+      controller-publish-secret:
+      node-stage-secret:
+      node-publish-secret:
+      controller-expand-secret:
+
 # Talos: /etc/iscsi is a read-only tmpfs mount — DirectoryOrCreate skips the strict type check.
 # hostPID required for nsenter strategy to find iscsid PID in the host process namespace.
 node:


### PR DESCRIPTION
## Proposal (not yet validated in CI staging — draft)

Adds three **xfs** variants of the existing iSCSI StorageClasses so NEW volumes can be expanded in place. Existing ext4 SCs are unchanged.

### Why
democratic-csi `truenas-iscsi` on Talos **cannot grow ext4 PVCs**: node-side `resize2fs` fails the online `EXT4_IOC_RESIZE_FS` ioctl with **EPERM** against the host-mounted globalmount. xfs grows via `xfs_growfs <mountpoint>` (mountpoint-based, no block-device ioctl), which succeeds.

### Verification (melodic-muse, 2026-06-28, throwaway resources)
With the `truenas_admin` passwordless sudo grant re-enabled:
1. Throwaway `truenas-iscsi-xfs-test` SC (clone of `truenas-iscsi-ephemeral` + `fsType: xfs`) → PVC provisioned + mounted as **xfs at 1Gi**, file written.
2. Expanded **1Gi → 2Gi**:
   - `ControllerExpandVolume` **succeeded** (`node_expansion_required: true`) — no `sudo: a password is required` (contrast: the same call failed repeatedly earlier in the day on a different PVC while sudo was off).
   - Node `NodeStageVolume` ran `xfs_growfs <globalmount>` cleanly.
   - After pod restart, `df` inside the pod showed **2Gi**, data preserved.
3. All throwaway resources deleted; `DeleteVolume` returned `{}`, no orphan zvol/PV.

### Scope / caveats
- **Additive only.** Existing ext4 PVs keep `fsType: ext4` and still require recreate-to-grow.
- StorageClass `fsType` is fixed at provision time — switching an existing PVC to xfs requires recreating it.
- Adds: `truenas-iscsi-xfs`, `truenas-iscsi-ssd-xfs`, `truenas-iscsi-ephemeral-xfs`.

Draft until the operator wants it applied / reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ttLFodpL1uoiYVGRdPoSM