### PR TITLE
deploy(vibrato): Monitor amber-OLED redesign → prod (c9a8206, #24)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:2e7a71e240650fcea5ddb1221b7e7d829d0c42e8
+          image: ghcr.io/gjcourt/vibrato:c9a8206a4b7790861634da29d96dad81778de2a5
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:2e7a71e240650fcea5ddb1221b7e7d829d0c42e8
+          image: ghcr.io/gjcourt/vibrato:c9a8206a4b7790861634da29d96dad81778de2a5
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps both vibrato overlays `2e7a71e`→`c9a8206` (vibrato PR #24, Monitor redesign).

**Ships:** the Monitor tab reworked as an amber-OLED display (true-black glass, big-font proportional title with amber sheen, status strip, machine glyphs) + a modern control bar replacing the D-pad — `Back` · `Up/Down` · one **context-aware primary** (`Menu` on the home screen / `Select` in a menu, off the frame's layout byte). Keyboard-native (↑ ↓ ⏎ Esc), shortcuts behind a `?`. UI-only; no core/server change.

- Verified: typecheck + 194 tests + prettier; 1 babysit critique round (keyboard Enter guard, `.stepper` class collision, popover dismiss); headless render matches the design.
- staging stays `LEVA_TRANSPORT=sim` (prod owns the ito). Plain tag bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)