### PR TITLE
fix(monitoring): set Alertmanager externalUrl to alerts.burntbytes.com

### DIFF
--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -1057,8 +1057,10 @@ alertmanager:
 
 
     ## The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. string  false
-    ##
-    externalUrl:
+    ## Set to the alerts.burntbytes.com ingress (HTTPRoute in this dir, behind Authelia)
+    ## so the "View In Alertmanager" links in notification emails resolve, instead of
+    ## defaulting to the in-cluster service DNS (unreachable from email/phone).
+    externalUrl: https://alerts.burntbytes.com
 
     ## The route prefix Alertmanager registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true,
     ## but the server serves requests under a different route prefix. For example for use with kubectl proxy.


### PR DESCRIPTION
## What

The **"View In Alertmanager"** button in alert emails points to the wrong host — `http://kube-prometheus-stack-alertmanager.monitoring:9093` (in-cluster service DNS, unreachable from a phone/email).

## Why

`alertmanager.alertmanagerSpec.externalUrl` was empty, so prometheus-operator defaults it to the internal service URL, and that's what gets baked into notification links. The public route (`alerts.burntbytes.com`, behind Authelia) was added in [#1013](https://github.com/gjcourt/homelab/pull/1013) but the `externalUrl` was never pointed at it.

## Fix

Set `externalUrl: https://alerts.burntbytes.com` (served at root, `routePrefix: /`). New emails will link there; clicking prompts Authelia auth, then lands on the alert.

## Validation

- `kustomize build infra/controllers` → OK
- Route already live (`alertmanager-https` → `alerts.burntbytes.com`, 42 h)
- No plaintext secrets

## Post-merge

- `flux reconcile kustomization infra-controllers -n flux-system`; the operator rolls the Alertmanager pod with `--web.external-url=https://alerts.burntbytes.com`
- Verify on the next alert email (or resend) that the button resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)