### PR TITLE
feat(vibrato): wire into cluster monitoring (ServiceMonitor + Grafana dashboard)

### DIFF
--- a/apps/base/vibrato/networkpolicy.yaml
+++ b/apps/base/vibrato/networkpolicy.yaml
@@ -26,6 +26,18 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # Prometheus scrapes GET /metrics on 8080. The scrape arrives as a normal
+    # pod-to-pod connection from the kube-prometheus-stack Prometheus pod, so it
+    # is not covered by the host/remote-node/ingress rule above and must be
+    # allowed explicitly (same pattern as overture's networkpolicy).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
   egress:
     # DNS via CoreDNS.
     - toEndpoints:

--- a/apps/production/vibrato/kustomization.yaml
+++ b/apps/production/vibrato/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: vibrato-prod
 resources:
   - ../../base/vibrato/
   - httproute.yaml
+  - servicemonitor.yaml
 labels:
   - pairs:
       env: production

--- a/apps/production/vibrato/servicemonitor.yaml
+++ b/apps/production/vibrato/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vibrato
+  namespace: vibrato-prod
+  labels:
+    # kube-prometheus-stack's Prometheus selects ServiceMonitors by the
+    # helm-default release label (serviceMonitorSelectorNilUsesHelmValues=true,
+    # serviceMonitorSelector={}). Without this label the SM is invisible to it.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: vibrato
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vibrato
+  # Scoped to the prod namespace on purpose. Only prod is wired to a real ito;
+  # staging (vibrato-stage) must not point at the single-connection physical
+  # machine, so it is deliberately left unscraped.
+  namespaceSelector:
+    matchNames:
+      - vibrato-prod
+  endpoints:
+    # The Vibrato server exposes GET /metrics on its single HTTP port (8080,
+    # named `http` on the Service). ~30s scrape — coarse on purpose: this feeds
+    # the trends/health dashboard, NOT per-shot dynamics (see vibrato-cm.yaml).
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/infra/configs/dashboards/kustomization.yaml
+++ b/infra/configs/dashboards/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - overture-cm.yaml
   - storage-csi-cm.yaml
   - thermalscope-cm.yaml
+  - vibrato-cm.yaml

--- a/infra/configs/dashboards/vibrato-cm.yaml
+++ b/infra/configs/dashboards/vibrato-cm.yaml
@@ -1,0 +1,374 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vibrato-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  vibrato.json: |
+    {
+      "title": "Vibrato (ito + leva!)",
+      "uid": "vibrato-overview",
+      "tags": ["homelab", "vibrato", "espresso"],
+      "schemaVersion": 38,
+      "refresh": "1m",
+      "time": { "from": "now-24h", "to": "now" },
+      "timepicker": {},
+      "description": "Trends and health for the Vibrato espresso controller over hours/days. Prometheus scrapes /metrics at ~30s, which is FAR too coarse for per-shot pressure/flow dynamics (a shot is ~25-40s) — this dashboard is for long-run trends and app health, NOT the live shot scope. The per-shot, high-rate scope lives inside the Vibrato app itself.",
+      "panels": [
+        {
+          "id": 100,
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 3 },
+          "type": "text",
+          "title": "",
+          "transparent": true,
+          "options": {
+            "mode": "markdown",
+            "content": "**Trends & health, not the shot scope.** Prometheus scrapes `/metrics` every ~30s — far coarser than a shot's second-by-second pressure/flow/phase dynamics (a shot lasts ~25-40s, so a whole shot is only ~1 sample). Read the timeseries below as **hours/days trends and app health**, never as a shot profile. Per-shot dynamics live in the Vibrato app's own live scope."
+          }
+        },
+        {
+          "id": 1,
+          "gridPos": { "x": 0, "y": 3, "w": 4, "h": 4 },
+          "type": "stat",
+          "title": "Vibrato Up",
+          "description": "vibrato_up — 1 while the Vibrato server is up and reporting. Distinct from up{job=\"vibrato\"} (whether Prometheus can scrape it at all).",
+          "targets": [
+            { "refId": "A", "expr": "vibrato_up", "legendFormat": "up" }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bool_on_off",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "red" },
+                  { "value": 1, "color": "green" }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 2,
+          "gridPos": { "x": 4, "y": 3, "w": 5, "h": 4 },
+          "type": "stat",
+          "title": "Shots (24h)",
+          "description": "increase(vibrato_shots_total[24h]) — shots pulled in the last 24h. Counter, so an app restart does not lose the running total.",
+          "targets": [
+            { "refId": "A", "expr": "sum(increase(vibrato_shots_total[24h]))", "legendFormat": "shots" }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": { "unit": "short", "decimals": 0 }
+          }
+        },
+        {
+          "id": 3,
+          "gridPos": { "x": 9, "y": 3, "w": 5, "h": 4 },
+          "type": "stat",
+          "title": "Profile Writes OK (24h)",
+          "description": "sum(increase(vibrato_profile_writes_total{result=\"success\"}[24h])) — successful profile-write-to-machine operations in the last 24h. NOTE: the `result` label value (success/ok) will be reconciled once the /metrics endpoint PR lands.",
+          "targets": [
+            { "refId": "A", "expr": "sum(increase(vibrato_profile_writes_total{result=\"success\"}[24h]))", "legendFormat": "ok" }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "green" } }
+          }
+        },
+        {
+          "id": 4,
+          "gridPos": { "x": 14, "y": 3, "w": 5, "h": 4 },
+          "type": "stat",
+          "title": "Profile Writes FAILED (24h)",
+          "description": "sum(increase(vibrato_profile_writes_total{result=\"fail\"}[24h])) — failed profile-write-to-machine operations in the last 24h. Non-zero means the closed-loop menu-nav writer aborted or diverged. NOTE: the `result` label value (fail/error) will be reconciled once the /metrics endpoint PR lands.",
+          "targets": [
+            { "refId": "A", "expr": "sum(increase(vibrato_profile_writes_total{result=\"fail\"}[24h]))", "legendFormat": "fail" }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" },
+                  { "value": 1, "color": "red" }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 5,
+          "gridPos": { "x": 19, "y": 3, "w": 5, "h": 4 },
+          "type": "stat",
+          "title": "Connection Drops (24h)",
+          "description": "increase(vibrato_connection_drops_total[24h]) — how many times the link to the ito/leva! machine dropped in the last 24h. A few is normal (machine power-cycled); a rising count points at a flaky control link.",
+          "targets": [
+            { "refId": "A", "expr": "sum(increase(vibrato_connection_drops_total[24h]))", "legendFormat": "drops" }
+          ],
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" },
+                  { "value": 1, "color": "yellow" },
+                  { "value": 5, "color": "red" }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 10,
+          "gridPos": { "x": 0, "y": 7, "w": 12, "h": 8 },
+          "type": "timeseries",
+          "title": "Pressure vs Target",
+          "description": "vibrato_pressure_bar (measured) against vibrato_pressure_target_bar (setpoint). Fixed 0-14 bar axis. At ~30s sampling this shows the setpoint you were holding and roughly where pressure sat — it does NOT resolve the intra-shot pressure curve.",
+          "targets": [
+            { "refId": "A", "expr": "vibrato_pressure_bar", "legendFormat": "pressure" },
+            { "refId": "B", "expr": "vibrato_pressure_target_bar", "legendFormat": "target" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pressurebar",
+              "min": 0,
+              "max": 14,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "target" },
+                "properties": [
+                  { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } },
+                  { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } },
+                  { "id": "custom.fillOpacity", "value": 0 }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "id": 11,
+          "gridPos": { "x": 12, "y": 7, "w": 12, "h": 8 },
+          "type": "timeseries",
+          "title": "Temperature",
+          "description": "vibrato_temp_c — group/brew temperature. Fixed 80-140 C axis to keep the working band readable. Watch for drift or recovery time between shots, not per-shot detail.",
+          "targets": [
+            { "refId": "A", "expr": "vibrato_temp_c", "legendFormat": "temp" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "celsius",
+              "min": 80,
+              "max": 140,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "auto"
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        },
+        {
+          "id": 12,
+          "gridPos": { "x": 0, "y": 15, "w": 12, "h": 8 },
+          "type": "timeseries",
+          "title": "Flow",
+          "description": "vibrato_flow_ml_s — volumetric flow. Fixed 0-10 ml/s axis. Coarse-sampled: use for trend/idle-vs-active, not the flow profile of a shot.",
+          "targets": [
+            { "refId": "A", "expr": "vibrato_flow_ml_s", "legendFormat": "flow" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "suffix:ml/s",
+              "min": 0,
+              "max": 10,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "auto"
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        },
+        {
+          "id": 13,
+          "gridPos": { "x": 12, "y": 15, "w": 12, "h": 8 },
+          "type": "timeseries",
+          "title": "Pump Phase Angle",
+          "description": "vibrato_phase_deg — pump control phase angle. Fixed 0-360 degree axis. The pressure-profiling firing angle sweeps continuously; here it reads as a coarse trend of where the pump was driven.",
+          "targets": [
+            { "refId": "A", "expr": "vibrato_phase_deg", "legendFormat": "phase" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "degree",
+              "min": 0,
+              "max": 360,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 0,
+                "showPoints": "auto"
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        },
+        {
+          "id": 20,
+          "gridPos": { "x": 0, "y": 23, "w": 8, "h": 8 },
+          "type": "timeseries",
+          "title": "Button Presses /min",
+          "description": "60 * sum(rate(vibrato_button_presses_total[5m])) — UI/virtual-button activity rate. A proxy for interactive use (direct MCc + the 6 virtual buttons).",
+          "targets": [
+            { "refId": "A", "expr": "60 * sum(rate(vibrato_button_presses_total[5m]))", "legendFormat": "presses/min" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "showPoints": "auto"
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        },
+        {
+          "id": 21,
+          "gridPos": { "x": 8, "y": 23, "w": 8, "h": 8 },
+          "type": "timeseries",
+          "title": "Profile Writes /min by result",
+          "description": "60 * sum by (result) (rate(vibrato_profile_writes_total[5m])) — profile-write-to-machine attempts split by outcome. A `fail` line lifting off zero is the signal the closed-loop writer is diverging. NOTE: `result` label values reconcile once the /metrics endpoint PR lands.",
+          "targets": [
+            { "refId": "A", "expr": "60 * sum by (result) (rate(vibrato_profile_writes_total[5m]))", "legendFormat": "{{result}}" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "showPoints": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "success" },
+                "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+              },
+              {
+                "matcher": { "id": "byName", "options": "fail" },
+                "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+              }
+            ]
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          }
+        },
+        {
+          "id": 22,
+          "gridPos": { "x": 16, "y": 23, "w": 8, "h": 8 },
+          "type": "timeseries",
+          "title": "Connection Drops /min",
+          "description": "60 * sum(rate(vibrato_connection_drops_total[5m])) — rate of control-link drops to the ito/leva! machine. Sustained non-zero = flaky link (repoint LEVA_HOST / check the machine).",
+          "targets": [
+            { "refId": "A", "expr": "60 * sum(rate(vibrato_connection_drops_total[5m]))", "legendFormat": "drops/min" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "showPoints": "auto",
+                "thresholdsStyle": { "mode": "line" }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "transparent" },
+                  { "value": 1, "color": "red" }
+                ]
+              }
+            }
+          },
+          "options": {
+            "legend": { "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          }
+        }
+      ]
+    }


### PR DESCRIPTION
## What

Wire Vibrato (espresso controller monitor) into cluster Prometheus + Grafana for an over-time trends/health view. A parallel workstream is adding the `GET /metrics` endpoint to the Vibrato server; this is the homelab side that scrapes and dashboards it.

## Changes

- **ServiceMonitor** (`apps/production/vibrato/servicemonitor.yaml`, wired into the prod overlay `kustomization.yaml`): scrapes the `vibrato` Service `http` port `/metrics` in `vibrato-prod`, 30s interval / 10s timeout. Carries the `release: kube-prometheus-stack` label the cluster's Prometheus selects on. **Mirrors `apps/base/overture/service-monitor.yaml`.** Prod-only on purpose — staging (`vibrato-stage`) must not point at the single-connection physical ito/leva! machine.
- **CiliumNetworkPolicy** (`apps/base/vibrato/networkpolicy.yaml`): adds an ingress rule allowing the `monitoring`-namespace Prometheus pod (`app.kubernetes.io/name: prometheus`) to reach `8080`. Scrapes are ordinary pod-to-pod traffic, not covered by the existing host/remote-node/ingress rule. **Mirrors `apps/base/overture/networkpolicy.yaml`.**
- **Grafana dashboard ConfigMap** (`infra/configs/dashboards/vibrato-cm.yaml`, `grafana_dashboard: "1"` sidecar label, wired into `infra/configs/dashboards/kustomization.yaml`): pressure vs target, temperature, flow, pump phase angle, plus app health (button-press rate, profile-write success/fail rate + 24h counts, connection drops, shots). Fixed sensible axes (pressure 0-14 bar, temp 80-140 C, flow 0-10 ml/s, phase 0-360 deg). **Mirrors the `overture-cm.yaml` / `modemscope-cm.yaml` dashboard style.**

## Important: coarse scrape, not the shot scope

Prometheus scrapes at ~30s — far too coarse for per-shot dynamics (a shot is ~25-40s, i.e. ~1 sample). The dashboard header text panel and its `description` make explicit that this is for **trends/health over hours/days**, and that the live per-shot scope lives inside the Vibrato app itself.

## Metric-name reconciliation needed once the endpoint PR lands

Panel `expr`s are built against the agreed contract: `vibrato_pressure_bar`, `vibrato_pressure_target_bar`, `vibrato_phase_deg`, `vibrato_flow_ml_s`, `vibrato_temp_c`, `vibrato_button_presses_total`, `vibrato_profile_writes_total{result}`, `vibrato_connection_drops_total`, `vibrato_shots_total`, `vibrato_up`. Reconcile if names change. In particular the **`vibrato_profile_writes_total{result=...}` label values** are assumed to be `success` / `fail` — the OK/FAIL stat tiles and the by-result timeseries/color overrides depend on those exact strings.

## Validation

- `kustomize build apps/production/vibrato` and `apps/base/vibrato` render clean; the ServiceMonitor comes out in `vibrato-prod` with the `release` label and a selector matching the Service's `app.kubernetes.io/name: vibrato`.
- `kustomize build infra/configs/dashboards` renders; `vibrato.json` parses as valid JSON (13 panels).
- `yamllint -c .yamllint` passes on all changed files.
- Not deployed / not reconciled — PR only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)