### PR TITLE
feat(immich): index home videos as external library

### DIFF
--- a/apps/production/immich/deployment-patch.yaml
+++ b/apps/production/immich/deployment-patch.yaml
@@ -89,6 +89,9 @@ spec:
               mountPath: /usr/src/app/upload
             - name: photos
               mountPath: /mnt/photos
+            - name: home-videos
+              mountPath: /mnt/home-videos
+              readOnly: true
             - name: oauth-config
               mountPath: /etc/immich
               readOnly: true
@@ -124,6 +127,9 @@ spec:
         - name: photos
           persistentVolumeClaim:
             claimName: immich-photos-pvc
+        - name: home-videos
+          persistentVolumeClaim:
+            claimName: immich-homevideo-pvc
         - name: oauth-config-template
           configMap:
             name: immich-oauth-config
@@ -222,6 +228,9 @@ spec:
               mountPath: /usr/src/app/upload
             - name: photos
               mountPath: /mnt/photos
+            - name: home-videos
+              mountPath: /mnt/home-videos
+              readOnly: true
             - name: dri
               mountPath: /dev/dri
             - name: oauth-config
@@ -244,6 +253,9 @@ spec:
         - name: photos
           persistentVolumeClaim:
             claimName: immich-photos-pvc
+        - name: home-videos
+          persistentVolumeClaim:
+            claimName: immich-homevideo-pvc
         - name: dri
           hostPath:
             path: /dev/dri

--- a/apps/production/immich/kustomization.yaml
+++ b/apps/production/immich/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - database.yaml
   - httproute.yaml
   - nfs-photos.yaml
+  - nfs-homevideo.yaml
   - objectstore.yaml
   - pdb-ml.yaml
   - scheduledbackup.yaml

--- a/apps/production/immich/nfs-homevideo.yaml
+++ b/apps/production/immich/nfs-homevideo.yaml
@@ -1,0 +1,45 @@
+# Read-only NFS mount of family/media/video/home so Immich can index home
+# videos alongside the photo timeline (Phase 5 of the media reorg). Disjoint
+# from the photos tree (phone videos live in photos/<person>/, camcorder/
+# export footage lives here), and Immich hash-dedupes, so no double-indexing.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: immich-homevideo-pv-prod
+  labels:
+    app: immich
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=3
+    - rsize=1048576
+    - wsize=1048576
+    - hard
+    - timeo=600
+    - retrans=2
+    - nolock
+  nfs:
+    server: 10.42.2.10
+    path: /mnt/main/family/media/video/home
+    readOnly: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-homevideo-pvc
+  namespace: immich-prod
+  labels:
+    app: immich
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: ""
+  volumeName: immich-homevideo-pv-prod
+  resources:
+    requests:
+      storage: 1Ti


### PR DESCRIPTION
Phase 5: RO NFS mount of `family/media/video/home` at `/mnt/home-videos` on the Immich server + ML pods, so home videos join the timeline. Disjoint from the photos tree + Immich hash-dedupes → no duplication. Cleaned first (29 misfiled files → _review). **Operator follow-up:** add `/mnt/home-videos` as an import path in Immich, then scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)