### PR TITLE
fix(audiobookshelf): point ffmpeg/ffprobe at /usr/bin

### DIFF
--- a/apps/base/audiobookshelf/configmap.yaml
+++ b/apps/base/audiobookshelf/configmap.yaml
@@ -6,9 +6,15 @@ metadata:
     app: audiobookshelf
 data:
   CONFIG_PATH: /usr/share/audiobookshelf/config
-  FFMPEG_PATH: /usr/lib/audiobookshelf-ffmpeg/ffmpeg
-  FFPROBE_PATH: /usr/lib/audiobookshelf-ffmpeg/ffprobe
+  # The 2.35.1 image ships ffmpeg/ffprobe from Alpine at /usr/bin (dynamically
+  # linked). The old /usr/lib/audiobookshelf-ffmpeg/ bundle path no longer
+  # exists in this image, which made every AudioFileScanner ffprobe spawn fail
+  # with ENOENT and every library scan return 0 items. Point at /usr/bin.
+  # (tone is not shipped in this image; TONE_PATH is only used for m4b metadata
+  # embedding, not scanning, so a missing path there is non-blocking.)
+  FFMPEG_PATH: /usr/bin/ffmpeg
+  FFPROBE_PATH: /usr/bin/ffprobe
   METADATA_PATH: /usr/share/audiobookshelf/metadata
   PORT: "13378"
-  TONE_PATH: /usr/lib/audiobookshelf-ffmpeg/tone
+  TONE_PATH: /usr/bin/tone
   TZ: America/Los_Angeles


### PR DESCRIPTION
## Problem
Audiobookshelf library scans returned **0 items** even though the NFS mounts (`/audiobooks`, `/podcasts`) and content were correct and readable. The scanner log showed, for every file:

```
ERROR: [AudioFileScanner] spawn /usr/lib/audiobookshelf-ffmpeg/ffprobe ENOENT
...
Library scan completed | 0 Added | 0 Updated | 0 Missing
```

## Root cause
The `audiobookshelf-container-env` ConfigMap hardcoded the **old bundled ffmpeg paths** (`/usr/lib/audiobookshelf-ffmpeg/{ffmpeg,ffprobe,tone}`). The `2.35.1` image ships Alpine's ffmpeg/ffprobe at **`/usr/bin`** and no longer has that bundle directory, so every `ffprobe` spawn failed with ENOENT and no audio files could be parsed.

## Fix
Point `FFMPEG_PATH`/`FFPROBE_PATH` at `/usr/bin`. Verified in-cluster: the repointed pod runs `ffprobe 8.0.1` successfully. (`tone` is not shipped in this image; `TONE_PATH` only affects m4b metadata embedding, not scanning, so it stays non-blocking.)

## Validation
- `kustomize build apps/production/audiobookshelf` + `apps/staging/audiobookshelf` pass
- Built output shows the corrected `/usr/bin` paths
- Live-validated on the prod pod before opening this PR (ffprobe spawns cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)