### PR TITLE
deploy(vibrato): bump image to d64b59e (fix LCD submenu frame truncation, #21)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:ae819da1dce230ec7ea08d3fe679eaf1b5be1db6
+          image: ghcr.io/gjcourt/vibrato:d64b59ec2276c0fb2a01cbf1d9775e991a4fae3d
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:ae819da1dce230ec7ea08d3fe679eaf1b5be1db6
+          image: ghcr.io/gjcourt/vibrato:d64b59ec2276c0fb2a01cbf1d9775e991a4fae3d
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps both vibrato overlays `ae819da` → `d64b59e` (vibrato PR #21).

**What #21 fixes:** the `FrameSplitter` truncated any LCD frame whose content contains a literal `>` (a submenu title/cursor glyph, e.g. `<101>Setup …>`) at the first `>`, yielding `<101>` → four blank rows. That was the entire "config submenus render blank" deep-nav wall — a client-side parser bug, not firmware/mode/ERR:TSTAT (all ruled out on the live bench). The top menu (no early `>`) was unaffected, which is why only submenus blanked.

**Also in the image:** splitter hardening — newline-bounded frame parsing, stray-opener resync, bounded buffer (DoS guard), `reset()` on disconnect — plus a seeded fuzz/property test suite (proven to fail against the old splitter). 168 tests green; verified live on the bench (submenu frames decode to full content).

- Image: `ghcr.io/gjcourt/vibrato:d64b59ec2276c0fb2a01cbf1d9775e991a4fae3d` (built + pushed, CI green)
- Both overlays bumped; staging stays `LEVA_TRANSPORT=sim` (splitter fix is in `@leva/core`, exercised regardless)
- `kustomize build` clean for both overlays

🤖 Generated with [Claude Code](https://claude.com/claude-code)