### PR TITLE
deploy(vibrato): bump image to b6133b6 (UI + scope + ratings + dose-style)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:815d25632689a7afdd53ee9704d7e7e3a8106714
+          image: ghcr.io/gjcourt/vibrato:b6133b6639e29e30efc355e0ff498f0762eb4d7a
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:815d25632689a7afdd53ee9704d7e7e3a8106714
+          image: ghcr.io/gjcourt/vibrato:b6133b6639e29e30efc355e0ff498f0762eb4d7a
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Brings `vibrato.stage/.burntbytes.com` up to current vibrato `main`. Was pinned at `815d256` (pre-tabbed-UI single panel); bumps staging + production overlays to `b6133b6639e29e30efc355e0ff498f0762eb4d7a`.

Includes: full tabbed UI (#3), tests + oscilloscope scope grid (#4), SQLite persistence + coffee-bean shot ratings & per-profile recall (#6), dose-by-style Brew selector (#7).

Plain image-tag bump — no immutable fields, no PV recreate. Staging preview picks it up on open; verify there, then merge to prod.

## Test plan
- [x] `kubectl kustomize apps/staging/vibrato` + `apps/production/vibrato` validate
- [ ] staging pod rolls to b6133b6, vibrato.stage.burntbytes.com serves the tabbed UI
- [ ] after merge: vibrato.burntbytes.com serves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)