### PR TITLE
feat(immich): Phase C — app v2.7.5 → v3.0.1 (server + ML)

### DIFF
--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-server
-          image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
+          image: ghcr.io/immich-app/immich-server:v3.0.1@sha256:46dedfc5848f7313bd6b584ea9f2648057430307aad6de56de968f6710a72cae
           ports:
             - name: http
               containerPort: 2283
@@ -121,7 +121,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           ports:
             - name: http
               containerPort: 3003

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -156,7 +156,7 @@ spec:
           # When bumping: update both the tag and the digest from
           # `docker manifest inspect ghcr.io/immich-app/immich-machine-learning:vX.Y.Z`
           # → pick the linux/amd64 entry's digest.
-          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -136,7 +136,7 @@ spec:
           - 109 # render group
       containers:
         - name: immich-machine-learning
-          image: ghcr.io/immich-app/immich-machine-learning@sha256:35b56970279afa31009822609f03fc892effe0107fdb796e5dae57979dc3267c
+          image: ghcr.io/immich-app/immich-machine-learning:v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
Final cutover of the Immich v3 upgrade. **Phase B (DB→VectorChord) is done and verified on prod** — 34,936 face + 68 smart embeddings migrated to `vector(512)`, `vectors` extension dropped, vchord indexes built, all on v2.7.5's automatic migration after PR #1029 + the manual superuser `CREATE EXTENSION vchord`.

This PR bumps **only the app images** server + ML → v3.0.1. The DB stays on the dual-extension migration image, which the staging rehearsal proved runs v3 cleanly. The DB→VectorChord-only cleanup is **deferred** to a staging-tested follow-up (avoids an untested DB image swap during cutover). Supersedes the app-bump half of #1030.

## Validation
- `kustomize build` OK for base/production/staging immich; prod renders v3.0.1 server + ML
- No plaintext secrets
- `Recreate` strategy → brief Immich outage on rollout (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)