### PR TITLE
deploy: vibrato prod to 3a7213b (servo tuning knobs)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:13889c7110bd3eb24560a4fc6044ac7978a69ae5
+          image: ghcr.io/gjcourt/vibrato:3a7213b2f8c5960eed8023844a9ed64c4dee2601
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps vibrato-prod 13889c7 → 3a7213b: live ?stableMs=/?fastMs= knobs to sweep the servo settle window on the machine (200ms over-jumped). Forward bump; kustomize passes.