### PR TITLE
chore(immich): repoint photos PV to media/photos (metadata-safe)

### DIFF
--- a/apps/production/immich/nfs-photos.yaml
+++ b/apps/production/immich/nfs-photos.yaml
@@ -17,7 +17,14 @@ spec:
   storageClassName: ""
   nfs:
     server: 10.42.2.10
-    path: /mnt/main/family/images/photos
+    # Repointed images/photos -> media/photos per assimilation-plan Phase 4c.
+    # METADATA-SAFE: the container mountPath (/mnt/photos, in deployment-patch)
+    # is UNCHANGED and media/photos has an identical <owner>/<year>/<month>
+    # substructure, so every asset's originalPath (/mnt/photos/...) stays the
+    # same and Immich matches all 141k assets — no re-import, albums/faces/people
+    # preserved. nfs.path is immutable, so applying needs a PV+PVC delete/recreate
+    # (Retain — NFS data safe); do it with immich scaled to 0.
+    path: /mnt/main/family/media/photos
     readOnly: false
   mountOptions:
     - nfsvers=3


### PR DESCRIPTION
Points Immich's prod external-library NFS PV at the migrated `/mnt/main/family/media/photos` (Phase 4c). **Metadata-safe by design**: the container `mountPath: /mnt/photos` is unchanged and `media/photos` has an identical `<owner>/<year>/<month>` substructure, so every asset's `originalPath` (`/mnt/photos/...`) stays the same — Immich matches all ~141k assets, **no re-import; albums/faces/people preserved**.

Baseline captured: 141,039 assets / 9 albums / 1,784 people / 63,856 faces. NFS export for the new path already created (id=9).

`nfs.path` is immutable -> one-time PV+PVC delete/recreate (Retain), run with immich scaled to 0; I'll verify the baseline is unchanged after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)