### PR TITLE
feat(dietpi-audio): reproducible Snapcast + Spotify Connect audio-node bundle

### DIFF
--- a/hosts/dietpi-audio/Automation_Custom_Script.sh
+++ b/hosts/dietpi-audio/Automation_Custom_Script.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# =============================================================================
+# DietPi Automation_Custom_Script — provision a Snapcast + Spotify Connect
+# audio node.
+#
+# Drop this on the DietPi boot partition as /boot/Automation_Custom_Script.sh
+# (see README). It runs once at the end of first-boot setup, as root.
+#
+# Result (matches the validated snap-test node):
+#   * snapclient joins the Snapcast group, output through a shared ALSA dmix.
+#   * go-librespot advertises this box as a Spotify Connect target (same DAC).
+#   * A wrapper auto-detects whatever USB DAC is plugged in (robust to swaps);
+#     a udev rule restarts both services the instant a DAC is added/removed.
+#   * Device name = the box's hostname (set it per-node in dietpi.txt).
+#
+# Idempotent — safe to re-run (e.g. `bash Automation_Custom_Script.sh`).
+# =============================================================================
+set -euo pipefail
+
+# ---- config (edit per site) -------------------------------------------------
+SNAPSERVER_HOST="${SNAPSERVER_HOST:-10.42.2.37}"   # snapcast LB VIP
+GLR_VERSION="${GLR_VERSION:-v0.7.4}"               # go-librespot release
+ZEROCONF_PORT="${ZEROCONF_PORT:-4070}"             # pinned (cross-VLAN friendly)
+NODE_NAME="$(hostname)"                            # Spotify/Snapcast device name
+
+log() { echo "[dietpi-audio] $*"; }
+
+# ---- 1. snapclient (DietPi software id 192) ---------------------------------
+if ! command -v snapclient >/dev/null 2>&1; then
+  log "installing Snapcast Client (dietpi-software 192)"
+  /boot/dietpi/dietpi-software install 192
+fi
+
+# ---- 2. go-librespot (arch-matched release binary) --------------------------
+if ! command -v go-librespot >/dev/null 2>&1; then
+  case "$(dpkg --print-architecture)" in
+    arm64) A=arm64 ;; armhf) A=armv6 ;; amd64) A=amd64 ;; *) A="$(dpkg --print-architecture)" ;;
+  esac
+  log "installing go-librespot ${GLR_VERSION} (${A})"
+  curl -fsSL "https://github.com/devgianlu/go-librespot/releases/download/${GLR_VERSION}/go-librespot_linux_${A}.tar.gz" -o /tmp/glr.tgz
+  tar -xzf /tmp/glr.tgz -C /tmp
+  install -m 755 /tmp/go-librespot /usr/local/bin/go-librespot
+fi
+
+# ---- 3. shared dmix so snapclient + go-librespot both reach the USB DAC ------
+# hw:0 = the USB DAC (the only sound card on a headless audio node). If onboard
+# audio ever appears, revisit (dmix would need to follow the USB card index).
+cat > /etc/asound.conf <<'EOF'
+pcm.!default { type plug; slave.pcm "dmixer" }
+pcm.dmixer {
+  type dmix
+  ipc_key 2048
+  ipc_perm 0666
+  slave { pcm "hw:0,0"; rate 48000; channels 2; period_size 1024; buffer_size 8192 }
+}
+ctl.!default { type hw; card 0 }
+EOF
+
+# ---- 4. snapclient: auto-detect wrapper + robust systemd override ------------
+cat > /usr/local/bin/snapclient-autodev <<EOF
+#!/bin/bash
+# Wait for a USB DAC, then run snapclient through the shared dmix 'default'
+# device so it coexists with go-librespot. systemd retries until a DAC appears.
+HOST="\${SNAPSERVER_HOST:-${SNAPSERVER_HOST}}"
+card=\$(awk '/USB/ && \$1 ~ /^[0-9]+\$/ {print \$1; exit}' /proc/asound/cards)
+[ -z "\$card" ] && { echo "snapclient-autodev: no USB audio card yet"; exit 1; }
+exec /usr/bin/snapclient --logsink=system --host "\$HOST" -s default --mixer software
+EOF
+chmod 755 /usr/local/bin/snapclient-autodev
+
+mkdir -p /etc/systemd/system/snapclient.service.d
+cat > /etc/systemd/system/snapclient.service.d/override.conf <<'EOF'
+[Unit]
+# retry indefinitely while no DAC is present (default burst limit gives up)
+StartLimitIntervalSec=0
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/snapclient-autodev
+Restart=always
+RestartSec=5
+EOF
+
+# ---- 5. go-librespot: config + service --------------------------------------
+mkdir -p /root/.config/go-librespot
+cat > /root/.config/go-librespot/config.yml <<EOF
+device_name: ${NODE_NAME}
+device_type: speaker
+audio_backend: alsa
+audio_device: default
+bitrate: 320
+zeroconf_enabled: true
+zeroconf_port: ${ZEROCONF_PORT}
+zeroconf_backend: builtin
+EOF
+
+cat > /etc/systemd/system/go-librespot.service <<'EOF'
+[Unit]
+Description=go-librespot (Spotify Connect)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+[Service]
+Environment=HOME=/root
+ExecStart=/usr/local/bin/go-librespot --config_dir /root/.config/go-librespot
+Restart=always
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---- 6. udev: restart BOTH on DAC plug/unplug -------------------------------
+cat > /etc/udev/rules.d/99-audio-node.rules <<'EOF'
+ACTION=="add",    SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/bin/systemctl --no-block restart snapclient go-librespot"
+ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card*", RUN+="/bin/systemctl --no-block restart snapclient go-librespot"
+EOF
+
+# ---- 7. enable + (re)start --------------------------------------------------
+systemctl daemon-reload
+udevadm control --reload-rules || true
+systemctl enable --now go-librespot
+systemctl enable snapclient
+systemctl restart snapclient || true
+
+log "done — node '${NODE_NAME}': snapclient=$(systemctl is-active snapclient) go-librespot=$(systemctl is-active go-librespot)"
+log "plug a USB DAC in and both bind automatically (dmix-shared)."

