### PR TITLE
feat(audiobookshelf): mount audiobooks + podcasts libraries (NFS RO)

### DIFF
--- a/apps/production/audiobookshelf/deployment-patch.yaml
+++ b/apps/production/audiobookshelf/deployment-patch.yaml
@@ -1,4 +1,4 @@
-# Deployment patches for production - DNS
+# Deployment patches for production - DNS + media libraries
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,3 +14,21 @@ spec:
         - ip: "10.42.2.40"
           hostnames:
             - auth.burntbytes.com
+      # Read-only NFS media mounts. In the Audiobookshelf UI, add a Book
+      # library pointing at /audiobooks and a Podcast library at /podcasts.
+      containers:
+        - name: audiobookshelf
+          volumeMounts:
+            - name: abs-audiobooks
+              mountPath: /audiobooks
+              readOnly: true
+            - name: abs-podcasts
+              mountPath: /podcasts
+              readOnly: true
+      volumes:
+        - name: abs-audiobooks
+          persistentVolumeClaim:
+            claimName: audiobookshelf-audiobooks-pvc
+        - name: abs-podcasts
+          persistentVolumeClaim:
+            claimName: audiobookshelf-podcasts-pvc

--- a/apps/production/audiobookshelf/kustomization.yaml
+++ b/apps/production/audiobookshelf/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base/audiobookshelf/
   - httproute.yaml
   - secret-sso.yaml
+  - nfs-media.yaml
 
 labels:
   - pairs:

--- a/apps/production/audiobookshelf/nfs-media.yaml
+++ b/apps/production/audiobookshelf/nfs-media.yaml
@@ -1,0 +1,96 @@
+# NFS-backed PersistentVolumes for the Audiobookshelf libraries (production).
+# Read-only mounts of the canonical media tree. Book library -> audiobooks/,
+# podcast library -> podcasts/ (split out of the old audiobooks/ bucket;
+# AA recordings moved to family/audio). Files are 0644/world-readable, so no
+# uid pinning is needed (unlike navidrome's 0700 music tree).
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: audiobookshelf-audiobooks-pv-prod
+  labels:
+    app: audiobookshelf
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: audiobookshelf-audiobooks-pvc
+    namespace: audiobookshelf-prod
+  mountOptions:
+    - nfsvers=3
+    - rsize=1048576
+    - wsize=1048576
+    - hard
+    - timeo=600
+    - retrans=2
+    - nolock
+  nfs:
+    server: 10.42.2.10
+    path: /mnt/main/family/media/audiobooks
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audiobookshelf-audiobooks-pvc
+  namespace: audiobookshelf-prod
+  labels:
+    app: audiobookshelf
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Ti
+  volumeName: audiobookshelf-audiobooks-pv-prod
+  storageClassName: ""
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: audiobookshelf-podcasts-pv-prod
+  labels:
+    app: audiobookshelf
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: audiobookshelf-podcasts-pvc
+    namespace: audiobookshelf-prod
+  mountOptions:
+    - nfsvers=3
+    - rsize=1048576
+    - wsize=1048576
+    - hard
+    - timeo=600
+    - retrans=2
+    - nolock
+  nfs:
+    server: 10.42.2.10
+    path: /mnt/main/family/media/podcasts
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audiobookshelf-podcasts-pvc
+  namespace: audiobookshelf-prod
+  labels:
+    app: audiobookshelf
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Ti
+  volumeName: audiobookshelf-podcasts-pv-prod
+  storageClassName: ""


### PR DESCRIPTION
Wires Audiobookshelf into the media tree (previously mounted no media). Two RO NFS PVs (navidrome pattern): `/audiobooks`→`family/media/audiobooks` (Book lib), `/podcasts`→`family/media/podcasts` (Podcast lib).

Phase 4 of the media reorg: the old `audiobooks/` bucket was split — podcasts promoted to `family/media/podcasts`, AA recordings moved to `family/audio`. Files are world-readable so the uid-1000 pod reads them without pinning.

**Operator follow-up:** in the ABS UI, add a Book library at `/audiobooks` and a Podcast library at `/podcasts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)