### PR TITLE
fix(alerts): tune noisy non-actionable alerts

### DIFF
--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -123,21 +123,46 @@ spec:
         # labels — every job is checked against its OWN max_age with a single
         # rule. `time() - <gauge>` keeps the gauge's labels; the `>` then
         # matches max_age by the same set.
+        # Severity is now split by tier. Historically this was hardcoded
+        # `critical` because Alertmanager dropped every warning to the 'null'
+        # receiver — a warning monitor never notified. PR #1081 added a
+        # warning->email route (24h daily-nag repeat), so warnings DO notify
+        # now, and staleness can carry a severity that matches the job's blast
+        # radius instead of paging everything at the 4h critical cadence.
+        #
+        # PROD / data-safety jobs (photo backups, zfs snapshots, prod syncs)
+        # stay critical: a missed run is a real risk that warrants the 4h nag.
         - alert: HomelabscopeJobStale
-          expr: time() - homelabscope_job_last_success_seconds > homelabscope_job_max_age_seconds
+          expr: >
+            time() - homelabscope_job_last_success_seconds{job!~"immich-photos-30d-sync|adguard-sync-stage"}
+            > homelabscope_job_max_age_seconds
           for: 10m
           labels:
-            # critical so the alert actually notifies: Alertmanager routes only
-            # severity=critical to the email-critical (Gmail SMTP) receiver;
-            # warning falls through to the 'null' receiver and would be dropped
-            # silently — a monitor that never notifies. Each job's generous
-            # per-job max_age budget + this 10m `for` debounce mean firing
+            # Generous per-job max_age budget + 10m `for` debounce mean firing
             # signals a real multi-cycle miss, not a flap.
             severity: critical
           annotations:
             summary: "Scheduled job {{ $labels.job }} is stale"
             description: >
               Job {{ $labels.job }} last succeeded {{ $value | humanizeDuration }} ago, exceeding its max-age budget. A scheduled/automatic job has stopped completing on time. Check the job's source: k8s CronJob (kubectl get cronjob -A), hestia textfile (/var/log on hestia), or the alcatraz pull log.
+        # STAGING / preview jobs (immich-photos-30d-sync, adguard-sync-stage) run
+        # in the ephemeral `*-stage` env and are rehearsals, not data-safety
+        # backups. They churn/fail during active work (e.g. the in-flight immich
+        # v3 migration) and are NOT worth a 4h critical page. Downgraded to
+        # warning: still surfaced as a once-a-day email nag via the #1081 warning
+        # route, without the critical cadence. Promote a job back to the critical
+        # block above if it ever becomes load-bearing.
+        - alert: HomelabscopeJobStale
+          expr: >
+            time() - homelabscope_job_last_success_seconds{job=~"immich-photos-30d-sync|adguard-sync-stage"}
+            > homelabscope_job_max_age_seconds
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Staging job {{ $labels.job }} is stale"
+            description: >
+              Staging/preview job {{ $labels.job }} last succeeded {{ $value | humanizeDuration }} ago, exceeding its max-age budget. This is a rehearsal job in the ephemeral `*-stage` environment, not a data-safety backup — expected to churn during active development. Check: kubectl get cronjob -A.
         # A job's heartbeat has vanished ENTIRELY — the specific failure mode
         # the pre-homelabscope setup could not see. When a textfile stops being
         # written (container gone, script crashing before the write) or a

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -552,6 +552,28 @@ alertmanager:
       - receiver: 'null'
         matchers:
           - alertname = "Watchdog"
+      # overture is intentionally OFF: the Deployment is scaled 0/0 and its CNPG
+      # cluster is hibernated (cnpg.io/hibernation=on), so the PodDisruptionBudget
+      # (minAvailable=1) permanently reports 0 healthy pods and
+      # KubePdbNotEnoughHealthyPods fires forever. This is expected, not an
+      # outage — mute it for overture-prod only. If overture is ever brought back
+      # up, delete this route so the PDB signal returns. See docs/STATUS.md.
+      - receiver: 'null'
+        matchers:
+          - alertname = "KubePdbNotEnoughHealthyPods"
+          - namespace = "overture-prod"
+      # Staging is an ephemeral PREVIEW environment, continuously rebuilt by CI
+      # from `master + open PRs` (see AGENTS.md). Warning-severity alerts there
+      # (failed/one-shot Jobs during a migration rehearsal, transient crashloops,
+      # CNPG churn on redeploy) are expected development noise and are validated
+      # interactively via the PR/staging workflow, NOT by email paging. Mute
+      # warnings from `*-stage` namespaces; staging CRITICALS still fall through
+      # to email below. This stops the immich-stage KubeJobFailed day-nag from
+      # the in-flight immich v3 migration rehearsal. Prod is unaffected.
+      - receiver: 'null'
+        matchers:
+          - namespace =~ ".+-stage"
+          - severity = "warning"
       # Critical alerts (Flux not-ready, NodeFilesystemReadOnly, LokiPushErrors)
       # go to email. repeat_interval is shorter than the global default because
       # email has no ack — re-nag every 4h while still firing.


### PR DESCRIPTION
George received ~20-30 alert emails today, none actionable. I queried Alertmanager + Prometheus, ranked by 24h volume, root-caused each, and made targeted fixes that cut email volume **without masking any production outage**.

## What was firing today (ranked)

| Alertname | Distinct series (24h) | Verdict | Emailing now? |
|---|---|---|---|
| `CNPGClusterDegraded` | 19 (02:43–05:23) | **False positive — already fixed by #1081**, not re-touched | No (expr returns empty fleet-wide) |
| `KubeJobFailed` | 10 | Staging churn (immich v3 migration rehearsal) + stale cron objects | Yes → **muted for staging** |
| `KubePdbNotEnoughHealthyPods` | 2 | Benign — overture intentionally hibernated | Suppressed → **muted for overture-prod** |
| `HomelabscopeJobStale` | 1 | Staging rehearsal job wired as **critical** (4h page) | Yes → **downgraded to warning** |
| `etcdMemberCommunicationSlow` / `UniFiPoESwitchTempHigh` / `NetscopeHighRetransmits` / `TrueNASISCSIScrapeErrors` / `KubeContainerWaiting` | 1 each | Transient, self-resolved | Left intact |

**The bulk of today's flood was the CNPG batch** — 19 healthy CNPG targets fired 02:43–05:23 as PR #1081's expr fix reconciled. With `send_resolved: true` and `group_by: [namespace]`, that's ~2 emails × 12 clusters on the way in and out ≈ the 20–30. It is already fixed (deployed expr returns empty across the fleet) and is **not** re-touched here.

## Changes

### 1. `KubePdbNotEnoughHealthyPods` / overture-prod → muted (Alertmanager route)
overture is intentionally OFF: Deployment `0/0` **and** its CNPG cluster carries `cnpg.io/hibernation=on`, so the PDB (`minAvailable=1`) permanently reports 0 healthy pods. Evidence: `kubectl -n overture-prod get pods` returns nothing; cluster annotation `cnpg.io/hibernation: on`. Scoped route → `null` for `alertname=KubePdbNotEnoughHealthyPods, namespace=overture-prod` only. If overture comes back, delete the route.

### 2. Staging warnings → muted (Alertmanager route)
`namespace=~".+-stage"` + `severity=warning` → `null`. Staging is an ephemeral preview env rebuilt from `master + open PRs` (AGENTS.md); warning-level job failures / crashloops there are expected dev noise, validated via the PR workflow not email. Kills the `immich-stage` `KubeJobFailed` day-nag (`immich-db-init`, `immich-photos-30d-sync`) from the in-flight immich v3 migration rehearsal. **Staging CRITICALs still page.** Prod unaffected.

### 3. `HomelabscopeJobStale` severity split (homelabscope PrometheusRule)
The staleness alert was hardcoded `severity: critical` (4h email repeat) **only because warnings used to be dropped** pre-#1081. #1081 added a `warning→email` route, so staleness can now carry a tier-appropriate severity. Split:
- **prod / data-safety jobs** (photo backups, zfs snapshots, prod syncs) → stay **critical**.
- **staging rehearsal jobs** (`immich-photos-30d-sync`, `adguard-sync-stage`) → **warning** (daily nag, not a 4h page).

Live PromQL confirms the split partitions the fleet correctly and silences **no** prod job.

## Validation
- `promtool check rules` ✅ both PrometheusRules
- `kustomize build infra/configs` and `infra/controllers` ✅
- `amtool check-config` ✅ on the rendered Alertmanager config
- Live Prometheus: critical staleness set fires nothing; warning set = staging only

## Real issue to actually look at (NOT silenced, surfaced)
- **`immich-stage` jobs are genuinely failing** — `immich-db-init` (a `vectorchord`/`earthdistance` extension-owner update) failed 20h ago and the `immich-photos-30d-sync` CronJob's last two runs failed. This is the immich v3 migration rehearsal churning in staging. Muted from *paging* (staging isn't paged) but flagged here: if you consider the v3 migration rehearsal "done", these failing jobs are worth a look; if it's still in flight, this is expected.
- **Low-volume transients left intact** (fired once, self-resolved today, not silenced): `etcdMemberCommunicationSlow` (3×), `UniFiPoESwitchTempHigh`, `NetscopeHighRetransmits`, `TrueNASISCSIScrapeErrors`. Worth a glance if they recur, but not noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet