### PR TITLE
chore(immich-staging): normalize DB to fixed 10Gi mirror of prod

### DIFF
--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -23,9 +23,19 @@ spec:
     enablePodMonitor: true
 
   storage:
-    # Expanded from 10Gi to 20Gi after filling up (pgdata ~9.5Gi as of 2026-04-17).
+    # Standard size = 10Gi, a fixed-size mirror of prod (immich-db-prod-cnpg-v3,
+    # live at 10Gi). Staging is a disposable rehearsal testbed; it does not need
+    # to hold a full prod-scale dataset, so we pin it to prod's shape rather than
+    # letting it drift (it had crept to 20Gi on 2026-04-17 while filling up).
+    #
+    # CNPG CANNOT shrink a PVC in-place, so changing this value from 20Gi to 10Gi
+    # does NOT take effect on the live cluster by itself — the staging DB Cluster
+    # must be destroyed and recreated for the new size to apply. Staging data is
+    # disposable/rebuildable, so this is safe to do at the operator's convenience.
+    # See docs/operations/apps/immich.md §10 "Staging DB: fixed 10Gi mirror of prod"
+    # for the exact recreate steps and the orphaned-PV cleanup checklist.
     storageClass: truenas-iscsi
-    size: 20Gi
+    size: 10Gi
 
   resources:
     requests:

--- a/docs/operations/apps/immich.md
+++ b/docs/operations/apps/immich.md
@@ -66,3 +66,80 @@ To verify Immich is working:
   - Verify `/dev/dri` is mounted correctly and the pod has the necessary privileges/groups (e.g., `video`, `render`).
   - Check the server logs for FFmpeg errors.
 - **Database Connection Issues**: Verify the CNPG cluster is healthy and the credentials secret matches the deployment environment variables.
+
+## 10. Staging DB: fixed 10Gi mirror of prod
+
+The staging Postgres cluster (`immich-db-staging-cnpg-v1`, ns `immich-stage`) is intended to be a **stable, fixed-size mirror of prod** for rehearsal — same shape as production (`immich-db-prod-cnpg-v3`, live at **10Gi**), just a smaller-scale disposable copy. The standard staging DB size is therefore **10Gi**, set in `apps/staging/immich/database.yaml` (`spec.storage.size`).
+
+### Why a recreate is required to change the size
+
+**CNPG cannot shrink a PVC in-place.** The staging PVCs had drifted to 20Gi; `apps/staging/immich/database.yaml` now declares 10Gi, but Flux applying that manifest does **not** shrink the live volumes. The size only takes effect when the Cluster (and its PVCs) is destroyed and recreated. Staging data is disposable/rebuildable, so this is safe to do whenever convenient.
+
+### Recreate procedure (operator, live cluster)
+
+Run from a machine with `kubectl` LAN access. Suspend Flux first so it does not race the delete.
+
+```bash
+# 1. Suspend Flux staging reconciliation so it doesn't recreate mid-delete.
+flux suspend kustomization apps-staging -n flux-system
+
+# 2. Scale immich-server down so nothing writes to the DB during teardown.
+kubectl scale deploy -n immich-stage immich-server --replicas=0
+
+# 3. Delete the CNPG Cluster (this removes the managed pods; PVCs are Retain so they persist).
+kubectl delete cluster -n immich-stage immich-db-staging-cnpg-v1
+
+# 4. Delete the live staging DB PVCs (currently 20Gi) so they can be recreated at 10Gi.
+#    Check first, then delete each one that belongs to the cluster:
+kubectl get pvc -n immich-stage | grep immich-db-staging-cnpg-v1
+kubectl delete pvc -n immich-stage <each immich-db-staging-cnpg-v1-N above>
+
+# 5. Resume Flux; it recreates the Cluster from Git at size: 10Gi.
+flux resume kustomization apps-staging -n flux-system
+flux reconcile kustomization apps-staging -n flux-system
+
+# 6. Watch the cluster bootstrap (recovery from S3 per bootstrap.recovery in the manifest).
+kubectl get cluster -n immich-stage -w
+kubectl get pods  -n immich-stage -l cnpg.io/cluster=immich-db-staging-cnpg-v1 -w
+
+# 7. Scale immich-server back up and verify the app.
+kubectl scale deploy -n immich-stage immich-server --replicas=1
+```
+
+New PVCs will be created at 10Gi. Verify with:
+
+```bash
+kubectl get cluster -n immich-stage immich-db-staging-cnpg-v1 -o jsonpath='{.spec.storage.size}'; echo
+kubectl get pvc -n immich-stage | grep immich-db-staging-cnpg-v1   # expect 10Gi
+```
+
+> Note: the staging cluster bootstraps via `bootstrap.recovery` (rebuilt from backup during the 2026-04-18 DR test). It restores from the S3 ObjectStore, so a recreate re-hydrates staging from the last good backup — no manual data reload needed. If the WAL/serverName path needs bumping during recovery, see the History comments in `database.yaml`.
+
+### Orphaned Retain PV cleanup (operator, destructive)
+
+Staging accumulated a backlog of `Released` + `Retain` PVs from prior CNPG replica churn (replicas -1/-2/-3/-4/-6 recycled multiple times) plus some stale app volumes. These are **not** in use (`Released` = no bound claim) and hold no data worth keeping — delete them to reclaim the underlying iSCSI/zvol space. Confirm each is still `Released` before deleting:
+
+```bash
+kubectl get pv | grep -i immich-stage | grep Released
+```
+
+Then delete each Released PV (do NOT touch any `Bound` PV — those back the live cluster):
+
+```bash
+# CNPG replica PVCs (old, recycled) — 9 volumes:
+kubectl delete pv pvc-03264ca4-89e8-47e6-a8ae-02e4498170c9   # immich-db-staging-cnpg-v1-1
+kubectl delete pv pvc-92fed6fa-85b7-453b-8a1d-1c24a5b307f1   # immich-db-staging-cnpg-v1-1
+kubectl delete pv pvc-f5cd392a-e666-4f99-b22e-55e582c12b95   # immich-db-staging-cnpg-v1-1
+kubectl delete pv pvc-06cc39fd-63f8-4c0b-bcdd-b27ad7555b3c   # immich-db-staging-cnpg-v1-2
+kubectl delete pv pvc-f31762ee-0322-43c8-be6b-b5d5e55da7c1   # immich-db-staging-cnpg-v1-2
+kubectl delete pv pvc-08245378-9a1a-454a-867a-798ebab2590d   # immich-db-staging-cnpg-v1-3
+kubectl delete pv pvc-cd8f88f9-c2cd-4f97-a766-d786667001bd   # immich-db-staging-cnpg-v1-3
+kubectl delete pv pvc-832d02bc-c96e-4d99-8d3d-dfb988687019   # immich-db-staging-cnpg-v1-4
+kubectl delete pv pvc-78526a2e-dc00-48ae-b93b-4dce00cb9273   # immich-db-staging-cnpg-v1-6
+# Stale app volumes (superseded by current Bound PVs):
+kubectl delete pv pvc-4a7d497e-02ce-4469-bb59-23e78ce3dc6f   # immich-upload-pvc-tmp (100Gi)
+kubectl delete pv pvc-5d411d62-80c3-4d53-b76b-232a51e8e60f   # immich-upload-pvc (100Gi, old)
+kubectl delete pv pvc-574d9a9b-d8cc-4b79-b2ea-9d29637856e3   # immich-model-cache-pvc (10Gi, old)
+```
+
+The underlying democratic-csi zvols/LUNs on TrueNAS/Synology are `Retain`, so deleting the PV frees the Kubernetes object but the backing dataset may need a separate reclaim on the NAS if space is tight. The PV UUIDs above are a snapshot from 2026-07-03 — always re-run the `grep Released` command and delete by current name.


### PR DESCRIPTION
## Summary

Make the Immich **staging** Postgres cluster a stable, fixed-size mirror of prod. Staging (`immich-db-staging-cnpg-v1`, ns `immich-stage`) had drifted to **20Gi** while prod (`immich-db-prod-cnpg-v3`) is **live at 10Gi**. This PR pins staging `spec.storage.size` to **10Gi** so the rehearsal testbed matches prod's shape instead of drifting under load.

**Manifest + docs only — nothing is applied to the cluster in this PR.**

## Files changed
- `apps/staging/immich/database.yaml` — `storage.size` 20Gi → 10Gi (+ explanatory comment).
- `docs/operations/apps/immich.md` — new §10 "Staging DB: fixed 10Gi mirror of prod" with the recreate procedure and the orphaned-PV cleanup checklist.

