### PR TITLE
fix(adguard): raise memory limit 1Gi→2Gi to stop OOMKills

### DIFF
--- a/apps/base/adguard/deployment.yaml
+++ b/apps/base/adguard/deployment.yaml
@@ -84,7 +84,12 @@ spec:
               memory: 512Mi
             limits:
               cpu: 500m
-              memory: 1Gi
+              # Bumped 1Gi -> 2Gi 2026-07-21: steady-state is ~400Mi, but a
+              # replica transiently spikes past 1Gi (querylog/stats GC) and gets
+              # OOMKilled (adguard-1 died 6x, exit 137), causing DNS blips.
+              # Nodes have huge headroom (~11% mem used). If 2Gi still OOMs,
+              # tune AdGuard's querylog retention in AdGuardHome.yaml instead.
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## What & why

`adguard-1` has been **OOMKilled 6× (exit 137)**, most recently ~19h ago, while `adguard-0` is clean. Steady-state memory is only **~400Mi** against the **1Gi** limit — a replica transiently spikes past 1Gi (querylog/stats GC) and gets killed, causing brief DNS outages. This also fired `ContainerOOMKilled` ~12×/week by email (a Tier-3 signal surfaced by the alert-noise cleanup).

## Fix

Raise the container memory limit **1Gi → 2Gi** in `apps/base/adguard/deployment.yaml`. Request stays at 512Mi. Node headroom is large (`talos-ykb-uir` at ~11% memory used), so 2Gi is comfortably safe.

If 2Gi still OOMs, the follow-up is tuning AdGuard's internal querylog retention in `AdGuardHome.yaml` (not manifest-controlled) — noted in an inline comment.

## Validation
- `kustomize build apps/production/adguard` passes
- `yamllint` clean
- Reversible, no data risk (limit change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet