### PR TITLE
fix(photos): repoint alcatraz-pull rrsync root to family/media/photos

### DIFF
--- a/docs/plans/2026-07-04-alcatraz-photos-pull.md
+++ b/docs/plans/2026-07-04-alcatraz-photos-pull.md
@@ -8,7 +8,7 @@ summary: "Retire the impossible hestia→alcatraz rsync push-back; alcatraz pull
 
 ## Problem
 
-hestia (`main/family/images/photos`) is the source of truth for the photo
+hestia (`main/family/media/photos`) is the source of truth for the photo
 library. Two flows keep alcatraz and hestia in sync:
 
 1. **alcatraz → hestia** (phone uploads): the hestia-side container
@@ -63,7 +63,7 @@ alcatraz (DSM Task Scheduler, runs as ROOT, ~05:00 daily)
            --exclude=@eaDir,.DS_Store,Thumbs.db \
            --rsh="ssh -T -x -i <key> -c chacha20-poly1305 -o Compression=no \
                   -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=<kh>" \
-           truenas_admin@10.42.2.10:/mnt/main/family/images/photos/<user>/ \
+           truenas_admin@10.42.2.10:/mnt/main/family/media/photos/<user>/ \
            /volume1/homes/<user>/Photos/
          chown -R <uid>:100 /volume1/homes/<user>/Photos/   # runs as root
 ```
@@ -93,7 +93,7 @@ Repo artifacts:
    `/volume1/homes/truenas-backup/immich-photos-pull/` (mode 755).
 2. **On hestia** (someone with hestia access — not the DSM operator): install
    the public key into `truenas_admin`'s `authorized_keys` with the
-   `rrsync -ro /mnt/main/family/images/photos` forced command.
+   `rrsync -ro /mnt/main/family/media/photos` forced command.
 3. **On alcatraz**: create a DSM Task Scheduler user-defined script, **run as
    `root`**, daily ~05:00, invoking the script.
 4. **Validate**: run the task manually; confirm files land under

--- a/docs/plans/2026-07-13-immich-photos-images-to-media.md
+++ b/docs/plans/2026-07-13-immich-photos-images-to-media.md
@@ -99,6 +99,17 @@ ssh truenas_admin@10.42.2.10 'sudo zfs list -o name,used,refer,mounted,mountpoin
 - [ ] #1108 merged, image rebuilt, compose digest bumped, feeder redeployed.
 - [ ] `media/photos` dataset-vs-dir decided and (if chosen) promoted + snapshotted.
 - [ ] Staging PVs + 30d-sync CronJob on `media/`, next sync green.
-- [ ] alcatraz-pull rrsync root on `media/photos`; alcatraz backup verified.
-- [ ] All docs reference `media/photos`; no `family/images/photos` references remain in the repo.
+- [x] alcatraz-pull rrsync root on `media/photos` (repointed 2026-07-21 — see note); alcatraz backup re-verifies on the next scheduled DSM pull.
+- [x] All docs reference `media/photos`; no `family/images/photos` references remain in the repo.
 - [ ] `family/images/*` datasets destroyed after parity + snapshot verification.
+
+> **2026-07-21 — orphaned step 7 (alcatraz-pull repoint) fixed.** When
+> `family/images/photos` was retired, the two `rrsync -ro` forced-command roots
+> in `truenas_admin@10.42.2.10`'s `authorized_keys` were left pointing at the
+> destroyed path, so `alcatraz-photos-pull` failed silently for ~8 days
+> (`HomelabscopeJobStale` fired but was buried in alert-email noise — see the
+> alert de-tuning PR). Both `authorized_keys` lines were repointed to
+> `/mnt/main/family/media/photos` (backup: `authorized_keys.bak-2026-07-21`),
+> and the repo doc/script references updated in this PR. The pull runs on the
+> Synology's DSM Task Scheduler; it should succeed on its next scheduled run and
+> auto-resolve the alert. Trigger it manually in DSM to confirm immediately.

--- a/docs/plans/2026-07-13-immich-photos-images-to-media.md
+++ b/docs/plans/2026-07-13-immich-photos-images-to-media.md
@@ -100,7 +100,7 @@ ssh truenas_admin@10.42.2.10 'sudo zfs list -o name,used,refer,mounted,mountpoin
 - [ ] `media/photos` dataset-vs-dir decided and (if chosen) promoted + snapshotted.
 - [ ] Staging PVs + 30d-sync CronJob on `media/`, next sync green.
 - [x] alcatraz-pull rrsync root on `media/photos` (repointed 2026-07-21 — see note); alcatraz backup re-verifies on the next scheduled DSM pull.
-- [x] All docs reference `media/photos`; no `family/images/photos` references remain in the repo.
+- [~] alcatraz-pull operational script + runbooks (`pull-from-hestia.sh`, `hosts/alcatraz/immich-photos-pull/README.md`, the 2026-07-04 alcatraz-pull plan) reference `media/photos`. A full repo-wide sweep is NOT done — the retired path still appears in ~40 spots across older/superseded plan docs (2026-05-20, 2026-06-01, 2026-07-05, 2026-07-06) and some current-state docs (`hosts/hestia/README.md`, `scripts/import-sd-photos.sh`). Most are legitimate history; the current-state ones are a separate docs-hygiene follow-up. (`/volume1/family/images/photos` is the alcatraz Synology path — a different filesystem — and is out of scope here.)
 - [ ] `family/images/*` datasets destroyed after parity + snapshot verification.
 
 > **2026-07-21 — orphaned step 7 (alcatraz-pull repoint) fixed.** When

--- a/hosts/alcatraz/immich-photos-pull/README.md
+++ b/hosts/alcatraz/immich-photos-pull/README.md
@@ -53,7 +53,7 @@ setuid patch). Full root cause + decision record:
 | Attribute | Value |
 |---|---|
 | Runs on | alcatraz (Synology DSM, `10.42.2.11`), as **root**, via the `immich-photos-pull` compose container (busybox crond) |
-| Source (server) | `truenas_admin@10.42.2.10:/mnt/main/family/images/photos/{mara,george}/` |
+| Source (server) | `truenas_admin@10.42.2.10:/mnt/main/family/media/photos/{mara,george}/` |
 | Destination (local) | `/volume1/homes/{mara,george}/Photos/` (owned `<uid>:100`; mara=1027, george=1028) |
 | Mode | `rsync -a --ignore-existing` (additive; **no `--delete`, ever**) |
 | SSH key | `/volume1/homes/truenas-backup/.ssh/id_ed25519_hestia` (mode 600) |
@@ -98,7 +98,7 @@ operator does not touch hestia.** The public key from step 1 goes into
 read-only rsync of the photos path:
 
 ```
-command="sudo -n --preserve-env=SSH_ORIGINAL_COMMAND /usr/bin/rrsync -ro /mnt/main/family/images/photos",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...alcatraz-photos-pull
+command="sudo -n --preserve-env=SSH_ORIGINAL_COMMAND /usr/bin/rrsync -ro /mnt/main/family/media/photos",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...alcatraz-photos-pull
 ```
 
 Two things about this line are load-bearing:

--- a/images/immich-photos-pull/pull-from-hestia.sh
+++ b/images/immich-photos-pull/pull-from-hestia.sh
@@ -50,13 +50,13 @@ GID_USERS=100
 # hestia rsync server (source of truth). truenas_admin (uid 950) has read on
 # the photo dirs; the authorized_keys entry there restricts this key to a
 # read-only rrsync rooted at the photos path (abbreviated as
-# command="rrsync -ro /mnt/main/family/images/photos" here; the real
+# command="rrsync -ro /mnt/main/family/media/photos" here; the real
 # authorized_keys line wraps it in `sudo -n --preserve-env=SSH_ORIGINAL_COMMAND`
 # — see README for the exact, load-bearing form). Because
 # rrsync confines the client to that root, source paths are RELATIVE to it
 # (e.g. "mara/") — an ABSOLUTE path gets the root prepended a second time and
 # fails ("change_dir ...photos/mnt/.../photos/mara: No such file"). The
-# authorizing rrsync root on hestia is: /mnt/main/family/images/photos
+# authorizing rrsync root on hestia is: /mnt/main/family/media/photos
 SRC_HOST="truenas_admin@10.42.2.10"
 
 # alcatraz per-user DSM Photos libraries (destination, local).


### PR DESCRIPTION
## What & why

`alcatraz-photos-pull` (Synology DSM Task Scheduler job that backs up the Immich photo library off hestia) **failed silently for ~8 days** — last success 2026-07-13, the exact day `family/images/photos` was destroyed in the images→media migration.

Root cause: the migration repointed the Immich/Jellyfin/Navidrome PVs but left **step 7 orphaned** — the two `rrsync -ro` forced-command roots in `truenas_admin@10.42.2.10`'s `authorized_keys` still pointed at the retired `/mnt/main/family/images/photos`. Every pull failed and the heartbeat went stale. `HomelabscopeJobStale` fired correctly but was buried under the TrueNAS alert-email flood (see #1161).

## Host fix (already applied, out of band)

Both `authorized_keys` `rrsync -ro` roots repointed `images/photos → media/photos` on 2026-07-21, backup at `authorized_keys.bak-2026-07-21`. Verified: new root exists, readable as root, contains `george/` + `mara/`; `sudo -n` NOPASSWD intact.

## This PR — repo sync (alcatraz-pull scope)

- `images/immich-photos-pull/pull-from-hestia.sh` — path comments → `media/photos`
- `hosts/alcatraz/immich-photos-pull/README.md` — source path + `authorized_keys` example → `media/photos`
- `docs/plans/2026-07-04-alcatraz-photos-pull.md` — the alcatraz-pull runbook: SOT statement, rsync source, and the **operator-step `rrsync` forced command** → `media/photos` (this last one was a live regression trap that would recreate the bug — caught in review)
- `docs/plans/2026-07-13-immich-photos-images-to-media.md` — check off the alcatraz-pull exit-criteria + dated note

## Scope note (corrected after review)

This PR fixes the **alcatraz-pull operational path** only. A repo-wide sweep of the retired `family/images/photos` name is **out of scope**: it still appears in ~40 spots, most of them legitimate historical narrative in older/superseded plan docs (2026-05-20, 2026-06-01, 2026-07-05, 2026-07-06). A few current-state docs (`hosts/hestia/README.md`, `scripts/import-sd-photos.sh`) are genuinely stale and worth a **separate docs-hygiene PR**. (`/volume1/family/images/photos` is the alcatraz Synology path — a different filesystem — not affected here.)

## Confirmation

The pull runs on the Synology's DSM Task Scheduler (I can't SSH to 10.42.2.11 to force it). It should succeed on its **next scheduled run** and auto-resolve the alert. To confirm now: DSM → Control Panel → Task Scheduler → run the pull task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet