### PR TITLE
chore(immich-photos-backup): bump image to 2026-07-13 (baked media/photos fix)

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-07-10@sha256:fd518899ac049ce1ba2c978eeba9bfc3ee64399895be5873aaa12732f600249e
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-07-13@sha256:2f75a11ce7e13a22c638c07433b1923df6630d5180461a2895885ebaff25da90
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Bumps the pinned digest to the CI-built `2026-07-13` image (from #1108's fix on master), so the hestia auto-deploy runs the corrected feeder that writes to canonical `media/photos`. The old `2026-07-10` image has the DST_BASE bug; a redeploy just clobbered the live hot-patch with it, so this closes the loop durably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)