### PR TITLE
deploy(vibrato): bump to ae819da (revert force-reconnect #17)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:6c82a8aaf923116f287ea687d06f54d6ebd1d570
+          image: ghcr.io/gjcourt/vibrato:ae819da1dce230ec7ea08d3fe679eaf1b5be1db6
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:6c82a8aaf923116f287ea687d06f54d6ebd1d570
+          image: ghcr.io/gjcourt/vibrato:ae819da1dce230ec7ea08d3fe679eaf1b5be1db6
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Rolls `vibrato-prod` + `vibrato-stage` from `6c82a8a` (#18) → `ae819da` (vibrato PR #19).

Removes PR #17's force-reconnect on LCD-mode entry. Verified on the bench that config **submenus** don't render over the virtual-display path regardless (sole ito client, machine awake, all fixes deployed — Setup still streams blank frames), and the forced reconnect destabilized the Monitor connection. Keeps #16 (mode-switch) and #18 (MCa wake). Restores the simpler, stable connection.

- Image `ae819da` built + published on vibrato main (CI green).
- Staging stays on the simulator transport (`LEVA_TRANSPORT=sim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)