### PR TITLE
feat(democratic-csi): switch to API driver (freenas-api-iscsi, api-key-only)

### DIFF
--- a/infra/controllers/democratic-csi/secret-driver-config.yaml
+++ b/infra/controllers/democratic-csi/secret-driver-config.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: democratic-csi-driver-config
-    namespace: democratic-csi
+  name: democratic-csi-driver-config
+  namespace: democratic-csi
 type: Opaque
 stringData:
-    driver-config-file.yaml: ENC[AES256_GCM,data:Zs/VJdb0XoKDmKFiUo4cT9bS5CcEPnvkxydcKWcBi4FBgKbyOT17Bpm/hmGV59khP8O6OECZlVrajFvdu7VdTlogs0WjbE/MHVPRqNti6h5h2LllUIW1senqSDf3F7ACuSDwVqA7xA7ueyiIkVQPhhSt11+SQJWV2KP9oqSilrqQDbY3C3hqUjXvFHGAjxrvgakK3r7aIMesj1dVE7SirzMgUFhPSPeYkNJY7fSGlI5MfibMxyrET9P/tO0AWqnEc1KTQsdYbkCZ9y0DNHUDIvGgKvycxQBnDvmauPeqPBoib7WhS6sZIqZe5ysQyEncHFSMwi2GzLpECuJDGa99eeNfJS+RW9LzUbnmYnlQ8RM8dfy0YDft4O98uymEmTH6OCTkdpyqlpe8ADW9t8rX6C2nmW91gfrf3jV7w18Zk0jD+DBVNu2nd6+kEd6h3gTQpefaAbXKK+g+VoqnROK3Nxcwiq/qQm5N1g+Jj5gIHVIX71522RP+GRWrDZ//Y6Y+qtOFM8F5ggyLHdBwISu+N8OLzTPk442qgTU6tY7YKwwRDmejHg8KmH5ra3Ofjr1U26oaIq5PUpl/s6RcV30s1y6ZLiyQIp9qsJsMAbsw1RKsAazOWRWP7ljAubO2H6JP62ko32OBSU5z36q0Di+lBaD6oFjf1kjLOb1DTKLXi5zk4kXA4wkUw3LuOBbrv5q5Xv4GiBEDEOinzGQvGOQ/MLqg7ZuCowkp+7kIs7PZ5TE0KmTFzqruOtih5+kyZXBm7KHV1GKpASIBf+IdA40KSdZNrG/9pNQAgASWkX61627g0rfjxL9d62GFkwpKUgOgMBR0AM/EnpXZ4SbnhHyJ3YdE4MhbRMtmyPGHs57Br/8elj+Ow43/j4G3FnlO5XDpi0cgQtei8pG6IvXWONkZmkIk/u4xGQrxQ8WQnLUNg481TpWxddp7pE+sPMF/kjW42xz8oShCwJIKhI3ImuoztegsUGcg4pUrfc5dNqnPmGSvtXoXrI9J72iVzRo1UlfbSkowrnKZ8LbH1NKjW0DL2cpxo3cwoPpUTNMOKn1ammnSnB6NGDz0/oTjcQ7Bem4UTsrN6P75FFHyRTCOVdsqgokdUhGnnfW27MTNDhunzWUE2WsinkJukpm3Dy/20HpQIcgMqW9iRKcR/cZd023KNyySAG1QHMAkjisIlPGgnyDTy/GJkqQOZWlBcf4uva9f94lewSXWT/WjnQRZLA8yrqeuh0OP+Tq/uSDr1aZVwKrIphulawpCj/p40/iA37N1E4VCPY4squT3b+Mi2x0Ww+6rHCQXvr7xV+tK4IPMRHaxik+u9BFi2Fn/1Qn2QvrGFRCzlfsrFlyEEObSzPrnQs/I6EMWvcsCBnHk44fxKn/aJnLREtTb32dl+lcz0qWg2/HbDM59g9pISotqAthGcIBEL8yt16YozyrZZJp0ViBbICQuLypNLwoVVrRn8fAWSN8zYF3cNM/T0VkZpQchDrRWnAxOQBgjJfyNUaU/K8pzRaFrbt8dKWM78ulOHtQGl17FJSgu43qiM7A0L5vb2dQfTIx/SLqM01ba4OJ9VCVoc5I0a+rmjQfpXeATGLwKq/XVE4dMj509ytO4DktgCWxKx8Altn47m0pB8MP7KYst/lHCZdpwYpwYWcoN1305+cDXAz+eTkhR3edejVBKvMCn5Z97VkS9V+3ya+jW4NdcuG6ERAIi84WaOz4ysQs4Zc7n/urdRBXwiWS6Voyw9g/Nk430WIE7lDQe9yl8AdzgAmDjjLBgwIlizus3oMQR8JgW/X3YGJM0fn2UwPeMrsBytpEXnbc0FE3S0awUwW9o6FKietIh0uX7NoNsCn8Psc4KnCGa9A8neC2Oem2drB0DUs6VI4Vd1WpSlGcDrtHPikvZssTinj5Eg8QM6QpTWhe0W7elWyjdSEHenGE20TatezI7fhfCjD74YNzeHg1WE/4g5YfnZZ2krC2W+bp1K8qbxdkv/fM5uRLO7w==,iv:pOhIQ9O9l5tY6ceVvcfFhAdWZpIfi5XAGDBB0ROLxUw=,tag:SjKCHDsbXe/eoqz7JvZ3eA==,type:str]
+  driver-config-file.yaml: ENC[AES256_GCM,data:zlJyqutGzyqOrfd0v2nLdsGxgL7AmBUS+lybv1Tf5r9IPzezVxEh4y7cX11xab6felyNSlNJR7RGo9YMjAq024PJHC+sque0HEYHg7kLX6mH2E/NaB7Sw2Ix8Fu1YbEE+Y8Q23iT2UxGEUUrqE07+dT/4alcD84ZdEbncvjYNQ7igagmmv92SVZHdP3yEzHNx/NF1HUN1R/khg1RMUgk138fSISQULgwstOABuRCU3sQZgcRmqXOjSUhEaIRmwHCyuCMJP7+RkxJwYPnDzeAjOWzYm9lmahhgDGurEqXPeIjgfNzFKXgq01dVZelsbEDFf/Isk5+/7Po2Lkc8BCxhx8yD3E/zXA48c7jR5hRep7Z/G14jl80S0XZXmDoid+gdz0KlclOqXIaFWLASyhqdYEHBGjJuvuG1QrlZBEHeRYHOu7AEdZe8kozCJokb5/LIrQrP5CbxKQf2jrGCkcSmj/GrbG+2iyVHEOiJdXvE+/bR++1wHhN0+6H+8FGiDUbVah2ScQgoax7CLA7eT02QQYB38dFIiUqDGMGNo5s9HT5CduDbMTSsSFXe7uhAFDB2iTNXHGYGDJ/OccQMRvSfhSFAy0h+tj38lCnTyJwSLJM/oEpCyF2o9gVtbtQhBNDq9VcqvX3YCcwzQ94TGp9SYS5P+l69qiwWx9nGFLM0DKx/602OKXRnXwSDCgIhIYOtO/it/SHarow1jpI7t2sxo65DNQ9wcybbvs2fZVUUKYLIjoRIWRCmAqWO8DcPeDH8mpntnyBG2UUPJfkSMkprMBmakl34UQnqAIBy+7PuK0fG/5kR/Owv589XVjphUk19gPQ0Ber0+UFelUolMq/AizEL0GLGtcwug3i1C81nIojvtZvBVlbIjYb+3x5YQxDudSnMjrhXtT95ERTT6f+JwOGpBXScKUzvVEgnwCPAV3+0OK2pMX449bAdpuha2OMMGRaOXts2u5TxrFKRohOw/3nWk9+W5Vry6f2oTQAV49QSGY+A420JAe7DEQmzt1SwwiNzt2zCM7fAnTuQAR/+vHneU7BOY80DL4NhFlewIu8OH9WGj4T00dKwh6sawxRPOq1x6NomU1oJg0msDCHHkplUvx9sAVzlllybmkb0+G1/pIQKUwxX0u/bjv4hjHXlwEGO96UUAClqBHFL8QlBPNcTq7E/BfdSMqgNW+9LkBYC81ixU47DK8XvbQTCg9uVAuY8OJBXFViSXzxeLfV+djFj6rssJ2cxOIZD1r3L/t+TolxxewrkC9nuvvfm2I/aad2H7AWo7w5Bmn8v+m+,iv:5ePCRK8vrl/41sSsaRNX/M8qepG7Z3EgQBjZGjaf4ws=,tag:54LiZrNj1Xk9T32NOCJx9g==,type:str]
 sops:
-    age:
-        - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEZ3BpWi9CS0MwZXFnOVBC
-            NFNQVFJsWWMwZ016dnRxS1k4QkE3SHRPaEVNCjhpd1dQbmE5N05mTEh5dE4reE4y
-            ZW9lbXhzUGRoZnFwa3Z2bXlXaFZXT3cKLS0tIDBWMkFkOEd3THZCTVNaRlFWeG5u
-            bFMyREFkZUJEUWpyU2Z2UzlhdHZXajAKFgUp0DNcbWlv2O8ppCCTWjZwXIRXuysQ
-            GdAEJFQLH+gG5NpliqXE8uGZSBLt/XAzvKFNfl+9xASrRX6FRchQew==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-29T22:56:51Z"
-    mac: ENC[AES256_GCM,data:XshFsOPbhf93sah2o5Xm3lyhyZ2z4EGMzDD277bvB1YVQVTIF3WMlHCt8tdVXxISLRV0Ndq7sVF/wYUfFGGmwHAf6vj13n2qJduc3NWusUdWCdAU0RGULKzxx4HlB9AfelAZYwaiu2MHPWPoUAIiyn+A4Oe2Gjv0fJkMWMrpcAM=,iv:EQuhEH9/bjg0xnHirB00+kwiUXBw3bgUlVRrz8hNwfc=,tag:LAHIDocB5M40W6wewWo2kg==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuT3FQTFJCM3huR0ZTZitW
+        VU1iSnZHdi96VmdNTUp2U1pJWDdwa3o3T2prCmdIMWNOUmxTTVJuMnFCeEF6UEc0
+        VWdBYnFXUlQyYmNSRHNKVUlDd1piQ3cKLS0tIE1idGRQUmkyS2dHOW5nQy9NZFdq
+        TFRsaWJwY3RzcEdZVWdQNThMNW9KVGMKe6i3yIAB31mvZGpsDRKDaGUBHkiapM5J
+        eR+gGAXY/o2WtQ7ELfNWFRkMU/Ix8QhCkXH/DQFNwh5zu05FNM1YFg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-28T22:33:13Z"
+  mac: ENC[AES256_GCM,data:ll8PFQPgVyiZh+0McJqhpCD9GqzyZpTCLRUKVWmvO+ZtOLt4E2oitOfEXeJzwRVgqy1qoJilr9fJulPoq3xY/QlRy0y2uQJli8z29dWIKFbL4GWNbbzSyitfGImtIYXJAyLHvSGIIOQOiVounyYeGOpPOLHjjILdNxKHD/I8sTs=,iv:2acdbxbvLFOU/vgBLfWK48+wlLAoL8Dpq0Uha/t0S0Y=,tag:JCO8Dpl2kfvQYoGs5wmQGw==,type:str]
+  version: 3.13.1

--- a/infra/controllers/democratic-csi/values.yaml
+++ b/infra/controllers/democratic-csi/values.yaml
@@ -3,7 +3,10 @@ csiDriver:
 
 driver:
   config:
-    driver: truenas-iscsi
+    # API-only driver (FreeNASApiDriver): all ops over the TrueNAS middleware API
+    # via the melodic-muse-csi key — no SSH/sudo. (Authoritative config lives in
+    # the existingConfigSecret below; this field is kept in sync for clarity.)
+    driver: freenas-api-iscsi
   existingConfigSecret: democratic-csi-driver-config
   existingConfigSecretKey: driver-config-file.yaml
 


### PR DESCRIPTION
## Summary
Switches democratic-csi from the SSH-based `truenas-iscsi` driver to the API-based **`freenas-api-iscsi`** (`FreeNASApiDriver`) — **api-key-only auth via the `melodic-muse-csi` key through the api-proxy; no SSH key, no sudo, no `truenas_admin` shell access.** Per plan `docs/plans/2026-06-28-democratic-csi-ssh-to-api-driver.md`.

- **SOPS secret** (`secret-driver-config.yaml`): `driver → freenas-api-iscsi`, `sshConnection` block removed. `httpConnection`/`zfs`/`iscsi` kept **byte-identical** — verified post-decrypt: `datasetParentName: main/k8s/iscsi`, `namePrefix: "csi-"`, `nameSuffix: "-k8s"` unchanged → existing 286 PVs keep binding.
- **values.yaml**: `driver.config.driver → freenas-api-iscsi` (kept in sync; secret is authoritative).
- `csiDriver.name` + all StorageClasses unchanged. Role pre-condition met (`melodic-muse-csi` has `SHARING_ADMIN` → iSCSI write).

## Rollout (post-merge, by me)
1. Flux reconcile → `rollout restart deploy/democratic-csi-controller`; confirm `FreeNASApiDriver`.
2. **Throwaway-PVC test gate** (provision → expand → snapshot → delete) before any CNPG/Immich.
3. Verify existing PVs still bound.

## Rollback
`git revert` (driver → `truenas-iscsi`, restore `sshConnection`) — SSH key + sudo still in place until verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)