### PR TITLE
deploy(vibrato): fast profile writing (#56)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:44ee3c4e1c6d1535085e8d2b37bb345d21496a00
+          image: ghcr.io/gjcourt/vibrato:3ec282813d6d67bddb0be845c01ddecb9ca8fc8a
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:44ee3c4e1c6d1535085e8d2b37bb345d21496a00
+          image: ghcr.io/gjcourt/vibrato:3ec282813d6d67bddb0be845c01ddecb9ca8fc8a
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `3ec28281` (vibrato #56). Change-detected fine step (~4-5× faster) + opt-in coarse hold-and-watch for big gaps (always undershoots — can't overshoot target or cross the bar→degrees floor). Server exposes `?coarseGap=&lead=` for live tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)