### PR TITLE
deploy(vibrato): bump prod to 75a4506 (Brew tab rich-telemetry fix)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:65e55e7bd87f11fb028149bb547bf7199201c5a0
+          image: ghcr.io/gjcourt/vibrato:75a4506d66ada33ed5a75d089b53c498546b49eb
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Deploys [gjcourt/vibrato#35](https://github.com/gjcourt/vibrato/pull/35) — pins the rich-frame `pressureBar` offset (`leva!-65D751CF` @ 196) and makes the Brew tab assert `rich` mode, so its readout tiles + shot chart finally populate with live telemetry.

- Image `ghcr.io/gjcourt/vibrato:75a4506…` verified present in ghcr.
- **Forward-only:** the current tag `65e55e7` is a git ancestor of `75a4506` (no rollback).
- `kustomize build apps/production/vibrato` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)