### PR TITLE
fix(homelabscope-heartbeat): enable Debian contrib so zfsutils-linux installs

### DIFF
--- a/images/homelabscope-heartbeat/Dockerfile
+++ b/images/homelabscope-heartbeat/Dockerfile
@@ -14,10 +14,21 @@
 FROM debian:bookworm-slim
 
 # openssh-client — SSH to alcatraz to read the pull log
-# zfsutils-linux  — `zfs list -t snapshot` (read-only; needs host /dev/zfs)
+# zfsutils-linux  — `zfs list -t snapshot` (read-only; needs host /dev/zfs).
+#                   Debian ships the ZFS userland in the `contrib` component,
+#                   which bookworm-slim doesn't enable by default — so enable it
+#                   first (deb822 `Components:` line, with a classic-format
+#                   fallback), else apt reports "no installation candidate".
+#                   --no-install-recommends keeps zfs-dkms (kernel build) out;
+#                   we only need the read-only zfs/zpool CLI.
 # bash, coreutils — the script uses bash-isms + GNU `date -d`
 # ca-certificates — general TLS hygiene
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+        sed -i 's/^Components: main$/Components: main contrib/' /etc/apt/sources.list.d/debian.sources; \
+    else \
+        echo 'deb http://deb.debian.org/debian bookworm main contrib' > /etc/apt/sources.list.d/contrib.list; \
+    fi \
+    && apt-get update && apt-get install -y --no-install-recommends \
         openssh-client \
         zfsutils-linux \
         bash \


### PR DESCRIPTION
## Problem
The `Build homelabscope-heartbeat` workflow **failed on master** right after #1052 merged:

```
E: Package 'zfsutils-linux' has no installation candidate
```

Debian ships the ZFS userland in the **`contrib`** component, which `debian:bookworm-slim` does not enable — so `apt-get install zfsutils-linux` has no candidate.

## Fix
Enable `contrib` before the install (deb822 `Components:` line, with a classic-format fallback). `--no-install-recommends` keeps `zfs-dkms` (kernel build) out — only the read-only `zfs`/`zpool` CLI is needed, and `heartbeat.sh` already falls back to the `.zfs` control dir if the userland can't reach `/dev/zfs`.

## Verification
Built locally (the build workflow only runs on push-to-master, not on PRs, so CI can't catch this):
- `docker buildx build --platform linux/amd64` **completes** ✅
- Image has working `zfs` CLI (`/usr/sbin/zfs`), GNU `date -d`, bash, ssh ✅

On merge, the master build workflow re-runs and should publish the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)