### PR TITLE
deploy(vibrato): paced single-step profile writing (#55)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:661e496e2230edb7519ccb0c3516e85642d3bac5
+          image: ghcr.io/gjcourt/vibrato:44ee3c4e1c6d1535085e8d2b37bb345d21496a00
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:661e496e2230edb7519ccb0c3516e85642d3bac5
+          image: ghcr.io/gjcourt/vibrato:44ee3c4e1c6d1535085e8d2b37bb345d21496a00
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `44ee3c4e` (vibrato #55).

Reverts the fast servo profile-value writer to **paced single-step**. Live LCD frame capture proved the leva! firmware accelerates a rapidly-repeated button (0.1→1.0/press), so the servo over-delivered ~10× and overshot targets by 10-30s before a damper crawled back — desyncing the on-device menu on 3 of 4 real write attempts. Paced presses one confirmed 0.1 step at a time: slower (~25-40s for a big move) but exact and reliable, no overshoot.

Flux `apps-production` is live; this reconciles normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)