### PR TITLE
feat(homepage): add Vibrato to the dashboard

### DIFF
--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -89,6 +89,12 @@
         description: Spaced-repetition flashcards (FSRS)
         # nginx /healthz returns 200 "ok"; root path is a SPA so probe the healthz endpoint.
         siteMonitor: https://flashcards.burntbytes.com/healthz
+    - Vibrato:
+        icon: mdi-coffee-maker
+        href: https://vibrato.burntbytes.com
+        description: Espresso machine monitor & control (ito + leva!)
+        # Root path is a SPA (tabbed UI); /healthz returns {"status":"ok"} in one hop.
+        siteMonitor: https://vibrato.burntbytes.com/healthz
 
 - Infrastructure:
     - Hestia:


### PR DESCRIPTION
Adds the newly-deployed **Vibrato** (espresso machine monitor/control) to the production Homepage under **Tools**.

- `href` → https://vibrato.burntbytes.com
- `siteMonitor` → `/healthz` (root is a SPA; health endpoint gives a clean status dot, same pattern as Ladder/Flashcards)
- icon `mdi-coffee-maker`

`kustomize build apps/production/homepage` passes; the entry renders in the configmap.