### PR TITLE
feat(immich): upgrade v2.7.5 → v3.0.1

### DIFF
--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -43,7 +43,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
+          # Multi-arch index digest for v3.0.1 (cluster is amd64; containerd
+          # resolves the amd64 sub-manifest). v3 is a MAJOR upgrade: it removes
+          # pgvecto.rs support — the CNPG DB MUST be migrated to VectorChord
+          # BEFORE this image reconciles. See docs/operations/2026-07-02-immich-v3-upgrade.md.
+          image: ghcr.io/immich-app/immich-server:v3.0.1@sha256:46dedfc5848f7313bd6b584ea9f2648057430307aad6de56de968f6710a72cae
           ports:
             - name: http
               containerPort: 2283
@@ -121,7 +125,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           ports:
             - name: http
               containerPort: 3003

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -4,10 +4,27 @@ metadata:
   name: immich-db-prod-cnpg-v3
   namespace: immich-prod
 spec:
-  description: Postgres cluster for Immich with pgvecto.rs for ML search
-  # Use pgvecto.rs 0.3.0 image (compatible with Immich's requirement >=0.2 <0.4)
-  # Note: pg17 not available with v0.3.0, using pg16 instead
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.3.0
+  description: Postgres cluster for Immich — pgvecto.rs → VectorChord migration window
+  # ==========================================================================
+  # OPERATOR-GATED — DO NOT let this reconcile blindly. Part of the Immich v3
+  # upgrade (pgvecto.rs is removed in Immich v3.0). Full procedure + ordering:
+  #   docs/operations/2026-07-02-immich-v3-upgrade.md
+  #
+  # This "migration" image bundles BOTH pgvecto.rs (vectors.so) AND VectorChord
+  # (vchord.so) + pgvector, so the cluster can still READ the existing
+  # pgvecto.rs vector columns while Immich (still on v2.7.5, which supports
+  # both) rebuilds the indexes as VectorChord on startup. Rolling to this image
+  # is NON-destructive on its own (it only ADDS vchord.so; nothing is dropped).
+  #
+  # ORDERING (see runbook): (1) back up + verify restore, (2) apply THIS image +
+  # vchord.so preload while Immich is STILL v2.7.5, (3) CREATE EXTENSION vchord
+  # + let immich-server auto-migrate/reindex, (4) verify search, (5) DROP
+  # EXTENSION vectors + drop vectors.so, (6) ONLY THEN bump immich-server/-ml to
+  # v3.0.1. Immich v3 has NO pgvecto.rs support and will NOT perform the
+  # pgvecto.rs→VectorChord data migration — it must be done on v2.x first.
+  # The DROP EXTENSION vectors step is ONE-WAY: no downgrade below Immich 1.133.
+  # ==========================================================================
+  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
   instances: 3
   enableSuperuserAccess: true
   inheritedMetadata:
@@ -26,8 +43,12 @@ spec:
     size: 10Gi
     storageClass: truenas-iscsi
   postgresql:
+    # Both preloaded during the migration window so existing pgvecto.rs columns
+    # stay readable while VectorChord is introduced. Post-migration (runbook
+    # step 5) drop back to just "vchord.so" and remove the vectors search_path.
     shared_preload_libraries:
       - "vectors.so"
+      - "vchord.so"
     parameters:
       search_path: '"$user", public, vectors'
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -151,12 +151,12 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          # Per-arch (linux/amd64) digest of :v2.7.5; this overrides the base
-          # multi-arch index pin so the GPU-accelerated build runs in production.
-          # When bumping: update both the tag and the digest from
-          # `docker manifest inspect ghcr.io/immich-app/immich-machine-learning:vX.Y.Z`
-          # → pick the linux/amd64 entry's digest.
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          # Multi-arch index digest of :v3.0.1 (the cluster is amd64; containerd
+          # resolves the amd64 sub-manifest for the GPU-accelerated build).
+          # When bumping: `docker buildx imagetools inspect
+          # ghcr.io/immich-app/immich-machine-learning:vX.Y.Z` → use the top-level
+          # "Digest:" (index) value.
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -4,10 +4,17 @@ metadata:
   name: immich-db-staging-cnpg-v1
   namespace: immich-stage
 spec:
-  description: Postgres cluster for Immich with pgvecto.rs for ML search — RECOVERY MODE
-  # Use pgvecto.rs 0.3.0 image (compatible with Immich's requirement >=0.2 <0.4)
-  # Note: pg17 not available with v0.3.0, using pg16 instead
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.3.0
+  description: Postgres cluster for Immich — pgvecto.rs → VectorChord migration window (RECOVERY MODE)
+  # ==========================================================================
+  # OPERATOR-GATED — see docs/operations/2026-07-02-immich-v3-upgrade.md.
+  # Migrate STAGING first (soak before prod). This "migration" image bundles
+  # BOTH pgvecto.rs (vectors.so) AND VectorChord (vchord.so) + pgvector so the
+  # existing pgvecto.rs vector columns stay readable while Immich (still v2.7.5)
+  # rebuilds them as VectorChord. Rolling to this image only ADDS vchord.so —
+  # non-destructive on its own. Do NOT bump immich to v3.0.1 until the
+  # VectorChord migration here is verified. DROP EXTENSION vectors is one-way.
+  # ==========================================================================
+  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
 
   instances: 3
 
@@ -60,8 +67,11 @@ spec:
           policy-type: database
 
   postgresql:
+    # Both preloaded during the migration window (see prod database.yaml).
+    # Post-migration: drop to just "vchord.so" and remove the vectors search_path.
     shared_preload_libraries:
       - "vectors.so"
+      - "vchord.so"
     parameters:
       search_path: '"$user", public, vectors'
 

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -136,7 +136,7 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning@sha256:35b56970279afa31009822609f03fc892effe0107fdb796e5dae57979dc3267c
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,7 +45,7 @@ Planned, not yet started:
 
 - [Network resilience + BGP completion](plans/2026-05-06-network-resilience-and-bgp-completion.md) — the consolidated plan that supersedes the earlier BGP rollout.
 - [democratic-csi least-privilege key](plans/2026-05-09-democratic-csi-least-privilege-key.md).
-- [Immich pgvecto.rs → VectorChord](plans/2026-06-02-immich-vectorchord-migration.md).
+- [Immich pgvecto.rs → VectorChord](plans/2026-06-02-immich-vectorchord-migration.md) — **upgrade staged** in [operations/2026-07-02-immich-v3-upgrade.md](operations/2026-07-02-immich-v3-upgrade.md) (PR, not applied). Immich v3.0.0 removed pgvecto.rs, so the v2.7.5→v3.0.1 bump is gated on this DB migration. Dual-extension CNPG image (`corentingiraud/cnpg-pgvector-vectorchord:16-migration`) resolves the plan's Constraint A / Open Question 1 → in-place swap (Option 3B) now viable. Operator-gated, one-way DB migration.
 
 ## Recently completed (last ~60 days)
 

