### PR TITLE
feat(immich): VectorChord Phase 2 — DB → official VectorChord-only image

### DIFF
--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -24,9 +24,9 @@ spec:
   # pgvecto.rs→VectorChord data migration — it must be done on v2.x first.
   # The DROP EXTENSION vectors step is ONE-WAY: no downgrade below Immich 1.133.
   # ==========================================================================
-  # Phase 1 keeps the migration image; Phase 2 (separate PR) swaps to the official
-  # VectorChord-only image — CNPG forbids changing image + config in one step.
-  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
+  # Official VectorChord-only image (Phase 2). Config already dropped vectors.so in
+  # Phase 1 (#1032), so this is an image-only change — CNPG accepts it.
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
   instances: 3
   enableSuperuserAccess: true
   inheritedMetadata:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -14,8 +14,8 @@ spec:
   # non-destructive on its own. Do NOT bump immich to v3.0.1 until the
   # VectorChord migration here is verified. DROP EXTENSION vectors is one-way.
   # ==========================================================================
-  # Phase 1 keeps the migration image; Phase 2 swaps to VectorChord-only.
-  imageName: ghcr.io/corentingiraud/cnpg-pgvector-vectorchord:16-migration@sha256:0e4f45d3eacbb948d2f9d229b1cf9018502568bf26b912b9babe77fdf6f5992a
+  # Official VectorChord-only image (Phase 2; config dropped vectors.so in Phase 1).
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2@sha256:649da2df5f079dd1f214e3a877cafd0208eff3779e9c60d14d243fbca5e11c97
 
   instances: 3
 


### PR DESCRIPTION
Final step of the VectorChord migration. **Image-only** swap — Phase 1 (#1032) already dropped `vectors.so` from preload, so changing just `imageName` is accepted by CNPG. Moves prod + staging CNPG DB off the community migration image to the **official** `ghcr.io/tensorchord/cloudnative-vectorchord:16-0.4.2`. Rolling restart (brief blip). **Validated on staging first** via the staging rebuild before merge to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)