### PR TITLE
fix(qbittorrent): repoint /downloads to family/media/video/movies

### DIFF
--- a/hosts/hestia/qbittorrent/docker-compose.yml
+++ b/hosts/hestia/qbittorrent/docker-compose.yml
@@ -11,7 +11,7 @@
 # Storage layout:
 #   /mnt/main/apps/qbittorrent/config   — qbit state (sqlite, .torrent files,
 #                                         settings, RSS feeds, categories)
-#   /mnt/main/media/movies              — downloads land directly in the
+#   /mnt/main/family/media/video/movies — downloads land directly in the
 #                                         Jellyfin movies library. This matches
 #                                         the alcatraz qbit layout so migrated
 #                                         .fastresume files resolve without
@@ -46,7 +46,7 @@ services:
       - TORRENTING_PORT=6881
     volumes:
       - /mnt/main/apps/qbittorrent/config:/config
-      - /mnt/main/media/movies:/downloads
+      - /mnt/main/family/media/video/movies:/downloads
     ports:
       - "8080:8080"
       - "6881:6881/tcp"


### PR DESCRIPTION
qbit /downloads pointed at `/mnt/main/media/movies`, emptied when `main/media` was retired → qbit lost its 69 movie torrents (seeding down). Repoints to the canonical library path so seeding resumes. Applied live via `app.update`; syncs the canonical compose. Also unblocked the `main/media` husk destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)