### PR TITLE
chore(navidrome): repoint music PV to merged family/media/music

### DIFF
--- a/apps/production/navidrome/nfs-music.yaml
+++ b/apps/production/navidrome/nfs-music.yaml
@@ -31,7 +31,11 @@ spec:
     - nolock
   nfs:
     server: 10.42.2.10
-    path: /mnt/main/media/music
+    # Repointed from /mnt/main/media/music (curated-only) to the merged
+    # family/media/music tree per assimilation-plan Phase 4a (curated FLAC +
+    # archive dump). PV nfs.path is immutable, so applying this requires a
+    # one-time PV+PVC delete/recreate (the PV is Retain — the NFS data is safe).
+    path: /mnt/main/family/media/music
     readOnly: true
 ---
 apiVersion: v1


### PR DESCRIPTION
Points Navidrome's production music NFS PV at the **merged** `/mnt/main/family/media/music` (76 artists = curated FLAC + archive dump, built in assimilation Phase 4a) instead of the curated-only `/mnt/main/media/music`.

`PV.spec.nfs.path` is immutable, so on merge this needs a **one-time PV+PVC delete/recreate** (the PV is `Retain` — the NFS data is untouched) + a navidrome pod restart. I'll run that operationally after merge and verify `/music` shows all 76 artists.

Validated: `kustomize build apps/production/navidrome` passes; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)