### PR TITLE
feat(ladder): deploy to ladder.burntbytes.com (LAN-only, Authelia)

### DIFF
--- a/apps/base/ladder/deployment.yaml
+++ b/apps/base/ladder/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ladder
+  namespace: ladder
+  labels:
+    app: ladder
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: ladder
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: ladder
+    spec:
+      serviceAccountName: ladder
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ghcr-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ladder
+          # Private code-only image on GHCR, pulled via the ghcr-secret. Pinned by
+          # digest (immutable) — bumps are explicit tag+digest PRs, never :latest.
+          image: ghcr.io/gjcourt/ladder:2026-07-03-20b7820@sha256:59696ef58170fa3e440714a95bda6e5e1e4d89a2ec30f5578321d5b22efc30ef
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: "8080"
+            - name: STATIC_DIR
+              value: /app/dist
+            - name: EDGAR_USER_AGENT
+              value: "ladder-fundamentals/0.1 (gjcourt@gmail.com)"
+            # The EDGAR proxy writes a disk cache; the container is non-root with a
+            # read-only root fs, so point it at the writable /cache emptyDir below.
+            - name: EDGAR_CACHE_DIR
+              value: /cache
+          resources:
+            requests:
+              cpu: 10m
+              memory: 48Mi
+            limits:
+              cpu: 200m
+              memory: 192Mi
+          # SPA + EDGAR proxy. /api/edgar/health returns {"ok":true} — an honest
+          # readiness signal. No livenessProbe: it would share path + timing with
+          # readiness and only add restart-flap risk (per
+          # docs/operations/2026-05-02-adding-an-app.md#health-probes).
+          readinessProbe:
+            httpGet:
+              path: /api/edgar/health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # EDGAR disk cache — ephemeral, rebuilt from public SEC data on restart.
+        - name: cache
+          emptyDir: {}
+        # Scratch for the Node process under a read-only root fs.
+        - name: tmp
+          emptyDir: {}

--- a/apps/base/ladder/httproute.yaml
+++ b/apps/base/ladder/httproute.yaml
@@ -1,0 +1,41 @@
+# LAN-only front door: https://ladder.burntbytes.com via the Cilium gateway.
+# The gateway's *.burntbytes.com listener already terminates TLS with the
+# wildcard cert, and internal DNS resolves *.burntbytes.com to the gateway's
+# LAN IP — so no per-host DNS or cert change is needed. Not tunneled = LAN-only.
+# Authelia ext_authz on the gateway gates every route; the one_factor rule for
+# this host lives in apps/production/authelia/configuration.yaml.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: ladder-http
+  namespace: ladder
+spec:
+  hostnames:
+    - ladder.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: ladder-https
+  namespace: ladder
+spec:
+  hostnames:
+    - ladder.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: ladder
+          port: 8080

--- a/apps/base/ladder/kustomization.yaml
+++ b/apps/base/ladder/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - httproute.yaml
+  # SOPS-encrypted, operator-created from secret-ghcr.yaml.example. CI / kustomize
+  # build fails until it exists — the intended gate (private GHCR image can't be
+  # pulled without it).
+  - secret-ghcr.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: ladder
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/ladder/namespace.yaml
+++ b/apps/base/ladder/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ladder
+  labels:
+    # Admits the HTTPRoute to the LAN gateway (app-gateway-production), serving
+    # https://ladder.burntbytes.com off the wildcard cert. The gateway only holds
+    # a LAN IP (home-c-pool) and is NOT tunneled to the internet, so ladder
+    # resolves + serves on the local network only. Authelia (ext_authz on the
+    # gateway) additionally gates it at one_factor — see apps/production/authelia.
+    http-ingress: "true"

