### PR TITLE
deploy(immich-photos-backup): bump to 2026-07-14 (activate 01:00 ET rsync)

### DIFF
--- a/hosts/hestia/immich-photos-backup/docker-compose.yml
+++ b/hosts/hestia/immich-photos-backup/docker-compose.yml
@@ -23,7 +23,7 @@
 
 services:
   immich-photos-backup:
-    image: ghcr.io/gjcourt/immich-photos-backup:2026-07-13@sha256:2f75a11ce7e13a22c638c07433b1923df6630d5180461a2895885ebaff25da90
+    image: ghcr.io/gjcourt/immich-photos-backup:2026-07-14@sha256:bd49f1ffab049f538b752fd5b585e7929eed13a7ed143a3168a01d348940f3aa
     container_name: immich-photos-backup
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Activates the schedule fix from #1121. The new image bakes crontab `0 1 * * *` (01:00 ET / 05:00 UTC) so the alcatraz→hestia photo pull runs **before** Immich's 07:00 UTC external-library scan (was 04:00 ET / 08:00 UTC, an hour after → ~24h ingest lag).

- Image `2026-07-13@sha256:2f75a11c…` → `2026-07-14@sha256:bd49f1ff…` (strictly increasing).
- Built from master by `build-immich-photos-backup` run after #1121 merged.
- On merge, `deploy-hestia` recreates the container.

**Verify post-deploy:** `sudo docker exec immich-photos-backup crontab -l` → `0 1 * * *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)