### PR TITLE
deploy(vibrato): #51–54 (scope + nav + observability + /metrics)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:3a7213b2f8c5960eed8023844a9ed64c4dee2601
+          image: ghcr.io/gjcourt/vibrato:661e496e2230edb7519ccb0c3516e85642d3bac5
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:65e55e7bd87f11fb028149bb547bf7199201c5a0
+          image: ghcr.io/gjcourt/vibrato:661e496e2230edb7519ccb0c3516e85642d3bac5
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato image to `661e496e` (main HEAD), rolling out four merged PRs:
- **#51** responsive fixed-axis scope-over-time live view
- **#52** two-beat wake-then-menu + segment-skip `NEXT` detection
- **#53** backend observability — profile attribution, event overlay, Prometheus `/metrics` (feeds the #1199 ServiceMonitor/dashboard)
- **#54** hold-to-repeat menu nav

Staging stays `LEVA_TRANSPORT=sim`. Flux `apps-production` is currently suspended for an unrelated ito session; it'll be resumed to reconcile this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)