### PR TITLE
deploy: vibrato prod to ce9542f (open-loop value stepping)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:6b1c3ebb9cf1b4e4f9efa264f19ce272538459d5
+          image: ghcr.io/gjcourt/vibrato:ce9542ff7aa7c5d3f74fe871407864cac08a92f1
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod **6b1c3ebb → ce9542ff** (vibrato #46): value stepping goes open-loop (count delta, fire at fast input cadence, verify once) to decouple the write from the ~10Hz redraw lag; navigation stays closed-loop. Adds `?fastMs=` to sweep the cadence. Ancestor→descendant, not a rollback. `kustomize build` passes.