### PR TITLE
deploy: vibrato prod to c7210cc (history rich channels + lint tooling)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:6efd7c120c5bc7058226f593f7dac40182e90203
+          image: ghcr.io/gjcourt/vibrato:c7210cc06e2527e387c20bb2f58702a1be7c9d8a
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps `vibrato-prod` image **6efd7c12 → c7210cc0**, rolling up everything merged since #40:

- **#41** — History replay draws the rich channels (phase / bias / setpoint), matching the brew view
- **#42** — comprehensive lint + hygiene tooling

## Safety
- `6efd7c12` is an ancestor of `c7210cc0` → strictly-forward, **not a rollback** (verified via `git merge-base --is-ancestor`).
- Image published by vibrato CI on the merge-to-main push: `ghcr.io/gjcourt/vibrato:c7210cc06e2527e387c20bb2f58702a1be7c9d8a` (also tagged `2026-07-24`, `latest`).
- `kustomize build apps/production/vibrato` passes; built output carries the new tag.
- No plaintext secrets in the diff.

After merge: `flux reconcile kustomization apps-production -n flux-system` to roll it out.