### PR TITLE
deploy(golinks): bump image to 2026-07-05-1

### DIFF
--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: golinks
-          image: ghcr.io/gjcourt/golinks:2026-07-05
+          image: ghcr.io/gjcourt/golinks:2026-07-05-1
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Ships **golinks #37** (wildcard/parameterized links — `go/pulls/10 → …/pull/10`).

- Built from merged `golinks@8dec1fd` → `ghcr.io/gjcourt/golinks:2026-07-05-1` (`sha256:afab612c…`), verified on ghcr.
- Bumps `apps/base/golinks/deployment.yaml` `2026-07-05` → `2026-07-05-1`.
- `kustomize build` passes for production. Security reviewed: capture is charset-locked single-segment, `*` confined to path/query with fixed origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet