### PR TITLE
fix(immich): reorder photo-backup rsync before the library scan + document the pipeline

### DIFF
--- a/docs/operations/apps/immich.md
+++ b/docs/operations/apps/immich.md
@@ -18,6 +18,102 @@ Immich is deployed as a set of microservices in the `immich-prod` (and `immich-s
 ### Hardware Acceleration
 Both the `immich-server` and `immich-machine-learning` pods mount `/dev/dri` from the host node to utilize the AMD GPU for hardware-accelerated video transcoding (VAAPI) and machine learning inference (ROCm).
 
+## 2a. Photo ingest pipeline (phone → Immich)
+
+**How a phone photo reaches Immich, end to end.** Immich does **not** receive uploads from the
+phone directly — the phone uploads to Synology Photos on **alcatraz**, and Immich indexes the
+files after they are pulled to **hestia** and a scheduled **external-library scan** runs.
+
+```
+ iPhone (Synology Photos app, auto-backup)
+   │  upload
+   ▼
+ alcatraz (Synology, 10.42.2.11)      /volume1/homes/<user>/Photos/YYYY/MM/…
+   │  nightly rsync PULL  (immich-photos-backup container ON hestia; additive, no --delete)
+   ▼
+ hestia (TrueNAS, 10.42.2.10)         /mnt/main/family/media/photos/<user>/YYYY/MM/…   ← SOT
+   │  NFS export (nfsvers=3)  →  immich-photos-pv-prod  →  mounted read-only at /mnt/photos
+   ▼
+ Immich external library "New External Library" (id beff0dc3-801a-4a07-b2c9-55d8a7e3a77b)
+   importPaths = {/mnt/photos/george, /mnt/photos/mara}
+   │  Immich indexes files on its scheduled EXTERNAL-LIBRARY SCAN (not on file arrival)
+   ▼
+ Photo appears in the Immich UI (photos.burntbytes.com)
+```
+
+Users pulled: **george, mara** (`USERS=(george mara)` in the backup script).
+The `family/images/photos` path is **retired** — everything is under `family/media/photos`
+since the 2026-07-13 images→media migration (feeder #1108). The NFS PV path was repointed to
+`media/photos` metadata-safely (same `<user>/<year>/<month>` substructure, so Immich matched all
+141k assets — no re-import).
+
+### Timing (this is the usual "my photos aren't in Immich yet" cause)
+
+Two independent nightly jobs, in **different** timezones:
+
+| Job | Where | Schedule | UTC |
+|-----|-------|----------|-----|
+| alcatraz→hestia rsync | `immich-photos-backup` container on hestia (TZ America/New_York) | `0 4 * * *` (04:00 ET) → **fixed to `0 1 * * *`** | 08:00 → **05:00** |
+| Immich external-library scan | immich-server (TZ America/Los_Angeles) | nightly 00:00 PT (Immich default) | **07:00** |
+| CNPG DB → S3 backup | in-cluster | 02:00 ET | 06:00 |
+
+**Root cause of the lag (fixed 2026-07-14):** the rsync used to run at 08:00 UTC — *one hour
+after* the 07:00 UTC scan. So each night the scan ingested the *previous* night's pull, then the
+rsync landed the new files, which then waited for the *next* night's scan → a photo took **~24 h+**
+to appear. Moving the rsync to 01:00 ET (05:00 UTC) puts it before both the CNPG backup and the
+scan, so the same night's scan ingests it. (Staging's 30-day sync already runs at 03:00 for the
+same reason — see §10.3.) Note a photo can still take up to ~a day to appear because pull+scan are
+once-nightly; for lower latency see "Faster ingest" below.
+
+### Verify each hop
+
+```sh
+# 1. on alcatraz — newest phone upload (run from the backup container, which holds the SSH key)
+ssh truenas_admin@10.42.2.10 'sudo docker exec immich-photos-backup sh -c \
+  "ssh -i /root/.ssh/id_ed25519_alcatraz truenas-backup@10.42.2.11 \
+   \"find /volume1/homes/george/Photos -type f -newermt today -printf %T+\ %p\\n | sort -r | head\""'
+
+# 2. on hestia — did it get pulled? + when did the rsync last succeed?
+ssh truenas_admin@10.42.2.10 'find /mnt/main/family/media/photos/george -type f -printf "%T+ %p\n" | sort -r | head
+  cat /var/lib/node-exporter/textfile/immich-backup.prom | grep last_success   # epoch of last OK run
+  sudo tail -5 /var/log/immich-photos-backup.log'                              # inside the container
+
+# 3. in Immich — is it indexed? + when did the library last scan?
+PG=pod/immich-db-prod-cnpg-v3-5
+kubectl exec -n immich-prod $PG -c postgres -- psql -d immich -tAc \
+  "SELECT name, \"refreshedAt\" FROM library;"                                 # last scan time
+kubectl exec -n immich-prod $PG -c postgres -- psql -d immich -tAc \
+  "SELECT \"originalPath\" FROM asset WHERE \"originalPath\" LIKE '%/george/2026/07/%' \
+   ORDER BY \"originalPath\" DESC LIMIT 5;"                                     # newest indexed
+```
+
+Immich v3 uses **singular** table names (`asset`, `library`); connect as the `postgres` OS user
+(`kubectl exec … -c postgres -- psql -d immich`) — the `immich` role is peer-auth only.
+
+### Force an immediate scan (photos already on hestia, waiting for the nightly scan)
+
+- **UI:** Administration → Libraries → *New External Library* → **⋯ → Scan**. Takes a few minutes.
+- **API:** `POST https://photos.burntbytes.com/api/libraries/beff0dc3-801a-4a07-b2c9-55d8a7e3a77b/scan`
+  with header `x-api-key: <admin API key>` (create one under Account Settings → API Keys).
+
+### Faster ingest (optional future work)
+
+The ~daily latency is inherent to once-nightly pull+scan. To cut it: (a) run the rsync more often
+(e.g. hourly) and (b) have the backup script **trigger the library scan via the API on successful
+rsync** (the robust, timezone-independent fix — it makes photos appear minutes after they land).
+That needs an admin API key mounted into the backup container + a reachable
+`photos.burntbytes.com/api`.
+
+### Where it can break (checklist)
+
+- **rsync FAILED** (metric `homelabscope_job_last_status{job="immich-photos-backup"}=1`): usually
+  the alcatraz NOPASSWD sudoers entry (needed for the source-side `chmod` that clears DSM's 0700
+  upload mode) or SSH host-key. See `hosts/hestia/immich-photos-backup/README.md`. Alert:
+  `ImmichPhotoBackupStale`.
+- **Files on hestia but not in Immich**: the scan hasn't run since they landed → force a scan.
+- **Wrong path**: photos must be under `family/media/photos/<user>/…` (NOT the retired
+  `family/images/…`); the NFS PV `nfs.path` must be `/mnt/main/family/media/photos`.
+
 ## 3. URLs
 - **Staging**: https://photos.stage.burntbytes.com
 - **Production**: https://photos.burntbytes.com

--- a/docs/operations/apps/immich.md
+++ b/docs/operations/apps/immich.md
@@ -53,17 +53,28 @@ Two independent nightly jobs, in **different** timezones:
 
 | Job | Where | Schedule | UTC |
 |-----|-------|----------|-----|
-| alcatraz→hestia rsync | `immich-photos-backup` container on hestia (TZ America/New_York) | `0 4 * * *` (04:00 ET) → **fixed to `0 1 * * *`** | 08:00 → **05:00** |
+| alcatraz→hestia rsync | `immich-photos-backup` container on hestia (TZ America/New_York) | `0 4 * * *` (04:00 ET) → **changed to `0 1 * * *`** | 08:00 → **05:00** |
 | Immich external-library scan | immich-server (TZ America/Los_Angeles) | nightly 00:00 PT (Immich default) | **07:00** |
 | CNPG DB → S3 backup | in-cluster | 02:00 ET | 06:00 |
 
-**Root cause of the lag (fixed 2026-07-14):** the rsync used to run at 08:00 UTC — *one hour
-after* the 07:00 UTC scan. So each night the scan ingested the *previous* night's pull, then the
-rsync landed the new files, which then waited for the *next* night's scan → a photo took **~24 h+**
-to appear. Moving the rsync to 01:00 ET (05:00 UTC) puts it before both the CNPG backup and the
-scan, so the same night's scan ingests it. (Staging's 30-day sync already runs at 03:00 for the
-same reason — see §10.3.) Note a photo can still take up to ~a day to appear because pull+scan are
-once-nightly; for lower latency see "Faster ingest" below.
+(UTC values are for EDT/PDT; in standard time each shifts +1 h. The *ordering* — rsync before
+scan — is DST-safe: ET and PT keep a constant 3 h offset, so 01:00 ET stays ~2 h before 00:00 PT
+year-round.)
+
+**Root cause of the lag:** the rsync used to run at 08:00 UTC — *one hour after* the 07:00 UTC
+scan. So each night the scan ingested the *previous* night's pull, then the rsync landed the new
+files, which then waited for the *next* night's scan → a photo took **~24 h+** to appear. Moving
+the rsync to 01:00 ET (05:00 UTC) puts it before both the CNPG backup and the scan, so the same
+night's scan ingests it. (Staging's 30-day sync already runs at 03:00 for the same reason — see
+§10.3.) Note a photo can still take up to ~a day to appear because pull+scan are once-nightly; for
+lower latency see "Faster ingest" below.
+
+> ⚠️ **Not live until redeployed.** The cron lives in `images/immich-photos-backup/crontab`, baked
+> into the image. The change takes effect only after (1) CI rebuilds the image on merge and (2) the
+> digest in `hosts/hestia/immich-photos-backup/docker-compose.yml` is bumped + the container
+> recreated (`deploy-hestia`). **Until then the running container still fires at 04:00 ET (08:00
+> UTC)** and the lag persists. Verify post-deploy: `sudo docker exec immich-photos-backup crontab -l`
+> should show `0 1 * * *`.
 
 ### Verify each hop
 
@@ -75,8 +86,8 @@ ssh truenas_admin@10.42.2.10 'sudo docker exec immich-photos-backup sh -c \
 
 # 2. on hestia — did it get pulled? + when did the rsync last succeed?
 ssh truenas_admin@10.42.2.10 'find /mnt/main/family/media/photos/george -type f -printf "%T+ %p\n" | sort -r | head
-  cat /var/lib/node-exporter/textfile/immich-backup.prom | grep last_success   # epoch of last OK run
-  sudo tail -5 /var/log/immich-photos-backup.log'                              # inside the container
+  cat /var/lib/node-exporter/textfile/immich-backup.prom | grep last_success       # epoch of last OK run
+  sudo docker logs --tail 15 immich-photos-backup'   # the log lives INSIDE the container (not on the host)
 
 # 3. in Immich — is it indexed? + when did the library last scan?
 PG=pod/immich-db-prod-cnpg-v3-5
@@ -251,12 +262,12 @@ The CronJob (busybox, daily at 03:00) does: (1) `find /src -type f -mtime -30` �
 
 1. Create the slice directory on the `main` pool:
    ```bash
-   sudo mkdir -p /mnt/main/family/images/photos-staging-30d
+   sudo mkdir -p /mnt/main/family/media/photos-staging-30d
    ```
-   It sits beside `photos/` under the existing `/mnt/main` NFS export, so **no new export is required** — confirm it is reachable at `10.42.2.10:/mnt/main/family/images/photos-staging-30d`.
+   It sits beside `photos/` under the existing `/mnt/main` NFS export, so **no new export is required** — confirm it is reachable at `10.42.2.10:/mnt/main/family/media/photos-staging-30d`.
 2. Make it **writable by the CronJob's NFS identity.** The job runs as UID 0; if the export root-squashes, `chown` the dir to the mapped identity or open it up (derived data, low sensitivity):
    ```bash
-   sudo chmod 0777 /mnt/main/family/images/photos-staging-30d   # simplest for a testbed
+   sudo chmod 0777 /mnt/main/family/media/photos-staging-30d   # simplest for a testbed
    ```
    Validate after the first run: `kubectl -n immich-stage create job --from=cronjob/immich-photos-30d-sync 30d-manual && kubectl -n immich-stage logs -f job/30d-manual` — expect a non-empty `du -sh` line and no `Permission denied`.
 

--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -1,6 +1,6 @@
 # immich-photos-backup
 
-Daily incremental **pull** of the Immich photo library from alcatraz (Synology, 10.42.2.11) into hestia's `main/family/images/photos`. Additive — brings phone uploads into hestia (the source of truth); no `--delete`, so direct-to-hestia SD-card imports are never wiped. Always-running container; busybox `crond` fires at 04:00 local.
+Daily incremental **pull** of the Immich photo library from alcatraz (Synology, 10.42.2.11) into hestia's `main/family/media/photos`. Additive — brings phone uploads into hestia (the source of truth); no `--delete`, so direct-to-hestia SD-card imports are never wiped. Always-running container; busybox `crond` fires at 01:00 local.
 
 The reverse leg — hestia→alcatraz, so alcatraz stays a full backup and DSM Photos picks up SD-card imports — is **not** a push from this container. It runs **from alcatraz** as a DSM Task Scheduler pull job: [`hosts/alcatraz/immich-photos-pull/`](../../alcatraz/immich-photos-pull/README.md). See ["Synology inbound-rsync limitation"](#synology-inbound-rsync-limitation) below for why a hestia-side push-back was retired.
 
@@ -19,9 +19,9 @@ No sudoers rule squares this. The fix is to reverse the direction: alcatraz **pu
 | Attribute | Value |
 |---|---|
 | Image | `ghcr.io/gjcourt/immich-photos-backup` (built from `images/immich-photos-backup/`) |
-| Schedule | `0 4 * * *` (after CNPG S3 backups at 02:00) |
+| Schedule | `0 1 * * *` (01:00 ET / 05:00 UTC — before the 07:00 UTC Immich scan; CNPG S3 backup follows at 02:00 ET) |
 | Sources | `truenas-backup@10.42.2.11:/volume1/homes/{george,mara}/Photos/` |
-| Destinations | `/mnt/main/family/images/photos/{george,mara}/` (ZFS, lz4, recordsize=1M, atime=off) |
+| Destinations | `/mnt/main/family/media/photos/{george,mara}/` (ZFS, lz4, recordsize=1M, atime=off) |
 | SSH key | `/mnt/main/apps/immich-photos-backup/ssh/id_ed25519_alcatraz` (mode 600, root) |
 | Metric | `immich_photos_backup_last_success_seconds` via node-exporter textfile collector |
 | Alert | `ImmichPhotoBackupStale` (fires after >36h) |
@@ -31,9 +31,9 @@ No sudoers rule squares this. The fix is to reverse the direction: alcatraz **pu
 Run on hestia as root (TrueNAS Web UI → System Settings → Shell).
 
 ### 1. ZFS datasets + snapshot tasks
-The destination dataset is `main/family/images/photos` (renamed from `main/backups/immich-photos` in the 2026-06-01 hestia-SOT migration — see `docs/plans/2026-06-01-hestia-photos-sot.md`). Snapshot tasks (daily/14, weekly/8, monthly/12) run on the `main/family` parent. To verify:
+The destination dataset is `main/family/media/photos` (renamed from `main/backups/immich-photos` in the 2026-06-01 hestia-SOT migration — see `docs/plans/2026-06-01-hestia-photos-sot.md`). Snapshot tasks (daily/14, weekly/8, monthly/12) run on the `main/family` parent. To verify:
 ```bash
-midclt call pool.dataset.query '[["id", "=", "main/family/images/photos"]]' \
+midclt call pool.dataset.query '[["id", "=", "main/family/media/photos"]]' \
   | jq '.[0] | {compression: .compression.value, recordsize: .recordsize.value, atime: .atime.value, mountpoint}'
 midclt call pool.snapshottask.query '[["dataset", "=", "main/family"]]' \
   | jq '.[] | {lifetime_value, lifetime_unit, schedule: .schedule | "\(.hour):\(.minute) dow=\(.dow) dom=\(.dom)"}'
@@ -100,7 +100,7 @@ Should print `/usr/bin/sudo` (or `/bin/sudo`) and `/bin/chmod`. If `chmod` resol
 Notes:
 - Commas inside the command args must be escaped (`g+rX\,o+rX`); unescaped commas separate multiple commands in sudoers.
 - Adding a third user (e.g. `kid1`) requires extending this file with another comma-separated command — same pattern.
-- DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 04:00 cron will fail loudly: `sudo -n` exits immediately, `&&` short-circuits, rsync exits with code `12` (protocol data stream error). Re-add the file post-upgrade.
+- DSM major-version upgrades may stomp on `/etc/sudoers.d/` entries. If a future DSM upgrade silently re-disables this, the next 01:00 cron will fail loudly: `sudo -n` exits immediately, `&&` short-circuits, rsync exits with code `12` (protocol data stream error). Re-add the file post-upgrade.
 - If a future DSM update sets `Defaults requiretty` in `/etc/sudoers`, NOPASSWD alone won't be enough — sudo will reject all non-tty invocations including this one. Confirm `sudo -l` from a non-interactive ssh continues to work after any DSM upgrade.
 
 Verify after install:
@@ -120,18 +120,18 @@ If not already running, node-exporter on hestia must be invoked with `--collecto
 - Paste the contents of `docker-compose.yml` from this directory
 - Install. Wait for state=RUNNING.
 
-### 6. Kick the first run manually (don't wait for 04:00)
+### 6. Kick the first run manually (don't wait for 01:00)
 ```bash
 docker exec -it ix-immich-photos-backup-immich-photos-backup-1 \
   /usr/local/bin/immich-photos-backup.sh
 ```
-First run pulls ~425 GB over gigabit (~30-60 min). Detach-safe via `docker logs -f` in another shell. On success the textfile metric is written and the container goes back to waiting for the next 04:00.
+First run pulls ~425 GB over gigabit (~30-60 min). Detach-safe via `docker logs -f` in another shell. On success the textfile metric is written and the container goes back to waiting for the next 01:00.
 
 ## Subsequent updates
 
 Every change to `images/immich-photos-backup/**` on `master` triggers `.github/workflows/build-immich-photos-backup.yml` → publishes `ghcr.io/gjcourt/immich-photos-backup:YYYY-MM-DD` (with `:latest` mirror). Bump the digest in `docker-compose.yml` in a follow-up PR; `.github/workflows/deploy-hestia.yml` then auto-applies via `truenas-update-app.sh`.
 
-The sudoers entry in section 3a is a **prerequisite** for any image whose script invokes `sudo -n /bin/chmod` (currently: all images since 2026-06-09). If the entry was wiped by a DSM upgrade and the script is updated in the meantime, the next 04:00 cron will fail until the entry is restored — verify before each digest bump if alcatraz had recent firmware updates.
+The sudoers entry in section 3a is a **prerequisite** for any image whose script invokes `sudo -n /bin/chmod` (currently: all images since 2026-06-09). If the entry was wiped by a DSM upgrade and the script is updated in the meantime, the next 01:00 cron will fail until the entry is restored — verify before each digest bump if alcatraz had recent firmware updates.
 
 To roll back: revert the digest in `docker-compose.yml` and merge; auto-deploy applies the prior image.
 

--- a/hosts/hestia/immich-photos-backup/README.md
+++ b/hosts/hestia/immich-photos-backup/README.md
@@ -4,7 +4,7 @@ Daily incremental **pull** of the Immich photo library from alcatraz (Synology, 
 
 The reverse leg — hestia→alcatraz, so alcatraz stays a full backup and DSM Photos picks up SD-card imports — is **not** a push from this container. It runs **from alcatraz** as a DSM Task Scheduler pull job: [`hosts/alcatraz/immich-photos-pull/`](../../alcatraz/immich-photos-pull/README.md). See ["Synology inbound-rsync limitation"](#synology-inbound-rsync-limitation) below for why a hestia-side push-back was retired.
 
-Sources are per-user `homes/<user>/Photos/` paths, not `family/images/photos/<user>/`. On the Synology side those family paths are symlinks into each user's home, with per-file ACLs that deny `truenas-backup` file open via the family path — so we sync from the homes path directly and re-map into the canonical hestia `family/images/photos/<user>/` layout.
+Sources are per-user `homes/<user>/Photos/` paths, not `family/images/photos/<user>/`. On the Synology side those family paths are symlinks into each user's home, with per-file ACLs that deny `truenas-backup` file open via the family path — so we sync from the homes path directly and re-map into the canonical hestia `family/media/photos/<user>/` layout.
 
 ### Synology inbound-rsync limitation
 

--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -3,7 +3,7 @@
 # (Renamed from main/backups/immich-photos in the 2026-06-01 hestia-SOT plan
 #  — see docs/plans/2026-06-01-hestia-photos-sot.md.)
 #
-# Always-running container; busybox crond fires the script at 04:00 local
+# Always-running container; busybox crond fires the script at 01:00 local
 # (TZ honored via the image's tzdata + the TZ env var below). Snapshots
 # are managed by a TrueNAS periodic-snapshot task on the dataset, not by
 # this stack.
@@ -27,7 +27,7 @@ services:
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:
-      # Cron's "0 4 * * *" entry only means "04:00 local" if crond reads TZ;
+      # Cron's "0 1 * * *" entry only means "01:00 local" if crond reads TZ;
       # alpine's tzdata package + this env var is what makes that work.
       - TZ=America/New_York
     volumes:

--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -1,5 +1,5 @@
-# Daily rsync of /volume1/family/images/photos on alcatraz (Synology DSM,
-# 10.42.2.11) into the local ZFS dataset main/family/media/photos.
+# Daily rsync of alcatraz phone uploads — /volume1/homes/<user>/Photos (Synology
+# DSM, 10.42.2.11) — into the local ZFS dataset main/family/media/photos.
 # (Renamed from main/backups/immich-photos in the 2026-06-01 hestia-SOT plan
 #  — see docs/plans/2026-06-01-hestia-photos-sot.md.)
 #

--- a/images/immich-photos-backup/Dockerfile
+++ b/images/immich-photos-backup/Dockerfile
@@ -1,7 +1,9 @@
 # Daily rsync of the immich photo library from alcatraz → hestia.
 #
 # Always-running container; busybox crond fires immich-photos-backup.sh
-# at 04:00 local time (after CNPG S3 backups complete at 02:00). The
+# at 01:00 ET (05:00 UTC) — before the CNPG S3 backup (02:00 ET) and, crucially,
+# before the Immich external-library scan (00:00 PT / 07:00 UTC), so same-night
+# photos are indexed that night, not a day later. See docs .../apps/immich.md §2a. The
 # script tees output to stdout (captured by `docker logs`) and writes
 # Prometheus textfile metrics on success.
 #
@@ -15,7 +17,7 @@ FROM alpine:3.23
 #   - openssh-client — for `ssh -i ${SSH_KEY} ...`
 #   - bash           — the script uses bash-isms (process substitution `>(tee ...)`)
 #   - tzdata         — so cron honors TZ env var; otherwise crond runs in UTC
-#                      and the "04:00" entry would fire at 20:00 ET
+#                      and the "01:00" entry would fire at 20:00 ET
 RUN apk add --no-cache \
         rsync \
         openssh-client \

--- a/images/immich-photos-backup/crontab
+++ b/images/immich-photos-backup/crontab
@@ -1,4 +1,7 @@
 # Daily immich photo library rsync from alcatraz → hestia.
-# 04:00 local time (TZ env var honored via tzdata in the image).
-# Runs ~30-60 min for the current ~425 GB library over gigabit.
-0 4 * * * /usr/local/bin/immich-photos-backup.sh
+# 01:00 ET (05:00 UTC) — MUST finish before the Immich external-library scan at
+# 00:00 PT (07:00 UTC), or freshly-pulled photos wait a full extra day for the
+# next night's scan. TZ (America/New_York) honored via tzdata in the image.
+# Sequencing: 01:00 rsync (~30-60 min) → 02:00 ET CNPG S3 backup → 03:00 ET
+# (07:00 UTC) Immich scan. See docs/operations/apps/immich.md §2a.
+0 1 * * * /usr/local/bin/immich-photos-backup.sh


### PR DESCRIPTION
## Problem
Two things: (1) the phone→Immich photo sync path was **undocumented** (context rebuilt from scratch each time), and (2) new phone photos took **~24h+** to show up in Immich.

## Root cause of the lag
- **alcatraz→hestia rsync** (`immich-photos-backup` container, TZ ET): `0 4 * * *` = 04:00 ET = **08:00 UTC**.
- **Immich external-library scan** (immich-server, TZ PT): nightly 00:00 PT = **07:00 UTC**.

The scan ran **one hour before** the rsync, so every night the scan ingested the *previous* pull, then the rsync landed new files that waited for the *next* night's scan. Confirmed live: newest indexed = `IMG_6274`; hestia had through `IMG_6279`, alcatraz had `IMG_6280`, all pending the next scan. Nothing lost — pure ordering.

## Fix
Move the rsync to `0 1 * * *` (01:00 ET / **05:00 UTC**) — before the CNPG S3 backup (02:00 ET) and before the scan (07:00 UTC). Same ordering staging's 30-day sync already uses (§10.3).

## Changes
- `docs/operations/apps/immich.md` §2a — full pipeline (hosts, paths, timing, per-hop verify commands, force-scan, where-it-breaks checklist).
- `images/immich-photos-backup/crontab` — `0 4` → `0 1` (+ Dockerfile/compose/README comments).
- Backup README: stale `family/images/photos` → `family/media/photos`.

## Deploy (post-merge)
The `images/**` change triggers a new image build in CI. Then bump the digest in `hosts/hestia/immich-photos-backup/docker-compose.yml` and recreate the container on hestia.

## Immediate relief (unrelated to merge)
George's pending photos will auto-appear at the next 07:00 UTC scan, or force now: Immich UI → Administration → Libraries → *New External Library* → Scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)