### PR TITLE
docs(homepage): document the measure→reorder loop

### DIFF
--- a/docs/operations/apps/homepage.md
+++ b/docs/operations/apps/homepage.md
@@ -39,10 +39,12 @@ To verify Homepage is working:
 3. Verify the `homepage` pod is running: `kubectl get pods -n homepage`
 
 ## 7. Monitoring & Alerting
-- **Metrics**: Homepage does not expose Prometheus metrics natively.
+- **Metrics**: Homepage itself exposes no Prometheus metrics. Tile *click* usage is
+  instrumented separately by the `homepage-clicks` beacon exporter (see §10), which exposes
+  `homepage_tile_clicks_total{service,group}` and is scraped via a `ServiceMonitor`.
 - **Logs**: Check the pod logs for configuration errors or widget connection issues:
   ```bash
-  kubectl logs -n homepage deploy/homepage
+  kubectl logs -n homepage-prod deploy/homepage
   ```
 
 ## 8. Disaster Recovery
@@ -56,3 +58,48 @@ To verify Homepage is working:
   - Verify any required authentication credentials (e.g., API keys, usernames/passwords) are correctly injected via environment variables or secrets.
 - **Kubernetes Widget Errors**: Ensure the `homepage` ServiceAccount has the correct RBAC permissions to read nodes and pods.
 - **Configuration Changes Not Applying**: Homepage hot-reloads configuration changes. If changes don't appear, verify the ConfigMap was updated in the cluster (`kubectl describe cm homepage -n homepage`) and check the pod logs for YAML parsing errors.
+
+## 10. Usage tracking & the measure→reorder loop
+
+The dashboard layout is meant to be **evidence-driven, not guessed**. Which tiles actually get
+used is measured, and the layout is re-ordered on that data on a repeating cadence. This closes the
+loop set up by the homepage organization plan — Phase 1 tracking (PR #1170) and Phase 2 re-order
+(PR #1171).
+
+### How click tracking works (Phase 1)
+1. **`custom.js`** (mounted at `/app/config/custom.js`, sourced from `apps/base/homepage/config/`)
+   attaches a delegated click listener to tile `<a>` links. On click it fires
+   `navigator.sendBeacon()` with `{service, group, href}` — non-blocking, so navigation is unaffected.
+2. **`homepage-clicks`** — a small Go beacon exporter (in the `*scope` mold, `apps/base/homepage-clicks/`)
+   receives the beacon, increments `homepage_tile_clicks_total{service,group}`, and serves `/metrics`.
+3. A **`ServiceMonitor`** has kube-prometheus-stack scrape it; the **`homepage-clicks-dashboard`**
+   Grafana ConfigMap renders clicks-over-time, top tiles, and never-clicked tiles.
+
+Privacy: self-hosted, single household, no third party — only a `service`/`group` label + timestamp,
+no PII. The dashboard is public, so the beacon accepts only simple same-origin payloads.
+
+Verify the beacon:
+```bash
+# counter increments after clicking a tile
+kubectl -n homepage-prod exec deploy/homepage-clicks -- wget -qO- localhost:8080/metrics | grep homepage_tile_clicks_total
+```
+
+### Layout: tabs + within-group order (Phase 2)
+- `settings.yaml` assigns each group to a tab via `layout.<group>.tab`: **Home** (Media, Tools) and
+  **Admin** (Infrastructure, Monitoring) — this halves first-paint clutter without removing access.
+- Within each group, tiles in `services.yaml` are ordered by expected daily-use frequency.
+- Rarely-used power-user deep-links (Prometheus, Alertmanager, raw Loki logs) live in the
+  **Observability** bookmarks group, not as tiles.
+
+### The loop (Phases 3–4, repeat every ~quarter)
+1. **Instrument** — already live (above); new tiles are tracked automatically (generic handler).
+2. **Collect** — let 2–4 weeks of real clicks accumulate before drawing conclusions.
+3. **Read** — open the Grafana "tile usage" panel: top tiles, click distribution, never-clicked tiles.
+4. **Re-order (a config-only PR)** — edit `apps/production/homepage/config/`:
+   - promote high-click tiles toward top-left (F-pattern), demote low-click ones;
+   - move never-clicked tiles (after a full quarter) to the Observability bookmarks or remove them;
+   - retab if a whole group's cadence changed. Run `kustomize build apps/production/homepage` to validate.
+5. **Annotate** — add a Grafana annotation at the merge so the next period's before/after is visible.
+6. **Measure again** — each re-order is a hypothesis the next period's data confirms or refutes.
+
+Never hand-order by intuition once data exists — let the panel drive it.


### PR DESCRIPTION
## What
Final closeout of the homepage organization plan: documents the usage-tracking + **measure→reorder loop** in the homepage runbook.

With Phase 1 (click tracking, #1170) and Phase 2 (Home/Admin tabs + frequency ordering, #1171) both shipped and live, this writes down the repeatable process so the remaining phases are a documented cadence rather than tribal knowledge:

- How the `homepage-clicks` beacon works (`custom.js` → `sendBeacon` → Go exporter → `homepage_tile_clicks_total` → ServiceMonitor → Grafana `homepage-clicks-dashboard`).
- The tab layout (`layout.<group>.tab`: Home = Media/Tools, Admin = Infra/Monitoring) and within-group frequency ordering.
- **The loop** (Phases 3–4, repeat ~quarterly): instrument → collect 2–4 weeks → read the Grafana panel → re-order via a config-only PR (promote top clicks, demote/prune never-clicked, retab) → annotate the change → measure again.
- Corrects the stale "Homepage does not expose Prometheus metrics" line (the beacon exposes tile-click metrics).

## Why
Phases 3–4 are inherently a data-collection wait (weeks of real clicks). This doc is the last *buildable* deliverable — it turns "re-order the dashboard someday" into a defined, evidence-driven procedure.

## Validation
- Docs-only change; no manifests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)