### PR TITLE
fix(navidrome): repoint staging music PV to canonical family/media/music

### DIFF
--- a/apps/staging/navidrome/nfs-music.yaml
+++ b/apps/staging/navidrome/nfs-music.yaml
@@ -31,7 +31,7 @@ spec:
     - nolock
   nfs:
     server: 10.42.2.10
-    path: /mnt/main/media/music
+    path: /mnt/main/family/media/music
     readOnly: true
 ---
 apiVersion: v1


### PR DESCRIPTION
Staging Navidrome's music PV pointed at the legacy `/mnt/main/media/music` husk (no real audio — all music is at `family/media/music`). Repoints staging to the canonical path so the stale `main/media/music` dataset can be retired (~30.7 GB reclaim). `nfs.path` is immutable → requires the -stage PV+PVC recreate (handled operationally alongside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet