### PR TITLE
deploy: vibrato prod to 8db7bee (tunable write settle)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:c7210cc06e2527e387c20bb2f58702a1be7c9d8a
+          image: ghcr.io/gjcourt/vibrato:8db7bee2957b65d50152d0595ada828af0eb99a2
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps `vibrato-prod` **c7210cc0 → 8db7bee2** for the fast-write experiment (vibrato #43).

The `write-to-machine` endpoint now accepts `?settleMs=N` (clamped 20-400, default 250) and returns `{ settleMs, steps, durationMs }`, so we can sweep the per-step LCD redraw settle live and find the fastest reliable write cadence.

## Safety
- `c7210cc0` is an ancestor of `8db7bee2` → strictly-forward, **not a rollback**.
- Image published by CI: `ghcr.io/gjcourt/vibrato:8db7bee2957b65d50152d0595ada828af0eb99a2` (also `2026-07-24`, `latest`).
- `kustomize build apps/production/vibrato` passes; no plaintext secrets.

After merge: `flux reconcile source git flux-system` + `flux reconcile kustomization apps-production -n flux-system`.