### PR TITLE
feat: expose Prometheus at prometheus.burntbytes.com behind Authelia

### DIFF
--- a/apps/production/authelia/configuration.yaml
+++ b/apps/production/authelia/configuration.yaml
@@ -18,6 +18,8 @@ access_control:
       policy: one_factor
     - domain: "alerts.burntbytes.com"
       policy: one_factor
+    - domain: "prometheus.burntbytes.com"
+      policy: one_factor
     - domain: "auth.burntbytes.com"
       policy: bypass
       resources:

--- a/infra/controllers/kube-prometheus-stack/httproute.yaml
+++ b/infra/controllers/kube-prometheus-stack/httproute.yaml
@@ -69,3 +69,39 @@ spec:
     - backendRefs:
         - name: kube-prometheus-stack-alertmanager
           port: 9093
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: prometheus-http
+  namespace: monitoring
+spec:
+  hostnames:
+    - prometheus.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: prometheus-https
+  namespace: monitoring
+spec:
+  hostnames:
+    - prometheus.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: kube-prometheus-stack-prometheus
+          port: 9090

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -4194,8 +4194,11 @@ prometheus:
     prometheusExternalLabelNameClear: false
 
     ## External URL at which Prometheus will be reachable.
+    ## Set to the prometheus.burntbytes.com ingress (HTTPRoute in this dir, behind Authelia)
+    ## so the Source / generatorURL links in alert notification emails resolve, instead of
+    ## defaulting to the in-cluster service DNS (unreachable from email/phone).
     ##
-    externalUrl: ""
+    externalUrl: https://prometheus.burntbytes.com
 
     ## Define which Nodes the Pods are scheduled on.
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector


### PR DESCRIPTION
## What

Expose Prometheus on the LAN at `prometheus.burntbytes.com`, behind Authelia `one_factor`, mirroring exactly how Alertmanager was exposed at `alerts.burntbytes.com` (PRs #1013 / #1022). Prometheus has no built-in auth; LAN-only ingress behind Authelia is the intended posture.

## Changes

- **`infra/controllers/kube-prometheus-stack/httproute.yaml`** — add `prometheus-http` (HTTP→HTTPS 301 redirect) and `prometheus-https` (backend `kube-prometheus-stack-prometheus:9090`) HTTPRoutes in ns `monitoring`, parentRef gateway `app-gateway-production` (ns `default`), sectionNames `http`/`https`. Identical structure to the alertmanager routes in the same file.
- **`apps/production/authelia/configuration.yaml`** — add access-control rule `prometheus.burntbytes.com` → `one_factor`, mirroring the `alerts.burntbytes.com` rule. Plaintext YAML, not SOPS-encrypted.
- **`infra/controllers/kube-prometheus-stack/values.yaml`** — set `prometheus.prometheusSpec.externalUrl` from `""` → `https://prometheus.burntbytes.com`, so the `Source` / `generatorURL` links in alert notification emails resolve instead of pointing at unreachable in-cluster service DNS. Comment style mirrors the alertmanager `externalUrl` fix.

## Differs from Alertmanager

- Backend service is `kube-prometheus-stack-prometheus` port `9090` (Alertmanager was `kube-prometheus-stack-alertmanager:9093`).
- The externalUrl field lives under `prometheus.prometheusSpec` (Alertmanager's was under `alertmanager.alertmanagerSpec`).
- Otherwise structurally identical.

## Validation

- `kustomize build infra/controllers` — passes
- `kustomize build apps/production/authelia` — passes
- Secret scan (`git diff --cached | grep -iE 'password|secret|key'`) — clean

## DNS

LAN resolution is covered by the existing `*.burntbytes.com` AdGuard wildcard rewrite (→ `10.42.2.40`, production gateway) documented in `docs/architecture/dns-strategy.md`. No per-host DNS entry exists for `alerts.burntbytes.com` either — the wildcard handles it. **No manual DNS step required.**

## Post-merge checklist

- [ ] `flux reconcile kustomization infra-controllers -n flux-system` (and `apps-production` for the Authelia config) to apply.
- [ ] Verify `https://prometheus.burntbytes.com` on the LAN prompts Authelia login, then loads the Prometheus UI.
- [ ] On the next alert email, confirm the `Source` link points at `https://prometheus.burntbytes.com/...` and resolves.
- [ ] No manual DNS change needed (wildcard covers it) — confirm resolution if the UI 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)