### PR TITLE
fix(immich-stage): repoint 30d-sync source to canonical media/photos

### DIFF
--- a/apps/staging/immich/nfs-photos.yaml
+++ b/apps/staging/immich/nfs-photos.yaml
@@ -78,7 +78,11 @@ spec:
   storageClassName: ""
   nfs:
     server: 10.42.2.10
-    path: /mnt/main/family/images/photos
+    # Canonical photo library (george:users, full tree). The old
+    # family/images/photos path broke the 30d-sync when that dataset was created
+    # root-owned 2026-07-11; media/photos is what prod Immich reads. See
+    # docs/plans/2026-07-13-immich-photos-images-to-media.md.
+    path: /mnt/main/family/media/photos
     readOnly: true
   mountOptions:
     - nfsvers=3


### PR DESCRIPTION
## Problem
The staging `immich-photos-30d-sync` has failed daily since ~2026-07-11, generating `KubeJobFailed` + `HomelabscopeJobStale` email noise. Root cause: it reads its source from `immich-photos-src-pv-staging` → `/mnt/main/family/**images**/photos`, which broke when that dataset was created root-owned on 07-11. It ran clean on 07-10 before that.

## Fix
Repoint the source PV to the canonical `/mnt/main/family/**media**/photos` — the full, `george:users`-owned library that prod Immich already reads without issue. Part of the `images→media` consolidation ([plan](../blob/master/docs/plans/2026-07-13-immich-photos-images-to-media.md)).

## Apply note (nfs.path is immutable)
Needs a coordinated PV+PVC recreate under suspended Flux:
```
flux suspend kustomization apps-staging -n flux-system
kubectl delete pvc immich-photos-src-pvc -n immich-stage
kubectl delete pv immich-photos-src-pv-staging
flux resume kustomization apps-staging -n flux-system   # recreates from manifest
```
`ReadOnlyMany` + `Retain`, source is untouched → no data risk. Then a 30d-sync run should Complete and the alerts clear.

## Validation
`kustomize build apps/staging/immich` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)