### PR TITLE
deploy(vibrato): bump staging + prod to fb7afab (Phase 1d + polish)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:c9a8206a4b7790861634da29d96dad81778de2a5
+          image: ghcr.io/gjcourt/vibrato:fb7afab9a0c8bf62397c9da5e754b56cc9247328
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:c9a8206a4b7790861634da29d96dad81778de2a5
+          image: ghcr.io/gjcourt/vibrato:fb7afab9a0c8bf62397c9da5e754b56cc9247328
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
## What

Roll vibrato from `c9a8206` (#24 monitor amber-OLED) to main HEAD **`fb7afab`**:
- vibrato **#30** — auto shot detection + variance overlay
- vibrato **#31** — phase-1d polish (mid-pull reconnect resume, auto-save tail trim, Control ±steppers)

Bumps both overlays; staging stays on the **simulator**, prod drives the real **ito**.

## Image
`ghcr.io/gjcourt/vibrato:fb7afab9a0c8bf62397c9da5e754b56cc9247328` — built + pushed by the vibrato `main` CI (image job success). Strictly forward from `c9a8206` (2026-07-19 → 2026-07-21).

## Validation
- `kustomize build apps/staging/vibrato` ✓ · `apps/production/vibrato` ✓
- Built image line resolves to `fb7afab9…` in both
- No plaintext secrets in the diff

## Rollout
Opening this PR rebuilds the `staging` branch (vibrato-stage picks up the new image on sim) for validation; merging to `master` reconciles `apps-production` and rolls the real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDWiDgQkA1bdtTSU14wsCF