### PR TITLE
deploy(golinks): bump image to 2026-07-05

### DIFF
--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: golinks
-          image: ghcr.io/gjcourt/golinks:2026-07-04
+          image: ghcr.io/gjcourt/golinks:2026-07-05
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Ships **golinks #36** (shortcode `go/` normalization — `go/ms` no longer fails validation).

- Built from merged `golinks@b8e9935` → `ghcr.io/gjcourt/golinks:2026-07-05` (`sha256:080b001c…`), verified on ghcr.
- Bumps `apps/base/golinks/deployment.yaml` `2026-07-04` → `2026-07-05`.
- `kustomize build` passes for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet