### PR TITLE
fix(homeassistant): allow egress to LAN device integrations (snapcast 1705 + ESPHome 6053)

### DIFF
--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -69,3 +69,13 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
+    # Snapcast server control port — the HASS Snapcast integration polls each
+    # snapclient as a media_player (volume) over the JSON-RPC control port.
+    - toEndpoints:
+        - matchLabels:
+            app: snapcast
+            k8s:io.kubernetes.pod.namespace: snapcast-prod
+      toPorts:
+        - ports:
+            - port: "1705"
+              protocol: TCP

--- a/apps/base/homeassistant/networkpolicy.yaml
+++ b/apps/base/homeassistant/networkpolicy.yaml
@@ -79,3 +79,14 @@ spec:
         - ports:
             - port: "1705"
               protocol: TCP
+    # ESPHome native API on the IoT VLAN (10.42.7.0/24) — IR blaster, presence
+    # sensors, etc. Discovery is inbound mDNS, so devices appear; but the "Add"
+    # flow (and steady-state control) needs HASS to reach the device on 6053.
+    # LAN hosts are classified as world by Cilium, so — like the Lutron bridge —
+    # a CIDR rule is required (the world rule above only opens 443/80).
+    - toCIDR:
+        - 10.42.7.0/24
+      toPorts:
+        - ports:
+            - port: "6053"
+              protocol: TCP


### PR DESCRIPTION
HASS's egress CiliumNetworkPolicy only allowed DNS / web / Lutron / mosquitto. That's why **discovered** LAN integrations show up (mDNS is inbound) but **can't be added** — the Add flow's outbound connection to the device is denied.

Adds egress for:
- **Snapcast** control port `1705` (in-cluster snapserver) → the Snapcast integration surfaces each snapclient as a media_player + volume slider.
- **ESPHome** native API `6053` on the `10.42.7.0/24` IoT VLAN → the IR blaster + presence sensors can be added/controlled.

Companion to #1114 (snapcast ingress). `kustomize build apps/{production,staging}/homeassistant` passes.