--- a/docs/operations/2026-07-02-immich-v3-upgrade.md
+++ b/docs/operations/2026-07-02-immich-v3-upgrade.md
@@ -1,0 +1,176 @@
+# Immich v2.7.5 → v3.0.1 upgrade runbook
+
+**Date:** 2026-07-02
+**Status:** staged (PR open, NOT applied). Operator-gated — do not merge/reconcile without executing the ordered steps below.
+**Scope:** Immich server + machine-learning bump to `v3.0.1`, plus the mandatory
+pgvecto.rs → VectorChord database migration that Immich v3 forces.
+
+> This runbook is the execution companion to the planning doc
+> [`docs/plans/2026-06-02-immich-vectorchord-migration.md`](../plans/2026-06-02-immich-vectorchord-migration.md).
+> That plan defaulted to a fresh-cluster rebuild (Option 3A) because no
+> dual-extension CNPG image had been sourced. That open question is now
+> **resolved**: `ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration`
+> ships pgvecto.rs + VectorChord + pgvector together, which makes the
+> **in-place extension swap (Option 3B)** viable and embedding-preserving. This
+> runbook executes 3B.
+
+---
+
+## 1. Why this is high-risk
+
+Immich **v3.0.0 removed all support for the pgvecto.rs vector extension.** Our
+CNPG cluster (`immich-db-prod-cnpg-v3`) is still on pgvecto.rs today
+(`cloudnative-pgvecto.rs:16-v0.3.0`, extension `vectors`, `shared_preload_libraries: vectors.so`).
+If Immich is bumped to v3 before the DB is migrated to VectorChord, the server
+**refuses to start** — v3 does the compatibility check and will not perform the
+pgvecto.rs→VectorChord data migration itself. The migration MUST be done while
+Immich is still on a v2.x build (v2.7.5 supports both extensions).
+
+**The vector migration is one-way.** Once the DB is on VectorChord and you have
+started Immich ≥ v1.133.0 against it, you must not downgrade Immich below
+1.133.0. `DROP EXTENSION vectors` is irreversible without a restore.
+
+Citations:
+- Immich v3.0.0 release / discussion #29439 — "drops support for pgvecto.rs";
+  `DB_VECTOR_EXTENSION=pgvecto.rs` now errors.
+- <https://docs.immich.app/install/upgrading/> — migrate to VectorChord; do not
+  downgrade below 1.133.0 after switching.
+- <https://immich.app/blog/v3-migration> — "Support for pgvecto.rs has been removed in v3."
+
+## 2. Version delta
+
+| Component | From | To |
+|---|---|---|
+| immich-server | `v2.7.5` (`sha256:c15bff75…`, index) | `v3.0.1` (`sha256:46dedfc5…`, index) |
+| immich-machine-learning | `v2.7.5` (`sha256:a2501141…`, index) | `v3.0.1` (`sha256:cb2128c5…`, index) |
+| CNPG DB (migration window) | `cloudnative-pgvecto.rs:16-v0.3.0` | `corentingiraud/cnpg-pgvector-vectorchord:16-migration` (`sha256:0e4f45d3…`) |
+| CNPG DB (end state, manual) | — | `ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2` (VectorChord-only) |
+| Vector extension | pgvecto.rs `vectors` 0.3.0 | VectorChord `vchord` 0.4.x |
+| Postgres major | 16 | **16 (unchanged)** |
+
+**Postgres major stays 16.** Immich v3 accepts PG `>= 14, < 20`; no PG bump is
+required or performed here. (PG17 + VectorChord is a separate follow-up.)
+
+## 3. Breaking changes in v3.0.0 (that matter to us)
+
+1. **pgvecto.rs removed** → VectorChord required. Handled by §4 below. (Highest risk.)
+2. **OAuth: insecure requests disallowed by default** and **`oauth.issuerUrl`
+   must parse as a valid URL.** Our config uses
+   `issuerUrl: https://auth.burntbytes.com` (valid, HTTPS) so **no config change
+   is needed** — but verify SSO login after the bump. If the Authelia hostAlias
+   path ever resolves over HTTP, set `oauth.allowInsecureRequests` in admin
+   settings (we should not need to).
+3. **class-validator → zod validation.** API error response objects changed
+   shape (`error`/`statusCode` fields removed, structured errors, correlationId
+   moved to `X-Correlation-ID` header). Only matters for external API scripts —
+   we have none.
+4. **Metric names changed** (underscores → dots/periods). Any Immich Grafana
+   panels / Prometheus rules keyed on old metric names will go blank. Check
+   dashboards post-upgrade; none are known to be load-bearing.
+5. Removed/changed API endpoints (replace-asset, getRandom, old timeline sync,
+   `/api/server/theme`, deviceId/deviceAssetId, video duration now in **ms** not
+   seconds, `AuditLogCleanup` job removed). No impact on our deployment; noted
+   for completeness. Deprecated server + ML env vars removed — we set none of them.
+
+## 4. Ordered upgrade procedure
+
+Do **staging fully first**, soak, then prod. Same steps, swap namespace/cluster names.
+
+### Phase A — BACK UP (do not skip)
+
+1. Trigger an on-demand CNPG base backup and confirm it completes:
+   ```
+   kubectl -n immich-prod get cluster immich-db-prod-cnpg-v3
+   # create an on-demand Backup CR against the barman objectstore, wait Completed
+   ```
+2. Verify the backup is **restorable** — spin a throwaway recovery cluster from
+   the objectstore in a temp namespace, query a few rows, tear it down
+   (same pattern as the 2026-04-18 DR drill).
+3. Belt-and-suspenders: export the embeddings so a full ML recompute is never
+   forced:
+   ```sql
+   COPY (SELECT * FROM face_search)  TO '/tmp/face_search.csv'  WITH (FORMAT CSV, HEADER);
+   COPY (SELECT * FROM smart_search) TO '/tmp/smart_search.csv' WITH (FORMAT CSV, HEADER);
+   ```
+   Push the CSVs to S3 alongside the WAL archive.
+
+### Phase B — introduce VectorChord (Immich STILL on v2.7.5)
+
+This PR already stages the `database.yaml` change to the dual-extension
+migration image with `shared_preload_libraries: [vectors.so, vchord.so]`. Apply
+**only that DB change** (not the app bump) first:
+
+4. Reconcile the `database.yaml` change (migration image). CNPG does a rolling
+   restart of the 3 instances onto the image that carries both `vectors.so` and
+   `vchord.so`. This is **non-destructive** — it only adds VectorChord; the
+   existing pgvecto.rs columns remain readable. Wait for the cluster to report
+   healthy (primary + 2 replicas) and WAL archiving green.
+5. Create the VectorChord extension (the `immich` role is DB owner but not a
+   superuser; `enableSuperuserAccess: true` lets you connect as `postgres` if
+   the immich role can't create it):
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS vchord CASCADE;   -- pulls in pgvector
+   GRANT ALL ON SCHEMA public TO immich;
+   ```
+6. Restart `immich-server` (still v2.7.5):
+   ```
+   kubectl -n immich-prod rollout restart deploy/immich-server
+   ```
+   Watch the logs. Immich's automatic pgvecto.rs→VectorChord migration (present
+   since server revision 228+ / ≥ v1.133.0) rebuilds the vector indexes. It is
+   **normal** for logs to sit on `Reindexing clip_index` / `Reindexing
+   face_index` for seconds–minutes. Wait for `Finished running migrations`.
+7. **Verify** before going further:
+   - Web UI loads; a **Smart Search** text query returns results.
+   - **Face** grouping still shows people; trigger Face Detection if needed.
+   - No `pgvecto.rs` DEPRECATION WARNING in `immich-server` logs.
+   - No background-worker errors in the PG logs.
+
+### Phase C — drop pgvecto.rs, land the app bump
+
+8. Remove the now-unused pgvecto.rs extension:
+   ```sql
+   DROP EXTENSION IF EXISTS vectors;   -- ONE-WAY. Backups from Phase A are the parachute.
+   ```
+9. (Optional, tidy) Edit `database.yaml` to drop `vectors.so` from
+   `shared_preload_libraries`, remove `vectors` from `search_path`, and — if you
+   want off the community migration image — repoint `imageName` to
+   `ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2`. Reconcile; another
+   rolling restart. (Can be deferred; the migration image is fine to run on.)
+10. **Now** bump Immich to v3.0.1 — reconcile the `deployment.yaml` /
+    `deployment-patch.yaml` image changes in this PR. `strategy: Recreate` means
+    a brief outage while server + ML restart. v3 runs its own schema migrations
+    on first boot.
+11. Verify: web UI, SSO login, uploads, Smart Search, Face grouping, Jobs page
+    all healthy; `kubectl -n immich-prod get pods` all Running.
+
+### Phase D — soak + cleanup
+
+- 24h prod soak. Confirm WAL archiving healthy, search/faces working, no
+  deprecation warnings.
+- Update `docs/operations/apps/immich.md` (the "PostgreSQL (CNPG)" bullet still
+  says pgvector/pgvecto.rs — flip to VectorChord) and `docs/STATUS.md`.
+
+## 5. Rollback
+
+| Failure point | Rollback |
+|---|---|
+| Phase B — VectorChord create / reindex fails, but `vectors` NOT yet dropped | Revert `database.yaml` to `cloudnative-pgvecto.rs:16-v0.3.0`; Immich v2.7.5 keeps using pgvecto.rs. No data lost. |
+| Phase C/D — after `DROP EXTENSION vectors` or after v3 boot | **No in-place downgrade.** Restore the Phase-A base backup into a fresh cluster and revert the app image PR. Embeddings also recoverable from the Phase-A CSVs. |
+| App v3 boot loops but DB already on VectorChord | Revert only the app image to a v2.x that supports VectorChord (≥ v1.133.0); DB stays. |
+
+**Hard rule:** never bump the app to v3 before Phase B verification passes —
+v3 cannot read pgvecto.rs data and cannot run the migration.
+
+## 6. Post-upgrade verification checklist
+
+- [ ] `kubectl -n immich-prod get pods` — server, ML, redis, 3× DB all Running/Ready
+- [ ] `kubectl -n immich-prod get cluster` — healthy, 3 instances, WAL archiving OK
+- [ ] Web UI loads at https://photos.burntbytes.com
+- [ ] SSO (Authelia OIDC) login works
+- [ ] Photo upload from mobile app succeeds
+- [ ] Smart Search text query returns results
+- [ ] People / face grouping intact
+- [ ] Admin → Jobs processing without errors
+- [ ] No `pgvecto.rs` deprecation warning in server logs
+- [ ] `SELECT extname FROM pg_extension;` shows `vchord`, not `vectors`

--- a/docs/plans/2026-06-02-immich-vectorchord-migration.md
+++ b/docs/plans/2026-06-02-immich-vectorchord-migration.md
@@ -1,6 +1,6 @@
 ---
 status: planned
-last_modified: 2026-06-10
+last_modified: 2026-07-02
 summary: "Migrate Immich CNPG from pgvecto.rs to VectorChord"
 ---
 
@@ -205,9 +205,20 @@ Risk: relies on the image supporting both extensions simultaneously (most CNPG-V
 | 5 | `apps/production/immich/database.yaml` v3 → v4 (new cluster, VectorChord) | Phase 3 |
 | 6 | `apps/production/immich/database.yaml` remove old v3 cluster | Phase 4 cleanup |
 
+## Update 2026-07-02 — Constraint A + Q1/Q2 resolved; forced by Immich v3
+
+Immich **v3.0.0 removed pgvecto.rs entirely**, so this migration is now a hard
+prerequisite for the v2.7.5 → v3.0.1 app upgrade (no longer "defer" — option 4
+is off the table). Constraint A is resolved: `ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration`
+is a CNPG image bundling pgvecto.rs + VectorChord + pgvector, so the in-place
+extension swap (**Option 3B**) is viable and embedding-preserving — no fresh
+cluster, no hours of ML recompute. Execution runbook + exact ordered steps:
+[`docs/operations/2026-07-02-immich-v3-upgrade.md`](../operations/2026-07-02-immich-v3-upgrade.md).
+The v3 bump + the migration-image swap are staged together in one (draft) PR.
+
 ## Open questions
 
-1. **Image source**: community CNPG-VectorChord vs. build our own? (Phase 0 deliverable.)
-2. **Cutover shape**: 3A (fresh cluster, regenerate embeddings) or 3B (in-place extension swap)? (Decided after Phase 0 + staging experience.)
+1. ~~**Image source**~~ **Resolved:** `corentingiraud/cnpg-pgvector-vectorchord:16-migration` (dual-extension) for the migration window; `tensorchord/cloudnative-vectorchord:16-0.4.2` (VectorChord-only) for the end state.
+2. ~~**Cutover shape**~~ **Resolved: 3B** (in-place extension swap) — the dual-extension image makes it safe and preserves embeddings.
 3. **Timing**: prod cutover during a low-traffic window (weekend morning)? Or coordinate around someone's Immich usage pattern?
 4. **Snapshot consideration**: should we ZFS-snapshot the staging iSCSI volume before Phase 1, in case Flux ordering surprises us? (Cheap; recommended.)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -80,7 +80,7 @@ see `scripts/plans-index/`).
 | :--- | :--- | :--- |
 | [2026-06-21-bluetooth-presence-system.md](2026-06-21-bluetooth-presence-system.md) | 2026-06-21 | BLE beacon presence/occupancy system (ESPresense → HA → Grafana) for who/how-many is home, per-room |
 | [2026-06-16-burntbytes-mailserver.md](2026-06-16-burntbytes-mailserver.md) | 2026-06-16 | Self-hosted mail for burntbytes.com (<10 accounts): Mailu on the cluster + VPS SMTP gateway + SES smarthost |
-| [2026-06-02-immich-vectorchord-migration.md](2026-06-02-immich-vectorchord-migration.md) | 2026-06-10 | Migrate Immich CNPG from pgvecto.rs to VectorChord |
+| [2026-06-02-immich-vectorchord-migration.md](2026-06-02-immich-vectorchord-migration.md) | 2026-07-02 | Migrate Immich CNPG from pgvecto.rs to VectorChord |
 | [2026-05-09-democratic-csi-least-privilege-key.md](2026-05-09-democratic-csi-least-privilege-key.md) | 2026-05-09 | Migrate democratic-csi to a least-privilege TrueNAS API key |
 | [2026-05-06-network-resilience-and-bgp-completion.md](2026-05-06-network-resilience-and-bgp-completion.md) | 2026-05-06 | Unified network resilience + BGP completion plan, phases A-F with GO gates |
 | [2026-03-08-drawer-inserts.md](2026-03-08-drawer-inserts.md) | 2026-05-03 | Cardboard drawer insert design (75×32×12 cm) — physical project, no repo artifacts |


### PR DESCRIPTION
## Summary

Bumps **immich-server + immich-machine-learning to `v3.0.1`** and stages the **mandatory pgvecto.rs → VectorChord DB migration** that Immich v3 forces.

**Draft on purpose.** Immich **v3.0.0 removed all support for the pgvecto.rs vector extension**, which our CNPG cluster still runs. v3 refuses to start against a pgvecto.rs DB and will *not* run the pgvecto.rs→VectorChord data migration itself — that must be done on a v2.x server first, and the DB migration is **one-way**. So this must NOT be merged/reconciled wholesale; the operator executes the ordered steps in the runbook, and the app-image bump only lands *after* the DB is on VectorChord.

## What's in the PR

- **App bump** (safe to reconcile *after* the DB migration): server + ML → `v3.0.1`, multi-arch index digests, in `apps/base/immich/deployment.yaml` + prod/staging `deployment-patch.yaml`.
- **DB migration image (operator-gated)**: `apps/{production,staging}/immich/database.yaml` → `ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration` (bundles pgvecto.rs + VectorChord + pgvector), with `vchord.so` added alongside `vectors.so`. Rolling to this image is **non-destructive** (adds VectorChord only). The destructive `DROP EXTENSION vectors` is a manual psql step, never in a manifest.
- **Runbook**: `docs/operations/2026-07-02-immich-v3-upgrade.md` — version delta, all breaking changes, ordered upgrade (backup → introduce VectorChord on v2.7.5 → verify → drop pgvecto.rs → bump to v3), rollback matrix, verification checklist.
- **Docs**: STATUS + the 2026-06-02 VectorChord plan updated (resolves its Constraint A / Open Questions 1-2 — dual-extension image sourced ⇒ in-place swap / Option 3B viable); plans index regenerated.

## The definitive vector-extension answer

**pgvecto.rs → VectorChord migration is REQUIRED for v3.0.1.** Immich v3.0.0 dropped pgvecto.rs; `DB_VECTOR_EXTENSION=pgvecto.rs` now errors (release discussion #29439, https://docs.immich.app/install/upgrading/, https://immich.app/blog/v3-migration). Postgres major stays **16** (v3 accepts PG ≥14 <20; no PG bump).

## Validation

- `kustomize build` passes for base / production / staging immich.
- Secret scan clean. No SOPS-encrypted files touched.
- Image tags strictly increasing (v2.7.5 → v3.0.1).

## NOT done (operator-only, one-way)

Nothing applied to the cluster. Backup+restore-verify, the DB migration-image reconcile, `CREATE EXTENSION vchord` / auto-reindex on v2.7.5, `DROP EXTENSION vectors`, and the final v3 app reconcile are all left to the owner per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)