### PR TITLE
fix(immich-photos-backup): feeder writes to media/photos (canonical), not images/photos

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -12,8 +12,8 @@
 #   1. SSH key at /mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz
 #      (private key, mode 600, owned by root). The matching public key
 #      lives in truenas-backup@10.42.2.11:~/.ssh/authorized_keys.
-#   2. ZFS dataset main/family/images/photos (created by midclt
-#      pool.dataset.create — see README for the exact command).
+#   2. Destination path main/family/media/photos (dataset-vs-dir promotion
+#      tracked in docs/plans/2026-07-13-immich-photos-images-to-media.md).
 #   3. node-exporter textfile collector at /var/lib/node-exporter/textfile
 #      so the Prometheus metric the script writes is scraped.
 #

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -13,15 +13,17 @@
 # docs/plans/2026-07-04-alcatraz-photos-pull.md.
 #
 # Pulls per-user Photos dirs from alcatraz (Synology NAS, 10.42.2.11) into the
-# local ZFS dataset main/family/images/photos. Snapshots are managed by a
-# TrueNAS periodic-snapshot task scheduled after this rsync completes.
+# canonical photo path main/family/media/photos (all media under family/media/;
+# dataset-vs-dir promotion tracked in
+# docs/plans/2026-07-13-immich-photos-images-to-media.md). Snapshots are managed
+# by a TrueNAS periodic-snapshot task scheduled after this rsync completes.
 #
 # Source-path note: on alcatraz, /volume1/family/images/photos/<user> is a
 # symlink into /volume1/homes/<user>/Photos (the real bytes live in each
 # user's home). truenas-backup has share-level read on family/ but per-file
 # ACLs from each user's Synology account deny file open via the family path —
 # so we sync from the homes path directly, mapping into the canonical hestia
-# layout family/images/photos/<user>/.
+# layout family/media/photos/<user>/.
 #
 # Mode-fix note: Synology DSM Photos uploads new files with POSIX mode 0700
 # (owner-only). truenas-backup is in gid=100(users), which matches the file

--- a/images/immich-photos-backup/immich-photos-backup.sh
+++ b/images/immich-photos-backup/immich-photos-backup.sh
@@ -36,7 +36,6 @@
 # stays stale. Loud failure is intentional — silent perm-denied was the
 # original bug.
 #
-DST_BASE="${DST_BASE:-/mnt/main/family/media/photos}"
 # container's busybox crond (see hosts/hestia/immich-photos-backup/).
 #
 # Reports backup freshness to node-exporter's textfile collector at
@@ -47,7 +46,7 @@ DST_BASE="${DST_BASE:-/mnt/main/family/media/photos}"
 set -euo pipefail
 
 USERS=(george mara)
-DST_BASE="/mnt/main/family/images/photos"
+DST_BASE="${DST_BASE:-/mnt/main/family/media/photos}"
 SSH_KEY="/root/.ssh/id_ed25519_alcatraz"
 # Bind-mounted from host so first-run host-key acceptance survives
 # container restarts; see docker-compose.yml.


### PR DESCRIPTION
## Problem
Immich prod stopped showing new photos after **Fri 2026-07-10**. Root cause: the photo feeder (`immich-photos-backup`, hestia cron) has been writing pulled phone photos to `/mnt/main/family/**images**/photos`, while prod Immich's external library reads `/mnt/main/family/**media**/photos`. Every photo since Friday landed in a folder Immich doesn't scan.

The earlier fix `ce1ca7c3 "write to media/photos"` was botched — it inserted the media/photos default into a comment block but left the real `DST_BASE="…/images/photos"` assignment intact below it, which won.

## Fix
Single env-overridable `DST_BASE` defaulting to the canonical `/mnt/main/family/media/photos` (all media under `family/media/` per the assimilation plan). Removes the stray override.

## Deploy / backfill
- CI rebuilds `ghcr.io/gjcourt/immich-photos-backup`; bump the digest in `hosts/hestia/immich-photos-backup/docker-compose.yml` and redeploy on hestia.
- One corrected run backfills everything since Friday (additive pull from alcatraz), then trigger the Immich library scan.

## Follow-up (separate PR)
Full `images → media` consolidation: staging PVs, alcatraz-pull `rrsync` root, hestia dataset/snapshots, docs — so nothing else still points at `family/images/photos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)