--- a/hosts/dietpi-audio/README.md
+++ b/hosts/dietpi-audio/README.md
@@ -1,0 +1,61 @@
+# dietpi-audio — reproducible Snapcast + Spotify Connect audio node
+
+Provisions a Raspberry Pi (DietPi) into a house audio endpoint identical to the
+validated **snap-test** node:
+
+- **snapclient** joins the Snapcast multi-room group (server `10.42.2.37`).
+- **go-librespot** advertises the box as a **Spotify Connect** target (point-to-point).
+- Both share one USB DAC via an ALSA **dmix** — no exclusive-access fight.
+- A wrapper **auto-detects whatever USB DAC is plugged in** (robust to swaps); a
+  udev rule restarts both services the instant a DAC is added/removed.
+
+This is the "convert all audio nodes to one setup" bundle — the design record is
+[lab `01-016`](https://github.com/gjcourt/lab/blob/main/01-audio-midi/01-016-diy-digital-domain-streamer.md).
+
+## Provision a node
+
+1. **Flash DietPi** to the SD/USB.
+2. On the boot partition, edit **`dietpi.txt`**:
+   - `AUTO_SETUP_NET_HOSTNAME=<room>` — this becomes the Snapcast **and** Spotify
+     device name (e.g. `kitchen`, `living-room`). One unique name per node.
+   - WiFi: `AUTO_SETUP_NET_WIFI_ENABLED=1` + SSID/key in `dietpi-wifi.txt`
+     (put the node on the IoT VLAN, same as the others).
+   - `AUTO_SETUP_INSTALL_SOFTWARE_ID=192` — Snapcast Client (the script also
+     installs it if missing).
+3. Copy **`Automation_Custom_Script.sh`** to the boot partition root as
+   `/boot/Automation_Custom_Script.sh`.
+4. **Boot.** DietPi installs snapclient, then runs the script: go-librespot, the
+   dmix `asound.conf`, the auto-detect wrapper + systemd overrides, and the udev
+   rule. When you plug a USB DAC in, both services bind automatically.
+
+## What it installs
+
+| Path | Purpose |
+|---|---|
+| `/usr/local/bin/go-librespot` | Spotify Connect daemon (release `v0.7.4`) |
+| `/root/.config/go-librespot/config.yml` | device name = hostname, output via dmix, zeroconf on `4070` |
+| `/etc/systemd/system/go-librespot.service` | runs it, `Restart=always` |
+| `/etc/asound.conf` | shared dmix (`default` → `hw:0`) |
+| `/usr/local/bin/snapclient-autodev` | waits for a USB DAC, runs snapclient via dmix |
+| `snapclient.service.d/override.conf` | uses the wrapper, retries indefinitely |
+| `/etc/udev/rules.d/99-audio-node.rules` | restart both on DAC add/remove |
+
+## Knobs (env vars at the top of the script)
+
+- `SNAPSERVER_HOST` (default `10.42.2.37`) · `GLR_VERSION` (`v0.7.4`) ·
+  `ZEROCONF_PORT` (`4070`).
+
+## Notes
+
+- **DAC assumption:** the USB DAC is ALSA card `0` (the only sound card on a
+  headless node). If you enable onboard/HDMI audio, the dmix slave (`hw:0`) needs
+  to follow the USB card index instead.
+- **Software volume** (`--mixer software`) is deliberate — it survives DAC swaps
+  (no dependence on the DAC exposing a hardware mixer). HASS controls it via the
+  native Snapcast integration (server control port `1705`).
+- **Spotify Connect across VLANs:** nodes sit on the IoT VLAN. If a node doesn't
+  appear in the Spotify app (phone on another VLAN), that's mDNS not crossing
+  VLANs — the port is pinned (`4070`) so it's allowable, but you'd need an mDNS
+  reflector + firewall allow between the phone's VLAN and the node's.
+
+Validated 2026-07-13 on `snap-test` (ADAM Audio D3V DAC).


### PR DESCRIPTION
## Summary
A DietPi first-boot bundle (`hosts/dietpi-audio/`) to provision any Pi into a house audio endpoint **identical to the validated snap-test node**, so all audio nodes can be converted to one setup:

- **snapclient** (Snapcast multi-room) + **go-librespot** (Spotify Connect point-to-point) sharing one USB DAC via ALSA **dmix**.
- **Auto-detect wrapper** binds whatever USB DAC is plugged in (robust to swaps); **udev** restarts both services on DAC add/remove.
- Device name = the box's **hostname** (set per-node in `dietpi.txt`).

## Contents
- `Automation_Custom_Script.sh` — idempotent first-boot provisioner (installs snapclient via DietPi id 192 + go-librespot v0.7.4, writes dmix `asound.conf`, the wrapper + systemd overrides, go-librespot config/service, udev rule).
- `README.md` — provisioning steps, what it installs, knobs, the DAC/dmix + cross-VLAN mDNS notes.

Validated live on `snap-test` (both paths playing simultaneously through an ADAM Audio D3V). Design record: lab `01-016`.

`bash -n` clean; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)