### PR TITLE
deploy: vibrato prod to 6b1c3eb (adaptive menu settle)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:f25906736f6bccb8543ae01697053e11c41bd0ab
+          image: ghcr.io/gjcourt/vibrato:6b1c3ebb9cf1b4e4f9efa264f19ce272538459d5
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod **f2590673 → 6b1c3ebb** (vibrato #45): menu presses self-pace to the machine's real redraw speed (wait-for-change, capped by settleMs) instead of a fixed per-step wait — navigation can't overshoot. Ancestor→descendant, not a rollback. `kustomize build` passes.