### PR TITLE
feat(photos-sync): retire hestia→alcatraz push-back, add alcatraz-pull job

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -35,6 +35,7 @@ Active plans (see [docs/plans/](plans/README.md) for the full status-grouped ind
 
 - [Alcatraz → hestia migration](plans/2026-05-20-alcatraz-to-hestia-migration.md) — non-photo data off alcatraz onto hestia ZFS; Phase 1 mostly done, Phase 2 backup pipeline live.
 - [Hestia as photos source-of-truth](plans/2026-06-01-hestia-photos-sot.md) — Immich NFS PV repointed to hestia; soak/verification underway.
+- [Alcatraz pulls photos from hestia](plans/2026-07-04-alcatraz-photos-pull.md) — impossible hestia→alcatraz rsync push-back (Synology setuid-root inbound-uid check) retired; backfill now runs from alcatraz as a DSM Task Scheduler pull job. Repo artifacts landed; DSM operator steps + DSM-Photos-indexing validation pending.
 - [Snapcast / HifiBerry rollout](plans/2026-05-03-snapcast-hifiberry-rollout.md) — server + LB IP live; per-device client setup remaining.
 - [Navidrome → Mopidy → Snapcast audio source](plans/2026-03-14-navidrome-snapcast-mopidy.md) — Mopidy sidecar in draft PR #426; not yet on master.
 - [Hestia memory benchmark](plans/2026-05-15-hestia-memory-benchmark.md) — 6-DIMM baseline captured; 8-DIMM comparison pending a physical DIMM swap.

--- a/docs/plans/2026-07-04-alcatraz-photos-pull.md
+++ b/docs/plans/2026-07-04-alcatraz-photos-pull.md
@@ -1,0 +1,111 @@
+---
+status: in-progress
+last_modified: 2026-07-04
+summary: "Retire the impossible hestia→alcatraz rsync push-back; alcatraz pulls from hestia as local root via a DSM Task Scheduler job"
+---
+
+# Alcatraz pulls photos from hestia (retire the push-back)
+
+## Problem
+
+hestia (`main/family/images/photos`) is the source of truth for the photo
+library. Two flows keep alcatraz and hestia in sync:
+
+1. **alcatraz → hestia** (phone uploads): the hestia-side container
+   `images/immich-photos-backup/` pulls each user's `homes/<user>/Photos/`
+   additively (no `--delete`). This works and stays.
+2. **hestia → alcatraz** (backfill): so alcatraz stays a full second copy and
+   DSM Photos indexes direct-to-hestia **SD-card imports** (see
+   `scripts/import-sd-photos.sh`), which never passed through alcatraz.
+
+Flow 2 was implemented as a **push** from the hestia container — a second
+rsync per user with `--ignore-existing --chown=<user>:users
+--rsync-path="sudo -n rsync"`. It never worked, and it **cannot** work.
+
+## Root cause (proven)
+
+Synology's `/bin/rsync` is **setuid-root**. In inbound server mode it
+authenticates the **real uid** of the process against the DSM account
+database. A hestia-initiated push has no working invocation:
+
+| Push invocation on alcatraz | Real uid | Result |
+|---|---|---|
+| `sudo rsync` (`--rsync-path="sudo -n rsync"`) | root | **Rejected** — root is a disabled DSM account ("user has disabled/expired" / "rsync service is no running"); 0 bytes |
+| `sudo -u mara rsync` | mara (1027) | **Rejected** — non-admin; the check gates on the administrators group |
+| bare `truenas-backup` (admin) rsync | truenas-backup | **Passes** the account check — but an admin that isn't the owning user **can't write** mara's private `0700` `homes/mara/Photos` with correct ownership |
+
+No sudoers rule squares this — it is Synology's inbound-rsync security model,
+not a permissions misconfiguration. (The **outbound** direction is unaffected:
+`truenas-backup` reading its own homes for the flow-1 pull is fine, modulo the
+separate `0700`-upload chmod fix already documented in the hestia runbook.)
+
+## Decision
+
+**Reverse the direction: alcatraz PULLS from hestia** (Option 1).
+
+- alcatraz's rsync is the **client**, writing to its **own local**
+  filesystem as **local root** → no inbound DSM account check applies, and
+  local root can `chown` received files to the owning DSM user.
+- The rsync **server** runs on **hestia** — plain Linux, no Synology setuid
+  patch, no account gate.
+
+The hestia-side push-back leg is removed from
+`images/immich-photos-backup/immich-photos-backup.sh` (a code comment plus this
+plan warn against re-adding it).
+
+## Architecture
+
+```
+alcatraz (DSM Task Scheduler, runs as ROOT, ~05:00 daily)
+  └─ pull-from-hestia.sh
+       for user in mara(1027) george(1028):
+         rsync -a --ignore-existing \
+           --exclude=@eaDir,.DS_Store,Thumbs.db \
+           --rsh="ssh -T -x -i <key> -c chacha20-poly1305 -o Compression=no \
+                  -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=<kh>" \
+           truenas_admin@10.42.2.10:/mnt/main/family/images/photos/<user>/ \
+           /volume1/homes/<user>/Photos/
+         chown -R <uid>:100 /volume1/homes/<user>/Photos/   # runs as root
+```
+
+- **Additive only.** `--ignore-existing` never overwrites alcatraz's
+  phone-upload originals; **no `--delete`, ever**.
+- **Runs as root** so the post-rsync `chown` can re-own the received tree to
+  the DSM account (rsync-received files land root-owned; DSM Photos only
+  indexes files owned by the account).
+- **Key restriction.** The `truenas_admin@hestia` `authorized_keys` line pins
+  this key to read-only rsync of the photos path (`rrsync -ro`), so a leak
+  can only read photos.
+- Runs at ~05:00, after hestia's 04:00 alcatraz→hestia pull, so the SD-card
+  imports it surfaces are already on hestia.
+
+Repo artifacts:
+- `hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh` — the pull script.
+- `hosts/alcatraz/immich-photos-pull/README.md` — operator runbook.
+- `images/immich-photos-backup/immich-photos-backup.sh` — push-back leg removed.
+- `hosts/hestia/immich-photos-backup/README.md` — limitation documented.
+
+## Operator steps (summary — full detail in the alcatraz runbook)
+
+1. **On alcatraz** (DSM admin / `truenas-backup`): `ssh-keygen` an
+   `id_ed25519_hestia` key (mode 600) under the path the script expects; place
+   `pull-from-hestia.sh` at
+   `/volume1/homes/truenas-backup/immich-photos-pull/` (mode 755).
+2. **On hestia** (someone with hestia access — not the DSM operator): install
+   the public key into `truenas_admin`'s `authorized_keys` with the
+   `rrsync -ro /mnt/main/family/images/photos` forced command.
+3. **On alcatraz**: create a DSM Task Scheduler user-defined script, **run as
+   `root`**, daily ~05:00, invoking the script.
+4. **Validate**: run the task manually; confirm files land under
+   `/volume1/homes/<user>/Photos` owned by `<uid>:users`; then confirm DSM
+   Photos indexes them (re-index if needed).
+
+## Open validation risk
+
+**Does DSM Photos surface rsync-dropped files?** rsync writes files outside
+DSM's normal upload path, so ownership/ACL/indexing behavior for those files is
+the main unknown. The go/no-go acceptance test is step 4: after a manual run,
+the SD-card imports must appear in each user's DSM Photos library (possibly
+after a `synoindex -R` / library re-index). If they don't index cleanly, revisit
+whether a `synoindex` trigger belongs in the script, or whether a different
+backfill mechanism is needed.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,10 +60,11 @@ see `scripts/plans-index/`).
 
 <!-- BEGIN PLANS INDEX -->
 
-### In progress (9)
+### In progress (10)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-07-04-alcatraz-photos-pull.md](2026-07-04-alcatraz-photos-pull.md) | 2026-07-04 | Retire the impossible hestia→alcatraz rsync push-back; alcatraz pulls from hestia as local root via a DSM Task Scheduler job |
 | [2026-06-17-alertmanager-smtp-alerting.md](2026-06-17-alertmanager-smtp-alerting.md) | 2026-06-17 | Route critical Alertmanager alerts to email via Gmail SMTP (replaces dead Signal channel) |
 | [2026-06-16-thermalscope-power-and-headroom.md](2026-06-16-thermalscope-power-and-headroom.md) | 2026-06-17 | thermalscope: add power/energy/cost (RAPL), thermal headroom, and throttle/degradation signals — phases 1–3 live; phase 4 pending |
 | [2026-06-01-hestia-photos-sot.md](2026-06-01-hestia-photos-sot.md) | 2026-06-10 | Make hestia the source of truth for family/ + homes/; repoint Immich NFS PV; alcatraz narrows to upload target |

--- a/hosts/alcatraz/immich-photos-pull/README.md
+++ b/hosts/alcatraz/immich-photos-pull/README.md
@@ -72,38 +72,63 @@ cat /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia.pub
 
 ### 2. Authorize the key on hestia (done by someone with hestia access — NOT this runbook's DSM operator)
 
-**A human/assistant with hestia access installs this line — the alcatraz-side
-operator does not touch hestia.** On hestia, append the public key from step 1
-to `truenas_admin`'s `authorized_keys`, restricted to **read-only rsync of the
-photos path** via an `rrsync` forced command:
+**A human/assistant with hestia access installs this key — the alcatraz-side
+operator does not touch hestia.** The public key from step 1 goes into
+`truenas_admin`'s authorized keys with a **forced command** that confines it to
+read-only rsync of the photos path:
 
 ```
-command="rrsync -ro /mnt/main/family/images/photos",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...alcatraz-photos-pull
+command="sudo -n --preserve-env=SSH_ORIGINAL_COMMAND /usr/bin/rrsync -ro /mnt/main/family/images/photos",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...alcatraz-photos-pull
 ```
 
-`rrsync -ro` locks this key to read-only rsync rooted at the photos directory —
-even if the key leaks it can only pull photos, never write or run a shell.
+Two things about this line are load-bearing:
 
-**If `rrsync` isn't present on TrueNAS SCALE** (it ships with rsync but the
-path varies; check `command -v rrsync` and `ls /usr/share/doc/rsync*/support/`):
-either
+- **It runs `rrsync` as root (`sudo -n`).** The photo *files* on hestia are
+  `0700`/owner-only (mara or george — inherited from the SD card by `rsync -a`).
+  `truenas_admin` can traverse the `0755` dirs but cannot read the files, and it
+  **cannot** be added to the owning `users` group — TrueNAS refuses
+  (`membership of this builtin group may not be altered`). So the read has to be
+  as root. `rrsync -ro` still hard-confines it: even as root the key can **only**
+  read-only-rsync this one path — no writes, no other files, no shell. Blast
+  radius if the key leaks ≈ read access to photos that alcatraz (where the key
+  lives) already holds. `--preserve-env=SSH_ORIGINAL_COMMAND` is required so the
+  client's rsync command survives `sudo`'s env reset and reaches `rrsync`.
+- **Paths are relative to the rrsync root.** `rrsync -ro <root>` prepends
+  `<root>` to every client path, so the script requests `mara/` / `george/`
+  (see `SRC_HOST` note in `pull-from-hestia.sh`), NOT the absolute
+  `/mnt/.../photos/mara/` — an absolute path gets the root prepended twice and
+  fails with `change_dir ...photos/mnt/.../photos/mara: No such file`.
 
-- fall back to an **unrestricted** key line on the trusted LAN and accept the
-  trade-off (this key can then run any command as `truenas_admin` — acceptable
-  only because the LAN is trusted and the key never leaves alcatraz), or
-- drop a tiny forced-command wrapper script that execs `rsync --server
-  --sender ...` limited to the photos path and point `command="..."` at it.
+**Install it via the TrueNAS middleware, not by editing the file.** TrueNAS
+manages `~truenas_admin/.ssh/authorized_keys` from the user's `sshpubkey` field;
+a direct file edit is clobbered on the next user update or reboot. Either use the
+UI (Credentials → Local Users → truenas_admin → Authorized Keys, append the line
+above, preserving existing keys) or the API, reading-appending-writing so the
+existing keys are kept:
 
-Verify from alcatraz once installed:
+```bash
+# on hestia (truenas_admin has passwordless sudo). Query current sshpubkey,
+# append the forced-command line, and write it back via user.update.
+sudo midclt call user.query '[["username","=","truenas_admin"]]'   # note the id + current sshpubkey
+sudo midclt call user.update <id> '{"sshpubkey": "<existing keys>\n<forced-command line>"}'
+```
+
+`sudo` NOPASSWD for `rrsync` must be available to `truenas_admin` — on TrueNAS
+its admin account already has passwordless sudo, so no extra sudoers entry is
+needed. (`rrsync` ships at `/usr/bin/rrsync` on TrueNAS SCALE.)
+
+Verify from alcatraz once installed — note the **relative** source path:
 
 ```bash
 rsync -n -a --rsh="ssh -i /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia \
     -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile=/volume1/homes/truenas-backup/.ssh/known_hosts_hestia" \
-    truenas_admin@10.42.2.10:/mnt/main/family/images/photos/george/ /tmp/pull-test/
+    truenas_admin@10.42.2.10:george/ /tmp/pull-test/
 ```
 
 A dry-run (`-n`) file list with no errors means the key + forced command work.
+A real (non-`-n`) pull of a file should transfer bytes; a push attempt must be
+refused with `rrsync error: sending to read-only server is not allowed`.
 
 ### 3. Place the script on alcatraz
 

--- a/hosts/alcatraz/immich-photos-pull/README.md
+++ b/hosts/alcatraz/immich-photos-pull/README.md
@@ -1,0 +1,169 @@
+# immich-photos-pull (alcatraz side)
+
+Daily additive **pull** of the Immich photo library from hestia → alcatraz,
+run **on alcatraz** by a DSM Task Scheduler job. This is the backup leg that
+keeps alcatraz a full second copy of the source-of-truth library on hestia —
+in particular it copies back direct-to-hestia SD-card imports (see
+`scripts/import-sd-photos.sh`) that alcatraz's phone-upload libraries never
+saw, so DSM Photos can index them.
+
+The complementary leg — phone uploads flowing alcatraz → hestia — runs from
+hestia (`hosts/hestia/immich-photos-backup/`). Together they converge both
+sides to the union, with hestia authoritative and no `--delete` in either
+direction.
+
+## Why this direction (not a hestia→alcatraz push)
+
+A hestia-initiated push **cannot work**: Synology's `/bin/rsync` is
+setuid-root and, in inbound server mode, authenticates the **real uid**
+against the DSM account database. `sudo rsync` → real uid root (a disabled DSM
+account) is rejected; `sudo -u mara rsync` → real uid mara (non-admin) is
+rejected; only an administrator (e.g. `truenas-backup`) passes the account
+check, but an admin that isn't the owning user can't write that user's private
+`0700` `homes/<user>/Photos` with correct ownership. No sudoers rule squares
+this — it's Synology's inbound-rsync security model.
+
+Reversing the direction sidesteps it: alcatraz's rsync is the **client**
+writing to its **own local** filesystem as **local root**, so no inbound
+account check applies and local root can `chown` the received files to the
+owning DSM user. The rsync **server** runs on hestia (plain Linux, no Synology
+setuid patch). Full root cause + decision record:
+[`docs/plans/2026-07-04-alcatraz-photos-pull.md`](../../../docs/plans/2026-07-04-alcatraz-photos-pull.md).
+
+| Attribute | Value |
+|---|---|
+| Runs on | alcatraz (Synology DSM, `10.42.2.11`), as **root**, via Task Scheduler |
+| Source (server) | `truenas_admin@10.42.2.10:/mnt/main/family/images/photos/{mara,george}/` |
+| Destination (local) | `/volume1/homes/{mara,george}/Photos/` (owned `<uid>:100`; mara=1027, george=1028) |
+| Mode | `rsync -a --ignore-existing` (additive; **no `--delete`, ever**) |
+| SSH key | `/volume1/homes/truenas-backup/.ssh/id_ed25519_hestia` (mode 600) |
+| Schedule | Daily ~05:00 local (after hestia's 04:00 pull) |
+| Script (on alcatraz) | `/volume1/homes/truenas-backup/immich-photos-pull/pull-from-hestia.sh` (mode 755) |
+
+## Operator setup
+
+### 1. SSH key on alcatraz
+
+Log in to alcatraz over SSH as a DSM admin (or the `truenas-backup` account)
+and generate a dedicated key for reaching hestia:
+
+```bash
+mkdir -p /volume1/homes/truenas-backup/.ssh
+ssh-keygen -t ed25519 -N '' \
+    -C 'alcatraz-photos-pull' \
+    -f /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia
+chmod 700 /volume1/homes/truenas-backup/.ssh
+chmod 600 /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia
+chmod 644 /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia.pub
+# known_hosts is created on first connect by StrictHostKeyChecking=accept-new;
+# pre-touch it so the file exists with the right perms:
+touch /volume1/homes/truenas-backup/.ssh/known_hosts_hestia
+chmod 644 /volume1/homes/truenas-backup/.ssh/known_hosts_hestia
+```
+
+Print the public key to hand to whoever installs it on hestia (step 2):
+
+```bash
+cat /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia.pub
+```
+
+> The key path is a config var at the top of `pull-from-hestia.sh`
+> (`SSH_KEY` / `KNOWN_HOSTS`). If you place the key elsewhere, edit those.
+
+### 2. Authorize the key on hestia (done by someone with hestia access — NOT this runbook's DSM operator)
+
+**A human/assistant with hestia access installs this line — the alcatraz-side
+operator does not touch hestia.** On hestia, append the public key from step 1
+to `truenas_admin`'s `authorized_keys`, restricted to **read-only rsync of the
+photos path** via an `rrsync` forced command:
+
+```
+command="rrsync -ro /mnt/main/family/images/photos",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...alcatraz-photos-pull
+```
+
+`rrsync -ro` locks this key to read-only rsync rooted at the photos directory —
+even if the key leaks it can only pull photos, never write or run a shell.
+
+**If `rrsync` isn't present on TrueNAS SCALE** (it ships with rsync but the
+path varies; check `command -v rrsync` and `ls /usr/share/doc/rsync*/support/`):
+either
+
+- fall back to an **unrestricted** key line on the trusted LAN and accept the
+  trade-off (this key can then run any command as `truenas_admin` — acceptable
+  only because the LAN is trusted and the key never leaves alcatraz), or
+- drop a tiny forced-command wrapper script that execs `rsync --server
+  --sender ...` limited to the photos path and point `command="..."` at it.
+
+Verify from alcatraz once installed:
+
+```bash
+rsync -n -a --rsh="ssh -i /volume1/homes/truenas-backup/.ssh/id_ed25519_hestia \
+    -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile=/volume1/homes/truenas-backup/.ssh/known_hosts_hestia" \
+    truenas_admin@10.42.2.10:/mnt/main/family/images/photos/george/ /tmp/pull-test/
+```
+
+A dry-run (`-n`) file list with no errors means the key + forced command work.
+
+### 3. Place the script on alcatraz
+
+Copy `pull-from-hestia.sh` from this directory onto alcatraz and make it
+executable:
+
+```bash
+mkdir -p /volume1/homes/truenas-backup/immich-photos-pull
+# copy pull-from-hestia.sh into that dir, then:
+chmod 755 /volume1/homes/truenas-backup/immich-photos-pull/pull-from-hestia.sh
+```
+
+### 4. DSM Task Scheduler job
+
+DSM Control Panel → **Task Scheduler** → **Create** → **Scheduled Task** →
+**User-defined script**.
+
+- **General**: User = **`root`** (required — the script `chown`s the received
+  files to each DSM account; only root can). Give it a name like
+  `immich-photos-pull`.
+- **Schedule**: Daily, ~**05:00** (after hestia's 04:00 alcatraz→hestia pull,
+  so the SD-card imports it surfaces are already on hestia).
+- **Task Settings**: Run command:
+  ```
+  /volume1/homes/truenas-backup/immich-photos-pull/pull-from-hestia.sh
+  ```
+  Tick "Send run details by email" (and set the notification address in
+  Control Panel → Notification) so a **non-zero exit** — which the script
+  returns if any user's pull or chown fails — lands in your inbox. DSM emails
+  task output on non-zero exit only if this is configured.
+
+### 5. First-run validation (the key acceptance test)
+
+Run the task manually (Task Scheduler → select the task → **Run**), then
+confirm:
+
+1. **Files landed with correct ownership** — the main risk of this approach is
+   ownership/ACL of rsync-dropped files:
+   ```bash
+   ls -la /volume1/homes/george/Photos | head
+   ls -la /volume1/homes/mara/Photos   | head
+   # owner column must be george/mara (uid 1028/1027), group users — NOT root.
+   ```
+   The tail of `/var/log/immich-photos-pull.log` should show `END (success)`.
+2. **DSM Photos indexes the new files** — this is the acceptance test. rsync
+   drops files outside DSM's normal upload path, so DSM Photos may not notice
+   them until it re-indexes. In DSM **Photos** → user's library, confirm the
+   SD-card imports now appear. If they don't, trigger a re-index: DSM Photos →
+   Settings → (re-index / rebuild the library), or `synoindex -R
+   /volume1/homes/<user>/Photos` from an SSH shell as that user. Treat "does
+   DSM Photos surface rsync-dropped files after a re-index" as the go/no-go for
+   this whole approach — it's the open risk called out in the plan doc.
+
+## Notes
+
+- **Additive only.** `--ignore-existing` never overwrites an alcatraz copy;
+  there is no `--delete`. alcatraz's phone-upload originals always win over
+  hestia's copy of the same file.
+- **No rsync sudoers on alcatraz.** The retired hestia→alcatraz push needed
+  (or would have needed) a `truenas-backup` sudo-rsync rule on alcatraz; the
+  pull needs none — the script runs as root locally. See the hestia-side
+  README for the (unrelated) chmod sudoers rule that still supports the
+  alcatraz→hestia pull.

--- a/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
+++ b/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
@@ -92,8 +92,20 @@ for entry in "${USERS[@]}"; do
   uid="${entry##*:}"
   src="${SRC_HOST}:${user}/"   # relative to the rrsync root (see SRC_HOST note)
   dst="${DST_BASE}/${user}/Photos/"
-  mkdir -p "${dst}"
   echo "--- $(date -u +%FT%TZ) pull ${user} (uid=${uid}): ${src} -> ${dst} ---"
+
+  # Guard mkdir like the rsync/chown below: a bare `mkdir -p` would trip set -e
+  # and abort the WHOLE run mid-loop — skipping the next user AND the final
+  # `=== END ... ===` trailer that the log tail / heartbeat keys off. Record the
+  # failure and skip to the next user instead, preserving the per-user isolation
+  # the rest of the loop is careful to keep.
+  rc=0
+  mkdir -p "${dst}" || rc=$?
+  if [[ ${rc} -ne 0 ]]; then
+    echo "!!! ${user} mkdir ${dst} failed rc=${rc}"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
 
   # -a: archive (recursive, perms/times/symlinks preserved).
   # --ignore-existing: additive — never clobber alcatraz's phone-upload copies;

--- a/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
+++ b/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Daily additive PULL of the Immich photo library from hestia -> alcatraz.
+#
+# Direction: this script runs ON alcatraz (Synology DSM, 10.42.2.11) as root
+# via a DSM Task Scheduler job, and PULLS from hestia (TrueNAS, 10.42.2.10),
+# which is the source of truth. hestia holds every photo — phone uploads that
+# were pulled up from alcatraz by the hestia-side backup container, PLUS
+# direct-to-hestia SD-card imports (see scripts/import-sd-photos.sh). This job
+# copies back to alcatraz anything hestia has that alcatraz's per-user
+# DSM Photos libraries lack, so alcatraz stays a full second copy and DSM
+# Photos can index the SD-card imports.
+#
+# Why the PULL direction (and NOT a hestia->alcatraz push): Synology's
+# /bin/rsync is setuid-root and, in inbound server mode, authenticates the
+# REAL uid against the DSM account database. A hestia-initiated push therefore
+# has no working invocation:
+#   * `sudo rsync`        -> real uid = root  -> root is a disabled DSM
+#                            account -> rejected ("user has disabled/expired").
+#   * `sudo -u mara rsync`-> real uid = mara  -> non-admin, rejected (the
+#                            check gates on the administrators group).
+#   * bare `truenas-backup`/admin rsync -> passes the account check, but an
+#                            admin that isn't mara cannot write mara's private
+#                            0700 homes/<user>/Photos with correct ownership.
+# No sudoers rule squares this — it's Synology's inbound-rsync security model.
+# Reversing the direction sidesteps it entirely: here alcatraz's rsync is the
+# CLIENT writing to its OWN local filesystem as local root, so no inbound
+# account check applies and local root can chown the received files to the
+# owning DSM user. The rsync SERVER runs on hestia (plain Linux, no Synology
+# setuid patch). Full root-cause + decision record:
+#   docs/plans/2026-07-04-alcatraz-photos-pull.md
+#
+# Invariant: ADDITIVE ONLY. --ignore-existing means an alcatraz copy of a file
+# is NEVER overwritten (alcatraz's phone-upload originals win); only files
+# alcatraz lacks are added. There is NO --delete in this direction, ever —
+# deleting on alcatraz would destroy phone-upload originals or DSM Photos state.
+
+set -euo pipefail
+
+# ---- Config (edit here) -----------------------------------------------------
+# "name:uid" per DSM user. The uid is used for the post-rsync chown so files
+# land owned by the DSM account (gid is always users=100). DSM uids:
+# mara=1027, george=1028; both users are also in gid 1023(http) but 100(users)
+# is what DSM Photos and the homes ACL key on.
+USERS=("mara:1027" "george:1028")
+GID_USERS=100
+
+# hestia rsync server (source of truth). truenas_admin (uid 950) has read on
+# the photo dirs; the authorized_keys entry there restricts this key to
+# read-only rsync of the photos path (see README).
+SRC_HOST="truenas_admin@10.42.2.10"
+SRC_BASE="/mnt/main/family/images/photos"     # <SRC_BASE>/<user>/
+
+# alcatraz per-user DSM Photos libraries (destination, local).
+DST_BASE="/volume1/homes"                     # <DST_BASE>/<user>/Photos/
+
+# SSH identity used to reach hestia. Generate as a DSM admin (or the
+# truenas-backup account) and drop the private key here, mode 600; the matching
+# public key goes into truenas_admin@hestia:~/.ssh/authorized_keys as a
+# read-only-rsync forced command (see README). Persist known_hosts alongside it
+# so accept-new only prompts on the very first run.
+SSH_KEY="/volume1/homes/truenas-backup/.ssh/id_ed25519_hestia"
+KNOWN_HOSTS="/volume1/homes/truenas-backup/.ssh/known_hosts_hestia"
+
+LOG="/var/log/immich-photos-pull.log"
+# ----------------------------------------------------------------------------
+
+exec > >(tee -a "${LOG}")
+exec 2>&1
+
+START_TS=$(date +%s)
+echo "=== $(date -u +%FT%TZ) START (hestia -> alcatraz pull) ==="
+
+# chacha20-poly1305 + no SSH compression matches the hestia-side backup's
+# high-throughput configuration. -T (no pty) and -x (no X11) keep the channel
+# minimal. StrictHostKeyChecking=accept-new pins the host key on first contact
+# and fails closed if it ever changes; UserKnownHostsFile persists that pin so
+# an unattended Task Scheduler run never blocks on an interactive prompt.
+RSYNC_RSH="ssh -T -x -i ${SSH_KEY} \
+           -o StrictHostKeyChecking=accept-new \
+           -o UserKnownHostsFile=${KNOWN_HOSTS} \
+           -c chacha20-poly1305@openssh.com -o Compression=no"
+
+FAILED=0
+for entry in "${USERS[@]}"; do
+  user="${entry%%:*}"
+  uid="${entry##*:}"
+  src="${SRC_HOST}:${SRC_BASE}/${user}/"
+  dst="${DST_BASE}/${user}/Photos/"
+  mkdir -p "${dst}"
+  echo "--- $(date -u +%FT%TZ) pull ${user} (uid=${uid}): ${src} -> ${dst} ---"
+
+  # -a: archive (recursive, perms/times/symlinks preserved).
+  # --ignore-existing: additive — never clobber alcatraz's phone-upload copies;
+  #   only pull files alcatraz is missing. NO --delete: this is a backfill, not
+  #   a mirror.
+  # Excludes: @eaDir (Synology indexer metadata), .DS_Store (macOS),
+  #   Thumbs.db (Windows) — junk that should never propagate.
+  if ! rsync -a --ignore-existing \
+        --exclude='@eaDir' \
+        --exclude='.DS_Store' \
+        --exclude='Thumbs.db' \
+        --rsh="${RSYNC_RSH}" \
+        --stats \
+        "${src}" "${dst}"; then
+    rc=$?
+    echo "!!! ${user} pull rsync failed rc=${rc}"
+    FAILED=$((FAILED + 1))
+    # Don't chown a half/failed transfer's tree — skip to the next user so one
+    # user's failure never aborts the other (set -e is scoped by the `if`).
+    continue
+  fi
+
+  # This Task Scheduler job runs as root SPECIFICALLY so this chown works:
+  # rsync-received files may land root-owned (client runs as root), but DSM
+  # Photos will only index files owned by the account. Re-own the whole tree
+  # to <uid>:users so newly pulled files match alcatraz's own uploads. Cheap
+  # and idempotent; safe to run every night over the full tree.
+  if ! chown -R "${uid}:${GID_USERS}" "${dst}"; then
+    rc=$?
+    echo "!!! ${user} chown ${uid}:${GID_USERS} ${dst} failed rc=${rc}"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+  echo "--- $(date -u +%FT%TZ) ${user} OK ---"
+done
+
+END_TS=$(date +%s)
+DURATION=$((END_TS - START_TS))
+
+if [[ ${FAILED} -eq 0 ]]; then
+  echo "=== $(date -u +%FT%TZ) END (success, ${DURATION}s) ==="
+  exit 0
+else
+  echo "=== $(date -u +%FT%TZ) END (FAILED, ${FAILED} of ${#USERS[@]} users, ${DURATION}s) ==="
+  # Non-zero exit so DSM Task Scheduler emails the run output (if configured).
+  exit 1
+fi

