### PR TITLE
fix(immich-photos-backup): write to media/photos (canonical Immich path)

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -1,5 +1,5 @@
 # Daily rsync of /volume1/family/images/photos on alcatraz (Synology DSM,
-# 10.42.2.11) into the local ZFS dataset main/family/images/photos.
+# 10.42.2.11) into the local ZFS dataset main/family/media/photos.
 # (Renamed from main/backups/immich-photos in the 2026-06-01 hestia-SOT plan
 #  — see docs/plans/2026-06-01-hestia-photos-sot.md.)
 #
@@ -43,7 +43,7 @@ services:
       # Backup destination — bind-mounted the whole main/family parent so the
       # same container can later extend to sync other family/ subdirs (audio,
       # literature, documents, etc.) without a compose change. Today the script
-      # only writes to family/images/photos.
+      # only writes to family/media/photos.
       - /mnt/main/family:/mnt/main/family
       # Prometheus textfile collector dir — script writes
       # immich-backup.prom on each successful run for the

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -36,7 +36,7 @@
 # stays stale. Loud failure is intentional — silent perm-denied was the
 # original bug.
 #
-# Deployed as a TrueNAS Custom App; cron at 04:00 daily is fired by the
+DST_BASE="${DST_BASE:-/mnt/main/family/media/photos}"
 # container's busybox crond (see hosts/hestia/immich-photos-backup/).
 #
 # Reports backup freshness to node-exporter's textfile collector at


### PR DESCRIPTION
Phase 4c moved Immich's read to `family/media/photos` but the daily alcatraz->hestia backup kept writing to `family/images/photos`, so recent phone photos never reached Immich (found ~89 stranded). Repoint `DST_BASE` -> `media/photos`.

Proven manually already: ran the backup into `media/photos`, reached **parity** with alcatraz (george 48097=48097, mara 93067=93067). This makes the **daily 04:00 cron** target the right tree. Needs image rebuild + compose tag bump + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)