### PR TITLE
fix(immich): expand CNPG DB storage 2Gi → 10Gi (KubePersistentVolumeFillingUp)

### DIFF
--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -18,9 +18,12 @@ spec:
   monitoring:
     enablePodMonitor: true
   storage:
-    # Actual usage: ~994Mi; target = 20% headroom → 2Gi.
-    # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
-    size: 2Gi
+    # Bumped 2Gi → 10Gi (2026-07-03): replica -4 hit 99% (0 bytes free), firing
+    # KubePersistentVolumeFillingUp (critical). 2Gi left no WAL/temp headroom over the
+    # ~1.1Gi dataset (WAL on -4 had grown to ~2Gi). CNPG expands in place online here
+    # (resizeInUseVolumes=true + truenas-iscsi allowVolumeExpansion + democratic-csi
+    # v1.9.5 online resize, PR #1019). NOTE: shrinking still needs cluster recreation.
+    size: 10Gi
     storageClass: truenas-iscsi
   postgresql:
     shared_preload_libraries:


### PR DESCRIPTION
## What

Replica **`immich-db-prod-cnpg-v3-4`** hit **99% (2024 M / 2040 M, 0 bytes free)** — `KubePersistentVolumeFillingUp` (critical). The CNPG cluster runs on **2 Gi** volumes with no headroom.

| Instance | Role | Fill |
|---|---|---|
| `…-4` | replica | **99.18% (0 free)** |
| `…-5` | primary | 54.5% |
| `…-6` | replica | 54.5% |

Dataset is ~1.1 Gi (primary + `-6`); `-4` carried ~2 Gi because **WAL/temp had grown** on that instance. The primary had room so Immich writes were unaffected, but a full replica risks replication breakage.

## Fix

Bump `spec.storage.size` **2 Gi → 10 Gi**. CNPG expands **in place, online** (`resizeInUseVolumes=true`, `truenas-iscsi` `allowVolumeExpansion`, and online resize now works on democratic-csi v1.9.5 / [#1019](https://github.com/gjcourt/homelab/pull/1019)) — no cluster recreation, no downtime.

## Validation

- `kustomize build apps/production/immich` → renders `size: 10Gi`, OK
- No plaintext secrets in diff
- Cluster currently healthy (3/3, WAL archiving + backups green)

## Post-merge

- `flux reconcile kustomization apps-production -n flux-system`
- Watch CNPG expand each PVC to 10 Gi (replicas first, then primary); confirm `-4` drops below threshold and the alert clears
- Watch whether `-4`'s WAL bloat recurs — if it does, investigate the replication-slot / checkpoint imbalance separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)