### PR TITLE
chore(immich): raise job concurrency to speed up library scans

### DIFF
--- a/apps/production/immich/config/immich-config.yaml
+++ b/apps/production/immich/config/immich-config.yaml
@@ -1,5 +1,25 @@
 ffmpeg:
   accel: vaapi
+# Job concurrency bumped above Immich defaults to speed up large library scans.
+# immich-server + immich-machine-learning share one 12-vCPU node (talos-kot-7x7),
+# and video transcode is hardware-accelerated on the node's Radeon iGPU (accel:
+# vaapi, /dev/dri passed in), so raising videoConversion off 1 lets the iGPU work
+# in parallel rather than serially draining the transcode backlog. Defaults were
+# metadataExtraction=5, thumbnailGeneration=3, videoConversion=1, faceDetection=2,
+# smartSearch=2, ocr=1.
+job:
+  metadataExtraction:
+    concurrency: 8
+  thumbnailGeneration:
+    concurrency: 6
+  videoConversion:
+    concurrency: 3
+  faceDetection:
+    concurrency: 3
+  smartSearch:
+    concurrency: 3
+  ocr:
+    concurrency: 3
 oauth:
   enabled: true
   issuerUrl: "https://auth.burntbytes.com"


### PR DESCRIPTION
Speeds up the in-progress library scan. Immich is **config-file managed** here (`IMMICH_CONFIG_FILE`), so job concurrency can't be changed via the admin UI/API — it lives in `apps/production/immich/config/immich-config.yaml`.

**Bumps** (from Immich defaults): metadataExtraction 5→8, thumbnailGeneration 3→6, videoConversion **1→3**, faceDetection 2→3, smartSearch 2→3, ocr 1→3.

Context: server + ML share one 12-vCPU node and sat at ~4 of 12 cores during the scan while 986 video + 216 OCR jobs drained one-at-a-time. Video transcode is **iGPU-accelerated** (`accel: vaapi`, `/dev/dri` passed into the pod), so a higher `videoConversion` lets the Radeon iGPU transcode in parallel — no offload to hestia needed (hestia has no GPU). Transcode policy unchanged (HEVC still transcodes to h264).

The configMapGenerator hash suffix triggers a pod rollout on merge, so the new concurrency applies automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet