### PR TITLE
deploy(golinks): bump image to 2026-07-04

### DIFF
--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: golinks
-          image: ghcr.io/gjcourt/golinks:2026-02-21
+          image: ghcr.io/gjcourt/golinks:2026-07-04
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Ships **golinks #35** (admin Edit/Delete controls restored — `isAdmin` mode-ordering fix for `none` auth mode).

- Built from merged `golinks@eec3872` → `ghcr.io/gjcourt/golinks:2026-07-04` (`sha256:5a3e16fc…`), verified on ghcr.
- Bumps `apps/base/golinks/deployment.yaml` `2026-02-21` → `2026-07-04` (strictly greater).
- `kustomize build` passes for staging + production overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet