### PR TITLE
fix(immich): unblock 30d-sync — bulk rsync + 4h deadline

### DIFF
--- a/apps/staging/immich/cronjob-photos-30d.yaml
+++ b/apps/staging/immich/cronjob-photos-30d.yaml
@@ -98,8 +98,21 @@ spec:
                   #    SRC, writes only to DST — originals are never modified. NUL delimiting
                   #    ( -print0 / --from0 ) keeps filenames with spaces intact.
                   cd "$SRC"
+                  # rsync exit 24 = "some files vanished before we could transfer them" —
+                  # expected and BENIGN when copying a LIVE prod tree (phones add/remove
+                  # photos mid-run). Tolerate ONLY 24 so a normal concurrent-churn run still
+                  # completes, prunes, and records success (the whole point of this fix —
+                  # otherwise the job would trade DeadlineExceeded for a spurious rsync
+                  # failure and keep the homelabscope alert firing). Any other nonzero — a
+                  # real rsync error, or a failed `find` surfaced through pipefail — is fatal
+                  # so backoffLimit retries and the failure stays visible.
+                  rc=0
                   find . -type f -mtime -30 -print0 \
-                    | rsync -a --from0 --files-from=- "$SRC"/ "$DST"/
+                    | rsync -a --from0 --files-from=- "$SRC"/ "$DST"/ || rc=$?
+                  if [ "$rc" -ne 0 ] && [ "$rc" -ne 24 ]; then
+                    echo "[30d-sync] transfer failed rc=$rc" >&2
+                    exit "$rc"
+                  fi
                   # 2. Prune slice entries older than 30 days (mtime preserved by rsync -a)
                   #    so the slice stays bounded.
                   find "$DST" -type f -mtime +30 -delete

--- a/apps/staging/immich/cronjob-photos-30d.yaml
+++ b/apps/staging/immich/cronjob-photos-30d.yaml
@@ -13,7 +13,19 @@
 #   * COPY (this job): source mounted READ-ONLY (can't harm originals), slice mounted
 #     RW. Robust across any mount topology; data duplication is bounded to ~30 days,
 #     which is fine for a small testbed. Copied files are indistinguishable from real
-#     files to Immich. cp -p preserves mtime so the age-based prune stays consistent.
+#     files to Immich. rsync -a preserves mtime so the age-based prune stays consistent.
+#
+# COPY MECHANISM — bulk incremental rsync, NOT a per-file shell loop:
+#   The previous implementation forked `mkdir`+`cp` once PER FILE while walking the
+#   multi-TB prod tree. That fork-storm never finished inside the deadline, so the job
+#   was killed with DeadlineExceeded on every run and never recorded a success. We now
+#   pipe the last-30-days file list into a SINGLE `rsync -a` (one process for the whole
+#   slice): rsync recreates the tree, preserves mtime, and skips files already present
+#   and up to date, so steady-state re-runs only transfer the day's new photos.
+#   Image swapped busybox → the sibling rsync image (ghcr.io/gjcourt/immich-photos-backup,
+#   Alpine + rsync 3.4.3 + bash) that immich-photos-backup / alcatraz-photos-pull use, so
+#   all three photo-sync jobs share one copy mechanism. `find` (busybox applet in that
+#   image) still does the date windowing at the filesystem, which Immich has no API for.
 #
 # After a sync, Immich must rescan the external library to index the delta. Immich's
 # built-in scheduled library scan (daily, admin default) handles this; the schedule
@@ -38,8 +50,14 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      # Cap a hung NFS mount so the job can't run forever.
-      activeDeadlineSeconds: 3600
+      # Cap a hung NFS mount so the job can't run forever, but leave enough headroom for
+      # the ONE-TIME initial seed: the first run copies the entire 30-day window into an
+      # empty slice AND rsync must stat every candidate file across the multi-TB prod tree
+      # over NFS. Steady-state runs are minutes (only the day's new photos transfer), but
+      # the cold seed needs hours — the old 1h cap killed it as DeadlineExceeded before it
+      # could ever record a success. 4h gives the seed room without letting a wedged mount
+      # hang indefinitely.
+      activeDeadlineSeconds: 14400
       backoffLimit: 2
       template:
         metadata:
@@ -57,27 +75,32 @@ spec:
             fsGroup: 0
           containers:
             - name: sync
-              # busybox 1.37 (same digest used by the immich init container). Provides
-              # find / cp / mkdir / du — no extra tooling needed.
-              image: busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+              # Sibling rsync image shared by immich-photos-backup / alcatraz-photos-pull
+              # (Alpine 3.23 + rsync 3.4.3 + bash + busybox find). Pinned by digest to the
+              # published 2026-07-04 build (public ghcr package — no pull secret needed).
+              # We override the image's baked-in crond/backup entrypoint with our own
+              # command; only its rsync + bash + find tooling is used here.
+              image: ghcr.io/gjcourt/immich-photos-backup:2026-07-04@sha256:a4811ef540b0b4b496a9e3970394ff856cceceb4537c80b4f4c75f9c9d7f2673
               command:
-                - sh
-                - -eu
+                - bash
+                - -euo
+                - pipefail
                 - -c
                 - |
                   SRC=/src   # full prod photo tree (read-only)
                   DST=/dst   # photos-staging-30d slice (read-write)
                   echo "[30d-sync] $(date -u) start"
+                  # 1. Select files modified in the last 30 days (filesystem date window —
+                  #    Immich has no date API) and hand the NUL-delimited list to a SINGLE
+                  #    rsync. -a recreates the tree + preserves mtime; --files-from restricts
+                  #    the transfer to exactly that list; rsync skips files already present
+                  #    and up to date, so re-runs only move the day's new photos. Reads from
+                  #    SRC, writes only to DST — originals are never modified. NUL delimiting
+                  #    ( -print0 / --from0 ) keeps filenames with spaces intact.
                   cd "$SRC"
-                  # 1. Copy files modified in the last 30 days into the slice, preserving
-                  #    tree + mtime. cp -u skips files already present and up to date.
-                  find . -type f -mtime -30 | while IFS= read -r f; do
-                    rel="${f#./}"
-                    dest="$DST/$rel"
-                    mkdir -p "$(dirname "$dest")"
-                    cp -pu "$SRC/$rel" "$dest"
-                  done
-                  # 2. Prune slice entries older than 30 days (mtime preserved by cp -p)
+                  find . -type f -mtime -30 -print0 \
+                    | rsync -a --from0 --files-from=- "$SRC"/ "$DST"/
+                  # 2. Prune slice entries older than 30 days (mtime preserved by rsync -a)
                   #    so the slice stays bounded.
                   find "$DST" -type f -mtime +30 -delete
                   # 3. Remove now-empty directories (rmdir no-ops on non-empty / the mount root).


### PR DESCRIPTION
## Problem

`apps/staging/immich/cronjob-photos-30d.yaml` (`immich-photos-30d-sync`, ns `immich-stage`) maintains the last-30-days slice of the prod photo tree for the Immich staging testbed. It copied by forking **`mkdir`+`cp` once per file** while walking the multi-TB read-only prod tree. That fork-storm never completed within the **1h `activeDeadlineSeconds`**, so every run was killed **DeadlineExceeded** and the job never recorded a success — `homelabscope_job_last_success_seconds{job="immich-photos-30d-sync"}` stayed stale.

Mounts were fine (both PVCs Bound); only the copy logic + deadline were wrong.

## Fix

Mirrors the sibling photo-sync jobs (`immich-photos-backup` / `alcatraz-photos-pull`), which already use rsync:

- **Image** busybox → the shared rsync image `ghcr.io/gjcourt/immich-photos-backup` (Alpine 3.23 + rsync 3.4.3 + bash + busybox `find`), pinned by the published `2026-07-04` digest (`sha256:a4811e…`, public ghcr package — no pull secret). The image's baked-in crond entrypoint is overridden; only its rsync/bash/find tooling is used.
- **Copy mechanism** per-file loop → a single `find . -type f -mtime -30 -print0 | rsync -a --from0 --files-from=- /src/ /dst/`. One rsync process recreates the tree, preserves mtime, is NUL-safe for spaced filenames, and skips up-to-date files so steady-state re-runs only transfer the day's new photos. Source stays mounted **read-only**; writes go only to the slice. Prune of `>30d` files + empty dirs unchanged.
- **Deadline** `activeDeadlineSeconds` 3600 → **14400 (4h)** so the one-time cold seed of the full 30-day window can finish; steady-state runs are minutes.

Intent unchanged (last-30-days prod photos → staging slice), only *how* it copies.

## Validation

- `kustomize build apps/staging/immich` passes (exit 0); rendered CronJob valid (deadline 14400, digest-pinned image, src `readOnly: true`, correct PVCs).
- Pipeline exercised **end-to-end inside the pinned image** (amd64): `find -mtime -30 -print0` selects only recent files incl. a spaced filename; `rsync -a --from0 --files-from=-` preserves tree + identical mtime; re-run transfers **0** files (incremental); prune removes an aged dst file + empty dirs; `bash -euo pipefail` parses correctly; empty file-list → rsync no-op exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet