### PR TITLE
chore(photos-sync): deploy duplex additive image (2026-07-04)

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-06-09@sha256:93a52aa278f27777b320a8b135d54474fd9059c363c7bb8439ff08505c5eb1b3
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-07-04@sha256:a4811ef540b0b4b496a9e3970394ff856cceceb4537c80b4f4c75f9c9d7f2673
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Rolls immich-photos-backup to the image built from #1046 — additive pull (no `--delete`) + `--ignore-existing` push-back. deploy-hestia auto-applies + recreates the (currently-stopped) container running the safe duplex sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)