### PR TITLE
feat(dietpi-audio): dual-home nodes — enable both wired + WiFi NICs

### DIFF
--- a/hosts/dietpi-audio/Automation_Custom_Script.sh
+++ b/hosts/dietpi-audio/Automation_Custom_Script.sh
@@ -25,6 +25,23 @@ NODE_NAME="$(hostname)"                            # Spotify/Snapcast device nam
 
 log() { echo "[dietpi-audio] $*"; }
 
+# ---- 0. dual-home: bring up BOTH wired + WiFi -------------------------------
+# DietPi configures only the "primary" adapter and comments out the other in
+# /etc/network/interfaces — on a WiFi-provisioned node that leaves eth0 as
+# `#allow-hotplug eth0`, so wired stays dead. Uncomment it (and wlan0 if WiFi is
+# set up) so a node works in any room, cabled or not; the unused NIC just has no
+# carrier and doesn't block boot (allow-hotplug, not auto). Idempotent; the
+# change takes effect on DietPi's end-of-first-run reboot.
+IFACES=/etc/network/interfaces
+if [ -f "$IFACES" ]; then
+  grep -q '^allow-hotplug eth0' "$IFACES" || \
+    { sed -i 's/^#[[:space:]]*allow-hotplug eth0/allow-hotplug eth0/' "$IFACES"; log "enabled eth0 (dual-homed with wlan0)"; }
+  if [ -f /etc/wpa_supplicant/wpa_supplicant.conf ]; then
+    grep -q '^allow-hotplug wlan0' "$IFACES" || \
+      { sed -i 's/^#[[:space:]]*allow-hotplug wlan0/allow-hotplug wlan0/' "$IFACES"; log "enabled wlan0 (dual-homed with eth0)"; }
+  fi
+fi
+
 # ---- 1. snapclient (DietPi software id 192) ---------------------------------
 if ! command -v snapclient >/dev/null 2>&1; then
   log "installing Snapcast Client (dietpi-software 192)"

--- a/hosts/dietpi-audio/README.md
+++ b/hosts/dietpi-audio/README.md
@@ -24,9 +24,18 @@ This is the "convert all audio nodes to one setup" bundle — the design record 
      installs it if missing).
 3. Copy **`Automation_Custom_Script.sh`** to the boot partition root as
    `/boot/Automation_Custom_Script.sh`.
-4. **Boot.** DietPi installs snapclient, then runs the script: go-librespot, the
-   dmix `asound.conf`, the auto-detect wrapper + systemd overrides, and the udev
+4. **Boot.** DietPi installs snapclient, then runs the script: it dual-homes the
+   node (both NICs — see below), then sets up go-librespot, the dmix
+   `asound.conf`, the auto-detect wrapper + systemd overrides, and the udev
    rule. When you plug a USB DAC in, both services bind automatically.
+
+**Networking — dual-homed by default.** DietPi only configures its "primary"
+adapter and comments out the other, so a WiFi-provisioned node comes up
+WiFi-only (`#allow-hotplug eth0`). Step 0 of the script uncomments the disabled
+NIC so **both wired and WiFi come up** — a node then works in any room whether or
+not there's an ethernet drop; the unused NIC just sits with no carrier. So you
+can hand a node WiFi creds and still drop it on wired later with no changes. (It
+takes effect on DietPi's end-of-first-run reboot.)
 
 ## What it installs
 


### PR DESCRIPTION
## Summary
Make DietPi audio nodes **dual-homed by default** — both wired and WiFi come up, so a node works in any room whether or not there's an ethernet drop.

**Why:** DietPi only configures its "primary" network adapter and comments out the other in `/etc/network/interfaces`. A WiFi-provisioned node comes up WiFi-only (`#allow-hotplug eth0`), so plugging it into a wired drop does nothing until you hand-edit that node — exactly what just had to be done on the `office` node.

**Change:** `Automation_Custom_Script.sh` gains a step 0 that idempotently uncomments the disabled NIC (`eth0` always; `wlan0` too when WiFi is set up). The unused NIC just sits with no carrier and doesn't block boot (`allow-hotplug`, not `auto`). Takes effect on DietPi's end-of-first-run reboot.

## Test plan
- [x] `bash -n` on the script — OK
- [x] Verified live on the `office` node: uncommenting `allow-hotplug eth0` is exactly what enabled wired there; eth0 with no cable stays down harmlessly, WiFi unaffected
- [ ] Next flashed node (already-cached image) comes up with both NICs after first-run reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)