### PR TITLE
github-mirror: daily backup of all GitHub repos to hestia

### DIFF
--- a/.github/workflows/build-github-mirror.yml
+++ b/.github/workflows/build-github-mirror.yml
@@ -1,0 +1,67 @@
+name: Build github-mirror
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'images/github-mirror/**'
+      - '.github/workflows/build-github-mirror.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gjcourt/github-mirror
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Mirrors the YYYY-MM-DD / YYYY-MM-DD-N convention in AGENTS.md and the
+      # immich-photos-backup / signal-bridge / mopidy workflows.
+      - name: Generate date tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ATTEMPT="${{ github.run_attempt }}"
+          if [ "$ATTEMPT" = "1" ]; then
+            echo "tag=$DATE" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$DATE-$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: images/github-mirror
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### github-mirror published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Pin the digest in \`hosts/hestia/github-mirror/docker-compose.yml\` in a follow-up PR." >> $GITHUB_STEP_SUMMARY

--- a/hosts/hestia/github-mirror/README.md
+++ b/hosts/hestia/github-mirror/README.md
@@ -1,0 +1,68 @@
+# github-mirror
+
+Daily off-site-on-hestia backup of **every** `gjcourt` GitHub repo — all branches
+and tags — as bare `git clone --mirror` clones under the family tree at
+`admin/backups/global/github/`. So if GitHub ever loses a repo (or you do), the
+full history is recoverable from hestia with `git clone <mirror>.git`.
+
+## Why hestia, not k8s
+
+github-mirror is a **hestia-data backup job**: the bytes land on hestia's local
+disk. Co-locating compute with the destination gives fast local git packfile I/O
+and skips an NFS-PV round-trip back to hestia (and the `runAsUser` + export
+gymnastics to write the write-protected `admin/backups` tree). The image itself is
+storage-agnostic, so the same artifact runs as a k8s CronJob where the target PVC
+is cluster-local — see [`k8s-cronjob.example.yaml`](./k8s-cronjob.example.yaml).
+
+## How it works
+
+- `entrypoint.sh` runs `github-mirror.sh` on start (seeds immediately), then every
+  `INTERVAL_SECONDS` (default 86400 = daily). A loop, not cron, so it runs cleanly
+  as a non-root uid.
+- `github-mirror.sh` lists every repo the token owns via the GitHub REST API, then
+  for each does `git clone --mirror` (first run) or `git remote update --prune`
+  (thereafter) into `/mirror`. `--mirror` captures **all** refs — branches, tags,
+  in-flight work — not just the default branch.
+- The token is read from a mounted file and passed per-command via
+  `http.extraHeader`, so it is **never** persisted into any repo's git config.
+- Emits `homelabscope_job_last_success_seconds{job="github-mirror"}` (and friends)
+  to the node-exporter textfile collector, so the generic `HomelabscopeJobStale` /
+  `HomelabscopeJobMetricAbsent` alerts cover it automatically (48h budget).
+
+## First-time setup (operator, on hestia)
+
+1. **GitHub token.** Create a fine-grained PAT — **Contents: Read-only**, scoped to
+   **All repositories** (owner: gjcourt). Save it (a trailing newline is fine —
+   it's stripped) into the locked keys area:
+   ```
+   umask 077
+   printf '%s' '<PAT>' | sudo tee /mnt/main/family/admin/keys/github-mirror.token >/dev/null
+   sudo chown 1028:1028 /mnt/main/family/admin/keys/github-mirror.token
+   sudo chmod 0600     /mnt/main/family/admin/keys/github-mirror.token
+   ```
+2. **Mirror destination**, george-owned so the container (uid 1028) can write it:
+   ```
+   sudo install -d -o 1028 -g 100 -m 0750 /mnt/main/family/admin/backups/global/github
+   ```
+3. **(Optional) metrics.** Ensure the node-exporter textfile dir is writable by uid
+   1028, else the staleness metric silently skips (the backup still runs):
+   ```
+   sudo chgrp 100 /var/lib/node-exporter/textfile && sudo chmod g+w /var/lib/node-exporter/textfile
+   ```
+4. **Deploy** the compose in this directory as a TrueNAS SCALE **Custom App**.
+
+## Bootstrap → steady state
+
+The compose ships `image: …:latest` as a placeholder. After this PR merges,
+`build-github-mirror.yml` publishes the first image; **pin its `@sha256:` digest**
+in `docker-compose.yml` in a follow-up PR (like the other hestia apps) and
+`deploy-hestia.yml` auto-rolls it. Thereafter, editing `images/github-mirror/**`
+rebuilds the image; bump the digest to deploy.
+
+## Restore
+
+```
+git clone /mnt/main/family/admin/backups/global/github/<repo>.git <repo>
+# or push it back to a fresh GitHub repo:
+git clone --mirror <mirror>.git && cd <repo>.git && git push --mirror git@github.com:gjcourt/<repo>.git
+```

--- a/hosts/hestia/github-mirror/docker-compose.yml
+++ b/hosts/hestia/github-mirror/docker-compose.yml
@@ -1,0 +1,45 @@
+# Daily mirror of every gjcourt GitHub repo (all branches + tags) into the family
+# tree at admin/backups/global/github/, as bare `git clone --mirror` clones.
+#
+# Runs on hestia (not k8s) on purpose: it's a hestia-data backup job, so compute
+# sits next to the bytes — local disk = fast git packfile I/O, and writes land
+# directly in the write-protected admin/backups tree with the correct owner (no
+# NFS PV round-trip back to hestia). The container runs as uid 1028 (george) so
+# the bare mirrors are owner-writable under the 0750 admin/backups tree. The image
+# is storage-agnostic, so the same artifact runs as a k8s CronJob where that fits
+# — see k8s-cronjob.example.yaml.
+#
+# First-time setup (see README.md):
+#   1. GitHub fine-grained PAT — Contents: Read-only, all repositories — saved at
+#        /mnt/main/family/admin/keys/github-mirror.token   (mode 0600, owner george)
+#   2. Mirror dir, george-owned:
+#        install -d -o 1028 -g 100 -m 0750 /mnt/main/family/admin/backups/global/github
+#   3. (metrics, optional) node-exporter textfile dir writable by uid 1028, else
+#      the homelabscope staleness metric silently skips.
+#
+# After bootstrap, every change to images/github-mirror/** triggers
+# build-github-mirror.yml which publishes a new tag; pin the digest below in a
+# follow-up PR and deploy-hestia.yml auto-rolls.
+services:
+  github-mirror:
+    # TODO(bootstrap): pin @sha256:<digest> in a follow-up PR after the first
+    # build-github-mirror.yml run publishes the image.
+    image: ghcr.io/gjcourt/github-mirror:latest
+    container_name: github-mirror
+    restart: unless-stopped
+    # Run as george:users so the bare mirrors are owner-writable under the
+    # write-protected (0750, no group write) admin/backups tree.
+    user: "1028:100"
+    environment:
+      - TZ=America/New_York
+      - GITHUB_USER=gjcourt
+      - DEST=/mirror
+      - TOKEN_FILE=/run/secrets/github-token
+      - INTERVAL_SECONDS=86400
+    volumes:
+      # GitHub PAT (Contents: read) — single-file RO mount from the locked keys area.
+      - /mnt/main/family/admin/keys/github-mirror.token:/run/secrets/github-token:ro
+      # Mirror destination — bare <repo>.git clones (read-open, write-protected).
+      - /mnt/main/family/admin/backups/global/github:/mirror
+      # Prometheus textfile collector for the homelabscope staleness metric.
+      - /var/lib/node-exporter/textfile:/var/lib/node-exporter/textfile

--- a/hosts/hestia/github-mirror/k8s-cronjob.example.yaml
+++ b/hosts/hestia/github-mirror/k8s-cronjob.example.yaml
@@ -1,0 +1,56 @@
+# EXAMPLE — not deployed here. This repo runs github-mirror on hestia (see
+# docker-compose.yml) because it's a hestia-data backup job: co-locating compute
+# with the destination bytes gives fast local git I/O and avoids an NFS PV round-
+# trip back to hestia. This manifest is kept so the image stays a portable,
+# reusable artifact — anyone whose backup target lives IN their cluster (a PVC on
+# cluster-local storage) can run the exact same image as a CronJob instead.
+#
+# To use it: point the `mirror` volume at your own PVC, provide the token via a
+# Secret, and set schedule/user to taste.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: github-mirror
+  namespace: github-mirror
+spec:
+  schedule: "0 4 * * *" # daily 04:00
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 1028
+            runAsGroup: 100
+            fsGroup: 100
+          containers:
+            - name: github-mirror
+              image: ghcr.io/gjcourt/github-mirror:latest
+              # The image loops by default (INTERVAL_SECONDS); for a CronJob we
+              # want a single pass then exit, so run the script directly.
+              command: ["/usr/local/bin/github-mirror.sh"]
+              env:
+                - name: GITHUB_USER
+                  value: gjcourt
+                - name: DEST
+                  value: /mirror
+                - name: TOKEN_FILE
+                  value: /run/secrets/github-token
+              volumeMounts:
+                - name: token
+                  mountPath: /run/secrets/github-token
+                  subPath: github-token
+                  readOnly: true
+                - name: mirror
+                  mountPath: /mirror
+          volumes:
+            - name: token
+              secret:
+                secretName: github-mirror-token # key: github-token
+            - name: mirror
+              persistentVolumeClaim:
+                claimName: github-mirror # your cluster-local RWO/RWX PVC

--- a/images/github-mirror/Dockerfile
+++ b/images/github-mirror/Dockerfile
@@ -1,0 +1,28 @@
+# Mirror every GitHub repo of an account (all branches + tags) to local disk as
+# bare `git clone --mirror` clones. Designed to run on hestia as a TrueNAS Custom
+# App — see hosts/hestia/github-mirror/docker-compose.yml — writing into the family
+# tree at admin/backups/global/github/.
+#
+# Runs the mirror once on start (seeds immediately) then every ${INTERVAL_SECONDS}
+# (default daily). A plain loop, not cron, so the container runs cleanly as a
+# NON-root uid: the write-protected admin/backups tree only accepts writes as its
+# owner (uid 1028 / george), which the compose sets via `user:`.
+#
+# The image is deliberately storage-agnostic (DEST is just an env/mount) so the
+# same artifact runs as a k8s CronJob elsewhere — see the example in
+# hosts/hestia/github-mirror/k8s-cronjob.example.yaml.
+FROM alpine:3.23
+
+# git   — the mirror engine
+# curl  — list repos via the GitHub REST API
+# jq    — parse the API JSON
+# bash  — the scripts use bash-isms
+# ca-certificates — HTTPS to github.com / api.github.com
+# tzdata — honor TZ for readable log timestamps
+RUN apk add --no-cache git curl jq bash ca-certificates tzdata
+
+COPY github-mirror.sh /usr/local/bin/github-mirror.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 0755 /usr/local/bin/github-mirror.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/github-mirror/entrypoint.sh
+++ b/images/github-mirror/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Run the mirror on start (seeds immediately), then every INTERVAL_SECONDS. A
+# simple loop instead of cron so the container runs cleanly as a non-root uid —
+# the write-protected admin/backups tree requires writes as uid 1028 (george),
+# and busybox crond wants root. A run failing (e.g. a transient GitHub blip)
+# never kills the loop; it just retries next cycle.
+set -uo pipefail
+
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-86400}" # default: daily
+
+while true; do
+  /usr/local/bin/github-mirror.sh || echo "[$(date -Is)] mirror run exited non-zero — retrying next cycle"
+  echo "[$(date -Is)] sleeping ${INTERVAL_SECONDS}s until next run"
+  sleep "${INTERVAL_SECONDS}"
+done

--- a/images/github-mirror/github-mirror.sh
+++ b/images/github-mirror/github-mirror.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Mirror ALL of a GitHub account's repos (every branch + tag) into $DEST as bare
+# `git clone --mirror` clones; refresh with `git remote update --prune` on later
+# runs (picks up new/changed refs, drops deleted branches). Private repos are
+# included — the token owns them.
+#
+# Token handling: read from a mounted file (never baked into the image) and
+# passed per-command via `http.extraHeader`, so it is NEVER persisted into any
+# repo's git config on disk (the stored remote URL is token-less).
+#
+# Emits homelabscope textfile metrics (infra/configs/homelabscope/) so the
+# generic HomelabscopeJobStale / …MetricAbsent alerts cover this job for free.
+set -uo pipefail
+
+GITHUB_USER="${GITHUB_USER:-gjcourt}"
+DEST="${DEST:-/mirror}"
+TOKEN_FILE="${TOKEN_FILE:-/run/secrets/github-token}"
+TEXTFILE_DIR="${TEXTFILE_DIR:-/var/lib/node-exporter/textfile}"
+TEXTFILE="${TEXTFILE_DIR}/github-mirror.prom"
+MAX_AGE_SECONDS="${MAX_AGE_SECONDS:-172800}" # 48h staleness budget (daily job + slack)
+
+log() { echo "[$(date -Is)] $*"; }
+
+start_ts=$(date +%s)
+log "=== github-mirror START (user=${GITHUB_USER}, dest=${DEST}) ==="
+
+if [ ! -r "${TOKEN_FILE}" ]; then
+  log "FATAL: token file ${TOKEN_FILE} not readable"
+  exit 1
+fi
+token="$(tr -d '[:space:]' <"${TOKEN_FILE}")"
+auth="Authorization: Bearer ${token}"
+
+mkdir -p "${DEST}"
+
+# List every repo the token owns (private included), paginated 100/page.
+repos=""
+page=1
+while :; do
+  resp="$(curl -fsS -H "${auth}" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/user/repos?per_page=100&page=${page}&affiliation=owner&sort=full_name")" || {
+    log "FATAL: GitHub API listing failed on page ${page}"
+    exit 1
+  }
+  count="$(printf '%s' "${resp}" | jq 'length')"
+  [ "${count}" -eq 0 ] && break
+  repos="${repos}$(printf '%s' "${resp}" | jq -r '.[].full_name')
+"
+  page=$((page + 1))
+done
+total="$(printf '%s\n' "${repos}" | grep -c . || true)"
+log "found ${total} repos"
+
+ok=0
+fail=0
+while IFS= read -r full; do
+  [ -n "${full}" ] || continue
+  name="${full#*/}"
+  dir="${DEST}/${name}.git"
+  if [ -d "${dir}" ]; then
+    if git --git-dir="${dir}" -c http.extraHeader="${auth}" remote update --prune >/dev/null 2>&1; then
+      ok=$((ok + 1))
+      log "updated  ${full}"
+    else
+      fail=$((fail + 1))
+      log "FAILED   update ${full}"
+    fi
+  else
+    # Token-less URL is what gets stored; the header authenticates this command only.
+    if git -c http.extraHeader="${auth}" clone --mirror "https://github.com/${full}.git" "${dir}" >/dev/null 2>&1; then
+      ok=$((ok + 1))
+      log "cloned   ${full}"
+    else
+      fail=$((fail + 1))
+      log "FAILED   clone ${full}"
+    fi
+  fi
+done <<EOF
+${repos}
+EOF
+
+end_ts=$(date +%s)
+dur=$((end_ts - start_ts))
+status=0
+[ "${fail}" -gt 0 ] && status=1
+log "=== DONE: ${ok} ok, ${fail} failed, ${dur}s ==="
+
+# homelabscope textfile metrics — best-effort. last_success updates on every
+# COMPLETED run (a few per-repo failures shouldn't trip the "job hasn't run"
+# staleness alert); last_status carries the fail signal separately. A read-only
+# collector dir must never fail the backup, hence the guards.
+if mkdir -p "${TEXTFILE_DIR}" 2>/dev/null; then
+  tmp="${TEXTFILE}.$$"
+  if {
+    echo "# HELP github_mirror_repos_total Repos discovered this run."
+    echo "# TYPE github_mirror_repos_total gauge"
+    echo "github_mirror_repos_total ${total}"
+    echo "# HELP github_mirror_repos_failed Repos that failed this run."
+    echo "# TYPE github_mirror_repos_failed gauge"
+    echo "github_mirror_repos_failed ${fail}"
+    echo "# HELP homelabscope_job_last_success_seconds Unix timestamp of the job's last successful run."
+    echo "# TYPE homelabscope_job_last_success_seconds gauge"
+    echo "homelabscope_job_last_success_seconds{job=\"github-mirror\"} ${end_ts}"
+    echo "# HELP homelabscope_job_last_duration_seconds Wall-clock duration of the job's last run (seconds)."
+    echo "# TYPE homelabscope_job_last_duration_seconds gauge"
+    echo "homelabscope_job_last_duration_seconds{job=\"github-mirror\"} ${dur}"
+    echo "# HELP homelabscope_job_last_status Last run status (0=ok, 1=fail)."
+    echo "# TYPE homelabscope_job_last_status gauge"
+    echo "homelabscope_job_last_status{job=\"github-mirror\"} ${status}"
+    echo "# HELP homelabscope_job_max_age_seconds Per-job staleness budget (seconds)."
+    echo "# TYPE homelabscope_job_max_age_seconds gauge"
+    echo "homelabscope_job_max_age_seconds{job=\"github-mirror\"} ${MAX_AGE_SECONDS}"
+  } >"${tmp}" 2>/dev/null; then
+    mv "${tmp}" "${TEXTFILE}" 2>/dev/null || log "note: could not move metric into ${TEXTFILE}"
+  else
+    rm -f "${tmp}" 2>/dev/null || true
+    log "note: could not write ${TEXTFILE}"
+  fi
+fi
+
+# Exit 0 on partial failures (the loop + staleness metric handle those); reserve
+# non-zero for FATAL conditions handled above.
+exit 0


### PR DESCRIPTION
## github-mirror — daily GitHub → hestia backup

A hestia Custom App that mirrors **every** `gjcourt` GitHub repo — all branches and tags — as bare `git clone --mirror` clones under the family tree at `admin/backups/global/github/`, refreshed daily. If GitHub ever loses a repo (or I do), the full history is recoverable from hestia.

### Why hestia, not k8s
It's a hestia-data backup job — the bytes land on hestia's local disk. Co-locating compute with the destination gives fast local git packfile I/O and skips an NFS-PV round-trip back to hestia (plus the `runAsUser`/export gymnastics to write the write-protected `admin/backups` tree). The image is storage-agnostic, so the same artifact runs as a k8s CronJob where the target PVC is cluster-local — kept as [`k8s-cronjob.example.yaml`](../blob/feat/github-mirror/hosts/hestia/github-mirror/k8s-cronjob.example.yaml) for portability/reuse.

### What's here
- **`images/github-mirror/`** — thin alpine + git/curl/jq. `entrypoint.sh` runs on start (seeds) then loops daily; `github-mirror.sh` lists repos via the GitHub API and does `clone --mirror` / `remote update --prune` each. Token read from a mounted file and passed via `http.extraHeader` so it's **never** persisted into repo config.
- **`hosts/hestia/github-mirror/`** — compose (runs as `1028:100`; token from `admin/keys/`, output to `admin/backups/global/github/`), README (operator setup + restore), and the example CronJob.
- **`.github/workflows/build-github-mirror.yml`** — publishes `ghcr.io/gjcourt/github-mirror` on `images/github-mirror/**` changes (mirrors the immich-photos-backup workflow).
- Emits `homelabscope_job_last_success_seconds{job="github-mirror"}` → covered by the generic `HomelabscopeJobStale` alerts (48h budget), no custom rule needed.

### Bootstrap (after merge)
1. This build workflow publishes the first image → **pin its `@sha256:` digest** in `docker-compose.yml` in a follow-up PR (like the other hestia apps).
2. Operator (me) on hestia: create a fine-grained PAT (**Contents: read**, all repos) → `admin/keys/github-mirror.token`; `install -d -o 1028 -g 100 -m 0750 admin/backups/global/github`; deploy the compose as a TrueNAS Custom App.

Fits the schema we just built: token in the locked `admin/keys/`, mirrors in the read-open/write-protected `admin/backups/global/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
