### PR TITLE
fix(vibrato): run staging against the simulator, not the real ito

### DIFF
--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -12,3 +12,10 @@ spec:
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"
+            # Staging runs against the simulator, never the real ito. The ito is a
+            # single physical machine with limited TCP connection slots; a staging
+            # preview sharing it (a) starves prod of the telemetry stream and
+            # (b) could send commands to the real machine (trigger a shot). Prod
+            # owns the ito; staging validates the app stack on canned frames.
+            - name: LEVA_TRANSPORT
+              value: "sim"


### PR DESCRIPTION
## Problem
Staging and production both set `LEVA_HOST=10.42.7.11` — the single physical ito. When the connection self-heal ([vibrato #12](https://github.com/gjcourt/vibrato/pull/12)) deployed to both environments:

1. **Staging starves prod.** The new watchdog + re-handshake makes staging actively re-grab the ito's telemetry stream on a 20s cycle; prod's Monitor went blank (`telemetry:1/12s`) until staging was scaled to 0 (then prod recovered to `telemetry:49/12s`).
2. **Safety.** A staging preview connected to the real espresso machine can *send it commands* (e.g. trigger a shot).

## Fix
Set `LEVA_TRANSPORT=sim` on the staging overlay. Staging validates the full app stack (tabbed UI, WS stream, oscilloscope chart) against the simulator's canned frames and never touches the machine. **Production owns the ito exclusively.**

## Validation
- `kustomize build apps/staging/vibrato` passes; `LEVA_TRANSPORT=sim` present in rendered output.
- Confirmed empirically: prod streams live again once staging is off the ito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)