### PR TITLE
feat(immich): Phase C — app → v3.0.1 + VectorChord-only DB cleanup [DRAFT/gated]

### DIFF
--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -43,7 +43,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
+          # Multi-arch index digest for v3.0.1 (cluster is amd64; containerd
+          # resolves the amd64 sub-manifest). v3 is a MAJOR upgrade: it removes
+          # pgvecto.rs support — the CNPG DB MUST be migrated to VectorChord
+          # BEFORE this image reconciles. See docs/operations/2026-07-02-immich-v3-upgrade.md.
+          image: ghcr.io/immich-app/immich-server:v3.0.1@sha256:46dedfc5848f7313bd6b584ea9f2648057430307aad6de56de968f6710a72cae
           ports:
             - name: http
               containerPort: 2283
@@ -121,7 +125,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           ports:
             - name: http
               containerPort: 3003

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -4,10 +4,25 @@ metadata:
   name: immich-db-prod-cnpg-v3
   namespace: immich-prod
 spec:
-  description: Postgres cluster for Immich with pgvecto.rs for ML search
-  # Use pgvecto.rs 0.3.0 image (compatible with Immich's requirement >=0.2 <0.4)
-  # Note: pg17 not available with v0.3.0, using pg16 instead
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.3.0
+  description: Postgres cluster for Immich with VectorChord (vchord) for ML search
+  # ==========================================================================
+  # PHASE C (end state) — VectorChord only. Full procedure + ordering:
+  #   docs/operations/2026-07-02-immich-v3-upgrade.md
+  #
+  # This is the post-migration cleanup: the dual-extension migration image
+  # (Phase B / PR-B) has been applied, `CREATE EXTENSION vchord CASCADE` was run
+  # as the postgres superuser, Immich v2.7.5 migrated the embeddings into
+  # VectorChord and dropped the old `vectors` extension, and search/faces were
+  # verified. This PR drops back to the slim VectorChord-only image
+  # (tensorchord/cloudnative-vectorchord) with only vchord.so preloaded and no
+  # `vectors` in the search_path.
+  #
+  # MUST NOT reconcile before Phase B is merged AND its manual migration +
+  # verify have completed — dropping vectors.so while the DB still holds
+  # pgvecto.rs data would break Immich. The vector migration is ONE-WAY: no
+  # downgrade below Immich 1.133 after this.
+  # ==========================================================================
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
   instances: 3
   enableSuperuserAccess: true
   inheritedMetadata:
@@ -26,10 +41,13 @@ spec:
     size: 10Gi
     storageClass: truenas-iscsi
   postgresql:
+    # VectorChord only. vectors.so (pgvecto.rs) was dropped in Phase C after the
+    # v2.7.5 migration moved the embeddings into VectorChord and dropped the
+    # `vectors` extension.
     shared_preload_libraries:
-      - "vectors.so"
+      - "vchord.so"
     parameters:
-      search_path: '"$user", public, vectors'
+      search_path: '"$user", public'
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -151,12 +151,12 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          # Per-arch (linux/amd64) digest of :v2.7.5; this overrides the base
-          # multi-arch index pin so the GPU-accelerated build runs in production.
-          # When bumping: update both the tag and the digest from
-          # `docker manifest inspect ghcr.io/immich-app/immich-machine-learning:vX.Y.Z`
-          # → pick the linux/amd64 entry's digest.
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          # Multi-arch index digest of :v3.0.1 (the cluster is amd64; containerd
+          # resolves the amd64 sub-manifest for the GPU-accelerated build).
+          # When bumping: `docker buildx imagetools inspect
+          # ghcr.io/immich-app/immich-machine-learning:vX.Y.Z` → use the top-level
+          # "Digest:" (index) value.
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -4,10 +4,18 @@ metadata:
   name: immich-db-staging-cnpg-v1
   namespace: immich-stage
 spec:
-  description: Postgres cluster for Immich with pgvecto.rs for ML search — RECOVERY MODE
-  # Use pgvecto.rs 0.3.0 image (compatible with Immich's requirement >=0.2 <0.4)
-  # Note: pg17 not available with v0.3.0, using pg16 instead
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.3.0
+  description: Postgres cluster for Immich with VectorChord (vchord) for ML search (RECOVERY MODE)
+  # ==========================================================================
+  # PHASE C (end state) — VectorChord only. See
+  # docs/operations/2026-07-02-immich-v3-upgrade.md.
+  # Post-migration cleanup: the Phase-B dual-extension migration image has been
+  # applied, `CREATE EXTENSION vchord CASCADE` was run as the postgres
+  # superuser, Immich v2.7.5 migrated the embeddings and dropped `vectors`, and
+  # search was verified. This drops to the slim VectorChord-only image with only
+  # vchord.so preloaded. MUST NOT reconcile before Phase B + its manual migration
+  # + verify have completed on staging. DROP EXTENSION vectors is one-way.
+  # ==========================================================================
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
 
   instances: 3
 
@@ -60,10 +68,11 @@ spec:
           policy-type: database
 
   postgresql:
+    # VectorChord only (see prod database.yaml). vectors.so dropped in Phase C.
     shared_preload_libraries:
-      - "vectors.so"
+      - "vchord.so"
     parameters:
-      search_path: '"$user", public, vectors'
+      search_path: '"$user", public'
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -136,7 +136,7 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning@sha256:35b56970279afa31009822609f03fc892effe0107fdb796e5dae57979dc3267c
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
## Phase C — Immich app → v3.0.1 + VectorChord-only DB cleanup  ⛔ DRAFT / DO NOT MERGE YET

Second of **two ordered PRs** replacing the former combined PR #1026. This is the
app bump + DB end-state cleanup. **It must not merge until Phase B
(#1029) is merged AND, on the target environment, the manual superuser
`CREATE EXTENSION vchord CASCADE` + `GRANT` have run, Immich v2.7.5 has migrated
the embeddings and dropped the old `vectors` extension, and Smart Search / faces
are verified.** Immich v3 has no pgvecto.rs support and cannot run that migration
itself; the non-superuser `immich` role cannot `CREATE EXTENSION`. See
`docs/operations/2026-07-02-immich-v3-upgrade.md` §4 (shipped in Phase B).

### What this PR changes
- App bump **v2.7.5 → v3.0.1** (strictly increasing): `apps/base/immich/deployment.yaml`
  (server + ML), `apps/production/immich/deployment-patch.yaml` (GPU ML digest),
  `apps/staging/immich/deployment-patch.yaml` (ML).
- **DB cleanup to the VectorChord-only end state** (prod + staging `database.yaml`):
  `imageName` → `ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2`
  (`sha256:649da2df…`), `shared_preload_libraries` → `[vchord.so]` only,
  `search_path` drops `vectors`. Dropping `vectors.so` is only correct **after**
  the Phase-B migration has removed the `vectors` extension — hence the gate.

### Ordering / rebase note
Branched from `origin/master` per repo rules, so its `database.yaml` diff shows
pgvecto.rs → VectorChord-only in one hop. Once Phase B merges, this PR will be
behind `master`; **rebase it onto master before merging** — the `database.yaml`
overlap with Phase B resolves in favour of this PR's end state.

### Staging auto-combine caveat
The `staging` branch is CI-rebuilt from **master + every open mergeable PR**
(drafts are NOT filtered out). While this PR is open alongside Phase B, CI would
try to combine them onto staging — the exact combined apply that crashlooped in
the rehearsal. They conflict on `database.yaml` so CI keeps only one
(order-dependent, and *this PR alone on staging = v3 on un-migrated data* is the
bad outcome). **Keep this PR a draft.** If you want zero staging churn, close it
until Phase B is merged, then reopen + rebase. **Production is never at risk** —
it reconciles only from `master`, which you sequence manually.

### Validation
- `kustomize build` passes for `apps/base/immich`, `apps/staging/immich`, `apps/production/immich`.
- Built output confirms server + ML at `v3.0.1`. Secret scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
