### PR TITLE
fix(immich): cap replication-slot WAL retention to prevent PVC fill

### DIFF
--- a/apps/production/immich/database.yaml
+++ b/apps/production/immich/database.yaml
@@ -51,6 +51,13 @@ spec:
       - "vchord.so"
     parameters:
       search_path: '"$user", public'
+      # Safety valve against WAL-pinning slots filling the 10Gi volume.
+      # Incident 2026-07-10: a dead replica slot (v3-4) + an orphan slot (v3-6)
+      # pinned ~13Gi of WAL, filled the replica PVC → CrashLoopBackOff AND the
+      # disk-space guard blocked the operator's reconcile, creeping the primary
+      # to 81%. Past this cap CNPG invalidates the lagging/dead slot instead of
+      # retaining WAL unbounded. Reloadable GUC (SIGHUP, no restart).
+      max_slot_wal_keep_size: "4GB"
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:


### PR DESCRIPTION
## Durability follow-up to the 2026-07-10 Immich CNPG incident

**Incident:** a dead replica slot (`_cnpg_..._v3_4`) plus an orphan slot (`..._v3_6`) pinned **~13 Gi of WAL**, filling the 10 Gi replica PVC. That:
1. tripped the instance's disk-space guard → replica refused to start → **CrashLoopBackOff (280 restarts)**, and
2. that *same* guard **blocked the operator's entire reconcile loop**, so the stale slots were never cleaned and the **primary crept to 81 %**.

Resolved operationally (rebuilt the replica via `kubectl cnpg destroy`; HA restored to 3/3). This PR is the **durability fix** so it can't recur.

## Change
Add one parameter to the immich CNPG cluster:
```yaml
postgresql:
  parameters:
    max_slot_wal_keep_size: "4GB"
```
Past 4 GB, CNPG **invalidates** a lagging/dead replication slot instead of retaining WAL unbounded — a safety valve for this recurring CNPG/iSCSI failure class. It's a **reloadable GUC** (SIGHUP, no restart). Storage is already `10Gi` (bumped 2026-07-03) and the DB is ~1 Gi, so 4 GB leaves ample headroom for normal WAL + the dataset.

## Validation
- `kustomize build apps/production/immich` passes; `max_slot_wal_keep_size: 4GB` present in the rendered `Cluster`.
- No secrets in the diff.

## Not in this PR
- An incident postmortem under `docs/operations/incidents/` and a fleet-wide `cnpgscope` health tool (being built separately) — this class of failure warrants both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet