### PR TITLE
deploy: vibrato prod to 6ba9f5c (paced per-step value stepping)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:f25906736f6bccb8543ae01697053e11c41bd0ab
+          image: ghcr.io/gjcourt/vibrato:6ba9f5c02a7e0df8c24e09caff25edad79d556cf
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod **f2590673 → 6ba9f5c** (vibrato #47). Supersedes the rollback: closed-loop read-after-every-press (can't run away) with value stepping paced to the ~120ms redraw. Ancestor→descendant, not a rollback. `kustomize build` passes. For the deliberate frame-capture test.