### PR TITLE
fix(flux): apps-* dependsOn infra-configs to enforce reconciliation order

### DIFF
--- a/clusters/melodic-muse/apps-production.yaml
+++ b/clusters/melodic-muse/apps-production.yaml
@@ -4,6 +4,13 @@ metadata:
   name: apps-production
   namespace: flux-system
 spec:
+  # Enforce the documented reconciliation order (infra-* -> apps-*): apps
+  # hard-depend on infra/configs resources (shared Gateway, cert-manager
+  # issuers, Cilium LB IP pools, network policies), so this must reconcile
+  # after infra-configs is Ready — otherwise on a cold bootstrap / full rebuild
+  # app Kustomizations apply before their prerequisites exist. See issue #1103.
+  dependsOn:
+    - name: infra-configs
   interval: 10m0s
   retryInterval: 1m
   timeout: 5m

--- a/clusters/melodic-muse/apps-staging.yaml
+++ b/clusters/melodic-muse/apps-staging.yaml
@@ -4,6 +4,13 @@ metadata:
   name: apps-staging
   namespace: flux-system
 spec:
+  # Enforce the documented reconciliation order (infra-* -> apps-*): apps
+  # hard-depend on infra/configs resources (shared Gateway, cert-manager
+  # issuers, Cilium LB IP pools, network policies), so this must reconcile
+  # after infra-configs is Ready. The dependsOn resolves against the
+  # same-namespace infra-configs Kustomization. See issue #1103.
+  dependsOn:
+    - name: infra-configs
   interval: 10m0s
   retryInterval: 1m
   timeout: 1m

--- a/clusters/melodic-muse/infra.yaml
+++ b/clusters/melodic-muse/infra.yaml
@@ -56,6 +56,9 @@ spec:
     name: flux-system
   path: ./infra/configs
   prune: true
+  # wait for configs (Gateway, issuers, LB IP pools) to be Ready, not merely
+  # applied, so apps-* dependents actually gate on them (see issue #1103).
+  wait: true
 
   # SOPS age decryption for secrets
   decryption:


### PR DESCRIPTION
Closes #1103.

## Problem
`AGENTS.md` states the reconciliation order as an invariant — `infra-crds → infra-controllers → infra-configs → apps-{production,staging}` — and the infra chain enforces it (`dependsOn` + `wait: true`). But **neither `apps-production` nor `apps-staging` declared any `dependsOn`**, so Flux reconciled them *concurrently* with infra. The documented ordering wasn't enforced by the manifests.

## Why it matters
`infra/configs/` holds resources apps hard-depend on: the shared **Gateway**, **cert-manager issuers**, **Cilium LB IP pools**, and network-policy scaffolding. On a **cold bootstrap / full rebuild** (or after an infra-configs change that recreates those), app Kustomizations could apply before their prerequisites exist and churn until the next 1-minute retry. Steady state self-heals; the hazard window is exactly the bootstrap/rebuild.

## Change
- `apps-production.yaml` / `apps-staging.yaml`: add `dependsOn: [infra-configs]`.
- `infra.yaml` (`infra-configs`): add `wait: true` so dependents gate on **Ready**, not merely *applied* (matching `infra-controllers`).

`apps-staging` tracks the `flux-system-staging` source, but `dependsOn` resolves against the same-namespace `infra-configs` Kustomization, which is correct.

## Validation
- All three files parse as valid YAML.
- No app manifests touched; changes are confined to the Flux Kustomization definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)