### PR TITLE
feat(immich): VectorChord Phase 1 (config) + unblock staging reconcile

### DIFF
--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -24,7 +24,7 @@ spec:
   # pgvecto.rs→VectorChord data migration — it must be done on v2.x first.
   # The DROP EXTENSION vectors step is ONE-WAY: no downgrade below Immich 1.133.
   # ==========================================================================
-  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
   instances: 3
   enableSuperuserAccess: true
   inheritedMetadata:
@@ -43,14 +43,12 @@ spec:
     size: 10Gi
     storageClass: truenas-iscsi
   postgresql:
-    # Both preloaded during the migration window so existing pgvecto.rs columns
-    # stay readable while VectorChord is introduced. Post-migration (runbook
-    # step 5) drop back to just "vchord.so" and remove the vectors search_path.
+    # VectorChord-only end state (migration to VectorChord complete 2026-07-03;
+    # pgvecto.rs `vectors` extension dropped). Only vchord.so is preloaded now.
     shared_preload_libraries:
-      - "vectors.so"
       - "vchord.so"
     parameters:
-      search_path: '"$user", public, vectors'
+      search_path: '"$user", public'
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:
@@ -65,12 +63,11 @@ spec:
       owner: immich
       secret:
         name: immich-db-credentials
+      # Fresh-bootstrap only (does NOT re-run on the existing cluster). VectorChord
+      # end state: create vchord (CASCADEs pgvector) — NOT the removed `vectors`.
       postInitSQL:
-        - CREATE EXTENSION IF NOT EXISTS vectors;
+        - CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
         - CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;
-        - GRANT ALL ON SCHEMA vectors TO immich;
-        - GRANT ALL ON ALL TABLES IN SCHEMA vectors TO immich;
-        - ALTER DEFAULT PRIVILEGES IN SCHEMA vectors GRANT ALL ON TABLES TO immich;
   # externalClusters references the ObjectStore via the plugin for PITR/restore.
   externalClusters:
     - name: immich-db-backup

--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -24,7 +24,9 @@ spec:
   # pgvecto.rs→VectorChord data migration — it must be done on v2.x first.
   # The DROP EXTENSION vectors step is ONE-WAY: no downgrade below Immich 1.133.
   # ==========================================================================
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
+  # Phase 1 keeps the migration image; Phase 2 (separate PR) swaps to the official
+  # VectorChord-only image — CNPG forbids changing image + config in one step.
+  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
   instances: 3
   enableSuperuserAccess: true
   inheritedMetadata:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -14,7 +14,8 @@ spec:
   # non-destructive on its own. Do NOT bump immich to v3.0.1 until the
   # VectorChord migration here is verified. DROP EXTENSION vectors is one-way.
   # ==========================================================================
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
+  # Phase 1 keeps the migration image; Phase 2 swaps to VectorChord-only.
+  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
 
   instances: 3
 
@@ -30,19 +31,15 @@ spec:
     enablePodMonitor: true
 
   storage:
-    # Standard size = 10Gi, a fixed-size mirror of prod (immich-db-prod-cnpg-v3,
-    # live at 10Gi). Staging is a disposable rehearsal testbed; it does not need
-    # to hold a full prod-scale dataset, so we pin it to prod's shape rather than
-    # letting it drift (it had crept to 20Gi on 2026-04-17 while filling up).
-    #
-    # CNPG CANNOT shrink a PVC in-place, so changing this value from 20Gi to 10Gi
-    # does NOT take effect on the live cluster by itself — the staging DB Cluster
-    # must be destroyed and recreated for the new size to apply. Staging data is
-    # disposable/rebuildable, so this is safe to do at the operator's convenience.
-    # See docs/operations/apps/immich.md §10 "Staging DB: fixed 10Gi mirror of prod"
-    # for the exact recreate steps and the orphaned-PV cleanup checklist.
+    # Target standard = 10Gi (mirror of prod). BUT this MUST stay at the live size
+    # (20Gi) until the staging DB Cluster is actually recreated — CNPG's admission
+    # webhook REJECTS a spec whose size is < the live PVCs ("can't shrink existing
+    # storage"), which blocks the ENTIRE apps-staging reconcile (learned the hard
+    # way 2026-07-03 — #1028 set 10Gi against a live 20Gi and broke reconcile).
+    # To reach 10Gi: destroy + recreate the Cluster (disposable data), and set 10Gi
+    # HERE in the same change. See docs/operations/apps/immich.md §10.
     storageClass: truenas-iscsi
-    size: 10Gi
+    size: 20Gi
 
   resources:
     requests:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -14,7 +14,7 @@ spec:
   # non-destructive on its own. Do NOT bump immich to v3.0.1 until the
   # VectorChord migration here is verified. DROP EXTENSION vectors is one-way.
   # ==========================================================================
-  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
 
   instances: 3
 
@@ -78,12 +78,11 @@ spec:
 
   postgresql:
     # Both preloaded during the migration window (see prod database.yaml).
-    # Post-migration: drop to just "vchord.so" and remove the vectors search_path.
+    # VectorChord-only end state (migration complete; `vectors` dropped).
     shared_preload_libraries:
-      - "vectors.so"
       - "vchord.so"
     parameters:
-      search_path: '"$user", public, vectors'
+      search_path: '"$user", public'
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).


### PR DESCRIPTION
Reworked after staging surfaced two CNPG constraints:

1. **VectorChord swap must be 2-phase.** CNPG forbids changing `imageName` + config together. **Phase 1 (this PR):** drop `vectors.so` from `shared_preload_libraries` and remove `vectors` from `search_path` (safe — the `vectors` extension is already dropped), image stays on the migration image; prod bootstrap postInitSQL → `CREATE EXTENSION vchord`. **Phase 2 (next PR):** swap imageName → official `tensorchord/cloudnative-vectorchord:16-0.4.2`.
2. **Unblock staging.** #1028 set staging DB to 10Gi against a live 20Gi cluster; CNPG's webhook rejects the shrink, breaking the whole `apps-staging` reconcile. Reverted to 20Gi (matches live); 10Gi only applies at a DB recreate.

Validated on staging via the staging rebuild before merge to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)