### PR TITLE
fix(cronjobs): auto-clean finished jobs to stop persistent KubeJobFailed noise

### DIFF
--- a/apps/base/adguard/cronjob-sync.yaml
+++ b/apps/base/adguard/cronjob-sync.yaml
@@ -10,9 +10,12 @@ spec:
   schedule: "0 */6 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # Auto-delete finished jobs after 1h so a stray failure doesn't linger as a
+      # persistent KubeJobFailed alert.
+      ttlSecondsAfterFinished: 3600
       activeDeadlineSeconds: 120
       backoffLimit: 1
       template:

--- a/infra/controllers/pingo/cronjob.yaml
+++ b/infra/controllers/pingo/cronjob.yaml
@@ -10,6 +10,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # Auto-delete finished jobs after 1h so a stray failure doesn't linger as a
+      # persistent KubeJobFailed alert (a 21h-old failed job spammed email 2026-07).
+      ttlSecondsAfterFinished: 3600
       template:
         metadata:
           labels:

--- a/infra/controllers/renovate-automerge/cronjob.yaml
+++ b/infra/controllers/renovate-automerge/cronjob.yaml
@@ -9,6 +9,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # Auto-delete finished jobs after 1h so a stray failure doesn't linger as a
+      # persistent KubeJobFailed alert.
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:

--- a/infra/controllers/renovate/cronjob.yaml
+++ b/infra/controllers/renovate/cronjob.yaml
@@ -8,6 +8,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # Auto-delete finished jobs after 1h so a stray failure doesn't linger as a
+      # persistent KubeJobFailed alert.
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:


### PR DESCRIPTION
## Problem
Email flood analysis traced part of the `KubeJobFailed` noise to **orphaned failed job objects**: a `pingo` job that failed once sat around for **21h**, keeping `KubeJobFailed` firing (and re-emailing on the 24h repeat) until it was manually deleted. Default retention keeps the last failed job indefinitely; a healthy every-5-min cron never evicts it.

## Fix (real fix, not a mute)
- `ttlSecondsAfterFinished: 3600` on the recurring cronjobs (`pingo`, `adguard-sync`) — a stray failure auto-deletes within an hour, so `KubeJobFailed` clears itself instead of sticking.
- `adguard` `failedJobsHistoryLimit: 3 → 1` (was retaining up to 3 stale failed jobs).

## Scope / not here
- Staging churn (`HomelabscopeJobStale`, `immich-photos-30d-sync`) is fixed at the source by the photos `images→media` migration, not muted.
- The `homelabscope-heartbeat` deploy-hestia failure emails are handled by the `hb-alert-fix` branch.

## Validation
`kustomize build` passes: `infra/controllers`, `apps/production/adguard`, `apps/staging/adguard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)