### PR TITLE
chore(jellyfin): consolidate prod TV libraries into family/media/video

### DIFF
--- a/apps/production/jellyfin/kustomization.yaml
+++ b/apps/production/jellyfin/kustomization.yaml
@@ -51,6 +51,11 @@ patches:
       - op: replace
         path: /metadata/name
         value: jellyfin-tvshows-pv-prod
+      # Consolidated (Phase 4): serve the family/media/video/tv content (the old
+      # media/tv-shows was empty). Prod-only; staging keeps the base path.
+      - op: replace
+        path: /spec/nfs/path
+        value: /mnt/main/family/media/video/tv
   - target:
       kind: PersistentVolumeClaim
       name: jellyfin-tvshows-pvc
@@ -65,6 +70,11 @@ patches:
       - op: replace
         path: /metadata/name
         value: jellyfin-tvanime-pv-prod
+      # Consolidated (Phase 4): media/tv-anime dataset zfs-remounted here.
+      # Prod-only; staging keeps the base path.
+      - op: replace
+        path: /spec/nfs/path
+        value: /mnt/main/family/media/video/tv-anime
   - target:
       kind: PersistentVolumeClaim
       name: jellyfin-tvanime-pvc


### PR DESCRIPTION
Phase 4 final media leg. Prod-only: tv-shows PV -> family/media/video/tv (94G, already there; old media/tv-shows was empty), tv-anime PV -> family/media/video/tv-anime (dataset zfs-remounted). Mountpaths unchanged; PV+PVC delete/recreate. NFS exports created. Staging unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)