### PR TITLE
fix(deploy-hestia): strip x-* compose extensions before app.update

### DIFF
--- a/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
+++ b/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
@@ -22,7 +22,7 @@
 x-deploy:
   name: homelabscope-heartbeat
   archived: false
-  archived-at: 2026-07-04
+  archived-at: "2026-07-04"
   archived-reason: ""
 
 services:

--- a/scripts/truenas-update-app.sh
+++ b/scripts/truenas-update-app.sh
@@ -176,6 +176,14 @@ async def main() -> None:
         # TrueNAS app.update expects custom_compose_config as a parsed dict
         # (not a YAML string).  Pydantic validation rejects raw strings.
         compose_dict = yaml.safe_load(new_yaml)
+        # Drop compose extension keys (x-*). They're deploy-tooling metadata
+        # (e.g. x-deploy), not part of the app's runtime compose, and can hold
+        # non-JSON-serializable scalars — an unquoted YAML date in
+        # x-deploy.archived-at parses to datetime.date and breaks json.dumps in
+        # the app.update call.
+        compose_dict = {
+            k: v for k, v in compose_dict.items() if not str(k).startswith("x-")
+        }
         log(f"calling app.update for '{APP_NAME}'")
         update = await call(
             ws,


### PR DESCRIPTION
## Problem
With `homelabscope-heartbeat` now created on TrueNAS, `deploy-hestia` gets past "app not found" to `app.update` — but fails:
```
TypeError: Object of type date is not JSON serializable
```
Its `x-deploy.archived-at: 2026-07-04` is an unquoted YAML date → parsed to `datetime.date` → breaks `json.dumps` of the compose sent to `app.update`.

## Fix
Strip `x-*` compose extension keys before `app.update` — they're deploy-tooling metadata (`x-deploy`), not part of the app's runtime compose, and shouldn't be pushed to TrueNAS at all. Prevents this for any app, not just heartbeat. Also quote `archived-at` as belt-and-suspenders.

## Result
Last piece of the deploy-hestia failure-email fix: with this + the app created, the `homelabscope-heartbeat` apply job goes green and the daily failure emails stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)