### PR TITLE
deploy(vibrato): bump image to 7fc5ac4 (ito connection self-heal)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:0d42c3fb770ba7de48c5c41b7e3215beb933cd10
+          image: ghcr.io/gjcourt/vibrato:7fc5ac4fc67a4c72255a35af2b0d6fd825d4cd4e
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:0d42c3fb770ba7de48c5c41b7e3215beb933cd10
+          image: ghcr.io/gjcourt/vibrato:7fc5ac4fc67a4c72255a35af2b0d6fd825d4cd4e
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Deploys [vibrato PR #12](https://github.com/gjcourt/vibrato/pull/12) — the ito espresso-controller link now self-heals.

## What changed in the app
- **Root cause fixed:** `ConnectionService` sent the `MCr` rich-mode handshake only in the explicit `connect()`, never on the transport's automatic reconnect — so a dropped link left a "connected" socket that never streamed (blank Monitor while `/healthz` reported `ito:connected`).
- Re-handshake on **every** reconnect + **TCP keepalive** + **inbound-freshness watchdog** (reconnects a `connected`-but-silent socket) + **capped exponential reconnect backoff**.
- 128 tests, 3 clean critique passes.

## Deploy
- Image `ghcr.io/gjcourt/vibrato:7fc5ac4…` (built + verified pushed on merge to main).
- Bumps both staging + production overlays from `0d42c3f` → `7fc5ac4` (plain tag bump, no immutable fields).
- Prod is currently the manually-restarted pod from earlier debugging; this makes recovery automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)