`instances: 3` left as-is (matches prod). No separate `walStorage` in either overlay. No other shape differences to normalize.

## ⚠️ CNPG caveat — recreate required for the size to take effect
CNPG **cannot shrink a PVC in-place**, so Flux applying this manifest does **not** shrink the live 20Gi volumes. The 10Gi size only applies after the staging DB Cluster + its PVCs are **destroyed and recreated**. Staging data is disposable (bootstraps from S3 via `bootstrap.recovery`), so this is safe whenever convenient. Full step-by-step (suspend Flux → scale immich down → delete Cluster + PVCs → resume Flux → verify) is in the runbook §10.

## Recommendation: standardize now, recreate at operator's convenience
I recommend **landing 10Gi as the standard (this PR) and deferring the recreate** rather than forcing a destroy/recreate immediately:
- Staging is functional at 20Gi today (a freshly-repaired replica just came healthy); there's no capacity pressure forcing the shrink.
- The recreate is a live, destructive, operator-gated op (delete Cluster + PVCs, re-bootstrap from S3) — better done deliberately than rushed.
- Pinning the manifest to 10Gi stops further drift and makes the next natural cluster recreate land at the right size automatically.

Net: the reclaim worth chasing now is the **orphaned Released PVs** below (free space, zero risk to the live cluster); the 20Gi→10Gi shrink can ride the next recreate.

## Operator cleanup checklist — orphaned Released/Retain PVs in `immich-stage`
Snapshot from `kubectl get pv | grep -i immich-stage | grep Released` on 2026-07-03. All `Released` (no bound claim) + `Retain`. **Do NOT touch any `Bound` PV** (those back the live cluster: `immich-db-staging-cnpg-v1-5/-7/-8`, `immich-upload-pvc`, `immich-model-cache-pvc`, `immich-photos-pvc`). Re-verify with the grep before deleting.

CNPG replica PVCs (old, recycled) — 9:
- [ ] `pvc-03264ca4-89e8-47e6-a8ae-02e4498170c9` — immich-db-staging-cnpg-v1-1
- [ ] `pvc-92fed6fa-85b7-453b-8a1d-1c24a5b307f1` — immich-db-staging-cnpg-v1-1
- [ ] `pvc-f5cd392a-e666-4f99-b22e-55e582c12b95` — immich-db-staging-cnpg-v1-1
- [ ] `pvc-06cc39fd-63f8-4c0b-bcdd-b27ad7555b3c` — immich-db-staging-cnpg-v1-2
- [ ] `pvc-f31762ee-0322-43c8-be6b-b5d5e55da7c1` — immich-db-staging-cnpg-v1-2
- [ ] `pvc-08245378-9a1a-454a-867a-798ebab2590d` — immich-db-staging-cnpg-v1-3
- [ ] `pvc-cd8f88f9-c2cd-4f97-a766-d786667001bd` — immich-db-staging-cnpg-v1-3
- [ ] `pvc-832d02bc-c96e-4d99-8d3d-dfb988687019` — immich-db-staging-cnpg-v1-4
- [ ] `pvc-78526a2e-dc00-48ae-b93b-4dce00cb9273` — immich-db-staging-cnpg-v1-6

Stale app volumes (superseded by current Bound PVs) — 3:
- [ ] `pvc-4a7d497e-02ce-4469-bb59-23e78ce3dc6f` — immich-upload-pvc-tmp (100Gi)
- [ ] `pvc-5d411d62-80c3-4d53-b76b-232a51e8e60f` — immich-upload-pvc (100Gi, old)
- [ ] `pvc-574d9a9b-d8cc-4b79-b2ea-9d29637856e3` — immich-model-cache-pvc (10Gi, old)

```bash
kubectl delete pv <name>   # for each Released PV above
```
democratic-csi zvols/LUNs are `Retain`, so deleting the PV frees the k8s object but the backing dataset may need a separate reclaim on the NAS if space is tight.

## Follow-up (optional)
Staging DB already has `monitoring.enablePodMonitor: true` (same as prod), so degradation is scraped. A dedicated CNPG-staging degraded alert could be added later if the recent 9-day wedged-replica incident recurs — noted as a follow-up, not done here to avoid alert sprawl.

## Validation
- `kustomize build apps/staging/immich` ✅ (renders `size: 10Gi`)
- `kustomize build apps/production/immich` ✅ (unaffected sanity)
- Secret scan clean; no SOPS edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)