### PR TITLE
deploy(vibrato): Control surface Phase 2 → prod (2e7a71e, #23)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:d64b59ec2276c0fb2a01cbf1d9775e991a4fae3d
+          image: ghcr.io/gjcourt/vibrato:2e7a71e240650fcea5ddb1221b7e7d829d0c42e8
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:d64b59ec2276c0fb2a01cbf1d9775e991a4fae3d
+          image: ghcr.io/gjcourt/vibrato:2e7a71e240650fcea5ddb1221b7e7d829d0c42e8
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps both vibrato overlays `d64b59e`→`2e7a71e` (vibrato PR #23, Control surface Phase 2).

**What ships:**
- Direct-command Control surface completed: multi-word `MCc` functions (drink variants, `PROFILE 1–4`, `P.PROF ±/OFF`, `NEXT PID`, `TEMP RESET`, `SP USER 1–3`), PID controls (select + gain nudges), and the Profiles "Make Active" wired to real `MCcPROFILE n`.
- **Security:** enforced `MCC_FORBIDDEN` deny-list server-side — the unauthenticated `/api/stream` socket can no longer reach `Restart Wifi`/`PUMP PB` via a hand-crafted frame.
- PID on/off toggles confirm; all tuning/profiles tiles gated to AWAKE (no mid-pull).

**Verification:** multi-word encoding **confirmed on the real firmware** (`MCcTEMP RESET` moved the dumped setpoint 92→90). 194 unit tests, CI green on #23.

- staging stays `LEVA_TRANSPORT=sim` (prod owns the physical ito exclusively).
- Plain image-tag bump, no immutable fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)