### PR TITLE
chore(homepage): rename brainstorm bookmark + refs to lab

### DIFF
--- a/apps/production/homepage/config/bookmarks.yaml
+++ b/apps/production/homepage/config/bookmarks.yaml
@@ -2,9 +2,9 @@
     - homelab:
         - abbr: HL
           href: https://github.com/gjcourt/homelab
-    - brainstorm:
-        - abbr: BS
-          href: https://github.com/gjcourt/brainstorm
+    - lab:
+        - abbr: LAB
+          href: https://github.com/gjcourt/lab
     - life:
         - abbr: LF
           href: https://github.com/gjcourt/life

--- a/apps/staging/homepage/config/bookmarks.yaml
+++ b/apps/staging/homepage/config/bookmarks.yaml
@@ -2,9 +2,9 @@
     - homelab:
         - abbr: HL
           href: https://github.com/gjcourt/homelab
-    - brainstorm:
-        - abbr: BS
-          href: https://github.com/gjcourt/brainstorm
+    - lab:
+        - abbr: LAB
+          href: https://github.com/gjcourt/lab
 
 - Reference:
     - Kubernetes Docs:

--- a/docs/operations/apps/flashcards-sync.md
+++ b/docs/operations/apps/flashcards-sync.md
@@ -4,7 +4,7 @@
 
 `flashcards-sync` is the server-side companion to the [flashcards](flashcards.md) web app. It persists per-user FSRS card state so the same user can study from multiple devices and converge their review schedule. The web client posts to `/api/sync` on the same hostname; the path is forwarded by the gateway to this service.
 
-Source: https://github.com/gjcourt/flashcards-sync . Plan: brainstorm/04-009 Phase 7 (cross-device sync).
+Source: https://github.com/gjcourt/flashcards-sync . Plan: lab/04-009 Phase 7 (cross-device sync).
 
 ## 2. Architecture
 

--- a/docs/operations/apps/flashcards.md
+++ b/docs/operations/apps/flashcards.md
@@ -4,7 +4,7 @@
 
 Flashcards is a multi-deck spaced-repetition study app using FSRS-4.5 scheduling. It's a static React/TypeScript SPA — entirely client-side, no backend, no database. All scheduling state lives in the user's `localStorage`.
 
-Source: https://github.com/gjcourt/flashcards · Plan: brainstorm/04-009.
+Source: https://github.com/gjcourt/flashcards · Plan: lab/04-009.
 
 ## 2. Architecture
 

--- a/docs/operations/apps/netscope.md
+++ b/docs/operations/apps/netscope.md
@@ -8,7 +8,7 @@ Netscope is a custom eBPF-based network traffic analyzer running as a DaemonSet 
 - **TCP smoothed RTT** as a histogram (fentry on `tcp_rcv_established`)
 - **DNS query latency** as a histogram (fentry `udp_sendmsg` / fexit `udp_recvmsg` pair)
 
-Source: https://github.com/gjcourt/netscope. Project plan: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md.
+Source: https://github.com/gjcourt/netscope. Project plan: https://github.com/gjcourt/lab/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md.
 
 The homelab is a single-cluster environment with no separate production environment for netscope; everything ships into the `netscope-stage` namespace and that is the operational target.
 
@@ -53,7 +53,7 @@ Netscope is deployed as a single Kubernetes `DaemonSet` (`netscope-agent`) in th
 - **Dashboard**: https://grafana.burntbytes.com/d/netscope-overview
 - **Prometheus targets**: https://prometheus.burntbytes.com/targets?search=netscope
 - **Source**: https://github.com/gjcourt/netscope
-- **Project plan / brainstorm**: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md
+- **Project plan / lab**: https://github.com/gjcourt/lab/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md
 - **SRTT verifier postmortem**: https://github.com/gjcourt/netscope/blob/main/docs/postmortems/2026-05-10-srtt-verifier-iterations.md
 
 ## 4. Configuration
@@ -216,5 +216,5 @@ Histogram buckets are denominated in **seconds**, not microseconds, despite the 
 
 ## 10. Related Documents
 - SRTT verifier iteration postmortem (canonical eBPF verifier debugging story for this project): https://github.com/gjcourt/netscope/blob/main/docs/postmortems/2026-05-10-srtt-verifier-iterations.md
-- Brainstorm / project plan: https://github.com/gjcourt/brainstorm/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md
+- Lab / project plan: https://github.com/gjcourt/lab/blob/main/03-homelab-automation/03-001-ebpf-based-network-traffic-analyzer.md
 - Source repo: https://github.com/gjcourt/netscope


### PR DESCRIPTION
## Summary
`gjcourt/brainstorm` was renamed to **`gjcourt/lab`**. This updates all references in the homelab repo.

- **Homepage bookmark** (staging + production `bookmarks.yaml`): label `brainstorm`→`lab`, abbr `BS`→`LAB`, href → `github.com/gjcourt/lab`
- **Operational docs** (`netscope.md`, `flashcards.md`, `flashcards-sync.md`): project-plan links and shorthand `brainstorm/NN-NNN` → `lab/NN-NNN`

Old GitHub URLs redirect, so nothing was broken — this is a correctness/hygiene update.

## Test plan
- [ ] Homepage renders the `lab` bookmark (LAB) pointing at github.com/gjcourt/lab after staging reconcile