### PR TITLE
deploy: vibrato prod to f259067 (write backout homing fix)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:8db7bee2957b65d50152d0595ada828af0eb99a2
+          image: ghcr.io/gjcourt/vibrato:f25906736f6bccb8543ae01697053e11c41bd0ab
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod **8db7bee2 → f2590673** (vibrato #44): the write-to-machine backout now cancels until the run screen instead of a fixed 8 presses, unblocking back-to-back writes. Ancestor→descendant (not a rollback). `kustomize build` passes. Reconcile after merge.