### PR TITLE
deploy(vibrato): roll prod to 63e8244 (profile-write + phase lines)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:23ec524e82887fd032fa390678c5b2b4b45e334a
+          image: ghcr.io/gjcourt/vibrato:63e82444118893ddc18c3d9ec522e62005b581ea
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Rolls vibrato-prod 23ec524 → 63e8244 (HEAD of vibrato main), shipping #38 (save-profile-to-machine) and #39 (phase / pump-power Brew lines + chart timeline auto-fit). `kustomize build apps/production/vibrato` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)