--- a/apps/base/ladder/networkpolicy.yaml
+++ b/apps/base/ladder/networkpolicy.yaml
@@ -1,0 +1,55 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ladder
+  namespace: ladder
+  labels:
+    app.kubernetes.io/name: ladder
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    ladder — static SPA + EDGAR proxy serving https://ladder.burntbytes.com on
+    8080. No DB. Ingress from the Cilium gateway proxy only. Egress is DNS plus
+    HTTPS to the two public SEC hosts (Fundamentals tab); nothing else. User
+    financial data never touches the server (client-side localStorage only).
+  endpointSelector:
+    matchLabels:
+      app: ladder
+  ingress:
+    # Cilium Envoy (Gateway API) binds upstream sockets to a dedicated proxy IP
+    # marked as reserved identity 8 ("ingress"). Same-node connections arrive as
+    # "host"; cross-node VXLAN connections as "remote-node". All three required.
+    # Kubelet readiness probes are auto-exempted.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # DNS via CoreDNS. The L7 dns rule lets Cilium's DNS proxy learn the SEC IPs
+    # so the toFQDNs egress below can resolve — required for FQDN policy to work.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # Public SEC data for the Fundamentals tab — these two hosts ONLY, on 443.
+    # No blanket world egress.
+    - toFQDNs:
+        - matchName: "www.sec.gov"
+        - matchName: "data.sec.gov"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/ladder/secret-ghcr.yaml
+++ b/apps/base/ladder/secret-ghcr.yaml
@@ -1,0 +1,41 @@
+# The GHCR package is PRIVATE, so Flux CANNOT pull the image until this secret
+# exists (SOPS-encrypted) at apps/base/ladder/secret-ghcr.yaml. kustomize build
+# fails until it exists — that failure is the intended operator gate.
+#
+# Create the real, encrypted secret (you run this — needs a ghcr PAT with
+# read:packages scope in $GHCR_PAT):
+#
+#   kubectl create secret docker-registry ghcr-secret \
+#     --docker-server=ghcr.io \
+#     --docker-username=gjcourt \
+#     --docker-password="$GHCR_PAT" \
+#     --namespace=ladder \
+#     --dry-run=client -o yaml \
+#     > apps/base/ladder/secret-ghcr.yaml
+#   sops -e -i apps/base/ladder/secret-ghcr.yaml
+#
+# The .sops.yaml "*secret*.yaml" rule encrypts the .dockerconfigjson data field.
+# Never commit an unencrypted secret-ghcr.yaml.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-secret
+  namespace: ladder
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:brUnebYzdzcCOriYldElB6NyyNZr0JNu7taSDhSWJ/UXztBMBs11481On/g3vuNQhzcWYTpM2uJyXTdWbEY3oeVDmq7swV6KXeKuTxlbNbpYrxFUm4hxJqInBRXHQbe9he1u8NRRID158p2gR+ej8j5VUBmA633njwYEESzST0kH7kXwcRBmpS/fe2zE122l5KAOE1xUIxmoctDPZLiBwyw/TFP78zOJu8SDTA65lFadvwrl368mtWxH7v0PhAyTFs0y89VHXpXMDIzmxUCsD4nnfOGPIVNdN7DPsgDSBQsAK34w5flPDA==,iv:XlsJdJJNb0zR8+K46GAdUTA1ka6lu6DgBWG1mv7+vVY=,tag:/NBiCDYGZwa+Smkv8O3T6Q==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwK0ZWNFdwc2M4alJQdzJH
+        cW1TbnYra011QVljb241N1dDNjZaWlh2eFNvCjFMQUhXVjRMUlp6bXR6ZkNVeWEr
+        dlhwTVJwWmUvRHRwclBEd2Z6SXRjbVUKLS0tIGhUcFJkU1g3MEE5WEY5bGk5aGFk
+        dkJUWE1kMUYxdm40RFF3NDJBeU54OFkK2aBcu2aWkwDvG0rKfXyOrAh0U2d/jRyf
+        YDyKinaKqx/aBXzezTO2cshENc4BWoTwznyEyNm06r1MiBKreWpJWg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-03T16:09:34Z"
+  mac: ENC[AES256_GCM,data:UllaIprrasoO/R0MMKX8CtnLde8StIbffcZLBlE/ImIjv2GEuGOZILupDEjrDxsPfPnSb69De0YO7v6aogNq9RNCScpu/oTTOwERsSwV6vWKDK5KzCImniPO8TXD8d8piwN/XA0w/QNLHbWxfwrN9oa2srzWhYf5/itIOH/psp4=,iv:3AaXiLjcD8cGG2RDbFmjmyMGhZ5qvcHCyTycEvvHcZs=,tag:ugJ5t4AAPhWvbMZRbKUymA==,type:str]
+  version: 3.13.1

--- a/apps/base/ladder/secret-ghcr.yaml.example
+++ b/apps/base/ladder/secret-ghcr.yaml.example
@@ -1,0 +1,29 @@
+# TEMPLATE — operator-only. ghcr.io image-pull secret for the PRIVATE
+# gjcourt/ladder image. The deployment references it as `ghcr-secret`.
+#
+# The GHCR package is PRIVATE, so Flux CANNOT pull the image until this secret
+# exists (SOPS-encrypted) at apps/base/ladder/secret-ghcr.yaml. kustomize build
+# fails until it exists — that failure is the intended operator gate.
+#
+# Create the real, encrypted secret (you run this — needs a ghcr PAT with
+# read:packages scope in $GHCR_PAT):
+#
+#   kubectl create secret docker-registry ghcr-secret \
+#     --docker-server=ghcr.io \
+#     --docker-username=gjcourt \
+#     --docker-password="$GHCR_PAT" \
+#     --namespace=ladder \
+#     --dry-run=client -o yaml \
+#     > apps/base/ladder/secret-ghcr.yaml
+#   sops -e -i apps/base/ladder/secret-ghcr.yaml
+#
+# The .sops.yaml "*secret*.yaml" rule encrypts the .dockerconfigjson data field.
+# Never commit an unencrypted secret-ghcr.yaml.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-secret
+  namespace: ladder
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: REPLACE_ME_BASE64_DOCKERCONFIGJSON

--- a/apps/base/ladder/service.yaml
+++ b/apps/base/ladder/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ladder
+  namespace: ladder
+  labels:
+    app: ladder
+spec:
+  # ClusterIP — the LAN gateway (HTTPRoute → https://ladder.burntbytes.com)
+  # routes to it. Fallback for debugging without DNS:
+  #   kubectl -n ladder port-forward svc/ladder 8080:8080
+  type: ClusterIP
+  selector:
+    app: ladder
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080

--- a/apps/base/ladder/serviceaccount.yaml
+++ b/apps/base/ladder/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ladder
+  namespace: ladder

--- a/apps/production/authelia/configuration.yaml
+++ b/apps/production/authelia/configuration.yaml
@@ -20,6 +20,8 @@ access_control:
       policy: one_factor
     - domain: "prometheus.burntbytes.com"
       policy: one_factor
+    - domain: "ladder.burntbytes.com"
+      policy: one_factor
     - domain: "auth.burntbytes.com"
       policy: bypass
       resources:

--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -46,6 +46,13 @@
         href: https://finance.burntbytes.com
         description: Net worth + IPS allocation dashboard
         siteMonitor: https://finance.burntbytes.com
+    - Ladder:
+        icon: mdi-ladder
+        href: https://ladder.burntbytes.com
+        description: Bond ladder + SEC fundamentals workbench
+        # /api/edgar/health returns {"ok":true}; the root path is a SPA, so probe
+        # the health endpoint for the status dot.
+        siteMonitor: https://ladder.burntbytes.com/api/edgar/health
     - Vitals:
         icon: mdi-heart-pulse
         href: https://vitals.burntbytes.com

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - homepage
   - immich
   - jellyfin
+  - ladder
   - linkding
   - mealie
   - memos

--- a/apps/production/ladder/kustomization.yaml
+++ b/apps/production/ladder/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ladder
+resources:
+  - ../../base/ladder/
+labels:
+  - includeSelectors: false
+    pairs:
+      env: production
+      app.kubernetes.io/instance: production


### PR DESCRIPTION
Deploys the `ladder` app (SEC-fundamentals SPA + EDGAR proxy) to
`https://ladder.burntbytes.com` — LAN-only via the Cilium gateway, gated by
Authelia `one_factor`. Mirrors the `finance-dashboard` app file-for-file.

