### PR TITLE
deploy(vibrato): persist profiles+history (PVC) + roll to 65e55e7

### DIFF
--- a/apps/base/vibrato/deployment.yaml
+++ b/apps/base/vibrato/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 5
+  # RWO data volume on a single replica: recreate the old pod before the new one
+  # so a rollout can't Multi-Attach the iSCSI PVC.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: vibrato
@@ -42,6 +46,8 @@ spec:
               value: "mqtt://mosquitto.mosquitto.svc:1883" # anonymous listener (allow_anonymous true)
             - name: LEVA_NODE_ID
               value: "vibrato" # overlays override per env
+            - name: LEVA_DATA_DIR
+              value: "/data" # persisted profiles + shot history (see pvc.yaml)
           readinessProbe:
             httpGet:
               path: /healthz
@@ -77,6 +83,12 @@ spec:
             # leaves no writable /tmp, so provide one.
             - name: tmp
               mountPath: /tmp
+            # Persistent store for saved profiles + shot history (LEVA_DATA_DIR).
+            - name: data
+              mountPath: /data
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: vibrato-data

--- a/apps/base/vibrato/kustomization.yaml
+++ b/apps/base/vibrato/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - networkpolicy.yaml
   - pdb.yaml
+  - pvc.yaml
   - service.yaml
 labels:
   - includeSelectors: false

--- a/apps/base/vibrato/pvc.yaml
+++ b/apps/base/vibrato/pvc.yaml
@@ -1,0 +1,17 @@
+# Persistent data dir for the app's JSON store (saved profiles + shot history).
+# Without this the store writes to the container's read-only root FS (`./data`)
+# and every write fails silently — profiles/history never persist. Mounted at
+# /data with LEVA_DATA_DIR=/data (see deployment.yaml). RWO + Retain (durable);
+# the deployment uses strategy: Recreate so a rollout doesn't Multi-Attach it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vibrato-data
+  namespace: vibrato
+spec:
+  storageClassName: truenas-iscsi
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:fb7afab9a0c8bf62397c9da5e754b56cc9247328
+          image: ghcr.io/gjcourt/vibrato:65e55e7bd87f11fb028149bb547bf7199201c5a0
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:fb7afab9a0c8bf62397c9da5e754b56cc9247328
+          image: ghcr.io/gjcourt/vibrato:65e55e7bd87f11fb028149bb547bf7199201c5a0
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
## 1. Fix persistence (the real bug)
The app saves profiles + shot history under `LEVA_DATA_DIR` (default `./data`), but `readOnlyRootFilesystem: true` makes that path unwritable — so every write **failed silently** and nothing ever persisted (profiles/history reset on every pod restart). Add durable storage:
- New **1Gi RWO iSCSI PVC** `vibrato-data` (`truenas-iscsi`, Retain), mounted at `/data`, with `LEVA_DATA_DIR=/data`.
- Deployment → `strategy: Recreate` so a single-replica rollout can't Multi-Attach the RWO volume.
- Writable by the pod (uid/fsGroup 65534 → PVC chowned by fsGroup).

## 2. Roll the image
`fb7afab` → **`65e55e7`** (main HEAD): Ember theme + System/Light/Dark toggle + duotone Control icons (#32), brew refresh-recovery (#33), dead-emoji cleanup (#34). Strictly forward.

Staging stays on the **simulator**; prod drives the real **ito**.

## Validation
- `kustomize build apps/staging/vibrato` ✓ · `apps/production/vibrato` ✓
- Built output carries the PVC, `/data` mount, `LEVA_DATA_DIR`, `Recreate`, and the new image
- No plaintext secrets
- Image `65e55e7…` built + pushed by vibrato main CI (image job success)

## Rollout note
First apply provisions the PVC (empty) — profiles/history start fresh, then persist across restarts from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDWiDgQkA1bdtTSU14wsCF