### PR TITLE
fix(photos-sync): duplex additive sync — hestia SOT, no --delete

### DIFF
--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -1,6 +1,6 @@
 # immich-photos-backup
 
-Daily incremental backup of the Immich photo library from alcatraz (Synology, 10.42.2.11) into the local ZFS dataset `main/family/images/photos`. Always-running container; in-container busybox `crond` fires the rsync at 04:00 local time.
+Daily DUPLEX sync of the Immich photo library between alcatraz (Synology, 10.42.2.11) and hestia's `main/family/images/photos`. **Pull** (alcatraz→hestia, additive) brings phone uploads in; **push-back** (hestia→alcatraz, `--ignore-existing`) copies anything hestia has that alcatraz lacks (e.g. direct SD-card imports) so alcatraz stays a full backup. No `--delete` in either direction — both sides converge to the union; hestia is authoritative. Always-running container; busybox `crond` fires at 04:00 local.
 
 Sources are per-user `homes/<user>/Photos/` paths, not `family/images/photos/<user>/`. On the Synology side those family paths are symlinks into each user's home, with per-file ACLs that deny `truenas-backup` file open via the family path — so we sync from the homes path directly and re-map into the canonical hestia `family/images/photos/<user>/` layout.
 
@@ -49,7 +49,7 @@ ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
 
 Synology DSM Photos uploads new files with POSIX mode `0700`. The owning group is `users` (gid 100) — which `truenas-backup` is also in, so the group bit's `---` denies before POSIX falls through to "other". rsync hits `send_files Permission denied (13)` on every new file and the run fails partially-but-silently (zero bytes transferred for new content; no metric update; the `ImmichPhotoBackupStale` alert eventually fires).
 
-The script's per-user rsync runs a `sudo -n chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod (and no `requiretty` constraint — see Notes below):
+The script's per-user PULL runs a `sudo -n chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. The PUSH-BACK additionally runs the remote rsync as `sudo -n rsync` so it can write into the user's home and `--chown` the files — so the sudoers below also permits `rsync` (verify the path with `which rsync` on alcatraz; typically `/bin/rsync`). That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod (and no `requiretty` constraint — see Notes below):
 
 ```bash
 # As a DSM admin (currently: manager) on alcatraz.
@@ -62,7 +62,7 @@ The script's per-user rsync runs a `sudo -n chmod -R g+rX,o+rX` on the source vi
 #      via DSM File Station (logged in as a DSM admin) — that skips sudo
 #      entirely and avoids the chicken-and-egg trap.
 cat > /tmp/immich-photos-backup.sudoers <<'EOF'
-truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos
+truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos, /bin/rsync, /usr/bin/rsync
 EOF
 sudo install -m 0440 -o root -g root \
     /tmp/immich-photos-backup.sudoers \
@@ -75,7 +75,7 @@ sudo -n true && echo "sudo still functional"
 
 # Sanity #2: the new rule is visible to truenas-backup. The output
 # displays `\,` literally — that's sudo -l showing the escape, normal.
-sudo -l -U truenas-backup 2>&1 | grep -i chmod
+sudo -l -U truenas-backup 2>&1 | grep -iE 'chmod|rsync'
 ```
 
 Sanity check the paths exist on your DSM (paths differ between Synology firmware versions):

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Daily incremental backup of the Immich photo library from alcatraz → hestia.
+# Daily DUPLEX sync of the Immich photo library between alcatraz and hestia.
+# Pull (alcatraz -> hestia): brings phone uploads into hestia (the source of truth).
+# Push-back (hestia -> alcatraz, --ignore-existing): copies anything hestia has that
+# alcatraz lacks (e.g. direct SD-card imports) so alcatraz stays a full backup.
+# No --delete in either direction -> both sides converge to the UNION; neither wipes
+# the other. hestia is authoritative; alcatraz is the phone-upload target + backup.
 #
 # Pulls per-user Photos dirs from alcatraz (Synology NAS, 10.42.2.11) into the
 # local ZFS dataset main/family/images/photos. Snapshots are managed by a
@@ -53,7 +58,9 @@ START_TS=$(date +%s)
 echo "=== $(date -u +%FT%TZ) START ==="
 
 # chacha20-poly1305 + no SSH compression matches the plan's high-throughput
