### PR TITLE
chore(alerts): route criticals to +critical alias (keep them in inbox)

### DIFF
--- a/infra/controllers/kube-prometheus-stack/values.yaml
+++ b/infra/controllers/kube-prometheus-stack/values.yaml
@@ -599,9 +599,16 @@ alertmanager:
         repeat_interval: 24h
     receivers:
     - name: 'null'
+    # Split alias 2026-07-21: criticals go to +critical, warnings to +alerts.
+    # A Gmail filter labels `to:gjcourt+alerts@gmail.com` (warnings) and skips
+    # the inbox — warnings become opt-in (look at the label when you want).
+    # Criticals land on +critical, which has NO skip-inbox filter, so genuine
+    # outages still reach the inbox. (This is the fix for the failure mode where
+    # a critical HomelabscopeJobStale was buried under warning-noise and a real
+    # 8-day photo-pull outage went unseen.)
     - name: 'email-critical'
       email_configs:
-        - to: 'gjcourt+alerts@gmail.com'
+        - to: 'gjcourt+critical@gmail.com'
           send_resolved: true
     - name: 'email-warning'
       email_configs:


### PR DESCRIPTION
## Why

Follow-on to alert de-tuning (#1161). Sets up an **opt-in-for-warnings / page-for-criticals** email model:

- **Warnings** → `gjcourt+alerts@gmail.com` — a Gmail filter labels these `Homelab/Alerts` and skips the inbox (opt-in: look at the label when you want).
- **Criticals** → `gjcourt+critical@gmail.com` — no skip-inbox filter, so genuine outages still land in the inbox.

This is the structural fix for the failure mode that hid the alcatraz-photos-pull outage: a `severity=critical` alert buried under a flood of `severity=warning` noise. Now the noise is opt-in and criticals stay visible.

## Change

One line in `infra/controllers/kube-prometheus-stack/values.yaml`: `email-critical` receiver `to:` `gjcourt+alerts@` → `gjcourt+critical@` (plus a comment). `email-warning` unchanged. Both are plus-aliases of the same mailbox — no new account/setup needed.

## Validation
- `kustomize build infra/controllers` passes
- `yamllint` clean
- Reversible; no rule/severity logic changed

Paired with two Gmail filters (created out of band): `to:gjcourt+alerts@` → label + skip inbox; and Renovate PR notifications → label + skip inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet