### PR TITLE
feat(firmware): IR-code updates (play rename, learn dump=all)

### DIFF
--- a/firmware/esphome/ir-blaster-learn.yaml
+++ b/firmware/esphome/ir-blaster-learn.yaml
@@ -64,7 +64,7 @@ remote_receiver:
     mode:
       input: true
       pullup: true # receiver has an internal pull-up; no external 10k needed
-  dump: nec # this remote is NEC. Use `all` to identify an unknown remote's
+  dump: all # this remote is NEC. Use `all` to identify an unknown remote's
   # protocol (one press → many speculative decodes; the one with a valid
   # command/complement is real), then set dump to just that protocol for
   # clean one-line-per-press captures.

--- a/firmware/esphome/ir-codes.yaml
+++ b/firmware/esphome/ir-codes.yaml
@@ -7,7 +7,7 @@
   decode: "NEC: address=0x3712, command=0xF40B"
 - name: "volume-up"
   decode: "NEC: address=0x3712, command=0xF50A"
-- name: "play-pause"
+- name: "play"
   decode: "NEC: address=0x3712, command=0xFD02"
 - name: "previous"
   decode: "NEC: address=0x3712, command=0xFC03"


### PR DESCRIPTION
Split out of #1098 (firmware half).

- `ir-codes.yaml`: rename DAC IR code `play-pause` → `play`
- `ir-blaster-learn.yaml`: learn/receiver dump mode `nec` → `all` (identify any remote's protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)