### PR TITLE
deploy(vibrato): ship #14-16 (menu mirror + MCu settings + mode-switch)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:43ad0afa0d4d6d5d71269d1d3343d13bdc4e55c8
+          image: ghcr.io/gjcourt/vibrato:47fb115af718abfc7722358bf8286a498ba6b818
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:43ad0afa0d4d6d5d71269d1d3343d13bdc4e55c8
+          image: ghcr.io/gjcourt/vibrato:47fb115af718abfc7722358bf8286a498ba6b818
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps vibrato (staging + production) `43ad0af` → `47fb115`, shipping three merged vibrato PRs:

- **#14** faithful on-device menu mirror — fixed the MC virtual-button protocol so the Monitor renders + navigates the real menu.
- **#15** real machine config via the `MCu` setup dump — read-only Settings tree (29 sections / 1714 live values), replacing the fabricated fields.
- **#16** `MC@`/`MCr` display mode-switch — config submenus render in the Monitor; server-side refcount so a Monitor disconnect can't strand the machine in LCD mode.

## Safety / checks
- Strict forward bump: `43ad0af` (#13) is an ancestor of `47fb115` (current vibrato main HEAD).
- `kustomize build` passes for `apps/production/vibrato` and `apps/staging/vibrato`.
- Staging stays on `LEVA_TRANSPORT=sim` (never touches the real ito).
- No plaintext secrets in the diff.
- ghcr image `ghcr.io/gjcourt/vibrato:47fb115…` verified present (tags: sha, 2026-07-18, latest).