### PR TITLE
feat(homelabscope): unified monitoring for every scheduled homelab job

### DIFF
--- a/.github/workflows/build-homelabscope-heartbeat.yml
+++ b/.github/workflows/build-homelabscope-heartbeat.yml
@@ -1,0 +1,67 @@
+name: Build homelabscope-heartbeat
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/homelabscope-heartbeat/**'
+      - '.github/workflows/build-homelabscope-heartbeat.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/homelabscope-heartbeat
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Mirrors the YYYY-MM-DD / YYYY-MM-DD-N convention in AGENTS.md and the
+      # immich-photos-backup / mopidy / snapcast workflows.
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: images/homelabscope-heartbeat
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### homelabscope-heartbeat published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Pin the digest in \`hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml\` and flip \`x-deploy.archived\` to false in a follow-up PR." >> $GITHUB_STEP_SUMMARY

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,7 +5,7 @@
 > this page links out. **Update this file in the same PR whenever** a plan's
 > status changes, an incident postmortem lands, or hardware/topology changes.
 >
-> Last updated: 2026-06-24
+> Last updated: 2026-07-04
 
 ## Cluster at a glance
 
@@ -38,6 +38,7 @@ Active plans (see [docs/plans/](plans/README.md) for the full status-grouped ind
 - [Snapcast / HifiBerry rollout](plans/2026-05-03-snapcast-hifiberry-rollout.md) — server + LB IP live; per-device client setup remaining.
 - [Navidrome → Mopidy → Snapcast audio source](plans/2026-03-14-navidrome-snapcast-mopidy.md) — Mopidy sidecar in draft PR #426; not yet on master.
 - [Hestia memory benchmark](plans/2026-05-15-hestia-memory-benchmark.md) — 6-DIMM baseline captured; 8-DIMM comparison pending a physical DIMM swap.
+- [homelabscope — scheduled-job monitoring](plans/2026-07-04-homelabscope.md) — unified `homelabscope_job_*` metric family + hestia node-exporter textfile scraper (fixes the orphaned/unscraped immich-backup metric) + cronjob recording rules + templated staleness/absence alerts + Grafana table. Repo artifacts landed; operator steps remain (deploy node-exporter, build+enable the heartbeat Custom App, bump the immich image digest).
 
 ## Next up
 

--- a/docs/plans/2026-07-04-homelabscope.md
+++ b/docs/plans/2026-07-04-homelabscope.md
@@ -64,12 +64,25 @@ Fed from three source types, all normalizing into that family:
    onto the family with `max(...) + labels: {job: <name>}`, and emits each job's
    `homelabscope_job_max_age_seconds` via `vector(N)`.
 
-**Alerting — one templated pair** (`homelabscope.alerts` group):
+**Alerting — one templated pair** (`homelabscope.alerts` group), both
+`severity: critical` so they actually deliver:
 - `HomelabscopeJobStale`: `time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds`
   — every job checked against its OWN budget with a single rule (last_success and
   max_age share a label set per job, so the comparison joins on `job`).
-- `HomelabscopeJobMetricAbsent`: `absent(...)` per critical job for 1h — catches
-  a heartbeat vanishing entirely, the failure mode the old setup missed.
+- `HomelabscopeJobMetricAbsent`: `absent(...)` for 1h — catches a heartbeat
+  vanishing entirely, the failure mode the old setup missed. Scoped to jobs with
+  a **live data source at merge**: `immich-photos-backup` (node-exporter, operator
+  step 1) plus the four cronjob-backed jobs. The three heartbeat-backed jobs
+  (`alcatraz-photos-pull`, `zfs-snapshot-main-{family,homes}`) are omitted until
+  the follow-up PR un-archives their exporter — guarding a not-yet-deployed
+  exporter would fire a guaranteed false critical on merge.
+
+**Delivery:** `severity: critical` routes through the existing `email-critical`
+receiver (Gmail SMTP, added by the 2026-06-17 alertmanager-smtp plan) to
+`gjcourt+alerts@gmail.com`. Verified with `amtool config routes test`:
+`severity=critical` → `email-critical`, `severity=warning` → `null`. The alerts
+were originally `severity: warning`, which routes to `null` and would have
+dropped every notification silently — the delivery gap this fixes.
 
 The dataless `ImmichPhotoBackupStale` alert is **retired** (superseded), with a
 tombstone comment in `infra/configs/alerts/prometheus-rules.yaml`.
@@ -110,6 +123,10 @@ This PR ships repo artifacts only — no live infra changes. To activate:
 3. **Enable the heartbeat Custom App.** Its compose ships `x-deploy.archived: true`
    (won't deploy against a nonexistent image). In a follow-up PR, pin the
    `@sha256` digest and flip `archived: false`; `deploy-hestia.yml` rolls it out.
+   **In that same follow-up, add `alcatraz-photos-pull`,
+   `zfs-snapshot-main-family`, and `zfs-snapshot-main-homes` back into the
+   `HomelabscopeJobMetricAbsent` `absent(...)` expr** — they are held out of this
+   PR's absent guard precisely because their exporter isn't live until this step.
 4. **Bump the immich-photos-backup image digest.** The edit to
    `images/immich-photos-backup/immich-photos-backup.sh` triggers a rebuild;
    pin the new digest in `hosts/hestia/immich-photos-backup/docker-compose.yml`
@@ -120,8 +137,11 @@ This PR ships repo artifacts only — no live infra changes. To activate:
 - The heartbeat's `.zfs/snapshot` fallback parses snapshot NAMES
   (`auto-YYYY-MM-DD_HH-MM-...`) in `America/Los_Angeles` (the observed schedule
   TZ); it's only used if in-container `zfs list` can't reach `/dev/zfs`.
-- Alert delivery: the monitoring stack's critical receiver is still `null`
-  (Signal decommission) — see the monitoring-enhancement plan. homelabscope
-  alerts evaluate correctly but delivery is gated on a receiver being chosen.
+- Alert delivery: **wired.** The critical receiver is `email-critical` (Gmail
+  SMTP, per the 2026-06-17 alertmanager-smtp plan), not `null` — the earlier
+  Signal-decommission gap was closed before this PR. homelabscope's alerts are
+  `severity: critical` so they route to it (verified with `amtool`). The one
+  operator dependency is the `alertmanager-smtp` secret, which already exists in
+  the cluster; no new secret is required by this PR.
 - `homelabscope_job_last_status` is only meaningful for jobs that report it
   (textfile writers set 0 on success); cronjob-backed rows omit it.

--- a/docs/plans/2026-07-04-homelabscope.md
+++ b/docs/plans/2026-07-04-homelabscope.md
@@ -1,0 +1,127 @@
+---
+status: in-progress
+last_modified: 2026-07-04
+summary: "homelabscope — one Prometheus metric family (homelabscope_job_last_success_seconds{job}) + textfile collector + cronjob recording rules + templated staleness/absence alerts + Grafana table monitoring EVERY scheduled homelab job; fixes the orphaned (unscraped) immich-backup metric"
+---
+
+# homelabscope — unified monitoring for every scheduled job
+
+## Problem
+
+The homelab runs a growing set of automatic/scheduled jobs — nightly photo
+syncs, ZFS snapshots, AdGuard config sync, Renovate, pingo — and **none of them
+were monitored as a class**. Each was either silent or wired up ad hoc.
+
+The sharpest failure: `immich-photos-backup.sh` faithfully wrote
+`immich_photos_backup_last_success_seconds` to the node-exporter textfile
+collector at `/var/lib/node-exporter/textfile/immich-backup.prom` on every run,
+and an `ImmichPhotoBackupStale` alert keyed off it — but **nothing scraped
+:9100 on hestia**. Only thermalscope (:9102) and ipmi-exporter (:9290) were up;
+there was no node-exporter. The metric was orphaned, the alert could never fire,
+and a stalled backup would have gone unnoticed. Verified 2026-07-04: `ss -ltn`
+on hestia shows 9102 + 9290 listening, **not 9100**, and the `.prom` file present
+but unscraped.
+
+The generalized gap: a job whose heartbeat **vanishes entirely** (container
+gone, CronJob deleted, script crashing before it writes) looks identical to
+"healthy" when nothing is watching.
+
+## Design
+
+**One metric family for all jobs**, regardless of where they run:
+
+| Metric | Meaning |
+|---|---|
+| `homelabscope_job_last_success_seconds{job="<name>"}` | unix ts of last success |
+| `homelabscope_job_last_duration_seconds{job="<name>"}` | wall-clock of last run |
+| `homelabscope_job_last_status{job="<name>"}` | 0=ok, 1=fail (where known) |
+| `homelabscope_job_max_age_seconds{job="<name>"}` | per-job staleness budget |
+
+Fed from three source types, all normalizing into that family:
+
+1. **hestia/alcatraz shell jobs → node-exporter textfile collector on hestia.**
+   A new node-exporter Custom App (`hosts/hestia/monitoring/docker-compose-node-exporter.yml`,
+   textfile collector only, :9100) exposes the `.prom` files, and a new
+   `ScrapeConfig` (`infra/configs/homelabscope/scrapeconfig.yaml`, static target
+   `10.42.2.10:9100`, `honorLabels: true`) scrapes them. This finally activates
+   the previously-orphaned immich metric.
+   - **immich-photos-backup** (hestia, `0 4 * * *`) — its textfile writer now
+     emits the homelabscope family alongside the legacy `immich_photos_backup_*`
+     series (back-compat kept for one release).
+   - **alcatraz-photos-pull** (alcatraz Synology DSM, ~05:00) and
+     **zfs-snapshot-main-{family,homes}** can't run an exporter, so a small
+     hestia-side **homelabscope-heartbeat** Custom App
+     (`images/homelabscope-heartbeat/` → `hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml`)
+     loops every 10 min and, read-only: SSHes to alcatraz (reusing the
+     immich-photos-backup key + `truenas-backup@10.42.2.11`) to parse the pull
+     log's last `=== <ts> END (success, Ns) ===` trailer; and reads
+     `zfs list -t snapshot` (newest creation = last success) with a
+     `.zfs/snapshot` directory-listing fallback.
+
+2. **k8s CronJobs → recording rules over kube-state-metrics** (no new exporter).
+   `infra/configs/homelabscope/prometheus-rule.yaml` projects
+   `kube_cronjob_status_last_successful_time` (verified present on this cluster)
+   onto the family with `max(...) + labels: {job: <name>}`, and emits each job's
+   `homelabscope_job_max_age_seconds` via `vector(N)`.
+
+**Alerting — one templated pair** (`homelabscope.alerts` group):
+- `HomelabscopeJobStale`: `time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds`
+  — every job checked against its OWN budget with a single rule (last_success and
+  max_age share a label set per job, so the comparison joins on `job`).
+- `HomelabscopeJobMetricAbsent`: `absent(...)` per critical job for 1h — catches
+  a heartbeat vanishing entirely, the failure mode the old setup missed.
+
+The dataless `ImmichPhotoBackupStale` alert is **retired** (superseded), with a
+tombstone comment in `infra/configs/alerts/prometheus-rules.yaml`.
+
+**Dashboard:** `infra/configs/dashboards/homelabscope-cm.yaml` — a table with one
+row per job (age, duration, status, health = age/budget colored red when over
+budget), stat tiles (jobs over budget / tracked / worst ratio), and a
+freshness-ratio timeseries. At-a-glance "are all my scheduled jobs healthy".
+
+## Job registry
+
+| Job | Source | Cadence | max-age | job label |
+|---|---|---|---|---|
+| immich-photos-backup | hestia textfile | daily 04:00 | 30h | `immich-photos-backup` |
+| alcatraz-photos-pull | heartbeat (ssh log) | daily ~05:00 | 30h | `alcatraz-photos-pull` |
+| zfs-snapshot main/family | heartbeat (zfs) | daily 05:00 | 30h | `zfs-snapshot-main-family` |
+| zfs-snapshot main/homes | heartbeat (zfs) | daily 05:00 | 30h | `zfs-snapshot-main-homes` |
+| immich-photos-30d-sync | cronjob (immich-stage) | daily 03:00 | 30h | `immich-photos-30d-sync` |
+| renovate | cronjob (renovate) | @daily | 30h | `renovate` |
+| adguard-sync (prod) | cronjob (adguard-prod) | `0 */6` | 14h | `adguard-sync-prod` |
+| adguard-sync (stage) | cronjob (adguard-stage) | `0 */6` | 14h | `adguard-sync-stage` |
+| renovate-automerge | cronjob (renovate) | `0 */6` | 14h | `renovate-automerge` |
+| pingo | cronjob (pingo) | `*/5` | 20m | `pingo` |
+
+Budgets: daily → 30h (one missed window), 6h → 14h, 5m → 20m.
+
+## Operator steps (require live hestia access; not done by this PR)
+
+This PR ships repo artifacts only — no live infra changes. To activate:
+
+1. **Deploy the node-exporter Custom App.** `hosts/hestia/monitoring/docker-compose-node-exporter.yml`
+   auto-deploys via `deploy-hestia.yml` on merge (stock image
+   `quay.io/prometheus/node-exporter:v1.9.1`). Confirm `:9100` comes up and the
+   ScrapeConfig target goes green in Prometheus.
+2. **Build the heartbeat image.** The first merge of `images/homelabscope-heartbeat/**`
+   triggers `build-homelabscope-heartbeat.yml`, publishing
+   `ghcr.io/gjcourt/homelabscope-heartbeat:<date>`.
+3. **Enable the heartbeat Custom App.** Its compose ships `x-deploy.archived: true`
+   (won't deploy against a nonexistent image). In a follow-up PR, pin the
+   `@sha256` digest and flip `archived: false`; `deploy-hestia.yml` rolls it out.
+4. **Bump the immich-photos-backup image digest.** The edit to
+   `images/immich-photos-backup/immich-photos-backup.sh` triggers a rebuild;
+   pin the new digest in `hosts/hestia/immich-photos-backup/docker-compose.yml`
+   in a follow-up PR (standard images/** two-step; NOT bumped here).
+
+## Deferred / assumptions
+
+- The heartbeat's `.zfs/snapshot` fallback parses snapshot NAMES
+  (`auto-YYYY-MM-DD_HH-MM-...`) in `America/Los_Angeles` (the observed schedule
+  TZ); it's only used if in-container `zfs list` can't reach `/dev/zfs`.
+- Alert delivery: the monitoring stack's critical receiver is still `null`
+  (Signal decommission) — see the monitoring-enhancement plan. homelabscope
+  alerts evaluate correctly but delivery is gated on a receiver being chosen.
+- `homelabscope_job_last_status` is only meaningful for jobs that report it
+  (textfile writers set 0 on success); cronjob-backed rows omit it.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,10 +60,11 @@ see `scripts/plans-index/`).
 
 <!-- BEGIN PLANS INDEX -->
 
-### In progress (9)
+### In progress (10)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-07-04-homelabscope.md](2026-07-04-homelabscope.md) | 2026-07-04 | homelabscope — one Prometheus metric family (homelabscope_job_last_success_seconds{job}) + textfile collector + cronjob recording rules + templated staleness/absence alerts + Grafana table monitoring EVERY scheduled homelab job; fixes the orphaned (unscraped) immich-backup metric |
 | [2026-06-17-alertmanager-smtp-alerting.md](2026-06-17-alertmanager-smtp-alerting.md) | 2026-06-17 | Route critical Alertmanager alerts to email via Gmail SMTP (replaces dead Signal channel) |
 | [2026-06-16-thermalscope-power-and-headroom.md](2026-06-16-thermalscope-power-and-headroom.md) | 2026-06-17 | thermalscope: add power/energy/cost (RAPL), thermal headroom, and throttle/degradation signals — phases 1–3 live; phase 4 pending |
 | [2026-06-01-hestia-photos-sot.md](2026-06-01-hestia-photos-sot.md) | 2026-06-10 | Make hestia the source of truth for family/ + homes/; repoint Immich NFS PV; alcatraz narrows to upload target |

--- a/hosts/hestia/monitoring/README.md
+++ b/hosts/hestia/monitoring/README.md
@@ -1,14 +1,37 @@
-# monitoring — hestia thermals + GPU metrics
+# monitoring — hestia thermals, power, and scheduled-job metrics
 
-Thermal/GPU observability for hestia.
+Prometheus exporters for hestia (a bare TrueNAS host outside the Talos
+node-exporter DaemonSet).
 
 ## Services
 
 | File | Purpose |
 |------|---------|
 | `docker-compose-nvtop.yml` | nvtop — interactive GPU process viewer |
-| `docker-compose.yml` | thermalscope — Prometheus thermal/GPU exporter on `:9102` |
+| `docker-compose.yml` | thermalscope — Prometheus thermal/GPU exporter on `:9102` (archived; GPUs sold) |
+| `docker-compose-ipmi-exporter.yml` | prometheus-ipmi-exporter — BMC fans/temps on `:9290` |
+| `docker-compose-node-exporter.yml` | node-exporter (textfile collector only) on `:9100` — serves the homelabscope `.prom` files |
+| `docker-compose-homelabscope-heartbeat.yml` | homelabscope-heartbeat — SSH-reads the alcatraz pull log + ZFS snapshot freshness, writes `.prom` files (archived until its image is built) |
+
+## homelabscope
+
+`node-exporter` + `homelabscope-heartbeat` back the **homelabscope** scheduled-job
+monitoring family (`homelabscope_job_*`). node-exporter exposes the textfile
+collector at `/var/lib/node-exporter/textfile` on `:9100`; the cluster-side
+`ScrapeConfig` + alerts + dashboard live in `infra/configs/homelabscope/` and
+`infra/configs/dashboards/homelabscope-cm.yaml`. See
+`docs/plans/2026-07-04-homelabscope.md`. Before homelabscope there was no
+`:9100` scraper on hestia, so `immich-photos-backup`'s textfile metric was
+orphaned — this is what fixes that.
+
+`homelabscope-heartbeat` ships `x-deploy.archived: true` until its image is
+built by `build-homelabscope-heartbeat.yml`; then pin the `@sha256` digest and
+flip `archived: false`.
 
 ## Deployment
 
-Deploy as a TrueNAS Custom App. Paste the YAML into SCALE UI → Apps → Custom App. Subsequent updates to `docker-compose.yml` flow through `.github/workflows/deploy-hestia.yml`.
+These composes are **operator-applied Custom Apps, not Flux-managed.** Deploy as
+a TrueNAS Custom App (paste the YAML into SCALE UI → Apps → Custom App on first
+run). Subsequent changes to `hosts/hestia/**/docker-compose*.yml` on `master`
+auto-deploy via `.github/workflows/deploy-hestia.yml` (except `x-deploy.archived`
+apps, which are skipped).

--- a/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
+++ b/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
@@ -1,0 +1,56 @@
+# homelabscope-heartbeat — hestia-side collector Custom App.
+#
+# Surfaces two scheduled jobs that can't run their own exporter into the
+# homelabscope metric family, by writing .prom files into the shared
+# node-exporter textfile dir (served by docker-compose-node-exporter.yml on
+# :9100 and scraped by the infra/configs/homelabscope ScrapeConfig):
+#
+#   alcatraz-photos-pull        — SSHes to alcatraz, parses the pull log's last
+#                                 `END (success, Ns)` trailer.
+#   zfs-snapshot-main-family    — newest ZFS snapshot creation time per dataset
+#   zfs-snapshot-main-homes       (last success = last snapshot).
+#
+# READ-ONLY: it reads the alcatraz log + ZFS snapshot list and writes only its
+# own .prom files. It mutates no data on either host.
+#
+# ARCHIVED until the image is built. This app references
+# ghcr.io/gjcourt/homelabscope-heartbeat, which build-homelabscope-heartbeat.yml
+# publishes on the first push of images/homelabscope-heartbeat/** to master.
+# Operator step after that first build: pin the @sha256 digest below and flip
+# archived to false so deploy-hestia.yml rolls it out. Deploying before the
+# image exists would crash-loop, so we keep it opted-out of auto-deploy.
+x-deploy:
+  name: homelabscope-heartbeat
+  archived: true
+  archived-at: 2026-07-04
+  archived-reason: image not yet built — flip false + pin digest after first CI publish
+
+services:
+  homelabscope-heartbeat:
+    image: ghcr.io/gjcourt/homelabscope-heartbeat:2026-07-04
+    container_name: homelabscope-heartbeat
+    restart: unless-stopped
+    # Root + privileged + /dev/zfs so `zfs list -t snapshot` can talk to the
+    # pool (read-only ioctls). If the in-container zfs userland can't reach the
+    # host module, heartbeat.sh falls back to the bind-mounted .zfs/snapshot
+    # control dirs — hence /mnt/main/family + /mnt/main/homes are mounted too.
+    privileged: true
+    user: "0:0"
+    environment:
+      - INTERVAL_SECONDS=600
+      - TZ=America/New_York
+      # TZ that the TrueNAS periodic-snapshot task names its snapshots in —
+      # only used by the .zfs/snapshot fallback (see heartbeat.sh).
+      - ZFS_SNAP_TZ=America/Los_Angeles
+    devices:
+      - /dev/zfs:/dev/zfs
+    volumes:
+      # Reuse the immich-photos-backup app's alcatraz credential — same key,
+      # same truenas-backup@10.42.2.11 account, read-only.
+      - /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz:/root/.ssh/id_ed25519_alcatraz:ro
+      - /mnt/main/apps/immich-photos-backup/ssh/known_hosts:/root/.ssh/known_hosts
+      # Shared textfile collector dir — heartbeat writes homelabscope-*.prom here.
+      - /var/lib/node-exporter/textfile:/var/lib/node-exporter/textfile
+      # ZFS snapshot fallback source (read-only) when `zfs list` is unavailable.
+      - /mnt/main/family:/mnt/main/family:ro
+      - /mnt/main/homes:/mnt/main/homes:ro

--- a/hosts/hestia/monitoring/docker-compose-node-exporter.yml
+++ b/hosts/hestia/monitoring/docker-compose-node-exporter.yml
@@ -1,0 +1,45 @@
+# node-exporter for hestia — homelabscope textfile collector host.
+#
+# Purpose: expose the Prometheus textfile collector at :9100 so the .prom files
+# under /var/lib/node-exporter/textfile actually reach Prometheus. Before this
+# app existed, immich-photos-backup.sh had been writing
+# /var/lib/node-exporter/textfile/immich-backup.prom on every run but NOTHING
+# scraped :9100 on hestia (only thermalscope :9102 and ipmi-exporter :9290 were
+# up) — so the metric was orphaned and its staleness alert could never fire.
+# This node-exporter + the infra/configs/homelabscope ScrapeConfig close that
+# gap and back the whole homelabscope_job_* metric family for hestia/alcatraz
+# shell jobs.
+#
+# Collectors: defaults are DISABLED (--collector.disable-defaults) and ONLY the
+# textfile collector is enabled. This host's general node metrics aren't the
+# goal here (hestia is a bare TrueNAS host outside the Talos node-exporter
+# DaemonSet, and thermalscope/ipmi already cover its thermals/power); keeping
+# the surface to the textfile collector avoids emitting a second, overlapping
+# set of node_* series and keeps the scrape tiny. The textfile writers
+# (immich-photos-backup + homelabscope-heartbeat) drop their .prom files into
+# the shared bind-mounted directory below.
+#
+# No healthcheck: the upstream image is distroless (no shell/curl), so any
+# CMD-SHELL test always fails. Prometheus up{job="homelabscope-node-exporter"}
+# scrape success is the real health signal.
+#
+# Image pinned to an explicit upstream release tag per the homelab image
+# discipline rule. Bump deliberately; never :latest.
+x-deploy:
+  name: node-exporter
+
+services:
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.1
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    command:
+      - --collector.disable-defaults
+      - --collector.textfile
+      - --collector.textfile.directory=/var/lib/node-exporter/textfile
+      - --web.listen-address=:9100
+    volumes:
+      # Shared textfile collector dir — written by immich-photos-backup and
+      # homelabscope-heartbeat, read here. Read-only: node-exporter only reads.
+      - /var/lib/node-exporter/textfile:/var/lib/node-exporter/textfile:ro

--- a/images/homelabscope-heartbeat/Dockerfile
+++ b/images/homelabscope-heartbeat/Dockerfile
@@ -1,0 +1,31 @@
+# homelabscope-heartbeat — hestia-side collector for scheduled jobs that can't
+# run their own exporter (alcatraz-photos-pull over SSH + ZFS snapshot freshness).
+#
+# Designed to run on hestia as a TrueNAS Custom App. Compose at
+# hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml.
+#
+# Debian (not alpine) base: the ZFS path prefers `zfs list` via zfsutils-linux,
+# and GNU date (`date -d "<iso>"`) is needed to parse the alcatraz log's ISO8601
+# timestamps + the .zfs fallback's snapshot-name timestamps. busybox date can't
+# do either. zfsutils-linux talks to the host /dev/zfs (bind-mounted by the
+# compose); if the in-container userland can't reach it, heartbeat.sh falls back
+# to the .zfs/snapshot control dir, so a zfs version mismatch degrades instead
+# of failing.
+FROM debian:bookworm-slim
+
+# openssh-client — SSH to alcatraz to read the pull log
+# zfsutils-linux  — `zfs list -t snapshot` (read-only; needs host /dev/zfs)
+# bash, coreutils — the script uses bash-isms + GNU `date -d`
+# ca-certificates — general TLS hygiene
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssh-client \
+        zfsutils-linux \
+        bash \
+        coreutils \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY heartbeat.sh /usr/local/bin/heartbeat.sh
+RUN chmod 0755 /usr/local/bin/heartbeat.sh
+
+ENTRYPOINT ["/usr/local/bin/heartbeat.sh"]

--- a/images/homelabscope-heartbeat/heartbeat.sh
+++ b/images/homelabscope-heartbeat/heartbeat.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# homelabscope-heartbeat — hestia-side collector for scheduled jobs that can't
+# run their own exporter.
+#
+# Two jobs are surfaced here, both READ-ONLY (this collector mutates nothing):
+#
+#   alcatraz-photos-pull   The nightly hestia -> alcatraz additive pull runs ON
+#                          alcatraz (Synology DSM Task Scheduler), so it can't
+#                          write to hestia's textfile dir. We SSH to alcatraz,
+#                          read the world-readable pull log, and parse the last
+#                          `=== <ts> END (success, Ns) ===` trailer for the last
+#                          success time + duration.
+#
+#   zfs-snapshot-main-*    TrueNAS periodic-snapshot tasks have no metric. The
+#                          newest snapshot's creation time per dataset IS the
+#                          last-success time, so we read `zfs list -t snapshot`
+#                          (falling back to the .zfs/snapshot control dir if the
+#                          zfs userland can't talk to /dev/zfs in-container).
+#
+# Every source normalizes into the homelabscope metric family and is written to
+# the node-exporter textfile collector dir; the hestia node-exporter (:9100)
+# serves it and the infra/configs/homelabscope ScrapeConfig scrapes it. Writes
+# are atomic (write .tmp, mv) so node-exporter never reads a half-written file.
+#
+# Runs as a long-lived container looping every INTERVAL_SECONDS so freshness
+# stays current between the once-a-day jobs it watches.
+
+set -uo pipefail
+
+# ---- Config (env-overridable) ----------------------------------------------
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-600}"
+TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node-exporter/textfile}"
+
+# alcatraz pull log (read over SSH). Key + user match the immich-photos-backup
+# app's existing alcatraz credential (bind-mounted from the host).
+ALCATRAZ_SSH="${ALCATRAZ_SSH:-truenas-backup@10.42.2.11}"
+ALCATRAZ_KEY="${ALCATRAZ_KEY:-/root/.ssh/id_ed25519_alcatraz}"
+ALCATRAZ_KNOWN_HOSTS="${ALCATRAZ_KNOWN_HOSTS:-/root/.ssh/known_hosts}"
+ALCATRAZ_LOG="${ALCATRAZ_LOG:-/var/log/immich-photos-pull.log}"
+
+# ZFS datasets to watch. "dataset:jobname:mountpoint" — mountpoint is used only
+# for the .zfs/snapshot fallback when `zfs list` is unavailable in-container.
+ZFS_TARGETS="${ZFS_TARGETS:-main/family:zfs-snapshot-main-family:/mnt/main/family main/homes:zfs-snapshot-main-homes:/mnt/main/homes}"
+# Timezone the TrueNAS snapshot schedule names its snapshots in (auto-<ts>);
+# only used by the .zfs/snapshot fallback to turn a snapshot NAME into an epoch.
+ZFS_SNAP_TZ="${ZFS_SNAP_TZ:-America/Los_Angeles}"
+
+# Staleness budgets (seconds). All watched jobs here are daily → 30h tolerates
+# one fully-missed window before HomelabscopeJobStale fires.
+MAX_AGE_DAILY="${MAX_AGE_DAILY:-108000}"
+# ----------------------------------------------------------------------------
+
+log() { echo "$(date -u +%FT%TZ) $*"; }
+
+# emit_job <job> <last_success_epoch> <duration_seconds> <status> <max_age>
+# Atomically writes the full homelabscope family for one job to its own .prom.
+emit_job() {
+  local job="$1" success="$2" duration="$3" status="$4" max_age="$5"
+  local out="${TEXTFILE_DIR}/homelabscope-${job}.prom"
+  cat > "${out}.tmp" <<EOF
+# HELP homelabscope_job_last_success_seconds Unix timestamp of the job's last successful run.
+# TYPE homelabscope_job_last_success_seconds gauge
+homelabscope_job_last_success_seconds{job="${job}"} ${success}
+# HELP homelabscope_job_last_duration_seconds Wall-clock duration of the job's last run (seconds).
+# TYPE homelabscope_job_last_duration_seconds gauge
+homelabscope_job_last_duration_seconds{job="${job}"} ${duration}
+# HELP homelabscope_job_last_status Last run status (0=ok, 1=fail).
+# TYPE homelabscope_job_last_status gauge
+homelabscope_job_last_status{job="${job}"} ${status}
+# HELP homelabscope_job_max_age_seconds Staleness budget for this job (seconds).
+# TYPE homelabscope_job_max_age_seconds gauge
+homelabscope_job_max_age_seconds{job="${job}"} ${max_age}
+EOF
+  mv "${out}.tmp" "${out}"
+}
+
+collect_alcatraz_pull() {
+  local job="alcatraz-photos-pull" line ts dur epoch
+  # Last successful END trailer, e.g.:
+  #   === 2026-07-05T01:11:09Z END (success, 52s) ===
+  line="$(ssh -T -x -i "${ALCATRAZ_KEY}" \
+            -o StrictHostKeyChecking=accept-new \
+            -o UserKnownHostsFile="${ALCATRAZ_KNOWN_HOSTS}" \
+            -o ConnectTimeout=15 -o BatchMode=yes \
+            "${ALCATRAZ_SSH}" \
+            "grep -a 'END (success' '${ALCATRAZ_LOG}' 2>/dev/null | tail -1")"
+  if [[ -z "${line}" ]]; then
+    log "alcatraz-pull: no successful END line found (ssh failed or job never succeeded) — leaving series absent"
+    return 1
+  fi
+  # Extract the ISO8601 UTC timestamp (field 2) and the duration integer.
+  ts="$(awk '{print $2}' <<<"${line}")"
+  dur="$(sed -n 's/.*(success, \([0-9][0-9]*\)s).*/\1/p' <<<"${line}")"
+  epoch="$(date -u -d "${ts}" +%s 2>/dev/null)"
+  if [[ -z "${epoch}" || -z "${ts}" ]]; then
+    log "alcatraz-pull: could not parse timestamp from: ${line}"
+    return 1
+  fi
+  emit_job "${job}" "${epoch}" "${dur:-0}" 0 "${MAX_AGE_DAILY}"
+  log "alcatraz-pull: last success ${ts} (epoch ${epoch}, ${dur:-?}s)"
+}
+
+# newest_snapshot_epoch <dataset> <mountpoint> -> echoes epoch, or empty.
+newest_snapshot_epoch() {
+  local dataset="$1" mountpoint="$2" creation snap name epoch
+  # Primary: ask ZFS directly. -Hp = tab-separated, parseable epoch creation;
+  # -s creation sorts oldest→newest so the last line is the newest snapshot.
+  creation="$(zfs list -t snapshot -Hp -o creation -s creation "${dataset}" 2>/dev/null | tail -1)"
+  if [[ -n "${creation}" ]]; then
+    echo "${creation}"
+    return 0
+  fi
+  # Fallback: the .zfs/snapshot control directory (no zfs userland needed).
+  # Snapshot names sort chronologically (auto-YYYY-MM-DD_HH-MM-...), so the
+  # lexically-last name is the newest; parse its embedded timestamp in the
+  # schedule's TZ. Brittle to the naming schema — documented assumption.
+  if [[ -d "${mountpoint}/.zfs/snapshot" ]]; then
+    snap="$(ls -1 "${mountpoint}/.zfs/snapshot" 2>/dev/null | sort | tail -1)"
+    if [[ -n "${snap}" ]]; then
+      name="$(sed -n 's/^auto-\([0-9-]*\)_\([0-9]*\)-\([0-9]*\).*/\1 \2:\3/p' <<<"${snap}")"
+      if [[ -n "${name}" ]]; then
+        epoch="$(TZ="${ZFS_SNAP_TZ}" date -d "${name}" +%s 2>/dev/null)"
+        [[ -n "${epoch}" ]] && { echo "${epoch}"; return 0; }
+      fi
+    fi
+  fi
+  return 1
+}
+
+collect_zfs_snapshots() {
+  local target dataset job mountpoint epoch
+  for target in ${ZFS_TARGETS}; do
+    dataset="${target%%:*}"
+    job="$(cut -d: -f2 <<<"${target}")"
+    mountpoint="${target##*:}"
+    epoch="$(newest_snapshot_epoch "${dataset}" "${mountpoint}")"
+    if [[ -z "${epoch}" ]]; then
+      log "zfs: no snapshot found for ${dataset} (job ${job}) — leaving series absent"
+      continue
+    fi
+    # Snapshots are instantaneous; duration is meaningless → 0.
+    emit_job "${job}" "${epoch}" 0 0 "${MAX_AGE_DAILY}"
+    log "zfs: ${dataset} newest snapshot epoch ${epoch} (job ${job})"
+  done
+}
+
+mkdir -p "${TEXTFILE_DIR}"
+log "homelabscope-heartbeat starting; interval=${INTERVAL_SECONDS}s textfile=${TEXTFILE_DIR}"
+while true; do
+  collect_alcatraz_pull || true
+  collect_zfs_snapshots || true
+  sleep "${INTERVAL_SECONDS}"
+done

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -137,6 +137,14 @@ DURATION=$((END_TS - START_TS))
 
 if [[ ${FAILED} -eq 0 ]]; then
   echo "=== $(date -u +%FT%TZ) END (success, ${DURATION}s) ==="
+  # Emits TWO metric families:
+  #   - immich_photos_backup_*        legacy series (back-compat; predates homelabscope)
+  #   - homelabscope_job_*{job=...}    the unified homelabscope family (see
+  #                                    infra/configs/homelabscope). The
+  #                                    homelabscope_job_max_age_seconds budget
+  #                                    (30h = 108000, daily job) is emitted here
+  #                                    so the generic HomelabscopeJobStale alert
+  #                                    can key off this job like any other.
   cat > "${TEXTFILE}.tmp" <<EOF
 # HELP immich_photos_backup_last_success_seconds Unix timestamp of last successful immich photos rsync
 # TYPE immich_photos_backup_last_success_seconds gauge
@@ -144,6 +152,18 @@ immich_photos_backup_last_success_seconds ${END_TS}
 # HELP immich_photos_backup_duration_seconds Wall-clock duration of last successful rsync
 # TYPE immich_photos_backup_duration_seconds gauge
 immich_photos_backup_duration_seconds ${DURATION}
+# HELP homelabscope_job_last_success_seconds Unix timestamp of the job's last successful run.
+# TYPE homelabscope_job_last_success_seconds gauge
+homelabscope_job_last_success_seconds{job="immich-photos-backup"} ${END_TS}
+# HELP homelabscope_job_last_duration_seconds Wall-clock duration of the job's last run (seconds).
+# TYPE homelabscope_job_last_duration_seconds gauge
+homelabscope_job_last_duration_seconds{job="immich-photos-backup"} ${DURATION}
+# HELP homelabscope_job_last_status Last run status (0=ok, 1=fail).
+# TYPE homelabscope_job_last_status gauge
+homelabscope_job_last_status{job="immich-photos-backup"} 0
+# HELP homelabscope_job_max_age_seconds Staleness budget for this job (seconds).
+# TYPE homelabscope_job_max_age_seconds gauge
+homelabscope_job_max_age_seconds{job="immich-photos-backup"} 108000
 EOF
   mv "${TEXTFILE}.tmp" "${TEXTFILE}"
   exit 0

--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -206,22 +206,16 @@ spec:
     # -------------------------------------------------------------------------
     # Backups: alcatraz → hestia immich photos
     #
-    # The /usr/local/bin/immich-photos-backup.sh cron on hestia writes
-    # `immich_photos_backup_last_success_seconds` to the node-exporter
-    # textfile collector at the end of every successful run. Daily runs hit
-    # at ~04:00; 36h tolerates one full missed window before alerting.
-    # -------------------------------------------------------------------------
-    - name: immich-photos-backup
-      rules:
-        - alert: ImmichPhotoBackupStale
-          expr: time() - immich_photos_backup_last_success_seconds > 36 * 3600
-          for: 10m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Immich photo backup hasn't completed in >36h"
-            description: >
-              Last successful immich-photos-backup.sh run on hestia was {{ $value | humanizeDuration }} ago. Daily cron is at 04:00; >36h means at least one full day's backup was missed. Check /var/log/immich-photos-backup.log on hestia and verify the ssh key to alcatraz still works.
+    # RETIRED 2026-07-04 — superseded by homelabscope. The old
+    # ImmichPhotoBackupStale alert keyed off immich_photos_backup_last_success_
+    # seconds, but NOTHING scraped hestia's node-exporter textfile collector
+    # (:9100), so the metric was orphaned and this alert could never fire. The
+    # homelabscope project (infra/configs/homelabscope/) stands up that scraper
+    # and generalizes staleness across every scheduled job: immich-photos-backup
+    # now writes homelabscope_job_last_success_seconds{job="immich-photos-backup"}
+    # and is covered by the generic HomelabscopeJobStale (30h budget) +
+    # HomelabscopeJobMetricAbsent alerts. See
+    # docs/plans/2026-07-04-homelabscope.md.
     # -------------------------------------------------------------------------
     # Flux reconciliation health
     #

--- a/infra/configs/dashboards/homelabscope-cm.yaml
+++ b/infra/configs/dashboards/homelabscope-cm.yaml
@@ -1,0 +1,277 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homelabscope-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  homelabscope.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 90,
+          "title": "Scheduled jobs — are they all healthy?",
+          "type": "row",
+          "panels": []
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Number of scheduled jobs currently past their own staleness budget (age > max_age). Mirrors the HomelabscopeJobStale alert. 0 = everything is fresh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 1},
+          "id": 1,
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+            "orientation": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "count(time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds) or vector(0)",
+              "instant": true,
+              "legendFormat": "over budget"
+            }
+          ],
+          "title": "Jobs over budget",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Total scheduled jobs currently reporting a last-success heartbeat into the homelabscope family.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 1},
+          "id": 2,
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+            "orientation": "auto",
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "count(homelabscope_job_last_success_seconds)",
+              "instant": true,
+              "legendFormat": "tracked"
+            }
+          ],
+          "title": "Jobs tracked",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Worst-case freshness across all jobs: the highest age/budget ratio right now. >1 (red) means at least one job is over budget.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 0.75}, {"color": "red", "value": 1}]},
+              "unit": "percentunit",
+              "decimals": 2
+            }
+          },
+          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 1},
+          "id": 3,
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+            "orientation": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "value"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "max(( time() - homelabscope_job_last_success_seconds ) / homelabscope_job_max_age_seconds) or vector(0)",
+              "instant": true,
+              "legendFormat": "worst"
+            }
+          ],
+          "title": "Worst freshness ratio",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "One row per scheduled job. Health = age / max-age budget: green <75%, orange 75-100%, RED when a job is past its budget (the same condition as HomelabscopeJobStale). Covers all three source types — hestia/alcatraz textfile jobs and k8s CronJobs — through the single homelabscope_job_* family.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false},
+              "thresholds": {"mode": "absolute", "steps": [{"color": "text", "value": null}]}
+            },
+            "overrides": [
+              {
+                "matcher": {"id": "byName", "options": "Health (age/budget)"},
+                "properties": [
+                  {"id": "unit", "value": "percentunit"},
+                  {"id": "decimals", "value": 2},
+                  {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+                  {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 0.75}, {"color": "red", "value": 1}]}}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Last success age"},
+                "properties": [{"id": "unit", "value": "s"}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Last duration"},
+                "properties": [{"id": "unit", "value": "s"}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Max age budget"},
+                "properties": [{"id": "unit", "value": "s"}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Status"},
+                "properties": [
+                  {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+                  {"id": "mappings", "value": [{"type": "value", "options": {"0": {"text": "OK", "color": "green"}, "1": {"text": "FAIL", "color": "red"}}}]},
+                  {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}
+                ]
+              }
+            ]
+          },
+          "gridPos": {"h": 14, "w": 24, "x": 0, "y": 5},
+          "id": 10,
+          "options": {
+            "showHeader": true,
+            "sortBy": [{"displayName": "Health (age/budget)", "desc": true}]
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "time() - homelabscope_job_last_success_seconds",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "homelabscope_job_last_duration_seconds",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "homelabscope_job_max_age_seconds",
+              "format": "table",
+              "instant": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "( time() - homelabscope_job_last_success_seconds ) / homelabscope_job_max_age_seconds",
+              "format": "table",
+              "instant": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "homelabscope_job_last_status",
+              "format": "table",
+              "instant": true,
+              "refId": "E"
+            }
+          ],
+          "transformations": [
+            {"id": "merge", "options": {}},
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {"Time": true, "instance": true},
+                "indexByName": {
+                  "job": 0,
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "Value #D": 3,
+                  "Value #C": 4,
+                  "Value #E": 5
+                },
+                "renameByName": {
+                  "job": "Job",
+                  "Value #A": "Last success age",
+                  "Value #B": "Last duration",
+                  "Value #C": "Max age budget",
+                  "Value #D": "Health (age/budget)",
+                  "Value #E": "Status"
+                }
+              }
+            }
+          ],
+          "title": "Scheduled job health",
+          "type": "table"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "description": "Freshness ratio (age / max-age budget) over time, per job. Crossing 1.0 (the red line) is the HomelabscopeJobStale condition. A daily job saw-tooths up toward its budget then drops to ~0 at each successful run.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2, "spanNulls": false, "fillOpacity": 5},
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
+              "unit": "percentunit"
+            }
+          },
+          "gridPos": {"h": 9, "w": 24, "x": 0, "y": 19},
+          "id": 11,
+          "options": {"tooltip": {"mode": "multi", "sort": "desc"}, "legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"]}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${datasource}"},
+              "expr": "( time() - homelabscope_job_last_success_seconds ) / homelabscope_job_max_age_seconds",
+              "legendFormat": "{{job}}"
+            }
+          ],
+          "title": "Freshness ratio over time (1.0 = stale)",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 39,
+      "tags": ["homelabscope", "jobs", "backups", "cron"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource",
+            "label": "Datasource"
+          }
+        ]
+      },
+      "time": {"from": "now-24h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Homelabscope — Scheduled Jobs",
+      "uid": "homelabscope",
+      "version": 1
+    }

--- a/infra/configs/dashboards/kustomization.yaml
+++ b/infra/configs/dashboards/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - application-health-cm.yaml
   - cluster-overview-cm.yaml
   - control-plane-cm.yaml
+  - homelabscope-cm.yaml
   - mqttscope-cm.yaml
   - netscope-cm.yaml
   - networking-gateway-cm.yaml

--- a/infra/configs/homelabscope/kustomization.yaml
+++ b/infra/configs/homelabscope/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - scrapeconfig.yaml
+  - prometheus-rule.yaml

--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -127,7 +127,13 @@ spec:
           expr: time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds
           for: 10m
           labels:
-            severity: warning
+            # critical so the alert actually notifies: Alertmanager routes only
+            # severity=critical to the email-critical (Gmail SMTP) receiver;
+            # warning falls through to the 'null' receiver and would be dropped
+            # silently — a monitor that never notifies. Each job's generous
+            # per-job max_age budget + this 10m `for` debounce mean firing
+            # signals a real multi-cycle miss, not a flap.
+            severity: critical
           annotations:
             summary: "Scheduled job {{ $labels.job }} is stale"
             description: >
@@ -139,19 +145,34 @@ spec:
         # nothing to evaluate. absent() over each critical job's exact matcher
         # synthesises a firing series carrying that job label, so the alert
         # names the missing job.
+        #
+        # SCOPE: absent() only guards jobs that HAVE a live data source at merge
+        # time. Guarding a job whose exporter isn't deployed yet turns absent()
+        # into a guaranteed false critical the moment this rule lands. Two
+        # heartbeat-backed jobs are intentionally omitted here and MUST be added
+        # back by the follow-up PR that un-archives the homelabscope-heartbeat
+        # Custom App (flips x-deploy.archived: false):
+        #   - alcatraz-photos-pull
+        #   - zfs-snapshot-main-family / zfs-snapshot-main-homes
+        # Their heartbeat writer ships archived: true in this PR, so their series
+        # cannot exist yet. immich-photos-backup IS kept: its textfile is served
+        # by the node-exporter Custom App that operator step 1 deploys as part of
+        # this rollout, and its absence is the acceptance signal for the orphaned-
+        # metric bug this PR fixes (the 1h `for` covers the deploy window).
         - alert: HomelabscopeJobMetricAbsent
           expr: >
             absent(homelabscope_job_last_success_seconds{job="immich-photos-backup"})
-            or absent(homelabscope_job_last_success_seconds{job="alcatraz-photos-pull"})
-            or absent(homelabscope_job_last_success_seconds{job="zfs-snapshot-main-family"})
-            or absent(homelabscope_job_last_success_seconds{job="zfs-snapshot-main-homes"})
             or absent(homelabscope_job_last_success_seconds{job="pingo"})
             or absent(homelabscope_job_last_success_seconds{job="renovate"})
             or absent(homelabscope_job_last_success_seconds{job="adguard-sync-prod"})
             or absent(homelabscope_job_last_success_seconds{job="adguard-sync-stage"})
           for: 1h
           labels:
-            severity: warning
+            # critical for the same reason as HomelabscopeJobStale: only
+            # severity=critical reaches the email receiver. A vanished heartbeat
+            # on a data-safety job (photo backup, zfs snapshot) is exactly the
+            # failure class this whole family exists to catch, so it must page.
+            severity: critical
           annotations:
             summary: "Homelabscope job {{ $labels.job }} heartbeat is absent"
             description: >

--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -1,0 +1,158 @@
+# homelabscope — unified monitoring for every scheduled/automatic homelab job.
+#
+# One metric family covers ALL scheduled jobs regardless of where they run:
+#
+#   homelabscope_job_last_success_seconds{job="<name>"}   unix ts of last success
+#   homelabscope_job_last_duration_seconds{job="<name>"}  wall-clock of last run
+#   homelabscope_job_last_status{job="<name>"}            0=ok, 1=fail (where known)
+#   homelabscope_job_max_age_seconds{job="<name>"}        per-job staleness budget
+#
+# The family is fed from three source types that all normalize into it:
+#
+#   1. hestia/alcatraz shell jobs → node-exporter textfile collector on hestia
+#      (immich-photos-backup, alcatraz-photos-pull, zfs-snapshot-main-*). These
+#      series arrive via the hestia-homelabscope ScrapeConfig; their max_age is
+#      emitted by the textfile writers themselves.
+#   2. k8s CronJobs → the recording rules in THIS file, which project
+#      kube_cronjob_status_last_successful_time (from kube-state-metrics) onto
+#      the family. No new exporter — kube-state-metrics already exposes it.
+#   3. (future) anything else that can write the family directly.
+#
+# Alerting is a single templated pair over the whole family (see the
+# homelabscope.alerts group): a generic staleness alert that compares each
+# job's age to its own max_age budget, plus an absence alert that catches a
+# heartbeat vanishing entirely (the failure mode the pre-homelabscope setup
+# missed — a job whose textfile stops being written looks identical to "no
+# alert" when nothing scrapes it).
+#
+# Prometheus discovers this rule via the kube-prometheus-stack ruleSelector
+# (release: kube-prometheus-stack).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: homelabscope
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # -----------------------------------------------------------------------
+    # Recording rules: k8s CronJobs → homelabscope_job_last_success_seconds
+    #
+    # kube_cronjob_status_last_successful_time{namespace,cronjob} is the unix
+    # timestamp of the CronJob's most recent successful completion (verified
+    # present on this cluster's kube-state-metrics). max() strips the source
+    # labels (namespace, cronjob, instance, the kube-state-metrics job label)
+    # down to a bare scalar, and `labels:` re-stamps the canonical homelabscope
+    # `job` label — yielding exactly homelabscope_job_last_success_seconds{job=…}
+    # with no leftover labels to break the family's identity.
+    #
+    # If a CronJob has never succeeded the source series is absent, the record
+    # produces nothing, and HomelabscopeJobMetricAbsent covers it.
+    # -----------------------------------------------------------------------
+    - name: homelabscope.cronjobs
+      rules:
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="pingo", cronjob="pingo"})
+          labels:
+            job: pingo
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"})
+          labels:
+            job: renovate
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate-automerge"})
+          labels:
+            job: renovate-automerge
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="adguard-prod", cronjob="adguard-sync"})
+          labels:
+            job: adguard-sync-prod
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="adguard-stage", cronjob="adguard-sync"})
+          labels:
+            job: adguard-sync-stage
+        - record: homelabscope_job_last_success_seconds
+          expr: max(kube_cronjob_status_last_successful_time{namespace="immich-stage", cronjob="immich-photos-30d-sync"})
+          labels:
+            job: immich-photos-30d-sync
+
+        # Per-CronJob staleness budgets. vector(N) yields a single unlabeled
+        # sample; `labels:` stamps the job. Kept alongside the last-success
+        # records so the generic HomelabscopeJobStale alert can join
+        # last_success and max_age on `job` uniformly across all source types.
+        #   5-minute job (pingo)          → 20m  = 1200
+        #   6-hour jobs (adguard ×2,       → 14h  = 50400
+        #     renovate-automerge)
+        #   daily jobs (renovate,          → 30h  = 108000
+        #     immich-photos-30d-sync)
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(1200)
+          labels:
+            job: pingo
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(108000)
+          labels:
+            job: renovate
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(50400)
+          labels:
+            job: renovate-automerge
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(50400)
+          labels:
+            job: adguard-sync-prod
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(50400)
+          labels:
+            job: adguard-sync-stage
+        - record: homelabscope_job_max_age_seconds
+          expr: vector(108000)
+          labels:
+            job: immich-photos-30d-sync
+
+    # -----------------------------------------------------------------------
+    # Alerts: one templated pair over the whole family.
+    # -----------------------------------------------------------------------
+    - name: homelabscope.alerts
+      rules:
+        # Generic staleness: a job hasn't succeeded within its own budget.
+        # last_success and max_age share an identical label set per job
+        # (textfile jobs carry {job,instance="hestia"}; cronjob records carry
+        # {job}), so the vector-to-vector comparison joins cleanly on those
+        # labels — every job is checked against its OWN max_age with a single
+        # rule. `time() - <gauge>` keeps the gauge's labels; the `>` then
+        # matches max_age by the same set.
+        - alert: HomelabscopeJobStale
+          expr: time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Scheduled job {{ $labels.job }} is stale"
+            description: >
+              Job {{ $labels.job }} last succeeded {{ $value | humanizeDuration }} ago, exceeding its max-age budget. A scheduled/automatic job has stopped completing on time. Check the job's source: k8s CronJob (kubectl get cronjob -A), hestia textfile (/var/log on hestia), or the alcatraz pull log.
+        # A job's heartbeat has vanished ENTIRELY — the specific failure mode
+        # the pre-homelabscope setup could not see. When a textfile stops being
+        # written (container gone, script crashing before the write) or a
+        # CronJob is deleted, the series disappears and staleness math has
+        # nothing to evaluate. absent() over each critical job's exact matcher
+        # synthesises a firing series carrying that job label, so the alert
+        # names the missing job.
+        - alert: HomelabscopeJobMetricAbsent
+          expr: >
+            absent(homelabscope_job_last_success_seconds{job="immich-photos-backup"})
+            or absent(homelabscope_job_last_success_seconds{job="alcatraz-photos-pull"})
+            or absent(homelabscope_job_last_success_seconds{job="zfs-snapshot-main-family"})
+            or absent(homelabscope_job_last_success_seconds{job="zfs-snapshot-main-homes"})
+            or absent(homelabscope_job_last_success_seconds{job="pingo"})
+            or absent(homelabscope_job_last_success_seconds{job="renovate"})
+            or absent(homelabscope_job_last_success_seconds{job="adguard-sync-prod"})
+            or absent(homelabscope_job_last_success_seconds{job="adguard-sync-stage"})
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Homelabscope job {{ $labels.job }} heartbeat is absent"
+            description: >
+              No homelabscope_job_last_success_seconds series exists for job {{ $labels.job }} for >1h. Its heartbeat has vanished entirely (textfile no longer written / exporter down, or the CronJob was removed) — distinct from "stale", which needs the series to still exist. Check the hestia node-exporter (:9100) and the homelabscope-heartbeat Custom App, or `kubectl get cronjob -A` for the CronJob-backed jobs.

--- a/infra/configs/homelabscope/scrapeconfig.yaml
+++ b/infra/configs/homelabscope/scrapeconfig.yaml
@@ -1,0 +1,44 @@
+# homelabscope — scrape the hestia node-exporter textfile collector.
+#
+# This is the missing scraper that makes the immich-photos-backup textfile
+# metric (and the new alcatraz-photos-pull / zfs-snapshot heartbeats) actually
+# reach Prometheus. Before homelabscope, immich-photos-backup.sh wrote
+# /var/lib/node-exporter/textfile/immich-backup.prom on every run but NOTHING
+# scraped :9100 on hestia (only thermalscope :9102 and ipmi-exporter :9290
+# existed) — so the ImmichPhotoBackupStale alert could never fire. This
+# ScrapeConfig closes that gap.
+#
+# node-exporter runs as a hestia TrueNAS Custom App
+# (hosts/hestia/monitoring/docker-compose-node-exporter.yml) with ONLY the
+# textfile collector enabled, serving :9100 on the host network.
+#
+# honorLabels: true is load-bearing. The textfile .prom files carry an explicit
+# `job` label (job="immich-photos-backup", job="alcatraz-photos-pull",
+# job="zfs-snapshot-main-family", …) — the homelabscope metric family is keyed
+# on `job`. Without honorLabels, Prometheus would rename that exposed label to
+# `exported_job` and stamp its own target job on top, breaking every
+# homelabscope_job_* series' identity. With honorLabels the exposed `job` wins;
+# only series that DON'T carry a job label (node-exporter's own scrape-meta
+# series, `up`) inherit the target job below.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: hestia-homelabscope
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  honorLabels: true
+  staticConfigs:
+    - targets:
+        - 10.42.2.10:9100
+      labels:
+        instance: hestia
+  relabelings:
+    # Applies only to series with no exposed job label (up, scrape meta). The
+    # homelabscope_job_* textfile series keep their own job via honorLabels.
+    - targetLabel: job
+      replacement: homelabscope-node-exporter
+  scrapeInterval: 60s
+  scrapeTimeout: 15s
+  metricsPath: /metrics

--- a/infra/configs/kustomization.yaml
+++ b/infra/configs/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - dashboards
   - flux-monitoring
   - gateway
+  - homelabscope
   - ipmi-exporter
   - netscope
   - network-policies


### PR DESCRIPTION
## What

**homelabscope** — one Prometheus metric family that monitors **every** automatic/scheduled homelab job, so a stalled or vanished job is finally caught as a class instead of ad hoc (or not at all).

The sharp bug it fixes: `immich-photos-backup.sh` wrote `immich_photos_backup_last_success_seconds` to hestia's node-exporter textfile dir on every run, and `ImmichPhotoBackupStale` alerted on it — but **nothing scraped `:9100` on hestia** (only `:9102` thermalscope + `:9290` ipmi). The metric was orphaned; the alert could never fire. Verified 2026-07-04: `ss -ltn` on hestia shows 9102+9290 up, not 9100.

## Metric family

`homelabscope_job_last_success_seconds{job}` + `_last_duration_seconds` + `_last_status` (0/1) + `_max_age_seconds`, fed from three sources that all normalize into it:

1. **hestia/alcatraz shell jobs → node-exporter textfile collector.** New node-exporter Custom App (`:9100`, textfile-only) + a `ScrapeConfig` (`honorLabels: true` so the textfile `job` labels survive). immich-photos-backup now emits the family (legacy series kept). alcatraz-photos-pull + zfs-snapshot-main-{family,homes} get a new **homelabscope-heartbeat** Custom App that SSH-reads the alcatraz pull log and reads ZFS snapshot freshness — **read-only**.
2. **k8s CronJobs → recording rules** over `kube_cronjob_status_last_successful_time` (verified present). No new exporter. Covers pingo, renovate, renovate-automerge, adguard-sync (prod+stage), immich-photos-30d-sync.

## Alerting + dashboard

- `HomelabscopeJobStale`: `time() - last_success > max_age` — every job vs its **own** budget in one rule.
- `HomelabscopeJobMetricAbsent`: `absent(...)` per critical job — catches a heartbeat vanishing entirely (the gap the old setup missed).
- Retires the dataless `ImmichPhotoBackupStale` (tombstoned).
- Grafana `homelabscope-cm.yaml`: one-row-per-job health table (red when over budget) + stat tiles + freshness-ratio timeseries.

## Jobs covered + max-ages

| Job | Source | max-age |
|---|---|---|
| immich-photos-backup | textfile | 30h |
| alcatraz-photos-pull | heartbeat (ssh) | 30h |
| zfs-snapshot-main-family / -homes | heartbeat (zfs) | 30h |
| immich-photos-30d-sync | cronjob | 30h |
| renovate | cronjob | 30h |
| adguard-sync-prod / -stage | cronjob | 14h |
| renovate-automerge | cronjob | 14h |
| pingo | cronjob | 20m |

## Validation

- `kustomize build infra/configs` ✅
- `promtool check rules` ✅ (14 rules)
- `bash -n` on both scripts ✅ · dashboard JSON parses ✅
- `make plans-index-check` ✅

## Operator steps (NOT done here — repo artifacts only, no live infra changes)

1. Deploy the node-exporter Custom App (auto via deploy-hestia on merge; stock image). Confirm `:9100` + ScrapeConfig green.
2. First merge builds `ghcr.io/gjcourt/homelabscope-heartbeat` via the new workflow.
3. Enable the heartbeat Custom App: it ships `x-deploy.archived: true` — pin the `@sha256` digest and flip `archived: false` in a follow-up PR.
4. Bump the immich-photos-backup image digest (the script edit triggers a rebuild; standard images/** two-step, not bumped here).

Details + job registry: `docs/plans/2026-07-04-homelabscope.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet