### PR TITLE
fix(zigbee2mqtt): fail-fast writability guard on iSCSI data mount

### DIFF
--- a/infra/controllers/zigbee2mqtt/deployment.yaml
+++ b/infra/controllers/zigbee2mqtt/deployment.yaml
@@ -20,7 +20,11 @@ spec:
       initContainers:
         - name: init-config
           image: busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
-          command: ['sh', '-c', "if [ ! -s /app/data/configuration.yaml ]; then cp -L /tmp/config/configuration.yaml /app/data/configuration.yaml; fi"]
+          # Guard against a stale/read-only iSCSI data mount (issue #1080): a hestia
+          # iSCSI target flap remounts the ext4 volume read-only, and z2m otherwise
+          # starts and burns hundreds of restarts on a confusing `ENOENT mkdir` deep
+          # in the app. Fail the init fast with a clear recovery hint instead.
+          command: ['sh', '-c', "SENTINEL=/app/data/.mount-writable; if ! ( touch $SENTINEL && rm -f $SENTINEL ) 2>/dev/null; then echo 'FATAL: /app/data not writable - stale/read-only iSCSI mount (see issue #1080); recover with: kubectl -n zigbee2mqtt scale deploy/zigbee2mqtt --replicas=0 then --replicas=1' >&2; exit 1; fi; if [ ! -s /app/data/configuration.yaml ]; then cp -L /tmp/config/configuration.yaml /app/data/configuration.yaml; fi"]
           volumeMounts:
             - name: config
               mountPath: /tmp/config


### PR DESCRIPTION
Refs #1080 (remediation option 1 — startup guard).

## Problem
When hestia's iSCSI target flaps, the Talos client correctly remounts z2m's RWO ext4 data volume **read-only**. z2m then starts and crashes on a confusing `ENOENT: no such file or directory, mkdir '/app/data/log/<ts>'` deep in the app — the parent dir exists, the write just fails. On 2026-07-09 it burned **493 restarts**, and because z2m runs under `infra-controllers` (with `wait: true`), it stalled the Flux infra reconciliation chain. Recovery needed a manual `scale 0 -> 1` to force a clean remount.

## Change
Prepend a writability sentinel to the existing `init-config` initContainer: `touch`+`rm` a file under `/app/data`. If it fails (read-only mount), fail the init **fast** with:
```
FATAL: /app/data not writable - stale/read-only iSCSI mount (see issue #1080);
recover with: kubectl -n zigbee2mqtt scale deploy/zigbee2mqtt --replicas=0 then --replicas=1
```
instead of letting z2m start and burn restarts on a cryptic app-level error. Combined with the existing `NodeFilesystemReadOnly` (critical, 2m) + `ContainerCrashLoopBackOff` alerts, a bad mount now surfaces immediately with an actionable log line and recovery command.

## Scope / what this does *not* do
This is the app-local fail-fast mitigation. It does **not** fix the root cause — hestia running **TrueNAS `26.0.0-BETA.1`** (a beta OS), which is the likely source of the target instability. That's tracked separately on #1080 (recommendation: get hestia onto a stable release). The broader "move config PVCs off single-target iSCSI" option is deferred (no reattach-tolerant backing exists in-cluster today; all 20+ PVCs are iSCSI→hestia).

## Validation
- `kustomize build infra/controllers` passes.
- Guard logic tested both paths: writable → proceeds; non-writable → FATAL + exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)