### PR TITLE
feat(immich): split server into api + microservices workers

### DIFF
--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -42,6 +42,25 @@ spec:
                     operator: In
                     values:
                       - high
+        # Co-location contract with immich-microservices (shared RWO
+        # immich-upload-pvc — see that Deployment). microservices has a *required*
+        # podAffinity onto this pod; this is the reciprocal *soft* pull so that
+        # when the api pod is (re)scheduled it lands on the node already running
+        # microservices + the attached volume. Kept SOFT on purpose: a required
+        # rule here would create a circular required podAffinity (neither could
+        # schedule first → cold-start deadlock) and would also break node-death
+        # failover. Soft means on kot-7x7 loss both pods fall back together (the
+        # api lands on a fallback node, microservices follows via its required
+        # rule, and the RWO volume reattaches there).
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: immich
+                    component: microservices
+                topologyKey: kubernetes.io/hostname
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -146,6 +165,11 @@ spec:
         # pods across nodes, and the second would fail to mount the volume
         # (Multi-Attach). If the api pod is not yet scheduled this pod stays
         # Pending until it is — acceptable for a background worker.
+        #
+        # The api pod carries the reciprocal *soft* podAffinity back onto this
+        # pod, so an api reschedule is pulled to the node already holding the
+        # volume + this worker. The reverse side is kept soft to avoid a circular
+        # required rule (cold-start deadlock) and to preserve node-death failover.
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -195,6 +219,13 @@ spec:
           # readiness, so it is deliberately omitted. A crash (e.g. DB never
           # connects) exits the process and is handled by the container restart
           # policy, not by a probe.
+          #
+          # Scope caveat: /metrics reflects "the worker process is up and its OTEL
+          # server is bound", NOT "the BullMQ job queue is draining". A wedged
+          # worker that stops consuming jobs while its HTTP server stays up would
+          # remain Ready. Detecting a stalled queue is a job for queue-depth
+          # alerting (immich_job_* / Redis queue length), tracked as a follow-up in
+          # observability, not something a k8s probe can express here.
           readinessProbe:
             httpGet:
               path: /metrics

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -52,6 +52,20 @@ spec:
         # failover. Soft means on kot-7x7 loss both pods fall back together (the
         # api lands on a fallback node, microservices follows via its required
         # rule, and the RWO volume reattaches there).
+        #
+        # Accepted residual risk (soft side): on an api-only Recreate roll
+        # (image/config bump), the old api pod is torn down first, then the new
+        # one schedules. Because this pull is only *preferred*, if kot-7x7 has no
+        # free capacity at that instant (microservices + an ML replica + the CNPG
+        # instance resident) the scheduler can place the new api pod on another
+        # node while microservices still holds immich-upload-pvc on kot-7x7 → the
+        # api pod stalls on Multi-Attach until capacity frees or an operator
+        # deletes it to retry. Mitigation is operational: keep CPU/mem headroom on
+        # kot-7x7 for one api pod (its requests are small: 250m/512Mi base). A
+        # hard fix (make this side required too) is rejected above (cold-start
+        # deadlock); the alternative of anchoring the *api* as required→micro is a
+        # design tradeoff (protects the api roll but makes api cold-start wait for
+        # the heavy worker) left for a follow-up if roll stalls are seen in prod.
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/apps/base/immich/deployment.yaml
+++ b/apps/base/immich/deployment.yaml
@@ -1,4 +1,8 @@
-# Immich Server - main API and web UI
+# Immich Server (api worker) - interactive read/serve path: web UI + API only.
+# Background jobs were split out into the immich-microservices Deployment below
+# (IMMICH_WORKERS_INCLUDE=api here / IMMICH_WORKERS_EXCLUDE=api there) so a large
+# scan/transcode backlog can't starve the interactive path. The Service still
+# points at component: server, so the web UI keeps working unchanged.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,6 +52,11 @@ spec:
             - name: http
               containerPort: 2283
               protocol: TCP
+          env:
+            # Run ONLY the api worker (web UI + API on :2283). All background job
+            # workers now run in the immich-microservices Deployment.
+            - name: IMMICH_WORKERS_INCLUDE
+              value: api
           envFrom:
             - configMapRef:
                 name: immich-config
@@ -68,6 +77,132 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+      volumes:
+        - name: upload
+          persistentVolumeClaim:
+            claimName: immich-upload-pvc
+---
+# Immich Microservices - background write/ingest path: thumbnails, metadata
+# extraction, video transcode, ML job dispatch, storage-template migration,
+# sidecar, library scan. Split out of immich-server (IMMICH_WORKERS_EXCLUDE=api)
+# so this CPU-heavy grind runs in its own process/cgroup and can't starve the
+# interactive api pod. No Service: nothing routes to it; it pulls work off the
+# Redis job queue.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-microservices
+  namespace: immich
+  labels:
+    app: immich
+    component: microservices
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: immich
+      component: microservices
+  strategy:
+    # Recreate (not RollingUpdate): microservices shares the ReadWriteOnce
+    # immich-upload-pvc with the api pod and is pinned to the same node via
+    # podAffinity. A RollingUpdate would spawn the replacement before the old pod
+    # terminates; if the scheduler ever placed the new pod on a different node it
+    # would deadlock on the RWO volume (Multi-Attach). Recreate tears the old pod
+    # down first, so the volume is free when the new one schedules.
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: immich
+        component: microservices
+    spec:
+      serviceAccountName: immich
+      automountServiceAccountToken: false
+      affinity:
+        # Soft node preference matches the api pod (cpu-tier=high) so both land on
+        # the high-airflow worker by default.
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: homelab.gjcourt.dev/cpu-tier
+                    operator: In
+                    values:
+                      - high
+        # REQUIRED co-location with the api pod. Both mount the RWO
+        # immich-upload-pvc, which only admits multiple pods when they are on the
+        # SAME node. This hard rule guarantees microservices schedules onto
+        # whatever node runs immich-server (component: server); relying on the soft
+        # cpu-tier preference alone could lose a scheduling race and split the two
+        # pods across nodes, and the second would fail to mount the volume
+        # (Multi-Attach). If the api pod is not yet scheduled this pod stays
+        # Pending until it is — acceptable for a background worker.
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: immich
+                  component: server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: immich-microservices
+          image: ghcr.io/immich-app/immich-server:v3.0.1@sha256:46dedfc5848f7313bd6b584ea9f2648057430307aad6de56de968f6710a72cae
+          env:
+            # Run every worker EXCEPT api (thumbnails, metadata, transcode, ML
+            # dispatch, storage-template migration, sidecar, library scan).
+            - name: IMMICH_WORKERS_EXCLUDE
+              value: api
+            # A microservices-only worker does NOT bind the API on :2283 — the
+            # Immich docs explicitly say to remove the 2283 port mapping from the
+            # microservices copy, so /api/server/ping is unavailable here.
+            # Enabling OTEL telemetry binds the microservices metrics HTTP server
+            # on IMMICH_MICROSERVICES_METRICS_PORT (default 8082), giving this pod
+            # a real HTTP surface for a readiness probe. That server only starts
+            # after the Nest app bootstraps (DB + Redis connected), so a 200 on
+            # /metrics is a genuine "worker is up" signal — not just a TCP liveness.
+            - name: IMMICH_TELEMETRY_INCLUDE
+              value: all
+          envFrom:
+            - configMapRef:
+                name: immich-config
+            - secretRef:
+                name: immich-db-credentials
+          ports:
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          volumeMounts:
+            - name: upload
+              mountPath: /usr/src/app/upload
+          # readinessProbe only, on the OTEL microservices metrics endpoint (:8082).
+          # This is the pod's sole HTTP surface. Readiness here gates rollout /
+          # availability reporting (there is no Service, so it gates no routing).
+          # No livenessProbe: the metrics endpoint is the only health surface, so a
+          # liveness probe would reuse the identical signal — this repo's rule
+          # (AGENTS.md) is to add liveness only with a signal distinct from
+          # readiness, so it is deliberately omitted. A crash (e.g. DB never
+          # connects) exits the process and is handled by the container restart
+          # policy, not by a probe.
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
           resources:
             requests:
               cpu: 250m

--- a/apps/base/immich/networkpolicy.yaml
+++ b/apps/base/immich/networkpolicy.yaml
@@ -84,10 +84,15 @@ spec:
       app: immich
       component: machine-learning
   ingress:
+    # Both the api (search-time CLIP encoding) and microservices (smart-search /
+    # face-detection job dispatch) workers call the ML service.
     - fromEndpoints:
         - matchLabels:
             app: immich
             component: server
+        - matchLabels:
+            app: immich
+            component: microservices
       toPorts:
         - ports:
             - port: "3003"
@@ -120,16 +125,21 @@ metadata:
     app.kubernetes.io/name: immich
     app.kubernetes.io/part-of: network-policies
 spec:
-  description: Ingress from server only on 6379; egress DNS only.
+  description: Ingress from api + microservices workers on 6379; egress DNS only.
   endpointSelector:
     matchLabels:
       app: immich
       component: redis
   ingress:
+    # Both workers use Redis: api for cache/session/websocket, microservices for
+    # the BullMQ job queue it consumes.
     - fromEndpoints:
         - matchLabels:
             app: immich
             component: server
+        - matchLabels:
+            app: immich
+            component: microservices
       toPorts:
         - ports:
             - port: "6379"
@@ -144,4 +154,75 @@ spec:
             - port: "53"
               protocol: UDP
             - port: "53"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-microservices
+  namespace: immich
+  labels:
+    app.kubernetes.io/name: immich
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: >-
+    Background worker. Ingress: kubelet readiness probe on 8082 (OTEL metrics).
+    Egress: DNS + CNPG + Redis + ML service + HTTPS. Mirrors the server egress.
+  endpointSelector:
+    matchLabels:
+      app: immich
+      component: microservices
+  ingress:
+    # kubelet health probe to the OTEL microservices metrics endpoint (:8082).
+    # The probe originates from the node, so allow host + remote-node.
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8082"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # CNPG PostgreSQL (pgvecto.rs variant).
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # In-namespace Redis for the job queue.
+    - toEndpoints:
+        - matchLabels:
+            app: immich
+            component: redis
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # In-namespace machine-learning service for CLIP / face recognition dispatch.
+    - toEndpoints:
+        - matchLabels:
+            app: immich
+            component: machine-learning
+      toPorts:
+        - ports:
+            - port: "3003"
+              protocol: TCP
+    # External HTTPS for reverse geocoding data, map tiles, metadata enrichment.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
               protocol: TCP

--- a/apps/base/immich/pdb.yaml
+++ b/apps/base/immich/pdb.yaml
@@ -10,6 +10,11 @@ spec:
   # blanket `app: immich` selector with maxUnavailable:0 would pin an
   # un-evictable pod to every node and block all node drains (Talos upgrades,
   # maintenance). ML has its own PDB in the production overlay.
+  #
+  # Microservices is also deliberately excluded: it's a background worker with no
+  # inbound traffic, so it needs no availability budget, and covering it with
+  # maxUnavailable:0 would block draining its node. It reschedules back onto the
+  # api pod's node via its required podAffinity after any eviction.
   selector:
     matchLabels:
       app: immich

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -95,13 +95,17 @@ spec:
             - name: oauth-config
               mountPath: /etc/immich
               readOnly: true
+          # api-only (interactive serve path). Background jobs moved to
+          # immich-microservices, so the api pod no longer needs the old 1-8 CPU
+          # headroom — sized down to leave room on kot-7x7 for the microservices
+          # pod co-located on the same node.
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1000m"
+              memory: "1Gi"
+              cpu: "500m"
             limits:
-              memory: "8Gi"
-              cpu: "8000m"
+              memory: "4Gi"
+              cpu: "4000m"
           livenessProbe:
             httpGet:
               path: /api/server/ping
@@ -116,6 +120,130 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
+      volumes:
+        - name: upload
+          persistentVolumeClaim:
+            claimName: immich-upload-pvc
+        - name: photos
+          persistentVolumeClaim:
+            claimName: immich-photos-pvc
+        - name: dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
+        - name: oauth-config-template
+          configMap:
+            name: immich-oauth-config
+        - name: oauth-config
+          emptyDir: {}
+---
+# Microservices worker (production) — same runtime environment as the api pod
+# (privileged VAAPI transcode, DB, OAuth/ffmpeg config via the oauth-config init
+# container) but running IMMICH_WORKERS_EXCLUDE=api (set in the base). This is the
+# heavy path, so it gets the bulk of the resources. Co-location with the api pod
+# (podAffinity in the base) keeps both on kot-7x7's RWO immich-upload-pvc.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-microservices
+  namespace: immich
+spec:
+  template:
+    spec:
+      hostAliases:
+        - ip: "10.42.2.40"
+          hostnames:
+            - auth.burntbytes.com
+      securityContext:
+        supplementalGroups:
+          - 44 # video group
+          - 100 # users group
+          - 109 # render group
+      initContainers:
+        - name: oauth-config
+          # busybox 1.37
+          image: busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+          command:
+            - sh
+            - -c
+            - |
+              sed "s/__CLIENT_SECRET_PLACEHOLDER__/${CLIENT_SECRET}/g" \
+                /config-template/immich-config.yaml > /config/immich-config.yaml
+          env:
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: immich-sso-secret
+                  key: client_secret
+          volumeMounts:
+            - name: oauth-config-template
+              mountPath: /config-template
+              readOnly: true
+            - name: oauth-config
+              mountPath: /config
+          resources:
+            requests:
+              memory: "16Mi"
+              cpu: "10m"
+            limits:
+              memory: "32Mi"
+              cpu: "50m"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: immich-microservices
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          env:
+            # Hardware Acceleration for AMD (video transcode runs in this worker).
+            - name: LIBVA_DRIVER_NAME
+              value: radeonsi
+            - name: LIBVA_DRIVERS_PATH
+              value: /usr/lib/jellyfin-ffmpeg/lib/dri
+            # Database connection - use CNPG service and credentials secret
+            - name: DB_HOSTNAME
+              value: immich-db-prod-cnpg-v3-rw.immich-prod.svc.cluster.local
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE_NAME
+              value: immich
+            - name: DB_USERNAME
+              value: immich
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-db-credentials
+                  key: password
+            # Immich v2.x config file for OAuth/OIDC + ffmpeg settings (same file
+            # the api pod reads; every worker must see the same config).
+            - name: IMMICH_CONFIG_FILE
+              value: "/etc/immich/immich-config.yaml"
+          volumeMounts:
+            - name: upload
+              mountPath: /usr/src/app/upload
+            - name: photos
+              mountPath: /mnt/photos
+            - name: dri
+              mountPath: /dev/dri
+            - name: oauth-config
+              mountPath: /etc/immich
+              readOnly: true
+          # Heavy path: metadata, thumbnails, ML dispatch, transcode,
+          # storage-template migration. Sized against kot-7x7 (12 vCPU / 64Gi,
+          # shared with the api pod + a CNPG instance).
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2000m"
+            limits:
+              memory: "8Gi"
+              cpu: "8000m"
       volumes:
         - name: upload
           persistentVolumeClaim:

--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -17,10 +17,11 @@ spec:
           hostnames:
             - auth.burntbytes.com
       securityContext:
+        # video(44)/render(109) dropped after the split: the api worker doesn't
+        # touch /dev/dri (all ffmpeg/VAAPI transcode moved to the microservices
+        # worker). Keep users(100) for upload/photos file access.
         supplementalGroups:
-          - 44 # video group
           - 100 # users group
-          - 109 # render group
       initContainers:
         - name: oauth-config
           # busybox 1.37
@@ -59,15 +60,13 @@ spec:
       containers:
         - name: immich-server
           securityContext:
-            privileged: true
+            # api worker does not transcode (that moved to the microservices
+            # worker), so it needs neither privileged mode nor /dev/dri. Kept root
+            # (uid 0) only so it can write client uploads to the root-owned iSCSI
+            # upload volume, matching the pre-split behaviour.
             runAsUser: 0
             runAsGroup: 0
           env:
-            # Hardware Acceleration for AMD
-            - name: LIBVA_DRIVER_NAME
-              value: radeonsi
-            - name: LIBVA_DRIVERS_PATH
-              value: /usr/lib/jellyfin-ffmpeg/lib/dri
             # Database connection - use CNPG service and credentials secret
             - name: DB_HOSTNAME
               value: immich-db-prod-cnpg-v3-rw.immich-prod.svc.cluster.local
@@ -90,8 +89,6 @@ spec:
               mountPath: /usr/src/app/upload
             - name: photos
               mountPath: /mnt/photos
-            - name: dri
-              mountPath: /dev/dri
             - name: oauth-config
               mountPath: /etc/immich
               readOnly: true
@@ -127,10 +124,6 @@ spec:
         - name: photos
           persistentVolumeClaim:
             claimName: immich-photos-pvc
-        - name: dri
-          hostPath:
-            path: /dev/dri
-            type: Directory
         - name: oauth-config-template
           configMap:
             name: immich-oauth-config

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -83,13 +83,131 @@ spec:
                 secretKeyRef:
                   name: immich-db-credentials
                   key: password
+          # api-only (interactive serve path); jobs moved to the microservices
+          # deployment. Staging is a small testbed, so keep this modest.
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1000m"
+              memory: "512Mi"
+              cpu: "250m"
             limits:
-              memory: "8Gi"
-              cpu: "4000m"
+              memory: "2Gi"
+              cpu: "2000m"
+          volumeMounts:
+            - name: upload
+              mountPath: /usr/src/app/upload
+            - name: photos
+              mountPath: /mnt/photos
+            - name: dri
+              mountPath: /dev/dri
+            - name: config-rendered
+              mountPath: /etc/immich
+              readOnly: true
+      volumes:
+        - name: upload
+          persistentVolumeClaim:
+            claimName: immich-upload-pvc
+        - name: photos
+          persistentVolumeClaim:
+            claimName: immich-photos-pvc
+        - name: dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
+        - name: config-template
+          configMap:
+            name: immich-config-file
+        - name: config-rendered
+          emptyDir: {}
+---
+# Microservices worker (staging) — rehearses the prod split topology at small
+# size. Same runtime env as the api pod (privileged VAAPI transcode, DB, JSON
+# OAuth/ffmpeg config via the init container) but IMMICH_WORKERS_EXCLUDE=api (base).
+# Co-located with the api pod (podAffinity in base) on staging's RWO upload PVC.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-microservices
+  namespace: immich
+spec:
+  template:
+    spec:
+      hostAliases:
+        - ip: "10.42.2.41"
+          hostnames:
+            - auth.stage.burntbytes.com
+      securityContext:
+        supplementalGroups:
+          - 44 # video group
+          - 109 # render group
+      initContainers:
+        - name: oauth-config
+          # busybox 1.37
+          image: busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+          command:
+            - sh
+            - -c
+            - |
+              sed "s/__CLIENT_SECRET_PLACEHOLDER__/${CLIENT_SECRET}/g" \
+                /config-template/immich-config.json > /config/immich-config.json
+          env:
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: immich-sso-secret
+                  key: client_secret
+          volumeMounts:
+            - name: config-template
+              mountPath: /config-template
+              readOnly: true
+            - name: config-rendered
+              mountPath: /config
+          resources:
+            requests:
+              memory: "16Mi"
+              cpu: "10m"
+            limits:
+              memory: "32Mi"
+              cpu: "50m"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: immich-microservices
+          securityContext:
+            privileged: true
+          env:
+            # Hardware Acceleration for AMD (video transcode runs in this worker).
+            - name: LIBVA_DRIVER_NAME
+              value: radeonsi
+            - name: LIBVA_DRIVERS_PATH
+              value: /usr/lib/jellyfin-ffmpeg/lib/dri
+            # Immich v2.x config file for OAuth/OIDC and ffmpeg settings
+            - name: IMMICH_CONFIG_FILE
+              value: /etc/immich/immich-config.json
+            # Database connection - use CNPG service and credentials secret
+            - name: DB_HOSTNAME
+              value: immich-db-staging-cnpg-v1-rw.immich-stage.svc.cluster.local
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE_NAME
+              value: immich
+            - name: DB_USERNAME
+              value: immich
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-db-credentials
+                  key: password
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "2000m"
           volumeMounts:
             - name: upload
               mountPath: /usr/src/app/upload

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -17,10 +17,8 @@ spec:
         - ip: "10.42.2.41"
           hostnames:
             - auth.stage.burntbytes.com
-      securityContext:
-        supplementalGroups:
-          - 44 # video group
-          - 109 # render group
+      # No supplementalGroups: the api worker doesn't touch /dev/dri after the
+      # split (transcode moved to the microservices worker).
       initContainers:
         - name: oauth-config
           # busybox 1.37
@@ -58,14 +56,9 @@ spec:
                 - ALL
       containers:
         - name: immich-server
-          securityContext:
-            privileged: true
+          # api worker does not transcode after the split, so it needs neither
+          # privileged mode nor /dev/dri (both moved to the microservices worker).
           env:
-            # Hardware Acceleration for AMD
-            - name: LIBVA_DRIVER_NAME
-              value: radeonsi
-            - name: LIBVA_DRIVERS_PATH
-              value: /usr/lib/jellyfin-ffmpeg/lib/dri
             # Immich v2.x config file for OAuth/OIDC and ffmpeg settings
             - name: IMMICH_CONFIG_FILE
               value: /etc/immich/immich-config.json
@@ -97,8 +90,6 @@ spec:
               mountPath: /usr/src/app/upload
             - name: photos
               mountPath: /mnt/photos
-            - name: dri
-              mountPath: /dev/dri
             - name: config-rendered
               mountPath: /etc/immich
               readOnly: true
@@ -109,10 +100,6 @@ spec:
         - name: photos
           persistentVolumeClaim:
             claimName: immich-photos-pvc
-        - name: dri
-          hostPath:
-            path: /dev/dri
-            type: Directory
         - name: config-template
           configMap:
             name: immich-config-file

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -58,6 +58,12 @@ spec:
         - name: immich-server
           # api worker does not transcode after the split, so it needs neither
           # privileged mode nor /dev/dri (both moved to the microservices worker).
+          securityContext:
+            # Root (uid 0) to write client uploads to the root-owned iSCSI upload
+            # volume — matches prod and removes the pre-split reliance on
+            # privileged mode's CAP_DAC_OVERRIDE for that write.
+            runAsUser: 0
+            runAsGroup: 0
           env:
             # Immich v2.x config file for OAuth/OIDC and ffmpeg settings
             - name: IMMICH_CONFIG_FILE

--- a/apps/staging/immich/deployment-patch.yaml
+++ b/apps/staging/immich/deployment-patch.yaml
@@ -129,8 +129,12 @@ spec:
           hostnames:
             - auth.stage.burntbytes.com
       securityContext:
+        # Mirror prod's group set so staging is a faithful rehearsal of the prod
+        # microservices worker: 44 (video) + 109 (render) for /dev/dri VAAPI
+        # transcode, 100 (users) for photo/upload file access.
         supplementalGroups:
           - 44 # video group
+          - 100 # users group
           - 109 # render group
       initContainers:
         - name: oauth-config
@@ -171,6 +175,11 @@ spec:
         - name: immich-microservices
           securityContext:
             privileged: true
+            # Explicit root (matches prod microservices) to write transcode /
+            # thumbnail output to the root-owned iSCSI upload volume, rather than
+            # relying on the image-default user + privileged CAP_DAC_OVERRIDE.
+            runAsUser: 0
+            runAsGroup: 0
           env:
             # Hardware Acceleration for AMD (video transcode runs in this worker).
             - name: LIBVA_DRIVER_NAME


### PR DESCRIPTION
## Why
`immich-server` currently runs **combined** — the api/web worker and every background job worker in one process (1 replica). During big scans (there's an 18,958-thumbnail backlog draining now) the background workers eat ~3.7 CPU in the *same* process that serves the UI, so the web UI goes sluggish when multiple people browse concurrently. This splits the interactive read/serve path from the background write/ingest grind.

## What
Two Deployments instead of one:

- **immich-server (api)** — keeps the name, the Service, and the `/api/server/ping` :2283 probe. `IMMICH_WORKERS_INCLUDE=api`. Sized down (no longer runs jobs): prod req 500m/1Gi, lim 4/4Gi; staging req 250m/512Mi, lim 2/2Gi.
- **immich-microservices (new)** — `IMMICH_WORKERS_EXCLUDE=api`. Same DB env, OAuth/ffmpeg config (oauth-config init container), privileged VAAPI transcode, and volumes as the api pod. **No Service.** Gets the bulk of the resources: prod req 2/4Gi, lim 8/8Gi; staging req 500m/1Gi, lim 2/2Gi.

Done in the **base** so staging rehearses the same topology (staging sized small).

### Co-location (RWO upload PVC)
Both pods mount `immich-upload-pvc` (**RWO** `truenas-iscsi`), which only admits multiple pods on a single node. microservices has a **required `podAffinity`** onto the api pod (`component: server`, topologyKey hostname) so a scheduling race can't split them across nodes → RWO Multi-Attach. Both use **`Recreate`** so a rollout never briefly double-schedules on another node and deadlocks on the volume.

### Microservices readiness probe (the key unknown — researched)
A microservices-only worker does **not** bind the API on :2283 (Immich docs say to remove the `2283:2283` mapping from the microservices copy), so `/api/server/ping` is unavailable there. Instead we enable OTEL telemetry (`IMMICH_TELEMETRY_INCLUDE=all`), which binds the **microservices metrics server on :8082** (`IMMICH_MICROSERVICES_METRICS_PORT` default). That server only comes up after the app bootstraps (DB + Redis connected), so `readinessProbe httpGet /metrics :8082` is a genuine "worker is up" signal. **No livenessProbe** — the metrics endpoint is the pod's only HTTP surface, so a liveness probe would reuse the identical signal (per AGENTS.md: liveness only with a signal distinct from readiness). Evidence: immich-charts `server.yaml` (metrics-api 8081 / metrics-ms 8082) and `upgrade_split_worker` branch `workers.yaml`; Immich env-var + jobs-workers docs.

### Network policy
New `immich-microservices` CiliumNetworkPolicy (egress DNS + CNPG 5432 + Redis 6379 + ML 3003 + world 443; ingress kubelet probe on 8082). Redis and ML ingress amended to also admit `component: microservices`.

### Lessons applied from the ML fan-out (#1073)
- **No dual-source volumes** — base defines only `upload`; overlays add the rest; each rendered volume is single-source (validated on both overlays).
- **PDB scoping** — microservices gets a distinct `component: microservices` label; the base PDB (`component in (server, redis)`) does not match it, and it gets no maxUnavailable:0 PDB (won't block node drains).
- **ML untouched** — prod stays 4-replica/RollingUpdate, staging 1-replica/Recreate.

## Validation
`kustomize build apps/production/immich` and `apps/staging/immich` both pass and render valid manifests: 4 Deployments + 3 Services per env (no microservices Service), correct WORKERS env on each, single-source volumes, api has Service + :2283 probe, microservices has :8082 probe + no Service, required podAffinity, Recreate. Server image tag unchanged (v3.0.1, same digest). No plaintext secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet