### PR TITLE
chore(jellyfin): repoint prod movies PV to consolidated family/media/video/movies

### DIFF
--- a/apps/production/jellyfin/kustomization.yaml
+++ b/apps/production/jellyfin/kustomization.yaml
@@ -31,6 +31,12 @@ patches:
       - op: replace
         path: /metadata/name
         value: jellyfin-movies-pv-prod
+      # Prod movies consolidated into the family tree (assimilation Phase 4);
+      # the media/movies dataset was zfs-remounted here. Staging stays on the
+      # base path. nfs.path is immutable -> one-time PV+PVC delete/recreate.
+      - op: replace
+        path: /spec/nfs/path
+        value: /mnt/main/family/media/video/movies
   - target:
       kind: PersistentVolumeClaim
       name: jellyfin-movies-pvc


### PR DESCRIPTION
Phase 4: the `media/movies` ZFS dataset was zfs-remounted (zero-copy) to `/mnt/main/family/media/video/movies`. Points prod Jellyfin's movies PV there via a **prod-only** overlay patch (staging stays on the base path). Container mountPath `/media/movies` unchanged → Jellyfin library metadata preserved. One-time PV+PVC delete/recreate (Retain). NFS export for the new path already created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)