### PR TITLE
deploy(vibrato): force-reconnect on LCD mode (#17)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:47fb115af718abfc7722358bf8286a498ba6b818
+          image: ghcr.io/gjcourt/vibrato:4f7f6cd79cb83a57f2f1d242c566e354638f4b06
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:47fb115af718abfc7722358bf8286a498ba6b818
+          image: ghcr.io/gjcourt/vibrato:4f7f6cd79cb83a57f2f1d242c566e354638f4b06
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps vibrato 47fb115 → 4f7f6cd, shipping #17 (force-reconnect entering LCD mode so config submenus render in the Monitor). Forward bump; `kustomize build` passes both overlays; staging stays on sim.