### PR TITLE
fix(cnpg): WAL-slot retention caps on healthy database clusters

### DIFF
--- a/apps/production/flashcards-sync/database.yaml
+++ b/apps/production/flashcards-sync/database.yaml
@@ -17,6 +17,14 @@ spec:
   storage:
     size: 5Gi
     storageClass: truenas-iscsi-ssd
+  postgresql:
+    parameters:
+      # Safety valve against a runaway/inactive replication slot pinning WAL and
+      # filling this PVC — the failure mode behind the 2026-07-10 immich incident
+      # (stale slots pinned ~13Gi of WAL → CrashLoop + blocked operator reconcile).
+      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
+      # unbounded. Sized well under the 5Gi volume. Reloadable GUC (SIGHUP).
+      max_slot_wal_keep_size: "2GB"
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true

--- a/apps/production/linkding/database.yaml
+++ b/apps/production/linkding/database.yaml
@@ -36,6 +36,16 @@ spec:
     size: 1Gi
     storageClass: truenas-iscsi
 
+  postgresql:
+    parameters:
+      # Safety valve against a runaway/inactive replication slot pinning WAL and
+      # filling this small 1Gi PVC — the failure mode behind the 2026-07-10 immich
+      # incident (stale slots pinned ~13Gi of WAL → CrashLoop + blocked reconcile).
+      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
+      # unbounded. Kept conservative (baseline usage + cap stays well under 1Gi).
+      # Reloadable GUC (SIGHUP, no restart).
+      max_slot_wal_keep_size: "256MB"
+
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:

--- a/apps/production/vitals/database.yaml
+++ b/apps/production/vitals/database.yaml
@@ -29,6 +29,15 @@ spec:
     # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
     size: 1Gi
     storageClass: truenas-iscsi
+  postgresql:
+    parameters:
+      # Safety valve against a runaway/inactive replication slot pinning WAL and
+      # filling this small 1Gi PVC — the failure mode behind the 2026-07-10 immich
+      # incident (stale slots pinned ~13Gi of WAL → CrashLoop + blocked reconcile).
+      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
+      # unbounded. Kept conservative (baseline usage + cap stays well under 1Gi).
+      # Reloadable GUC (SIGHUP, no restart).
+      max_slot_wal_keep_size: "256MB"
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:

--- a/apps/staging/immich/database.yaml
+++ b/apps/staging/immich/database.yaml
@@ -82,6 +82,12 @@ spec:
       - "vchord.so"
     parameters:
       search_path: '"$user", public'
+      # Safety valve against a runaway/inactive replication slot pinning WAL and
+      # filling this 5Gi PVC — the failure mode behind the 2026-07-10 immich-PROD
+      # incident (stale slots pinned ~13Gi of WAL → CrashLoop + blocked reconcile).
+      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
+      # unbounded. Reloadable GUC (SIGHUP, no restart).
+      max_slot_wal_keep_size: "2GB"
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).


### PR DESCRIPTION
## Summary

Fleet backstop following the immich WAL-slot cap (#1092). An inactive/lagging replication slot pinning WAL until the PVC fills (→ CrashLoop + blocked operator reconcile) is a generic CNPG failure mode, so this adds `max_slot_wal_keep_size` to the clusters with enough headroom to take a cap **safely today**:

| Cluster | PVC | Cap |
|---|---|---|
| flashcards-prod | 5Gi | 2GB |
| immich-stage | 5Gi | 2GB |
| linkding-prod | 1Gi | 256MB |
| vitals-prod | 1Gi | 256MB |

Sizing: baseline usage + cap stays well under each volume, and well above normal replica lag (MB-scale), so the valve only trips on a genuine runaway. Reloadable GUC (SIGHUP) — applied without restart, as proven on immich-prod in #1092 (0 restarts).

**Deliberately excluded:** the tight 1Gi clusters already ~65% full (golinks-prod, memos-prod, memos-stage) — a cap can't create headroom on an already-full volume. They need a PVC bump first and get a separate follow-up PR (B).

This is also newly *observable*: with #1094 the `cnpg_*` metrics finally flow, so the effect shows on the CloudNativePG dashboard.

## Test plan
- [x] `kustomize build` passes for all four overlays; rendered Cluster manifests carry the expected cap
- [ ] Post-merge: `SHOW max_slot_wal_keep_size` matches on each primary, 0 pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)