### PR TITLE
fix(github-mirror): Basic auth for git clones (not Bearer)

### DIFF
--- a/images/github-mirror/github-mirror.sh
+++ b/images/github-mirror/github-mirror.sh
@@ -29,7 +29,12 @@ if [ ! -r "${TOKEN_FILE}" ]; then
   exit 1
 fi
 token="$(tr -d '[:space:]' <"${TOKEN_FILE}")"
-auth="Authorization: Bearer ${token}"
+# GitHub git-over-HTTPS needs BASIC auth (the token as the password), NOT Bearer.
+# Bearer is accepted by the REST API but rejected by the git endpoints, which then
+# fall back to prompting for a username → "could not read Username" and every clone
+# fails. Basic works for both the API and git, and via http.extraHeader the token
+# still never lands in any repo's stored config (the remote URL stays token-less).
+auth="Authorization: Basic $(printf 'x-access-token:%s' "${token}" | base64 | tr -d '\n')"
 
 mkdir -p "${DEST}"
 


### PR DESCRIPTION
The mirror listed all 72 repos (the REST API accepts `Bearer`) but **every clone failed** with `could not read Username` — GitHub's git-over-HTTPS endpoints reject `Bearer` and fall back to a username prompt. Switch to **Basic auth** (token as password) via `http.extraHeader`, which works for both the API and git. Verified live inside the running container (Bearer clone fails; Basic clone succeeds). Token still never persists into repo config.

After merge: build republishes the image; then I pin the new digest in the compose so `deploy-hestia` recreates the container with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)