### PR TITLE
chore(overture): hibernate production Postgres (app is intentionally 0/0)

### DIFF
--- a/apps/production/overture/database.yaml
+++ b/apps/production/overture/database.yaml
@@ -3,6 +3,12 @@ kind: Cluster
 metadata:
   name: overture-db-production-cnpg-v1
   namespace: overture-prod
+  annotations:
+    # Hibernated 2026-07-08: the overture app deployment is intentionally scaled
+    # to 0/0, so its 3-instance HA Postgres is shut down to free resources and
+    # keep it out of the storage-outage recovery path. PVCs and data are
+    # preserved; resume by flipping this to "off" when the app is turned back on.
+    cnpg.io/hibernation: "on"
 spec:
   description: Postgres cluster for the overture application (production)
   imageName: ghcr.io/cloudnative-pg/postgresql:17.5


### PR DESCRIPTION
Hibernates the overture production Postgres via `cnpg.io/hibernation: "on"`.

**Why:** `deployment/overture` is scaled to 0/0 by design, so its 3-instance HA Postgres serves nothing — pure resource overhead, and it was part of the read-only-remount blast radius during today's hestia storage outage.

**Safe/reversible:** hibernation stops the instance pods but retains the PVCs + data. Resume anytime by flipping the annotation to `"off"`.

`kustomize build apps/production/overture` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet