### PR TITLE
rollback: vibrato prod to f259067 (open-loop write regression)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:ce9542ff7aa7c5d3f74fe871407864cac08a92f1
+          image: ghcr.io/gjcourt/vibrato:f25906736f6bccb8543ae01697053e11c41bd0ab
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
**Explicit, intentional rollback** — image tag moves backwards on purpose (per AGENTS.md, explicit rollback PRs are allowed).

The open-loop value-stepping writer (`ce9542ff`, vibrato #46) **runs away**: a live LCD frame capture showed shot-1 Pump swept `2.8b → 12.9b` (rail) → down across the bar/degrees boundary to `59°` and back, never converging — the batch fires faster than the machine settles, so the post-batch verify read is stale and the loop diverges. It errored before committing (profile intact), but it's unsafe to leave deployed.

Rolls back to `f2590673` (#44) — the closed-loop fixed-settle writer that wrote cleanly at 78 steps. A paced-per-step replacement is being built and will supersede this **forward**.

`kustomize build` passes.