### PR TITLE
chore(alerts): de-tune the noisiest Prometheus alerts (~85% email cut)

### DIFF
--- a/apps/base/modemscope/prometheus-rule.yaml
+++ b/apps/base/modemscope/prometheus-rule.yaml
@@ -152,11 +152,18 @@ spec:
         # ModemOFDMMetricsAbsent closes for OFDM. Accepted as low-probability
         # (all 31 channels would have to go NA at once, and
         # modemscope_downstream_channels would read 0) rather than papered over.
+        # De-tuned 2026-07-21: the CODA-56 overheats and sheds uncorrectable
+        # codewords during thermal events (known issue — pending 40mm heatsink +
+        # Noctua fan; see modem-thermal notes). At `> 1 for 15m` this paged
+        # ~38x/week on brief, self-clearing thermal blips. Raised to a sustained
+        # `> 10 for 30m` so only genuine line degradation (well past the known
+        # thermal baseline) pages. RE-TIGHTEN back toward `> 1` once the fan fix
+        # lands and the modem stops overheating.
         - alert: ModemUncorrectableErrors
           expr: |
             (sum(rate(modemscope_downstream_uncorrectables_total[15m])) or vector(0))
-              + (sum(rate(modemscope_downstream_ofdm_uncorrectables_total[15m])) or vector(0)) > 1
-          for: 15m
+              + (sum(rate(modemscope_downstream_ofdm_uncorrectables_total[15m])) or vector(0)) > 10
+          for: 30m
           labels:
             namespace: modemscope
             severity: warning

--- a/apps/base/truenas-iscsi-monitor/prometheus-rule.yaml
+++ b/apps/base/truenas-iscsi-monitor/prometheus-rule.yaml
@@ -35,11 +35,20 @@ spec:
             summary: "TrueNAS iSCSI extents do not match democratic-csi name pattern"
             description: "{{ $value }} extents in the last 15m did not match csi-pvc-<UUID>-k8s. Either democratic-csi changed its naming template or someone created a non-CSI extent. Update EXTENT_NAME_RE in the exporter script if naming changed."
 
+        # De-tuned 2026-07-21: ~20% of scrape cycles hit a transient
+        # "timed out while waiting for handshake response" on the wss://
+        # connection, then self-recover on the next cycle (exporter keeps
+        # publishing fresh metrics). At `> 5 for 5m` this flapped ~180x/week
+        # by email. The REAL "exporter can't reach TrueNAS" signal is
+        # TrueNASISCSIScraperStale (no successful scrape in 10m) above — that
+        # is unaffected by transient blips. This rule now fires only on a
+        # sustained error storm (a genuinely broken API key / TrueNAS down for
+        # 30m+), not on normal handshake flakiness.
         - alert: TrueNASISCSIScrapeErrors
-          expr: increase(truenas_iscsi_scrape_errors_total[15m]) > 5
-          for: 5m
+          expr: increase(truenas_iscsi_scrape_errors_total[15m]) > 20
+          for: 30m
           labels:
             severity: warning
           annotations:
-            summary: "TrueNAS iSCSI exporter is throwing scrape errors"
-            description: "{{ $value }} errors in the last 15m. Common causes: TrueNAS API key expired/rotated; TrueNAS unreachable on wss://10.42.2.10/api/current; K8s API token issue."
+            summary: "TrueNAS iSCSI exporter is throwing sustained scrape errors"
+            description: "{{ $value }} errors in the last 15m, sustained 30m+. Beyond normal transient wss handshake timeouts — check for an expired/rotated TrueNAS API key or TrueNAS unreachable on wss://10.42.2.10/api/current. (For a hard exporter outage see TrueNASISCSIScraperStale.)"

--- a/infra/configs/thermalscope/prometheus-rule.yaml
+++ b/infra/configs/thermalscope/prometheus-rule.yaml
@@ -126,14 +126,20 @@ spec:
         # rollup) to avoid double-firing on Sensor1/Sensor2 which read
         # identical values per drive. 65°C is conservative; throttling
         # typically kicks in around 70-75°C.
+        # De-tuned 2026-07-21: single-drive Talos nodes peak at ~64–65°C under
+        # normal load, so `> 65 for 5m` flapped ~20x/week — yet observed
+        # headroom-to-critical never dropped below 20°C, so 65°C is nowhere near
+        # dangerous here. Raised to `> 70 for 15m`. The genuine danger signal is
+        # ThermalScopeNVMeHeadroomLow (< 5°C to the drive's own crit threshold)
+        # below, which is untouched.
         - alert: ThermalScopeNVMeTemperatureHigh
-          expr: thermalscope_nvme_temperature_celsius{sensor="Composite"} > 65
-          for: 5m
+          expr: thermalscope_nvme_temperature_celsius{sensor="Composite"} > 70
+          for: 15m
           labels:
             severity: warning
           annotations:
             summary: "NVMe {{ $labels.device }} on {{ $labels.instance }} is hot"
-            description: "{{ $labels.device }} (Composite) on {{ $labels.instance }} is {{ $value }}°C (threshold 65°C)."
+            description: "{{ $labels.device }} (Composite) on {{ $labels.instance }} is {{ $value }}°C (threshold 70°C). See ThermalScopeNVMeHeadroomLow for the real thermal-danger signal."
 
         # Scoped to hestia because 83°C is the NVIDIA RTX 4090 thermal
         # warning threshold. AMD iGPUs run hotter by design — see
@@ -181,11 +187,15 @@ spec:
         # nodename for exactly this reason). 0.85/80 chosen to sit below the
         # 85°C ThermalScopeCPUTemperatureHigh threshold while still
         # requiring genuinely high heat alongside the clock drop.
+        # De-tuned 2026-07-21: `for: 10m` still flapped ~12x/week as the
+        # freq-ratio dipped in and out under bursty load. Lengthened to 20m so
+        # only genuinely sustained throttling (hot AND slow for 20m) pages; the
+        # compound condition (low freq ratio AND Tctl > 80) is already specific.
         - alert: ThermalScopeCPUThrottling
           expr: |
             instance:thermalscope_cpu_freq_ratio < 0.85
               and on(instance) max by(instance)(thermalscope_cpu_temperature_celsius{sensor="Tctl"}) > 80
-          for: 10m
+          for: 20m
           labels:
             severity: warning
           annotations:

--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -586,7 +586,14 @@ alertmanager:
       # non-critical fell through to the default 'null' receiver and was silently
       # dropped — which is why week-long crashloops went unnoticed
       # (ContainerCrashLoopBackOff is severity=warning). See #1080.
-      - receiver: 'email-critical'
+      #
+      # Routed to 'email-warning' (send_resolved:false, 2026-07-21) rather than
+      # 'email-critical': warnings were sending a second "[RESOLVED]" email every
+      # time they cleared, which for flappy warnings was ~40% of all alert mail.
+      # For a warning, the firing notification is enough — we don't need to be
+      # told it stopped. Criticals still send resolved (knowing an outage cleared
+      # matters, and there's no ack channel).
+      - receiver: 'email-warning'
         matchers:
           - severity = "warning"
         repeat_interval: 24h
@@ -596,6 +603,10 @@ alertmanager:
       email_configs:
         - to: 'gjcourt+alerts@gmail.com'
           send_resolved: true
+    - name: 'email-warning'
+      email_configs:
+        - to: 'gjcourt+alerts@gmail.com'
+          send_resolved: false
     templates:
     - '/etc/alertmanager/config/*.tmpl'
 


### PR DESCRIPTION
## Problem

Homelab alert email is **~362 alert emails/week (~52/day)** — half the inbox. The routing itself is sane (warnings repeat 24h, criticals 4h); the flood comes from **flapping warning-severity rules** plus **resolved-email duplication**.

### Top offenders (7-day sample)
| Alert | Emails/7d | Share |
|---|---|---|
| TrueNASISCSIScrapeErrors | 181 | 50% |
| HomelabscopeJobStale (alcatraz-photos-pull) | 41 | 11% |
| ModemUncorrectableErrors | 38 | 10% |
| ThermalScope NVMe temp + CPU throttle | 32 | 9% |
| etcdMemberCommunicationSlow | ~24 | 7% |
| adguard ContainerOOMKilled | 12 | 3% |

Two multipliers `repeat_interval` can't stop: `send_resolved: true` doubles every alert, and flapping rules re-notify each fire→resolve→fire cycle.

## Changes (Tier 1 + 2)

**Tier 1 — biggest levers**
- **TrueNASISCSIScrapeErrors** `> 5 for 5m` → `> 20 for 30m`. Root-caused live: ~20% of scrape cycles hit a transient `wss://` handshake timeout and self-recover (exporter keeps publishing fresh metrics). The real "exporter can't reach TrueNAS" signal is **TrueNASISCSIScraperStale** (no success in 10m), which is unaffected. -50%.
- **Alertmanager**: new `email-warning` receiver with `send_resolved: false`; warnings route there. No more "[RESOLVED]" duplicate for warnings. Criticals keep `send_resolved: true`. -40% of the remainder.

**Tier 2 — known/expected noise**
- **ModemUncorrectableErrors** `> 1 for 15m` → `> 10 for 30m`. CODA-56 sheds codewords during known thermal events (pending 40mm-fan fix). Comment says re-tighten afterward.
- **ThermalScopeNVMeTemperatureHigh** `> 65 for 5m` → `> 70 for 15m`. Live check: drives peak ~64–65°C with **20°C+ headroom-to-critical**; `NVMeHeadroomLow (<5°C)` stays the real danger signal.
- **ThermalScopeCPUThrottling** `for: 10m` → `for: 20m`.

## Left intact — Tier 3 (real signals, investigating separately)
`HomelabscopeJobStale/alcatraz-photos-pull` (photo pipeline may be stalled), `adguard ContainerOOMKilled` (memory limit likely too low), `etcdMemberCommunicationSlow`. These point at actual conditions, not noise — deliberately **not** muted.

## Validation
- `kustomize build` passes: infra/controllers, infra/configs, apps/production, modemscope, truenas-iscsi-monitor
- `yamllint -c .yamllint` clean on all four edited files
- No threshold *lowered*; no rule deleted; no critical-severity behavior changed

Expected result: ~362/wk → well under ~50/wk, with every genuine-outage signal preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet