### PR TITLE
deploy(vibrato): roll prod to 6efd7c1 (shot-detector fix + auto default-on)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:63e82444118893ddc18c3d9ec522e62005b581ea
+          image: ghcr.io/gjcourt/vibrato:6efd7c120c5bc7058226f593f7dac40182e90203
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Ships vibrato #40 to prod: the Brew chart now draws during a physical-button pull (ShotDetector treats rising pressure as an active shot — state stays OFF + no flow meter on the S1 Mini V2), and auto-record defaults ON. `kustomize build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)