--- a/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
+++ b/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
@@ -45,10 +45,14 @@ USERS=("mara:1027" "george:1028")
 GID_USERS=100
 
 # hestia rsync server (source of truth). truenas_admin (uid 950) has read on
-# the photo dirs; the authorized_keys entry there restricts this key to
-# read-only rsync of the photos path (see README).
+# the photo dirs; the authorized_keys entry there restricts this key to a
+# read-only rrsync rooted at the photos path
+# (command="rrsync -ro /mnt/main/family/images/photos", see README). Because
+# rrsync confines the client to that root, source paths are RELATIVE to it
+# (e.g. "mara/") — an ABSOLUTE path gets the root prepended a second time and
+# fails ("change_dir ...photos/mnt/.../photos/mara: No such file"). The
+# authorizing rrsync root on hestia is: /mnt/main/family/images/photos
 SRC_HOST="truenas_admin@10.42.2.10"
-SRC_BASE="/mnt/main/family/images/photos"     # <SRC_BASE>/<user>/
 
 # alcatraz per-user DSM Photos libraries (destination, local).
 DST_BASE="/volume1/homes"                     # <DST_BASE>/<user>/Photos/
@@ -84,7 +88,7 @@ FAILED=0
 for entry in "${USERS[@]}"; do
   user="${entry%%:*}"
   uid="${entry##*:}"
-  src="${SRC_HOST}:${SRC_BASE}/${user}/"
+  src="${SRC_HOST}:${user}/"   # relative to the rrsync root (see SRC_HOST note)
   dst="${DST_BASE}/${user}/Photos/"
   mkdir -p "${dst}"
   echo "--- $(date -u +%FT%TZ) pull ${user} (uid=${uid}): ${src} -> ${dst} ---"

--- a/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
+++ b/hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh
@@ -46,8 +46,10 @@ GID_USERS=100
 
 # hestia rsync server (source of truth). truenas_admin (uid 950) has read on
 # the photo dirs; the authorized_keys entry there restricts this key to a
-# read-only rrsync rooted at the photos path
-# (command="rrsync -ro /mnt/main/family/images/photos", see README). Because
+# read-only rrsync rooted at the photos path (abbreviated as
+# command="rrsync -ro /mnt/main/family/images/photos" here; the real
+# authorized_keys line wraps it in `sudo -n --preserve-env=SSH_ORIGINAL_COMMAND`
+# — see README for the exact, load-bearing form). Because
 # rrsync confines the client to that root, source paths are RELATIVE to it
 # (e.g. "mara/") — an ABSOLUTE path gets the root prepended a second time and
 # fails ("change_dir ...photos/mnt/.../photos/mara: No such file"). The
@@ -99,28 +101,36 @@ for entry in "${USERS[@]}"; do
   #   a mirror.
   # Excludes: @eaDir (Synology indexer metadata), .DS_Store (macOS),
   #   Thumbs.db (Windows) — junk that should never propagate.
-  if ! rsync -a --ignore-existing \
+  # `|| rc=$?` (not `if ! rsync`) so ${rc} captures rsync's REAL exit code for
+  # the log (23=partial, 12=protocol, etc. — the codes the header cares about);
+  # a plain `if ! rsync` would make $? the negation's status (always 0). The
+  # `|| ...` list also suppresses set -e, so one user's failure never aborts the
+  # loop — we record it and skip to the next user.
+  rc=0
+  rsync -a --ignore-existing \
         --exclude='@eaDir' \
         --exclude='.DS_Store' \
         --exclude='Thumbs.db' \
         --rsh="${RSYNC_RSH}" \
         --stats \
-        "${src}" "${dst}"; then
-    rc=$?
+        "${src}" "${dst}" || rc=$?
+  if [[ ${rc} -ne 0 ]]; then
     echo "!!! ${user} pull rsync failed rc=${rc}"
     FAILED=$((FAILED + 1))
-    # Don't chown a half/failed transfer's tree — skip to the next user so one
-    # user's failure never aborts the other (set -e is scoped by the `if`).
+    # Don't chown a half/failed transfer's tree — skip to the next user.
     continue
   fi
 
   # This Task Scheduler job runs as root SPECIFICALLY so this chown works:
   # rsync-received files may land root-owned (client runs as root), but DSM
   # Photos will only index files owned by the account. Re-own the whole tree
-  # to <uid>:users so newly pulled files match alcatraz's own uploads. Cheap
-  # and idempotent; safe to run every night over the full tree.
-  if ! chown -R "${uid}:${GID_USERS}" "${dst}"; then
-    rc=$?
+  # to <uid>:users so newly pulled files match alcatraz's own uploads.
+  # Idempotent (a no-op re-chown just bumps ctime); runs over the full tree
+  # every night, so cost scales with inode count, not with what was pulled.
+  # `|| rc=$?` for the same real-exit-code + set -e reasons as the rsync above.
+  rc=0
+  chown -R "${uid}:${GID_USERS}" "${dst}" || rc=$?
+  if [[ ${rc} -ne 0 ]]; then
     echo "!!! ${user} chown ${uid}:${GID_USERS} ${dst} failed rc=${rc}"
     FAILED=$((FAILED + 1))
     continue

--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -1,8 +1,20 @@
 # immich-photos-backup
 
-Daily DUPLEX sync of the Immich photo library between alcatraz (Synology, 10.42.2.11) and hestia's `main/family/images/photos`. **Pull** (alcatraz→hestia, additive) brings phone uploads in; **push-back** (hestia→alcatraz, `--ignore-existing`) copies anything hestia has that alcatraz lacks (e.g. direct SD-card imports) so alcatraz stays a full backup. No `--delete` in either direction — both sides converge to the union; hestia is authoritative. Always-running container; busybox `crond` fires at 04:00 local.
+Daily incremental **pull** of the Immich photo library from alcatraz (Synology, 10.42.2.11) into hestia's `main/family/images/photos`. Additive — brings phone uploads into hestia (the source of truth); no `--delete`, so direct-to-hestia SD-card imports are never wiped. Always-running container; busybox `crond` fires at 04:00 local.
+
+The reverse leg — hestia→alcatraz, so alcatraz stays a full backup and DSM Photos picks up SD-card imports — is **not** a push from this container. It runs **from alcatraz** as a DSM Task Scheduler pull job: [`hosts/alcatraz/immich-photos-pull/`](../../alcatraz/immich-photos-pull/README.md). See ["Synology inbound-rsync limitation"](#synology-inbound-rsync-limitation) below for why a hestia-side push-back was retired.
 
 Sources are per-user `homes/<user>/Photos/` paths, not `family/images/photos/<user>/`. On the Synology side those family paths are symlinks into each user's home, with per-file ACLs that deny `truenas-backup` file open via the family path — so we sync from the homes path directly and re-map into the canonical hestia `family/images/photos/<user>/` layout.
+
+### Synology inbound-rsync limitation
+
+A hestia→alcatraz **push** (which an earlier "duplex" version attempted via `--rsync-path="sudo -n rsync"`) **cannot work** and has been retired. Synology's `/bin/rsync` is **setuid-root** and, in inbound server mode, authenticates the **real uid** against the DSM account database:
+
+- `sudo rsync` → real uid = **root**, a disabled DSM account → rejected ("user has disabled/expired").
+- `sudo -u mara rsync` → real uid = **mara**, non-admin → rejected (the check gates on the administrators group).
+- Only an **administrator** (e.g. `truenas-backup`) passes the account check — but an admin that isn't the owning user can't write that user's private `0700` `homes/<user>/Photos` with correct ownership.
+
+No sudoers rule squares this. The fix is to reverse the direction: alcatraz **pulls** from hestia as local root (no inbound account check applies, and local root can chown the received files). That job lives in [`hosts/alcatraz/immich-photos-pull/`](../../alcatraz/immich-photos-pull/README.md). **No rsync sudoers entry on alcatraz is needed** — only the chmod sudoers rule (section 3a) that supports this container's pull leg remains.
 
 | Attribute | Value |
 |---|---|
@@ -49,7 +61,7 @@ ssh -i /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz \
 
 Synology DSM Photos uploads new files with POSIX mode `0700`. The owning group is `users` (gid 100) — which `truenas-backup` is also in, so the group bit's `---` denies before POSIX falls through to "other". rsync hits `send_files Permission denied (13)` on every new file and the run fails partially-but-silently (zero bytes transferred for new content; no metric update; the `ImmichPhotoBackupStale` alert eventually fires).
 
-The script's per-user PULL runs a `sudo -n chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. The PUSH-BACK additionally runs the remote rsync as `sudo -n rsync` so it can write into the user's home and `--chown` the files — so the sudoers below also permits `rsync` (verify the path with `which rsync` on alcatraz; typically `/bin/rsync`). That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod (and no `requiretty` constraint — see Notes below):
+The script's per-user PULL runs a `sudo -n chmod -R g+rX,o+rX` on the source via rsync's `--rsync-path` before each transfer to fix this. That requires NOPASSWD sudo for `truenas-backup` on exactly that chmod (and no `requiretty` constraint — see Notes below). No `rsync` grant is needed: the retired hestia→alcatraz push-back is gone (see ["Synology inbound-rsync limitation"](#synology-inbound-rsync-limitation)), so the sudoers rule covers only the chmod:
 
 ```bash
 # As a DSM admin (currently: manager) on alcatraz.
@@ -62,7 +74,7 @@ The script's per-user PULL runs a `sudo -n chmod -R g+rX,o+rX` on the source via
 #      via DSM File Station (logged in as a DSM admin) — that skips sudo
 #      entirely and avoids the chicken-and-egg trap.
 cat > /tmp/immich-photos-backup.sudoers <<'EOF'
-truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos, /bin/rsync, /usr/bin/rsync
+truenas-backup ALL=(root) NOPASSWD: /bin/chmod -R g+rX\,o+rX /volume1/homes/george/Photos, /bin/chmod -R g+rX\,o+rX /volume1/homes/mara/Photos
 EOF
 sudo install -m 0440 -o root -g root \
     /tmp/immich-photos-backup.sudoers \
@@ -75,7 +87,7 @@ sudo -n true && echo "sudo still functional"
 
 # Sanity #2: the new rule is visible to truenas-backup. The output
 # displays `\,` literally — that's sudo -l showing the escape, normal.
-sudo -l -U truenas-backup 2>&1 | grep -iE 'chmod|rsync'
+sudo -l -U truenas-backup 2>&1 | grep -i chmod
 ```
 
 Sanity check the paths exist on your DSM (paths differ between Synology firmware versions):

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Daily DUPLEX sync of the Immich photo library between alcatraz and hestia.
-# Pull (alcatraz -> hestia): brings phone uploads into hestia (the source of truth).
-# Push-back (hestia -> alcatraz, --ignore-existing): copies anything hestia has that
-# alcatraz lacks (e.g. direct SD-card imports) so alcatraz stays a full backup.
-# No --delete in either direction -> both sides converge to the UNION; neither wipes
-# the other. hestia is authoritative; alcatraz is the phone-upload target + backup.
+# Daily incremental PULL of the Immich photo library from alcatraz -> hestia.
+# Brings phone uploads into hestia (the source of truth); additive, no --delete.
+#
+# The reverse leg (hestia -> alcatraz, so alcatraz stays a full backup and DSM
+# Photos gets direct-to-hestia SD-card imports) is NOT done here. It runs FROM
+# alcatraz as a DSM Task Scheduler pull job — see hosts/alcatraz/immich-photos-pull/.
+# Do NOT re-add a hestia-side sudo-rsync push-back: Synology's setuid-root
+# /bin/rsync authenticates the real uid against the DSM account DB in inbound
+# server mode, so `sudo rsync` (root, disabled account) and `sudo -u <user>
+# rsync` (non-admin) are both rejected, and an admin that isn't the owner can't
+# write the user's private 0700 homes/<user>/Photos. Root cause + decision:
+# docs/plans/2026-07-04-alcatraz-photos-pull.md.
 #
 # Pulls per-user Photos dirs from alcatraz (Synology NAS, 10.42.2.11) into the
 # local ZFS dataset main/family/images/photos. Snapshots are managed by a
@@ -114,22 +120,11 @@ for user in "${USERS[@]}"; do
     FAILED=$((FAILED + 1))
   fi
 
-  # --- duplex push-back: hestia -> alcatraz, copy only what alcatraz lacks ---
-  # --ignore-existing never overwrites alcatraz's copy (no conflicts, no --delete);
-  # it only adds missing files (e.g. SD-card imports made directly on hestia).
-  # Remote rsync runs via `sudo -n rsync` so it can write into the user's home and
-  # --chown the files to the right owner. This needs a truenas-backup sudoers entry
-  # for rsync on alcatraz (see README, "Sudoers entry on alcatraz"). A push-back
-  # failure is a WARNING only -- the pull above is what the staleness alert keys off.
-  if ! rsync -avh --ignore-existing --chown="${user}:users" \
-        --exclude='@eaDir' \
-        --exclude='.DS_Store' \
-        --exclude='Thumbs.db' \
-        --rsh="${RSYNC_RSH}" \
-        --rsync-path="sudo -n rsync" \
-        "${dst}" "${src}"; then
-    echo "!!! ${user} push-back (hestia->alcatraz backup) failed rc=$? -- pull OK; check alcatraz sudoers for rsync"
-  fi
+  # hestia -> alcatraz backup is NOT a push from here. It runs FROM alcatraz as
+  # a DSM Task Scheduler pull job (hosts/alcatraz/immich-photos-pull/). Do not
+  # re-add a `--rsync-path="sudo -n rsync"` push-back: Synology's setuid-root
+  # /bin/rsync rejects it in inbound server mode (real-uid DSM-account check).
+  # See docs/plans/2026-07-04-alcatraz-photos-pull.md.
 done
 
 END_TS=$(date +%s)


### PR DESCRIPTION
## Why

hestia is the source of truth for the photo library. The alcatraz→hestia phone-upload pull works. The reverse leg — hestia→alcatraz backfill, so alcatraz stays a full backup and DSM Photos indexes direct-to-hestia SD-card imports — was implemented as a **push** from the hestia container (`--rsync-path="sudo -n rsync"`). **It cannot work.**

**Root cause (proven):** Synology's `/bin/rsync` is **setuid-root** and authenticates the **real uid** against the DSM account DB in inbound server mode:

| Push invocation on alcatraz | Real uid | Result |
|---|---|---|
| `sudo rsync` | root | Rejected — root is a disabled DSM account; 0 bytes |
| `sudo -u mara rsync` | mara | Rejected — non-admin (check gates on administrators group) |
| bare `truenas-backup` (admin) | truenas-backup | Passes account check, but can't write mara's private `0700` homes with correct ownership |

No sudoers rule squares this.

## Fix (Option 1: reverse direction)

alcatraz **pulls** from hestia via a DSM Task Scheduler job, running as **root**: alcatraz's rsync is the client writing to its own local filesystem, so no inbound account check applies and local root can `chown` received files to the owning DSM user. The rsync server runs on hestia (plain Linux).

## Changes

- **New** `hosts/alcatraz/immich-photos-pull/pull-from-hestia.sh` — additive `rsync -a --ignore-existing` (no `--delete`), per-user chown to `<uid>:100`, restricted read-only-rsync SSH key, per-user failure isolation.
- **New** `hosts/alcatraz/immich-photos-pull/README.md` — DSM operator runbook (key gen, hestia `authorized_keys` forced command, Task Scheduler job, first-run + DSM-Photos-indexing validation).
- **Edit** `images/immich-photos-backup/immich-photos-backup.sh` — remove the dead push-back leg; comment guards re-adding it.
- **Edit** `hosts/hestia/immich-photos-backup/README.md` — document the Synology inbound-rsync limitation; drop the now-unneeded `rsync` grant from the alcatraz sudoers line (chmod rule for the pull stays).
- **New** `docs/plans/2026-07-04-alcatraz-photos-pull.md` (+ regen index) and a STATUS.md entry.

## Follow-ups / notes

- The image script change triggers `build-immich-photos-backup.yml`. A **follow-up PR** must bump the `docker-compose.yml` digest to deploy it — **not done here.**
- **Requires a human with live access** (not automated in this PR): (a) installing the `authorized_keys` forced-command line on hestia once the alcatraz key exists; (b) all DSM-side steps (key gen, script placement, Task Scheduler job, indexing validation).
- Scripts pass `bash -n`; no shellcheck available in-env. No kustomize overlays touched. Plans index in sync (`make plans-index-check` ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet