### PR TITLE
deploy: vibrato prod to 13889c7 (servo value writer)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:6ba9f5c02a7e0df8c24e09caff25edad79d556cf
+          image: ghcr.io/gjcourt/vibrato:13889c7110bd3eb24560a4fc6044ac7978a69ae5
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod **6ba9f5c02a7e0df8c24e09caff25edad79d556cf → 13889c7** (vibrato #49): value stepping is now the servo (proportional jump + halving damping + settle-until-stable + boundary clamp), validated in sim + mock. For the deliberate frame-capture test on the machine; roll back to 6ba9f5c02a7e0df8c24e09caff25edad79d556cf (#47, reliable) if reality disagrees. Ancestor→descendant. `kustomize build` passes.