### PR TITLE
feat(authelia): gate finance.burntbytes.com behind one_factor

### DIFF
--- a/apps/production/authelia/configuration.yaml
+++ b/apps/production/authelia/configuration.yaml
@@ -22,6 +22,8 @@ access_control:
       policy: one_factor
     - domain: "ladder.burntbytes.com"
       policy: one_factor
+    - domain: "finance.burntbytes.com"
+      policy: one_factor
     - domain: "auth.burntbytes.com"
       policy: bypass
       resources:


### PR DESCRIPTION
`finance.burntbytes.com` serves the personal-finance dashboard (real net-worth data) but had **no auth gate** — it relied on LAN-only with Authelia `default_policy: bypass`. Adds a `one_factor` rule, matching the other sensitive internal apps (alerts/prometheus/ladder). Confirmed finance-dashboard routes via `app-gateway-production` (gateway-wide Authelia ext_authz), so the rule takes effect. LAN still bypasses via the internal-network rule; off-LAN now requires Authelia login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)