-# configuration. --delete keeps each user's destination tight to its source.
+# configuration. No --delete: hestia is the SOURCE OF TRUTH (superset). The pull is
+# additive, so phone uploads flow in but direct-to-hestia imports (e.g. an SD-card
+# import via import-sd-photos.sh) are NEVER wiped. See docs/plans/2026-06-01-hestia-photos-sot.md.
 #
 # Host-key handling: when run from cron there's no stdin to answer a
 # `Are you sure you want to continue connecting?` prompt — without
@@ -70,8 +77,8 @@ echo "=== $(date -u +%FT%TZ) START ==="
 #                  dir. Synology recreates them on alcatraz as needed.
 #   .DS_Store      macOS Finder metadata; same deal.
 #   Thumbs.db      Windows thumbnail cache.
-# --delete-excluded ensures excludes also remove anything that landed in
-# the destination from earlier runs.
+# (Excluded junk is simply not copied. With no --delete, any junk from an earlier
+#  run stays on hestia -- harmless, and never touches real photos.)
 RSYNC_RSH="ssh -T -i ${SSH_KEY} \
            -o StrictHostKeyChecking=accept-new \
            -o UserKnownHostsFile=${KNOWN_HOSTS} \
@@ -94,7 +101,7 @@ for user in "${USERS[@]}"; do
   # of the loud-failure mode we want. -n exits immediately with
   # "sudo: a password is required", which surfaces in the cron log.
   REMOTE_RSYNC="sudo -n /bin/chmod -R g+rX,o+rX /volume1/homes/${user}/Photos && rsync"
-  if ! rsync -avh --delete --delete-excluded \
+  if ! rsync -avh \
         --exclude='@eaDir' \
         --exclude='.DS_Store' \
         --exclude='Thumbs.db' \
@@ -103,8 +110,25 @@ for user in "${USERS[@]}"; do
         --stats \
         "${src}" "${dst}"; then
     rc=$?
-    echo "!!! ${user} rsync failed rc=${rc}"
+    echo "!!! ${user} PULL rsync failed rc=${rc}"
     FAILED=$((FAILED + 1))
+  fi
+
+  # --- duplex push-back: hestia -> alcatraz, copy only what alcatraz lacks ---
+  # --ignore-existing never overwrites alcatraz's copy (no conflicts, no --delete);
+  # it only adds missing files (e.g. SD-card imports made directly on hestia).
+  # Remote rsync runs via `sudo -n rsync` so it can write into the user's home and
+  # --chown the files to the right owner. This needs a truenas-backup sudoers entry
+  # for rsync on alcatraz (see README, "Sudoers entry on alcatraz"). A push-back
+  # failure is a WARNING only -- the pull above is what the staleness alert keys off.
+  if ! rsync -avh --ignore-existing --chown="${user}:users" \
+        --exclude='@eaDir' \
+        --exclude='.DS_Store' \
+        --exclude='Thumbs.db' \
+        --rsh="${RSYNC_RSH}" \
+        --rsync-path="sudo -n rsync" \
+        "${dst}" "${src}"; then
+    echo "!!! ${user} push-back (hestia->alcatraz backup) failed rc=$? -- pull OK; check alcatraz sudoers for rsync"
   fi
 done
 


### PR DESCRIPTION
**Root cause of Mara's vanished 2010–2012 photos:** the alcatraz→hestia rsync used `--delete`, mirroring hestia to alcatraz's state. Photos imported *directly* to hestia (SD-card offloads via `import-sd-photos.sh`) were never on alcatraz, so the next 04:00 sync **deleted them** — confirmed by immich indexing them Jun 27 and no ZFS snapshot ever holding them (sub-24h lifespan).

**Fix — duplex union sync, no `--delete` either way:**
- **Pull** alcatraz→hestia: additive (phone uploads flow into the SOT).
- **Push-back** hestia→alcatraz: `--ignore-existing` (copies only what alcatraz lacks) so alcatraz stays a full backup. Remote `sudo -n rsync` + `--chown`; a push-back failure is a warning, not a job failure.

hestia is now the true source of truth (superset); alcatraz = phone-upload target + complete backup. **Operator step:** the push-back needs an `rsync` entry in the truenas-backup sudoers on alcatraz (README updated). Completes `docs/plans/2026-06-01-hestia-photos-sot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)