### PR TITLE
fix(cnpg): right-size WAL working set on the tight 1Gi clusters (no PVC bump)

### DIFF
--- a/apps/production/golinks/database.yaml
+++ b/apps/production/golinks/database.yaml
@@ -45,10 +45,23 @@ spec:
         matchLabels:
           policy-type: database
   storage:
-    # Actual usage: ~488Mi; target = 20% headroom → 1Gi.
-    # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
+    # The DB itself is ~8Mi; the ~0.5Gi of prior "usage" was almost entirely WAL
+    # (CNPG defaults wal_keep_size=512MB + max_wal_size=1GB on a 1Gi volume). WAL is
+    # right-sized via postgresql.parameters below, so 1Gi is now generous. Shrinking
+    # a PVC still needs cluster recreation (CNPG can't shrink in-place), so 1Gi stays.
     size: 1Gi
     storageClass: truenas-iscsi
+  postgresql:
+    parameters:
+      # Tiny DB (~8Mi) on a 1Gi volume. CNPG's defaults — wal_keep_size 512MB +
+      # max_wal_size 1GB — size WAL for a large database and let pg_wal grow to ~60%
+      # of the volume in steady state (the WAL-fraction WARN). Right-size the WAL
+      # working set to the volume, and hard-cap slot retention as the backstop against
+      # the 2026-07-10 immich slot-pinning failure mode. All three are reloadable
+      # (SIGHUP) GUCs — no restart; pg trims excess WAL on the next checkpoint.
+      max_wal_size: "256MB"
+      wal_keep_size: "128MB"
+      max_slot_wal_keep_size: "256MB"
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).
   plugins:

--- a/apps/production/memos/database.yaml
+++ b/apps/production/memos/database.yaml
@@ -31,10 +31,24 @@ spec:
           policy-type: database
 
   storage:
-    # Actual usage: ~633Mi; target = 20% headroom → 1Gi.
-    # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
+    # The DB itself is ~8Mi; the ~0.6Gi of prior "usage" was almost entirely WAL
+    # (CNPG defaults wal_keep_size=512MB + max_wal_size=1GB on a 1Gi volume). WAL is
+    # right-sized via postgresql.parameters below, so 1Gi is now generous. Shrinking
+    # a PVC still needs cluster recreation (CNPG can't shrink in-place), so 1Gi stays.
     size: 1Gi
     storageClass: truenas-iscsi
+
+  postgresql:
+    parameters:
+      # Tiny DB (~8Mi) on a 1Gi volume. CNPG's defaults — wal_keep_size 512MB +
+      # max_wal_size 1GB — size WAL for a large database and let pg_wal grow to ~60%
+      # of the volume in steady state (the WAL-fraction WARN). Right-size the WAL
+      # working set to the volume, and hard-cap slot retention as the backstop against
+      # the 2026-07-10 immich slot-pinning failure mode. All three are reloadable
+      # (SIGHUP) GUCs — no restart; pg trims excess WAL on the next checkpoint.
+      max_wal_size: "256MB"
+      wal_keep_size: "128MB"
+      max_slot_wal_keep_size: "256MB"
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).

--- a/apps/staging/memos/database.yaml
+++ b/apps/staging/memos/database.yaml
@@ -31,10 +31,24 @@ spec:
           policy-type: database
 
   storage:
-    # Actual usage: ~634Mi; target = 20% headroom → 1Gi.
-    # Requires cluster recreation (CNPG cannot shrink PVCs in-place).
+    # The DB itself is ~8Mi; the ~0.6Gi of prior "usage" was almost entirely WAL
+    # (CNPG defaults wal_keep_size=512MB + max_wal_size=1GB on a 1Gi volume). WAL is
+    # right-sized via postgresql.parameters below, so 1Gi is now generous. Shrinking
+    # a PVC still needs cluster recreation (CNPG can't shrink in-place), so 1Gi stays.
     storageClass: truenas-iscsi
     size: 1Gi
+
+  postgresql:
+    parameters:
+      # Tiny DB (~8Mi) on a 1Gi volume. CNPG's defaults — wal_keep_size 512MB +
+      # max_wal_size 1GB — size WAL for a large database and let pg_wal grow to ~60%
+      # of the volume in steady state (the WAL-fraction WARN). Right-size the WAL
+      # working set to the volume. Single-instance (no replica slots), but the slot
+      # cap is a harmless backstop. All reloadable (SIGHUP) GUCs — no restart; pg
+      # trims excess WAL on the next checkpoint.
+      max_wal_size: "256MB"
+      wal_keep_size: "128MB"
+      max_slot_wal_keep_size: "256MB"
 
   # Bootstrap from backup if available, otherwise initialize fresh
   # To restore: uncomment recovery section and comment out initdb


### PR DESCRIPTION
## Summary

PR B for the CNPG WAL work — but the investigation flipped the fix. golinks-prod / memos-prod / memos-stage were WARN at ~60-74% full on 1Gi, but the databases are **~8Mi each**. The fill is entirely **WAL**, and it's **not slot-pinning** (slots retain 0 bytes). The cause is CNPG's default WAL sizing on a tiny volume:

- `wal_keep_size = 512MB` — forces half the 1Gi volume retained
- `max_wal_size = 1024MB` — lets pg_wal grow to the whole volume between checkpoints

**No PVC bump needed** (the original plan) — that would throw disk at a misconfiguration. Instead, right-size WAL to the volume + add the slot backstop:

| Param | Value |
|---|---|
| max_wal_size | 256MB |
| wal_keep_size | 128MB |
| max_slot_wal_keep_size | 256MB |

All reloadable (SIGHUP) — no restart; Postgres trims excess WAL on the next checkpoint, dropping steady-state pg_wal from ~576Mi toward ~256Mi (~60% → ~25% of 1Gi), clearing the WARN. Also fixes the storage comments, which had mistaken WAL bloat for data.

## Test plan
- [x] `kustomize build` passes for all three overlays; params render
- [ ] Post-merge: params applied on each primary (`SHOW`), 0 restarts, pg_wal shrinks, cnpgscope WARN clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)