### PR TITLE
feat(homepage): add Prometheus + Alertmanager to the Monitoring group

### DIFF
--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -159,6 +159,16 @@
                 type: number
                 options:
                   maximumFractionDigits: 1
+    - Prometheus:
+        icon: prometheus.png
+        href: https://prometheus.burntbytes.com
+        description: Metrics & query UI
+        siteMonitor: https://prometheus.burntbytes.com
+    - Alertmanager:
+        icon: alertmanager.png
+        href: https://alerts.burntbytes.com
+        description: Active alerts & silences
+        siteMonitor: https://alerts.burntbytes.com
     - Grafana:
         icon: grafana.png
         href: https://grafana.burntbytes.com


### PR DESCRIPTION
Adds **Prometheus** and **Alertmanager** tiles to the production Homepage *Monitoring* group, next to Grafana and the Cluster Resources widget. Each has an `href` + `siteMonitor` (status ping), mirroring the Grafana entry.

- **Alertmanager** → `https://alerts.burntbytes.com` (live now)
- **Prometheus** → `https://prometheus.burntbytes.com` (resolves once [#1023](https://github.com/gjcourt/homelab/pull/1023) merges)

Both sit behind Authelia, LAN-only via the `*.burntbytes.com` wildcard.

## Validation
- `kustomize build apps/production/homepage` → OK (renders both tiles)
- No plaintext secrets

## Post-merge
- `flux reconcile kustomization apps-production -n flux-system`; Homepage reloads its ConfigMap and the tiles appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)