### PR TITLE
chore(immich-stage): move 30d photo slice to family/media/photos-staging-30d

### DIFF
--- a/apps/staging/immich/cronjob-photos-30d.yaml
+++ b/apps/staging/immich/cronjob-photos-30d.yaml
@@ -1,7 +1,7 @@
 # Maintains the last-30-days slice of the prod photo tree for the Immich staging
 # testbed. Immich's external library indexes EVERY file under its mounted path and has
 # no built-in date window, so we bound the set at the filesystem: this CronJob keeps
-# /mnt/main/family/images/photos-staging-30d equal to "files modified in the last 30
+# /mnt/main/family/media/photos-staging-30d equal to "files modified in the last 30
 # days" from the full tree, and prunes anything older so the slice stays small.
 #
 # APPROACH — rsync-style COPY, not symlinks, not hardlinks:

--- a/apps/staging/immich/nfs-photos.yaml
+++ b/apps/staging/immich/nfs-photos.yaml
@@ -2,7 +2,7 @@
 #
 # Two volumes back the "last-30-days" staging testbed:
 #   * immich-photos-pv-staging / immich-photos-pvc → the 30-day SLICE
-#     (/mnt/main/family/images/photos-staging-30d). This is BOTH what Immich indexes
+#     (/mnt/main/family/media/photos-staging-30d). This is BOTH what Immich indexes
 #     as its external library (mounted at /mnt/photos in immich-server) AND the RW
 #     destination the sync CronJob writes into. Bounded by design → keeps staging small.
 #   * immich-photos-src-pv-staging / immich-photos-src-pvc → the FULL prod photo tree,
@@ -10,10 +10,16 @@
 #     compute the 30-day slice; the RO mount means the real photos can't be harmed.
 #
 # Repointed 2026-07 from Synology (10.42.2.11 /volume1/...) to hestia
-# (10.42.2.10 /mnt/main/family/images/...) — hestia is the photo SOT since 2026-06-01
+# (10.42.2.10 /mnt/main/family/...) — hestia is the photo SOT since 2026-06-01
 # (see apps/production/immich/nfs-photos.yaml and docs/plans/2026-06-01-hestia-photos-sot.md).
 #
-# OPERATOR PREREQ: the photos-staging-30d directory must exist on hestia and be
+# Moved 2026-07-13 from family/images/photos-staging-30d → family/media/photos-staging-30d
+# as part of retiring the legacy family/images tree (all media now lives under
+# family/media/). The slice is its own ZFS dataset (main/family/photos-staging-30d,
+# 20G quota) mounted at /mnt/main/family/media/photos-staging-30d — quota keeps the
+# staging testbed fixed-size. See docs/plans/2026-07-13-immich-photos-images-to-media.md.
+#
+# OPERATOR PREREQ: the photos-staging-30d dataset must exist on hestia and be
 # writable by the CronJob's NFS identity. See docs/operations/apps/immich.md §10.
 apiVersion: v1
 kind: PersistentVolume
@@ -31,7 +37,7 @@ spec:
   storageClassName: ""
   nfs:
     server: 10.42.2.10
-    path: /mnt/main/family/images/photos-staging-30d
+    path: /mnt/main/family/media/photos-staging-30d
     readOnly: false
   mountOptions:
     - nfsvers=3


### PR DESCRIPTION
## Summary
Retires the legacy `family/images` tree by moving the immich-staging **30-day photo slice** off it. The staging slice PV (`immich-photos-pv-staging`) now points at `/mnt/main/family/media/photos-staging-30d` — its own ZFS dataset with a **20G quota** (keeps the staging testbed fixed-size) — instead of `family/images/photos-staging-30d`.

This unblocks destroying the `main/family/images` dataset (438G of redundant *shadowed* photos, provably a subset of `media/photos`, + the emptied slice) to reclaim ~446G.

## Already done on hestia (non-destructive)
- Created dataset `main/family/photos-staging-30d`, mounted `/mnt/main/family/media/photos-staging-30d`, quota 20G.
- rsync-migrated the slice: **1631/1631 files, 0 unique-to-source** (byte-parity verified).
- Old `images/photos-staging-30d` left intact until cutover.

## Coordinated cutover required (PV `nfs.path` is immutable → recreate)
This is **not** a hot Flux apply. Operator sequence:
1. `flux suspend kustomization apps-staging -n flux-system`
2. Scale `immich-server` + `immich-microservices` (immich-stage) to 0 (release the NFS mount).
3. Repoint the TrueNAS NFS export (share id=7) from `images/photos-staging-30d` → `media/photos-staging-30d`.
4. `kubectl -n immich-stage delete pvc immich-photos-pvc` + `kubectl delete pv immich-photos-pv-staging`.
5. Merge this PR; `flux resume` + reconcile → recreates PV/PVC at the new path, scales pods back.
6. Verify staging pods mount `media/photos-staging-30d` and immich-stage is healthy.
7. `zfs destroy -r main/family/images` (irreversible — gated on a fresh safety snapshot).

## Test plan
- [x] `kustomize build apps/staging/immich` passes
- [ ] staging pods remount the new path, immich-stage healthy
- [ ] old export gone, `family/images` destroyed, ~446G reclaimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet