### PR TITLE
feat(modemscope): deploy the DOCSIS cable-modem exporter

### DIFF
--- a/apps/base/modemscope/deployment.yaml
+++ b/apps/base/modemscope/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: modemscope
+  namespace: modemscope
+  labels:
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/component: exporter
+spec:
+  # Single replica on purpose. Two would double the poll rate against the
+  # modem's small embedded GoAhead server for no redundancy benefit — if this
+  # pod is down the only loss is modem telemetry, and Prometheus already
+  # alerts on that via ModemscopeExporterDown.
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: modemscope
+      app.kubernetes.io/component: exporter
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: modemscope
+        app.kubernetes.io/component: exporter
+    spec:
+      serviceAccountName: modemscope
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          image: "ghcr.io/gjcourt/modemscope:ea9d82a@sha256:758696f601ec5cd1e60590719ed4f5ff41bba4a179aad4bdfb0740d1d6da3c76"
+          imagePullPolicy: IfNotPresent
+          env:
+            # The DOCSIS modem's management address. Reachable from the pod
+            # network via the UCGF; endpoints are unauthenticated, so no secret.
+            - name: MODEMSCOPE_MODEM_URL
+              value: "https://192.168.100.1"
+            - name: MODEMSCOPE_LISTEN_ADDR
+              value: ":9104"
+            # Total modem-I/O budget per scrape. Must stay below the
+            # ServiceMonitor's scrapeTimeout (10s) or a slow modem times the
+            # scrape out before modemscope_up=0 can be delivered.
+            - name: MODEMSCOPE_TIMEOUT
+              value: "8s"
+          ports:
+            - name: metrics
+              containerPort: 9104
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          readinessProbe:
+            # /healthz reports that the exporter is running, deliberately NOT
+            # whether the modem is reachable. This modem reboots often, and
+            # that is the very thing being measured: if readiness tracked modem
+            # health, the pod would go unready on every reboot, Prometheus would
+            # stop scraping, and modemscope_up=0 — the signal we care most about
+            # — would never be recorded. An unreachable modem is a metric, not
+            # an unready pod.
+            httpGet:
+              path: /healthz
+              port: 9104
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # No livenessProbe: it would share /healthz with readiness and so
+          # carry no distinct signal. The exporter has no persistent connection
+          # to wedge — each scrape is an independent HTTP fetch — so there is no
+          # failure mode a restart fixes that readiness doesn't already surface.
+          # (Matches the thermalscope/mqttscope rationale.)
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/apps/base/modemscope/kustomization.yaml
+++ b/apps/base/modemscope/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - servicemonitor.yaml
+  - prometheus-rule.yaml
+  - networkpolicy.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: modemscope
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/modemscope/namespace.yaml
+++ b/apps/base/modemscope/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: modemscope
+  labels:
+    app: modemscope
+    # Like mqttscope, this is a plain in-cluster Deployment with no host
+    # access — it reads the cable modem's HTTP status endpoints over the
+    # network and runs unprivileged, non-root, read-only-rootfs. The
+    # restricted PSA level is fully satisfiable, so enforce it.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/modemscope/networkpolicy.yaml
+++ b/apps/base/modemscope/networkpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: modemscope
+  namespace: modemscope
+  labels:
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    DOCSIS cable-modem health exporter. Ingress: Prometheus scrape on 9104 +
+    host/remote-node for kubectl port-forward. Egress: DNS + the cable modem's
+    management address (192.168.100.1) on 443.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: modemscope
+  ingress:
+    # kubectl port-forward arrives via the kubelet/API path = host + remote-node.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9104"
+              protocol: TCP
+    # Prometheus scrape.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9104"
+              protocol: TCP
+  egress:
+    # DNS.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # The cable modem's management interface, off-cluster on the DOCSIS
+    # management subnet and routed via the UCGF. Scoped to /32 rather than the
+    # whole /24: only the modem itself is ever polled, and this subnet is
+    # otherwise not ours.
+    - toCIDR:
+        - 192.168.100.1/32
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/base/modemscope/prometheus-rule.yaml
+++ b/apps/base/modemscope/prometheus-rule.yaml
@@ -1,0 +1,175 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: modemscope-alerts
+  namespace: modemscope
+  labels:
+    # kube-prometheus-stack's Prometheus discovers PrometheusRules by this
+    # label (ruleSelector). Same pattern as the netscope/mqttscope rules.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/component: exporter
+spec:
+  groups:
+    # -------------------------------------------------------------------------
+    # Exporter + modem reachability
+    # -------------------------------------------------------------------------
+    - name: modemscope-exporter
+      rules:
+        - alert: ModemscopeExporterDown
+          expr: up{job="modemscope"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "modemscope exporter is unreachable"
+            description: >
+              Prometheus has been unable to scrape the modemscope exporter for
+              5+ minutes. The pod is down or its /metrics endpoint is failing.
+              Check: kubectl -n modemscope get pods -l app.kubernetes.io/name=modemscope
+
+        # Complements the per-target alert above: fires if the metric name
+        # disappears cluster-wide (exporter gone or SM no longer discovered).
+        - alert: ModemscopeMetricsAbsent
+          expr: absent(modemscope_up)
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "modemscope metrics absent"
+            description: >
+              No `modemscope_up` series has been observed for 10+ minutes. The
+              exporter Deployment is down or the ServiceMonitor is no longer
+              discovering it. Check: kubectl -n modemscope get servicemonitor,pods
+
+        # The exporter is up and being scraped, but cannot read the modem —
+        # the modem is unreachable or mid-reboot. Distinct from scrape health.
+        - alert: ModemUnreachable
+          expr: modemscope_up == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cannot read the cable modem's status endpoints"
+            description: >
+              modemscope has been unable to read https://192.168.100.1 for 5+
+              minutes (modemscope_up=0). The modem is unreachable, wedged, or
+              stuck rebooting. Sustained beyond a few minutes this is an outage,
+              not a reboot.
+
+    # -------------------------------------------------------------------------
+    # DOCSIS line health — what modemscope exists to detect.
+    # -------------------------------------------------------------------------
+    - name: modemscope-docsis
+      rules:
+        # THE headline alert. Every error counter the modem exposes resets on
+        # reboot, so a silently rebooting modem looks *healthier* the more it
+        # reboots — counters keep returning to zero. Uptime going backwards is
+        # the only signal that catches it. A healthy cable modem's uptime is
+        # measured in weeks; more than two reboots in an hour is pathological.
+        - alert: ModemRebooting
+          expr: resets(modemscope_uptime_seconds[1h]) > 2
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cable modem has rebooted {{ $value }} times in the last hour"
+            description: >
+              The modem's uptime went backwards {{ $value }} times in an hour.
+              A healthy modem does not reboot at all. Each reboot drops the WAN
+              for 30-60s and wipes every DOCSIS error counter. Suspect the modem
+              itself (overheating, failing hardware) or a plant fault forcing
+              re-registration. This graph is the evidence to hand the ISP.
+
+        - alert: ModemRebootedRecently
+          expr: resets(modemscope_uptime_seconds[24h]) > 0
+          for: 10m
+          labels:
+            severity: info
+          annotations:
+            summary: "Cable modem rebooted in the last 24h"
+            description: >
+              The modem's uptime went backwards {{ $value }} time(s) in 24h.
+              Informational — one reboot may be an ISP config push. Recurrences
+              are what matter; see ModemRebooting.
+
+        # Uncorrectables are unrecoverable data: FEC could not repair the
+        # codeword, so it is lost and TCP must retransmit. This is what is
+        # actually felt as latency spikes and stalls. Correcteds are NOT
+        # alerted on: they are repaired and lossless, and a busy line always
+        # has some.
+        #
+        # Both carriers are summed on purpose. On DOCSIS 3.1 the OFDM carrier
+        # does most of the work, so watching only the QAM channels can report a
+        # clean line while the carrier that matters is losing data.
+        - alert: ModemUncorrectableErrors
+          expr: |
+            sum(rate(modemscope_downstream_uncorrectables_total[15m]))
+              + sum(rate(modemscope_downstream_ofdm_uncorrectables_total[15m])) > 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cable line is losing data ({{ $value | humanize }} uncorrectable codewords/sec)"
+            description: >
+              Sustained uncorrectable codewords for 15+ minutes — unrecoverable
+              data, felt as packet loss and latency spikes. Note this fires on a
+              *rate*, not a total: a burst of uncorrectables around each modem
+              reboot is expected re-lock noise, whereas a sustained rate between
+              reboots means the plant is genuinely degraded. Check SNR/power and
+              cross-reference ModemRebooting.
+
+        # The DOCSIS 3.1 carrier dropping lock is a major capacity loss and an
+        # ISP-side/plant signal, not a LAN one.
+        - alert: ModemOFDMUnlocked
+          expr: max(modemscope_downstream_ofdm_locked) == 0
+          for: 10m
+          labels:
+            severity: warning
+
+          annotations:
+            summary: "No DOCSIS 3.1 OFDM receiver is locked"
+            description: >
+              Every OFDM receiver has lost lock for 10+ minutes, so the modem is
+              running on legacy QAM channels only — a large bandwidth loss. This
+              is a plant/ISP-side condition.
+
+        # The modem re-running its registration state machine means it dropped
+        # off the CMTS and is re-joining — an ISP/line event, never a LAN one.
+        - alert: ModemReregistering
+          expr: min(modemscope_docsis_init_state) == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Modem is not fully registered on the CMTS"
+            description: >
+              A DOCSIS registration stage (ranging/dhcp/registration/bpi) has
+              been unhealthy for 10+ minutes. The modem is struggling to join or
+              stay joined to the CMTS — an ISP-side or line condition.
+
+        - alert: ModemDownstreamSNRLow
+          expr: min(modemscope_downstream_snr_db) < 33
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Downstream SNR is low ({{ $value | humanize }} dB)"
+            description: >
+              A downstream channel has been below 33 dB for 15+ minutes, the
+              point at which 256QAM starts producing uncorrectable errors.
+              Suspect a physical plant fault: loose/corroded connector, a
+              splitter, or water ingress.
+
+        - alert: ModemUpstreamPowerHigh
+          expr: max(modemscope_upstream_power_dbmv) > 51
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Upstream transmit power is high ({{ $value | humanize }} dBmV)"
+            description: >
+              The modem has been transmitting above 51 dBmV for 15+ minutes — it
+              is shouting to be heard, which means excessive loss on the line
+              (long run, too many splitters, or a bad connection). Above ~54 dBmV
+              it will start dropping off the network entirely.

--- a/apps/base/modemscope/service.yaml
+++ b/apps/base/modemscope/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: modemscope
+  namespace: modemscope
+  labels:
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/component: exporter
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/component: exporter
+  ports:
+    - name: metrics
+      port: 9104
+      targetPort: metrics
+      protocol: TCP

--- a/apps/base/modemscope/serviceaccount.yaml
+++ b/apps/base/modemscope/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: modemscope
+  namespace: modemscope

--- a/apps/base/modemscope/servicemonitor.yaml
+++ b/apps/base/modemscope/servicemonitor.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: modemscope
+  namespace: modemscope
+  labels:
+    # kube-prometheus-stack's Prometheus selects ServiceMonitors by the
+    # helm-default release label (serviceMonitorSelectorNilUsesHelmValues=true).
+    # Without this label the SM is invisible to it.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: modemscope
+    app.kubernetes.io/component: exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: modemscope
+      app.kubernetes.io/component: exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      # Must stay above the exporter's MODEMSCOPE_TIMEOUT (8s): if Prometheus
+      # gives up first, a slow-but-alive modem never gets to report
+      # modemscope_up=0 — the signal is lost exactly when it matters.
+      scrapeTimeout: 10s
+      # Force job="modemscope" so the PrometheusRule alerts (which match on
+      # job="modemscope") align with the scraped series — the operator
+      # otherwise auto-derives "modemscope/modemscope".
+      relabelings:
+        - targetLabel: job
+          replacement: modemscope

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - linkding
   - mealie
   - memos
+  - modemscope
   - mqttscope
   - navidrome
   - openwebui

--- a/apps/production/modemscope/kustomization.yaml
+++ b/apps/production/modemscope/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: modemscope
+resources:
+  - ../../base/modemscope/
+labels:
+  - includeSelectors: false
+    pairs:
+      env: production
+      app.kubernetes.io/instance: production


### PR DESCRIPTION
## Summary

Deploys [`gjcourt/modemscope`](https://github.com/gjcourt/modemscope) — the homelab's **first WAN-side visibility**. Nothing has ever watched the uplink.

The motivation is concrete, not speculative. The Hitron CODA-56 was caught **rebooting 4 times in 62 minutes** at irregular intervals (13 / 16 / 32 min), which lines up with two days of unexplained QoS problems. That's the failure mode nothing else can see:

> Every DOCSIS error counter the modem exposes **resets on reboot** — so a silently rebooting modem looks *healthier* the more it reboots. Ping recovers, the speed test passes, and the outage leaves no evidence. `resets(modemscope_uptime_seconds)` is the only signal that catches it.

## What lands

| | |
|---|---|
| **Deployment** | single replica on **:9104** (9101/9102/9103 are taken by netscope / thermalscope / thermalscope-smart + mqttscope) |
| **Security** | restricted PSA, non-root (65532), read-only rootfs, all caps dropped, no SA token |
| **NetworkPolicy** | Cilium egress scoped to **`192.168.100.1/32:443`** — only the modem is ever polled. No secret; the endpoints are unauthenticated |
| **ServiceMonitor** | 30s interval, 10s scrapeTimeout, `job="modemscope"` forced so the rules match |
| **Alerts** | 10 rules, promtool-validated |

## Decisions worth reviewing

- **`readinessProbe` tracks the exporter, not the modem.** Deliberate and load-bearing: this modem reboots constantly and *that is what we're measuring*. If readiness followed modem health, the pod would go unready on every reboot, Prometheus would stop scraping, and `modemscope_up=0` — the signal we care most about — would never be recorded. An unreachable modem is a metric, not an unready pod.
- **`MODEMSCOPE_TIMEOUT=8s` < `scrapeTimeout=10s`.** If Prometheus gives up first, a slow-but-alive modem never gets to report `up=0`.
- **Uncorrectables alert on a *rate*, not a total.** A burst around each reboot is expected re-lock noise; a sustained rate between reboots is real degradation. (Learned the hard way — a since-boot average made a clean line look like it was bleeding 1.5 errors/sec.)
- **Correcteds are deliberately not alerted on** — they're repaired and lossless.
- **QAM *and* OFDM uncorrectables are summed.** On DOCSIS 3.1 the OFDM carrier does most of the work, so watching QAM alone can report a clean line while the carrier that matters bleeds.
- **Single replica on purpose** — two would double the poll rate against the modem's fragile embedded GoAhead server for no redundancy benefit.

## Test plan

- [x] `kustomize build apps/production/modemscope` passes (7 resources)
- [x] `kustomize build apps/production` (whole overlay) passes
- [x] `promtool check rules` — **SUCCESS: 10 rules found**
- [x] `yamllint -c .yamllint` clean
- [x] Image pinned by digest, verified to exist: `ghcr.io/gjcourt/modemscope:ea9d82a@sha256:758696f6…`
- [x] Exporter verified end-to-end against the real CODA-56 (31 DS + 6 US channels + OFDM, ~0.2s scrape); pod→modem reachability confirmed from the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)