### PR TITLE
fix(snapcast): allow in-cluster HASS to reach the control port (1705)

### DIFF
--- a/apps/base/snapcast/networkpolicy.yaml
+++ b/apps/base/snapcast/networkpolicy.yaml
@@ -37,6 +37,19 @@ spec:
             # (cast.burntbytes.com) or the LB IP directly.
             - port: "6680"
               protocol: TCP
+    # HASS Snapcast integration runs in-cluster; its pod identity isn't a
+    # world/host/ingress entity, so the rule above never matches it. Allow the
+    # homeassistant namespaces to reach the control port (1705) so each snapclient
+    # surfaces as a media_player with a volume slider.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: homeassistant-prod
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: homeassistant-stage
+      toPorts:
+        - ports:
+            - port: "1705"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Problem
Adding the HASS Snapcast integration fails — HASS can't connect to the snapserver on `1705` (verified: connect from the HASS pod to `snapcast.snapcast-prod:1705` **times out**).

Root cause: the snapcast `CiliumNetworkPolicy` allows `1704/1705/1780` only from `fromEntities: [host, remote-node, ingress, world]` (LAN snapclients + Snapweb). HASS runs **in-cluster**, so its pod identity isn't any of those entities → Cilium default-denies.

## Fix
Add an ingress rule allowing the `homeassistant-prod` / `homeassistant-stage` namespaces to reach the control port `1705`. Each snapclient (including `snap-test`) then surfaces in HASS as a `media_player` with a volume slider.

## Validation
`kustomize build apps/{production,staging}/snapcast` passes.

## After merge
Flux reconciles the policy → the HASS Snapcast integration (host `snapcast.snapcast-prod.svc.cluster.local`, port `1705`) connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)