### PR TITLE
feat(homepage): tile-click beacon tracking (Phase 1)

### DIFF
--- a/.github/workflows/build-homepage-clicks.yml
+++ b/.github/workflows/build-homepage-clicks.yml
@@ -1,0 +1,60 @@
+name: Build homepage-clicks
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/homepage-clicks/**'
+      - '.github/workflows/build-homepage-clicks.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/homepage-clicks
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Immutable per-commit tag (date + short SHA) — avoids the same-day tag
+      # collision that a bare YYYY-MM-DD hits when code is rebuilt twice in a day.
+      - name: Generate date-sha tag
+        id: tag
+        run: echo "tag=$(date -u +%Y-%m-%d)-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: images/homepage-clicks
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### homepage-clicks published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Pin this tag in \`apps/base/homepage-clicks/deployment.yaml\` in a follow-up PR." >> $GITHUB_STEP_SUMMARY

--- a/apps/base/homepage-clicks/deployment.yaml
+++ b/apps/base/homepage-clicks/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage-clicks
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage-clicks
+    app.kubernetes.io/component: exporter
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage-clicks
+      app.kubernetes.io/component: exporter
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: homepage-clicks
+        app.kubernetes.io/component: exporter
+    spec:
+      serviceAccountName: homepage-clicks
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          # PLACEHOLDER TAG — the image is built + pushed by
+          # .github/workflows/build-homepage-clicks.yml only after this lands on
+          # master. Repin to the real `YYYY-MM-DD-<sha7>@sha256:<digest>` emitted
+          # by that workflow in a follow-up PR (see the workflow's step summary),
+          # per the homelab image-discipline rule. Until then this Deployment
+          # will not pull — the ServiceMonitor target stays down and the
+          # /api/clicks route returns 5xx, which is expected pre-build.
+          image: "ghcr.io/gjcourt/homepage-clicks:latest"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: LISTEN_PORT
+              value: "9107"
+            - name: BEACON_PATH
+              value: /api/clicks
+            # Same-origin allowlist: only beacons from the dashboard's own host.
+            - name: ALLOWED_ORIGINS
+              value: https://home.burntbytes.com
+          ports:
+            - name: metrics
+              containerPort: 9107
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9107
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # No livenessProbe: /healthz reports only "the HTTP server is up",
+          # which is the same signal readiness already uses — per the repo's
+          # health-probe convention (and matching mqttscope), a liveness probe
+          # sharing that signal would only add restart-flapping, not recovery.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/apps/base/homepage-clicks/kustomization.yaml
+++ b/apps/base/homepage-clicks/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No namespace.yaml: this Deployment lives alongside the homepage app in the
+# `homepage` namespace (retargeted to `homepage-prod` by the production
+# overlay), so the /api/clicks HTTPRoute path can forward to it without a
+# cross-namespace ReferenceGrant. The homepage base owns the namespace object.
+resources:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - servicemonitor.yaml
+  - networkpolicy.yaml
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: homepage-clicks
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/part-of: homelab
+      app.kubernetes.io/managed-by: flux

--- a/apps/base/homepage-clicks/networkpolicy.yaml
+++ b/apps/base/homepage-clicks/networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homepage-clicks
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage-clicks
+    app.kubernetes.io/part-of: network-policies
+spec:
+  description: |
+    Homepage tile-click beacon exporter. Ingress: the gateway forwards
+    `home.burntbytes.com/api/clicks` here on 9107 (arriving as host /
+    remote-node / ingress identities, same as the homepage app), plus the
+    Prometheus scrape on 9107. Egress: DNS only — the exporter makes no
+    outbound calls (it only receives POSTs and serves /metrics).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: homepage-clicks
+  ingress:
+    # Cilium Envoy (Gateway API) forwards /api/clicks from the dedicated proxy
+    # IP (reserved identity "ingress"); same-node connections arrive as "host",
+    # cross-node VXLAN as "remote-node". All three are required, mirroring the
+    # homepage app's own ingress rule. Kubelet probes are auto-exempted.
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9107"
+              protocol: TCP
+    # Prometheus scrape.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9107"
+              protocol: TCP
+  egress:
+    # DNS resolution via CoreDNS (the exporter needs no other egress).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/base/homepage-clicks/service.yaml
+++ b/apps/base/homepage-clicks/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage-clicks
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage-clicks
+    app.kubernetes.io/component: exporter
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: homepage-clicks
+    app.kubernetes.io/component: exporter
+  ports:
+    - name: metrics
+      port: 9107
+      targetPort: metrics
+      protocol: TCP

--- a/apps/base/homepage-clicks/serviceaccount.yaml
+++ b/apps/base/homepage-clicks/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage-clicks
+  namespace: homepage

--- a/apps/base/homepage-clicks/servicemonitor.yaml
+++ b/apps/base/homepage-clicks/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: homepage-clicks
+  namespace: homepage
+  labels:
+    # kube-prometheus-stack's Prometheus selects ServiceMonitors by the
+    # helm-default release label (serviceMonitorSelectorNilUsesHelmValues=true).
+    # Without this label the SM is invisible to it.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: homepage-clicks
+    app.kubernetes.io/component: exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage-clicks
+      app.kubernetes.io/component: exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      # Force job="homepage-clicks" so any future PrometheusRule / dashboard
+      # queries keyed on that job align with the scraped series (the operator
+      # otherwise auto-derives "homepage/homepage-clicks" or the prod-namespace
+      # equivalent).
+      relabelings:
+        - targetLabel: job
+          replacement: homepage-clicks

--- a/apps/base/homepage/config/custom.js
+++ b/apps/base/homepage/config/custom.js
@@ -1,1 +1,80 @@
 // Custom JS — overridden per environment if needed.
+//
+// Tile-click beacon. Homepage tiles are plain <a href> links, so nothing is
+// recorded when one is clicked. This delegated listener fires a fire-and-forget
+// navigator.sendBeacon() to the same-origin /api/clicks endpoint on every tile
+// click, letting the homepage-clicks exporter increment
+// homepage_tile_clicks_total{service,group} for Grafana. See
+// apps/base/homepage-clicks/ and images/homepage-clicks/.
+//
+// Robustness: it keys off Homepage's stable custom classes
+// (.service-title-text / .service-name / .service-group-name), not layout
+// classes, so it survives theme + tab changes. It is best-effort: any failure
+// is swallowed so navigation is never blocked, and it does nothing if
+// sendBeacon is unavailable.
+(function () {
+  "use strict";
+
+  if (!("sendBeacon" in navigator)) {
+    return;
+  }
+
+  var BEACON_URL = "/api/clicks";
+  var MAX_LEN = 64;
+
+  function tileName(anchor) {
+    // .service-name holds the tile title AND a nested .service-description <p>.
+    // Clone it, drop the description, and read what's left.
+    var nameEl = anchor.querySelector(".service-name");
+    if (!nameEl) {
+      return "";
+    }
+    var clone = nameEl.cloneNode(true);
+    var desc = clone.querySelector(".service-description");
+    if (desc) {
+      desc.parentNode.removeChild(desc);
+    }
+    return (clone.textContent || "").trim().slice(0, MAX_LEN);
+  }
+
+  function groupName(anchor) {
+    var groupEl = anchor.closest(".services-group");
+    if (!groupEl) {
+      return "";
+    }
+    var h = groupEl.querySelector(".service-group-name");
+    return h ? (h.textContent || "").trim().slice(0, MAX_LEN) : "";
+  }
+
+  // Capture phase so the beacon is queued before the browser starts navigating
+  // away (which can otherwise cancel a bubbling-phase handler).
+  document.addEventListener(
+    "click",
+    function (event) {
+      try {
+        var target = event.target;
+        if (!target || !target.closest) {
+          return;
+        }
+        // Only service tiles carry .service-title-text; bookmarks and widgets
+        // don't, so they're ignored.
+        var anchor = target.closest("a.service-title-text");
+        if (!anchor) {
+          return;
+        }
+        var service = tileName(anchor);
+        if (!service) {
+          return;
+        }
+        var payload = JSON.stringify({ service: service, group: groupName(anchor) });
+        // sendBeacon(string) sends text/plain;charset=UTF-8 — a CORS-safelisted
+        // "simple" request, so no preflight; the exporter parses the JSON body
+        // regardless of content type.
+        navigator.sendBeacon(BEACON_URL, payload);
+      } catch (err) {
+        // Never let tracking interfere with navigation.
+      }
+    },
+    true,
+  );
+})();

--- a/apps/production/homepage-clicks/kustomization.yaml
+++ b/apps/production/homepage-clicks/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Retargets the base (namespace `homepage`) into `homepage-prod`, the same
+# namespace as the homepage app — so the homepage HTTPRoute's /api/clicks path
+# forwards to this Service without a cross-namespace ReferenceGrant.
+namespace: homepage-prod
+resources:
+  - ../../base/homepage-clicks/
+labels:
+  - includeSelectors: false
+    pairs:
+      env: production
+      app.kubernetes.io/instance: production

--- a/apps/production/homepage/httproute.yaml
+++ b/apps/production/homepage/httproute.yaml
@@ -29,7 +29,18 @@ spec:
     - name: app-gateway-production
       namespace: default
       sectionName: https
+  # Rules are evaluated specific-first by Cilium HTTPRoute matching:
+  # `/api/clicks` is forwarded to the homepage-clicks beacon exporter (same
+  # namespace, no ReferenceGrant needed) so the tile-click handler in
+  # custom.js can POST same-origin; everything else hits the Homepage web app.
   rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/clicks
+      backendRefs:
+        - name: homepage-clicks
+          port: 9107
     - backendRefs:
         - name: homepage
           port: 3000

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - golinks
   - homeassistant
   - homepage
+  - homepage-clicks
   - immich
   - jellyfin
   - ladder

--- a/images/homepage-clicks/Dockerfile
+++ b/images/homepage-clicks/Dockerfile
@@ -1,0 +1,23 @@
+# homepage-clicks — Homepage dashboard tile-click beacon exporter.
+#
+# Accepts same-origin `navigator.sendBeacon()` POSTs from Homepage's custom.js
+# and increments a labelled Prometheus counter (homepage_tile_clicks_total)
+# served on :9107. In the same "scope" family as mqttscope (a plain in-cluster
+# Deployment, no host access) — stdlib http.server + prometheus_client only,
+# runs unprivileged with a read-only root filesystem.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY exporter.py .
+
+EXPOSE 9107
+
+# nobody:nogroup — unprivileged; pairs with readOnlyRootFilesystem in the
+# Deployment (the exporter writes nothing to disk).
+USER 65534:65534
+
+ENTRYPOINT ["python", "-u", "exporter.py"]

--- a/images/homepage-clicks/README.md
+++ b/images/homepage-clicks/README.md
@@ -1,0 +1,83 @@
+# homepage-clicks
+
+A tiny click-beacon exporter for the [Homepage](https://gethomepage.dev)
+dashboard. Homepage tiles are plain `<a href>` links, so nothing is recorded
+when a tile is clicked. This service is the counting half of a lightweight,
+self-hosted usage tracker in the same "scope" spirit as
+[`mqttscope`](../mqttscope/) / netscope / thermalscope.
+
+## How it works
+
+1. A delegated click handler injected into Homepage's `custom.js`
+   (`apps/base/homepage/config/custom.js`) fires
+   `navigator.sendBeacon('/api/clicks', '{"service","group"}')` on every tile
+   click, deriving the service + group from the tile DOM
+   (`.service-name` / `.service-group-name`).
+2. The production gateway routes `home.burntbytes.com/api/clicks` (a
+   same-origin path match on the Homepage HTTPRoute) to this Deployment.
+3. This exporter increments `homepage_tile_clicks_total{service,group}` and
+   serves it at `/metrics`; kube-prometheus-stack scrapes it via a
+   ServiceMonitor.
+4. A Grafana dashboard (`infra/configs/dashboards/homepage-clicks-cm.yaml`)
+   renders clicks-over-time, top tiles, and never-clicked tiles.
+
+`/metrics` and `/healthz` are served on the pod port but are **not** exposed
+through the gateway — only `POST /api/clicks` is routed publicly.
+
+## Metrics
+
+| metric | type | labels | meaning |
+|---|---|---|---|
+| `homepage_tile_clicks_total` | counter | `service`, `group` | tile clicks |
+| `homepage_beacon_requests_total` | counter | `result` | POSTs by outcome |
+| `homepage_beacon_series` | gauge | – | distinct `{service,group}` pairs |
+
+`result` is one of `accepted`, `rejected_origin`, `rejected_ratelimit`,
+`rejected_payload`, `rejected_series_cap`.
+
+## Privacy / abuse posture
+
+The Homepage dashboard is **public**, so `/api/clicks` is reachable by anyone
+who can reach the gateway. The exporter stores only a service label +
+timestamp — **no PII, no IP, no href, no user agent**. Three cheap defences
+bound the blast radius of a bad actor:
+
+1. **Origin allowlist** — rejects POSTs whose `Origin` isn't the dashboard's
+   own host. A filter, not a security boundary (a non-browser client can forge
+   `Origin`); it stops casual cross-site beacons.
+2. **Global token-bucket rate limit** — caps sustained + burst intake.
+3. **Series cap** — refuses to register a *new* `{service,group}` pair beyond
+   `MAX_SERIES`, so a spammer cannot explode Prometheus cardinality. Known
+   pairs keep counting.
+
+Label values are also length-capped and charset-restricted before becoming a
+metric label.
+
+## Config (env)
+
+| var | default | meaning |
+|---|---|---|
+| `LISTEN_PORT` | `9107` | metrics + beacon HTTP port |
+| `BEACON_PATH` | `/api/clicks` | POST path the gateway forwards here |
+| `ALLOWED_ORIGINS` | `https://home.burntbytes.com` | comma-separated allowlist; empty disables |
+| `MAX_LABEL_LEN` | `64` | max chars per label value |
+| `MAX_SERIES` | `256` | max distinct `{service,group}` pairs |
+| `RATE_QPS` | `20` | sustained beacons/sec (token refill) |
+| `RATE_BURST` | `40` | token-bucket capacity |
+| `MAX_BODY_BYTES` | `4096` | max request body read |
+
+## Local test
+
+```sh
+pip install -r requirements.txt
+python exporter.py &
+curl -s -XPOST -H 'Origin: https://home.burntbytes.com' \
+  -d '{"service":"Immich","group":"Media"}' localhost:9107/api/clicks -i
+curl -s localhost:9107/metrics | grep homepage_tile_clicks_total
+```
+
+## Build
+
+Built + pushed by `.github/workflows/build-homepage-clicks.yml` on changes to
+`images/homepage-clicks/**`, tagged `YYYY-MM-DD-<sha7>`. Repin the deployment
+image to the emitted `tag@sha256:digest` in a follow-up PR.

--- a/images/homepage-clicks/exporter.py
+++ b/images/homepage-clicks/exporter.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""homepage-clicks — a tiny click-beacon exporter for the Homepage dashboard.
+
+Homepage (gethomepage.dev) tiles are plain `<a href>` links, so nothing is
+recorded when a tile is clicked. This exporter is the counting half of a
+lightweight, self-hosted usage tracker in the same "scope" spirit as
+mqttscope / netscope / thermalscope:
+
+  * A ~20-line delegated click handler injected into Homepage's `custom.js`
+    fires `navigator.sendBeacon('/api/clicks', '{"service","group"}')` on
+    every tile click.
+  * The gateway routes `home.burntbytes.com/api/clicks` (same-origin path
+    match) to this Deployment, which increments the labelled Prometheus
+    counter `homepage_tile_clicks_total{service,group}` and serves it at
+    `/metrics` for kube-prometheus-stack to scrape.
+
+Grafana then renders clicks-over-time, top tiles, and never-clicked tiles,
+turning dashboard re-ordering from a guess into a measured decision.
+
+Privacy / abuse posture. The Homepage dashboard is PUBLIC, so `/api/clicks`
+is reachable by anyone who can reach the gateway. We store only a service
+label + timestamp (no PII, no IP, no href, no user agent). Because the
+endpoint is public, three cheap defences bound the blast radius of a bad
+actor spamming it:
+
+  1. Origin allowlist   — reject POSTs whose Origin isn't the dashboard's own
+                          host. (A filter, not a security boundary: a
+                          non-browser client can forge Origin. It stops
+                          casual cross-site beacons, nothing more.)
+  2. Global rate limit  — a token bucket caps sustained + burst intake.
+  3. Series cap         — refuse to register a *new* {service,group} label
+                          pair once MAX_SERIES distinct pairs are known, so a
+                          spammer cannot explode Prometheus cardinality. Known
+                          pairs keep counting.
+
+Label values are also length-capped and charset-restricted before they ever
+become a metric label.
+
+Config (all via env):
+  LISTEN_PORT      metrics + beacon HTTP port          (default: 9107)
+  BEACON_PATH      POST path the gateway forwards here  (default: /api/clicks)
+  ALLOWED_ORIGINS  comma-separated Origin allowlist;
+                   empty disables the check
+                   (default: https://home.burntbytes.com)
+  MAX_LABEL_LEN    max chars per label value            (default: 64)
+  MAX_SERIES       max distinct {service,group} pairs   (default: 256)
+  RATE_QPS         sustained beacons/sec (token refill)  (default: 20)
+  RATE_BURST       token-bucket capacity                (default: 40)
+  MAX_BODY_BYTES   max request body read                 (default: 4096)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
+
+log = logging.getLogger("homepage-clicks")
+
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+LISTEN_PORT = int(_env("LISTEN_PORT", "9107"))
+BEACON_PATH = _env("BEACON_PATH", "/api/clicks")
+ALLOWED_ORIGINS = {
+    o.strip()
+    for o in _env("ALLOWED_ORIGINS", "https://home.burntbytes.com").split(",")
+    if o.strip()
+}
+MAX_LABEL_LEN = int(_env("MAX_LABEL_LEN", "64"))
+MAX_SERIES = int(_env("MAX_SERIES", "256"))
+RATE_QPS = float(_env("RATE_QPS", "20"))
+RATE_BURST = float(_env("RATE_BURST", "40"))
+MAX_BODY_BYTES = int(_env("MAX_BODY_BYTES", "4096"))
+
+# Permitted characters in a label value. Covers every current tile/group name
+# ("Home Assistant", "AdGuard Home", "Cluster Resources", "Living Room") plus a
+# little slack; anything else is rejected rather than sanitised, so a weird
+# payload never silently becomes a bogus metric.
+_LABEL_RE = re.compile(r"^[\w \-.()/&+']+$")
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+tile_clicks = Counter(
+    "homepage_tile_clicks_total",
+    "Homepage dashboard tile clicks, by tile and group.",
+    ["service", "group"],
+)
+
+# Operational visibility into the beacon endpoint itself: how many POSTs came
+# in and why they were accepted/rejected. Handy for spotting abuse or a broken
+# client without reading logs.
+beacon_requests = Counter(
+    "homepage_beacon_requests_total",
+    "Beacon POSTs received, by outcome.",
+    ["result"],
+)
+
+# Distinct {service,group} pairs currently tracked — watch this against
+# MAX_SERIES to know if the cardinality cap is being approached.
+beacon_series = Gauge(
+    "homepage_beacon_series",
+    "Number of distinct {service,group} label pairs currently tracked.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Token-bucket rate limiter (global, thread-safe)
+# ---------------------------------------------------------------------------
+class TokenBucket:
+    def __init__(self, rate: float, capacity: float) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._tokens = capacity
+        self._last = time.monotonic()
+        self._lock = threading.Lock()
+
+    def take(self) -> bool:
+        with self._lock:
+            now = time.monotonic()
+            self._tokens = min(
+                self._capacity, self._tokens + (now - self._last) * self._rate
+            )
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return True
+            return False
+
+
+_bucket = TokenBucket(RATE_QPS, RATE_BURST)
+
+# Distinct {service,group} pairs seen so far — the cardinality cap set.
+_seen: set[tuple[str, str]] = set()
+_seen_lock = threading.Lock()
+
+
+def _clean(value: object) -> str | None:
+    """Coerce, trim, length-cap and charset-check one label value. Returns the
+    cleaned string, or None if it is empty or contains disallowed characters."""
+    if not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v or len(v) > MAX_LABEL_LEN:
+        return None
+    if not _LABEL_RE.match(v):
+        return None
+    return v
+
+
+def _record(service: str, group: str) -> str:
+    """Increment the click counter, honouring the distinct-series cap. Returns
+    the outcome string used as the beacon_requests result label."""
+    key = (service, group)
+    with _seen_lock:
+        if key not in _seen:
+            if len(_seen) >= MAX_SERIES:
+                return "rejected_series_cap"
+            _seen.add(key)
+            beacon_series.set(len(_seen))
+    tile_clicks.labels(service=service, group=group).inc()
+    return "accepted"
+
+
+# ---------------------------------------------------------------------------
+# HTTP: POST <BEACON_PATH>  +  GET /metrics  +  GET /healthz
+# ---------------------------------------------------------------------------
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _empty(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self):  # noqa: N802 - stdlib naming
+        if self.path == "/healthz":
+            body = b"ok\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if self.path.startswith("/metrics"):
+            output = generate_latest()
+            self.send_response(200)
+            self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+            self.send_header("Content-Length", str(len(output)))
+            self.end_headers()
+            self.wfile.write(output)
+            return
+        self._empty(404)
+
+    def do_POST(self):  # noqa: N802 - stdlib naming
+        # Route: only the configured beacon path is a valid POST target.
+        if self.path.split("?", 1)[0] != BEACON_PATH:
+            self._empty(404)
+            return
+
+        # Origin allowlist (a filter, not a security boundary — see module docstring).
+        if ALLOWED_ORIGINS:
+            origin = self.headers.get("Origin", "")
+            if origin not in ALLOWED_ORIGINS:
+                beacon_requests.labels(result="rejected_origin").inc()
+                self._empty(403)
+                return
+
+        # Global rate limit.
+        if not _bucket.take():
+            beacon_requests.labels(result="rejected_ratelimit").inc()
+            self._empty(429)
+            return
+
+        # Bounded body read + JSON parse.
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            length = 0
+        if length <= 0 or length > MAX_BODY_BYTES:
+            beacon_requests.labels(result="rejected_payload").inc()
+            self._empty(400)
+            return
+        try:
+            raw = self.rfile.read(length)
+            data = json.loads(raw.decode("utf-8", "strict"))
+        except Exception:  # noqa: BLE001 - any parse failure is a bad payload
+            beacon_requests.labels(result="rejected_payload").inc()
+            self._empty(400)
+            return
+
+        if not isinstance(data, dict):
+            beacon_requests.labels(result="rejected_payload").inc()
+            self._empty(400)
+            return
+
+        service = _clean(data.get("service"))
+        # group is optional; an empty/blank group is recorded as "".
+        group_raw = data.get("group")
+        group = "" if group_raw in (None, "") else _clean(group_raw)
+        if service is None or group is None:
+            beacon_requests.labels(result="rejected_payload").inc()
+            self._empty(400)
+            return
+
+        result = _record(service, group)
+        beacon_requests.labels(result=result).inc()
+        # sendBeacon ignores the response body/status; 204 either way.
+        self._empty(204 if result == "accepted" else 429)
+
+    def log_message(self, *args):  # silence per-request logging
+        return
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    # Initialise the outcome series so they exist at 0 before the first POST.
+    for r in (
+        "accepted",
+        "rejected_origin",
+        "rejected_ratelimit",
+        "rejected_payload",
+        "rejected_series_cap",
+    ):
+        beacon_requests.labels(result=r)
+    beacon_series.set(0)
+
+    httpd = ThreadingHTTPServer(("", LISTEN_PORT), Handler)
+    log.info(
+        "serving POST %s + /metrics + /healthz on :%s (origins=%s, max_series=%s)",
+        BEACON_PATH,
+        LISTEN_PORT,
+        sorted(ALLOWED_ORIGINS) or "<any>",
+        MAX_SERIES,
+    )
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/images/homepage-clicks/requirements.txt
+++ b/images/homepage-clicks/requirements.txt
@@ -1,0 +1,1 @@
+prometheus_client>=0.20,<1

--- a/infra/configs/dashboards/homepage-clicks-cm.yaml
+++ b/infra/configs/dashboards/homepage-clicks-cm.yaml
@@ -1,0 +1,234 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage-clicks-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  homepage-clicks.json: |
+    {
+      "title": "Homepage Tile Usage",
+      "uid": "homepage-clicks",
+      "tags": ["homelab", "homepage", "usage"],
+      "schemaVersion": 38,
+      "refresh": "1m",
+      "time": { "from": "now-30d", "to": "now" },
+      "timepicker": {},
+      "panels": [
+        {
+          "id": 1,
+          "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+          "type": "stat",
+          "title": "Total Clicks (range)",
+          "description": "Total tile clicks recorded across the whole dashboard over the selected time range. This is the raw volume signal — how much the dashboard is used, period.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(increase(homepage_tile_clicks_total[$__range]))",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } }
+        },
+        {
+          "id": 2,
+          "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+          "type": "stat",
+          "title": "Distinct Tiles Clicked",
+          "description": "Number of distinct {service,group} tiles the beacon has ever seen a click for (homepage_beacon_series). Compare against the total tile count on the dashboard — the gap is the set of never-clicked tiles.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "max(homepage_beacon_series)",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } }
+        },
+        {
+          "id": 3,
+          "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+          "type": "stat",
+          "title": "Beacon Target Up",
+          "description": "Whether Prometheus is currently scraping the homepage-clicks exporter (up{job=\"homepage-clicks\"}). 0 means the exporter is down or unscraped and clicks are being lost.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "max(up{job=\"homepage-clicks\"})",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } },
+                { "type": "value", "options": { "1": { "text": "UP", "color": "green" } } }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "red" },
+                  { "value": 1, "color": "green" }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 4,
+          "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+          "type": "stat",
+          "title": "Rejected Beacons (range)",
+          "description": "Beacon POSTs rejected over the range (bad origin, rate-limited, bad payload, or series-cap). A small non-zero count is normal on a public endpoint; a spike suggests abuse or a broken client.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(increase(homepage_beacon_requests_total{result=~\"rejected.*\"}[$__range]))",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" },
+                  { "value": 100, "color": "yellow" },
+                  { "value": 1000, "color": "red" }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 10,
+          "gridPos": { "x": 0, "y": 4, "w": 24, "h": 9 },
+          "type": "timeseries",
+          "title": "Clicks Over Time, by Tile",
+          "description": "Per-tile click rate over time (increase per scrape interval, summed by service). Shows how usage shifts — including before/after a re-order — so a layout change becomes a measurable hypothesis rather than a guess.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (service) (increase(homepage_tile_clicks_total[$__rate_interval]))",
+              "legendFormat": "{{service}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 60,
+                "stacking": { "mode": "normal", "group": "A" },
+                "lineWidth": 0
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 20,
+          "gridPos": { "x": 0, "y": 13, "w": 12, "h": 10 },
+          "type": "bargauge",
+          "title": "Top Tiles (range)",
+          "description": "Tiles ranked by total clicks over the range (topk 25). The promote list — high-traffic tiles belong top-left / on the Home tab.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "topk(25, sum by (service) (increase(homepage_tile_clicks_total[$__range])))",
+              "legendFormat": "{{service}}",
+              "instant": true
+            }
+          ],
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "showUnfilled": true
+          },
+          "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } }
+        },
+        {
+          "id": 21,
+          "gridPos": { "x": 12, "y": 13, "w": 12, "h": 10 },
+          "type": "table",
+          "title": "Clicks by Tile + Group (least used first)",
+          "description": "Every tile that has been clicked in the range, with its group, sorted ascending. The bottom of this list plus any tile absent from it entirely are the demote/prune candidates for the next re-order.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (service, group) (increase(homepage_tile_clicks_total[$__range]))",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "transformations": [
+            { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "service": "Tile", "group": "Group", "Value": "Clicks" } } },
+            { "id": "sortBy", "options": { "fields": {}, "sort": [{ "field": "Clicks", "desc": false }] } }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 } }
+        },
+        {
+          "id": 30,
+          "gridPos": { "x": 0, "y": 23, "w": 12, "h": 8 },
+          "type": "timeseries",
+          "title": "Beacon Request Outcomes",
+          "description": "Beacon POST outcomes over time (accepted vs the rejection reasons). Operational health of the endpoint itself — a rising rejected_series_cap or rejected_ratelimit line means the caps are being hit.",
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (result) (increase(homepage_beacon_requests_total[$__rate_interval]))",
+              "legendFormat": "{{result}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 1 }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "id": 31,
+          "gridPos": { "x": 12, "y": 23, "w": 12, "h": 8 },
+          "type": "text",
+          "title": "Reading this dashboard",
+          "options": {
+            "mode": "markdown",
+            "content": "**Never-clicked tiles** don't appear here — the beacon only creates a series after a tile's first click. To find them, compare the tiles listed in *Clicks by Tile + Group* against the full tile inventory in `apps/production/homepage/config/services.yaml`; any tile not listed has zero clicks in the range.\n\n**The loop:** collect 2-4 weeks -> promote the top of *Top Tiles*, demote/retab the bottom of *Clicks by Tile + Group* and the never-clicked set -> ship a `services.yaml` re-order PR -> watch *Clicks Over Time* confirm the shift.\n\nData source: `homepage_tile_clicks_total{service,group}` from the `homepage-clicks` beacon exporter, fed by the `custom.js` click handler."
+          }
+        }
+      ]
+    }

--- a/infra/configs/dashboards/kustomization.yaml
+++ b/infra/configs/dashboards/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - cluster-overview-cm.yaml
   - cnpg-cm.yaml
   - control-plane-cm.yaml
+  - homepage-clicks-cm.yaml
   - homelabscope-cm.yaml
   - modemscope-cm.yaml
   - mqttscope-cm.yaml


### PR DESCRIPTION
## What

Phase 1 of the [Homepage organization plan](../blob/master/) — instrument per-tile click usage so re-ordering the dashboard becomes data-driven. Homepage tiles are plain `<a href>` links, so today nothing is recorded on click.

A lightweight, self-hosted tracker in the `*scope` mold:

```
custom.js click handler  --sendBeacon /api/clicks-->  homepage-clicks exporter
   (same-origin)                                      homepage_tile_clicks_total{service,group}
                                                                 |
                                              ServiceMonitor -> Prometheus -> Grafana
```

## Contents

| Area | Change |
|---|---|
| `images/homepage-clicks/` | Python stdlib + `prometheus_client` exporter. Accepts same-origin `sendBeacon` POSTs at `/api/clicks`, increments `homepage_tile_clicks_total{service,group}` at `/metrics`. Origin allowlist + token-bucket rate limit + distinct-series cap bound abuse on the public endpoint; stores only label + timestamp (no PII). `Dockerfile` + `build-homepage-clicks.yml` (date-sha tag, mirrors `build-mqttscope`). |
| `apps/base/homepage-clicks/` + `apps/production/homepage-clicks/` | Deployment / Service / ServiceMonitor / CiliumNetworkPolicy, in the `homepage`(`-prod`) namespace so the HTTPRoute path forwards same-origin **without a ReferenceGrant**. Wired into `apps/production/kustomization.yaml`. |
| `apps/production/homepage/httproute.yaml` | `/api/clicks` -> `homepage-clicks:9107`, else -> `homepage:3000` (flashcards specific-first pattern). |
| `apps/base/homepage/config/custom.js` | Delegated capture-phase click handler keyed on Homepage's stable `.service-title-text` / `.service-name` / `.service-group-name` classes. Best-effort, never blocks navigation. |
| `infra/configs/dashboards/homepage-clicks-cm.yaml` | "Homepage Tile Usage" Grafana dashboard: clicks over time, top tiles, least-used table, beacon health. |

## Validation

- `kustomize build apps/production`, `apps/staging`, `infra/configs` all pass.
- Beacon resources land in `homepage-prod`; HTTPRoute routes `/api/clicks` first, catch-all second; updated `custom.js` flows into the prod homepage ConfigMap.
- Dashboard JSON parses (9 panels).
- `yamllint -c .yamllint -s` clean on all changed YAML.
- Exporter exercised locally: good POST -> 204, bad Origin -> 403, wrong path -> 404, bad/hostile payload -> 400, counter + series gauge increment correctly.

## Operator follow-ups

1. **Image must build first.** The Deployment pins `ghcr.io/gjcourt/homepage-clicks:latest` as a placeholder. On merge, `build-homepage-clicks.yml` publishes `YYYY-MM-DD-<sha7>`; **repin the deployment to that `tag@sha256:digest` in a follow-up PR** (per image discipline). Until then the pod won't pull, the ServiceMonitor target stays down, and `/api/clicks` returns 5xx — expected pre-build.
2. **Grafana dashboard** auto-imports via the `grafana_dashboard` sidecar label (no manual import).
3. No secrets required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet