### PR TITLE
fix(jellyfin): expand cache PVC 5Gi → 20Gi (KubePersistentVolumeFillingUp)

### DIFF
--- a/apps/production/jellyfin/storage.yaml
+++ b/apps/production/jellyfin/storage.yaml
@@ -31,6 +31,9 @@ spec:
   storageClassName: truenas-iscsi
   resources:
     requests:
-      # Actual usage: ~32Mi. Jellyfin 10.11+ requires 2GiB free in /cache;
-      # bumped from 1Gi to 5Gi to satisfy that check.
-      storage: 5Gi
+      # /cache holds transcode segments + image/metadata cache and grows with use.
+      # Hit 5Gi (99.6% full, 0 bytes free) on 2026-07-02, firing
+      # KubePersistentVolumeFillingUp (critical). Bumped 5Gi -> 20Gi for transcode
+      # headroom; storageClassName truenas-iscsi has allowVolumeExpansion=true so
+      # this expands online.
+      storage: 20Gi


### PR DESCRIPTION
## What

`jellyfin-cache-pvc` fired **KubePersistentVolumeFillingUp (critical)** on 2026-07-02 — it was **99.6% full (5.18 G / 5.2 G, 0 bytes free)**. Jellyfin's `/cache` mount accumulates transcode segments + image/metadata cache and had long outgrown the "~32Mi actual usage" the old comment assumed.

## Fix

Bump the production cache PVC request **5Gi → 20Gi** for transcode headroom. `truenas-iscsi` has `allowVolumeExpansion=true`, so Flux + democratic-csi expand the iSCSI LUN online (no data loss, no recreate).

## Validation

- `kustomize build apps/production/jellyfin` → renders `storage: 20Gi`, build OK
- No plaintext secrets in diff
- Config PVC untouched (7.7% used, healthy)

## Post-merge

- `flux reconcile kustomization apps-production -n flux-system`
- Confirm PVC `.status.capacity` reaches 20Gi and the alert clears
- democratic-csi SSH driver needs `truenas_admin` sudo ON for the LUN resize (per runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)