### PR TITLE
fix(cnpg): uniform WAL right-sizing on the remaining 1Gi clusters (linkding, vitals)

### DIFF
--- a/apps/production/linkding/database.yaml
+++ b/apps/production/linkding/database.yaml
@@ -38,12 +38,15 @@ spec:
 
   postgresql:
     parameters:
-      # Safety valve against a runaway/inactive replication slot pinning WAL and
-      # filling this small 1Gi PVC — the failure mode behind the 2026-07-10 immich
-      # incident (stale slots pinned ~13Gi of WAL → CrashLoop + blocked reconcile).
-      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
-      # unbounded. Kept conservative (baseline usage + cap stays well under 1Gi).
-      # Reloadable GUC (SIGHUP, no restart).
+      # Tiny DB on a 1Gi volume. CNPG's defaults — wal_keep_size 512MB + max_wal_size
+      # 1GB — size WAL for a large database and can let pg_wal grow to ~60% of the
+      # volume (the WAL-fraction WARN). Right-size the WAL working set to the volume,
+      # and hard-cap slot retention as the backstop against the 2026-07-10 immich
+      # slot-pinning failure mode. All three are reloadable (SIGHUP) GUCs — no restart;
+      # pg trims excess WAL on the next checkpoint. Matches the other 1Gi clusters
+      # (golinks/memos, #1096).
+      max_wal_size: "256MB"
+      wal_keep_size: "128MB"
       max_slot_wal_keep_size: "256MB"
 
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).

--- a/apps/production/vitals/database.yaml
+++ b/apps/production/vitals/database.yaml
@@ -31,12 +31,15 @@ spec:
     storageClass: truenas-iscsi
   postgresql:
     parameters:
-      # Safety valve against a runaway/inactive replication slot pinning WAL and
-      # filling this small 1Gi PVC — the failure mode behind the 2026-07-10 immich
-      # incident (stale slots pinned ~13Gi of WAL → CrashLoop + blocked reconcile).
-      # Past this cap CNPG invalidates the lagging slot instead of retaining WAL
-      # unbounded. Kept conservative (baseline usage + cap stays well under 1Gi).
-      # Reloadable GUC (SIGHUP, no restart).
+      # Tiny DB on a 1Gi volume. CNPG's defaults — wal_keep_size 512MB + max_wal_size
+      # 1GB — size WAL for a large database and can let pg_wal grow to ~60% of the
+      # volume (the WAL-fraction WARN). Right-size the WAL working set to the volume,
+      # and hard-cap slot retention as the backstop against the 2026-07-10 immich
+      # slot-pinning failure mode. All three are reloadable (SIGHUP) GUCs — no restart;
+      # pg trims excess WAL on the next checkpoint. Matches the other 1Gi clusters
+      # (golinks/memos, #1096).
+      max_wal_size: "256MB"
+      wal_keep_size: "128MB"
       max_slot_wal_keep_size: "256MB"
   # WAL archiving and base backups via the Barman Cloud Plugin (v0.11.0).
   # S3 configuration is defined in objectstore.yaml (ObjectStore CRD).


### PR DESCRIPTION
## Summary

Completes the 1Gi-cluster tuning. linkding-prod and vitals-prod got the slot cap in #1095 but not the WAL working-set tuning from #1096, so they still carry CNPG's defaults (`wal_keep_size=512MB`, `max_wal_size=1GB`) — the same latent bloat that pushed golinks/memos into WARN. This brings every 1Gi CNPG cluster to an identical config:

| Param | Value |
|---|---|
| max_wal_size | 256MB |
| wal_keep_size | 128MB |
| max_slot_wal_keep_size | 256MB (from #1095) |

Reloadable (SIGHUP) — no restart; Postgres trims excess WAL on the next checkpoint.

## Test plan
- [x] `kustomize build` passes for both overlays; all three params render
- [ ] Post-merge: params applied on each primary, 0 restarts, pg_wal trims

🤖 Generated with [Claude Code](https://claude.com/claude-code)