### PR TITLE
fix(vibrato): RollingUpdate maxSurge:0 instead of Recreate

### DIFF
--- a/apps/base/vibrato/deployment.yaml
+++ b/apps/base/vibrato/deployment.yaml
@@ -8,10 +8,15 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 5
-  # RWO data volume on a single replica: recreate the old pod before the new one
-  # so a rollout can't Multi-Attach the iSCSI PVC.
+  # RWO data volume on a single replica: terminate the old pod before starting the
+  # new one so a rollout can't Multi-Attach the iSCSI PVC. maxSurge:0 gives the
+  # Recreate effect while staying type RollingUpdate (Recreate forbids the live,
+  # API-defaulted rollingUpdate block — dry-run rejects it).
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: vibrato


### PR DESCRIPTION
Follow-up to #1159. The `strategy: Recreate` change failed Flux's server-side dry-run:

```
Deployment "vibrato" is invalid: spec.strategy.rollingUpdate: Forbidden:
may not be specified when strategy `type` is 'Recreate'
```

The live Deployment carries an API-defaulted `spec.strategy.rollingUpdate` block; `Recreate` forbids it, so `apps-production` never applied (prod stayed on the old image, no PVC — but healthy).

Fix: keep `type: RollingUpdate` with `maxSurge: 0` / `maxUnavailable: 1` — the old pod terminates before the new one starts, giving the same anti-Multi-Attach guarantee for the RWO `vibrato-data` PVC, without the validation conflict.

Verified with `kubectl apply --server-side --dry-run=server` against the live cluster: the Deployment applies without the strategy error (the only remaining diff is the image field, owned by Flux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDWiDgQkA1bdtTSU14wsCF