## What this adds
- **`apps/base/ladder/`** — namespace, serviceaccount, deployment, service,
  HTTPRoute (`ladder-http` 301→ `ladder-https`), CiliumNetworkPolicy,
  `secret-ghcr.yaml.example`, kustomization.
- **`apps/production/ladder/`** — production overlay, wired into
  `apps/production/kustomization.yaml`.
- **Authelia** — `ladder.burntbytes.com → one_factor`.
- **Homepage** — `Ladder` tile in the **Tools** group (next to Finance).

## Container contract (as deployed)
- Image **pinned by digest**: `ghcr.io/gjcourt/ladder:2026-07-03-20b7820@sha256:59696ef…c30ef` (private GHCR).
- Port **8080**, non-root **uid 1000**, `NODE_ENV=production`, `readOnlyRootFilesystem: true`.
- Env: `PORT=8080`, `STATIC_DIR=/app/dist`, `EDGAR_USER_AGENT=…`, `EDGAR_CACHE_DIR=/cache`.
- Writable `emptyDir`s at **`/cache`** (EDGAR disk cache) and **`/tmp`** (Node scratch under RO rootfs).
- **readinessProbe** on `GET /api/edgar/health` (→ `{"ok":true}`); no livenessProbe (no distinct signal — per the repo health-probe rule).

## Security posture
- **Egress is scoped**: DNS to kube-dns (with L7 DNS rule so Cilium can resolve FQDNs) + `toFQDNs` **`www.sec.gov`** and **`data.sec.gov`** on 443 **only**. No blanket world egress.
- **Ingress**: gateway proxy only (`fromEntities: [host, remote-node, ingress]`).
- **Authelia `one_factor`** for `ladder.burntbytes.com` (ext_authz on the gateway; default policy is bypass, so the explicit rule is what gates it).
- No user financial data hits the server — the app proxies public SEC data only; user data is client-side localStorage.

## SOPS gate (why CI `kustomize build` will fail until the operator acts)
The GHCR package is **private**, so Flux cannot pull without a `ghcr-secret` in
the `ladder` namespace. Per the operator-only-secrets rule, this PR ships only
`secret-ghcr.yaml.example`; the real `secret-ghcr.yaml` is referenced by the
kustomization but intentionally absent, so `kustomize build apps/base/ladder`
(and the production overlay) **fail until the operator creates + encrypts it** —
that failure is the intended gate, identical to how `finance-dashboard` handles it.

## Operator checklist (before this can go live)
1. **Create + encrypt the pull secret** (needs a GHCR PAT with `read:packages` in `$GHCR_PAT`):
   ```
   kubectl create secret docker-registry ghcr-secret \
     --docker-server=ghcr.io --docker-username=gjcourt \
     --docker-password="$GHCR_PAT" --namespace=ladder \
     --dry-run=client -o yaml > apps/base/ladder/secret-ghcr.yaml
   sops -e -i apps/base/ladder/secret-ghcr.yaml
   ```
   Commit the encrypted file to this branch (this un-breaks `kustomize build` / CI).
2. Merge, then **`flux reconcile kustomization apps-production -n flux-system`**.
3. **Verify**: `https://ladder.burntbytes.com` prompts Authelia (one_factor), the SPA loads, and the **Fundamentals** tab pulls a company (confirms egress to `www.sec.gov` / `data.sec.gov` works).
4. Confirm the **Ladder** tile shows a green status dot on Homepage.

## Validation done
- `kustomize build` passes for `apps/base/ladder`, `apps/production/ladder`,
  `apps/production/authelia`, `apps/production/homepage` (verified with a throwaway
  placeholder secret that was **not** committed).
- Without the secret, both ladder overlays fail on the missing `secret-ghcr.yaml`
  — the documented SOPS gate.
- Secret scan: only the `.example` placeholder (`REPLACE_ME_BASE64_DOCKERCONFIGJSON`) — no real credential.

**Do not merge** until the operator has committed the encrypted `secret-ghcr.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)