### PR TITLE
deploy(vibrato): bump image to 43ad0af (UI wss:// mixed-content fix)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:7fc5ac4fc67a4c72255a35af2b0d6fd825d4cd4e
+          image: ghcr.io/gjcourt/vibrato:43ad0afa0d4d6d5d71269d1d3343d13bdc4e55c8
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:7fc5ac4fc67a4c72255a35af2b0d6fd825d4cd4e
+          image: ghcr.io/gjcourt/vibrato:43ad0afa0d4d6d5d71269d1d3343d13bdc4e55c8
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Deploys [vibrato #13](https://github.com/gjcourt/vibrato/pull/13): Monitor WebSocket used hard-coded `ws://`, blocked as mixed content on the https origin — Monitor stuck on connecting/NO SIGNAL while the ito stream was healthy. Now scheme-matched (`wss://` on https). Bumps both overlays 7fc5ac4 → 43ad0af; staging stays on sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)