### PR TITLE
deploy(vibrato): reconcile + scrollable chart + menu-open hardening

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:3ec282813d6d67bddb0be845c01ddecb9ca8fc8a
+          image: ghcr.io/gjcourt/vibrato:9634a44c3f6671812efb5ccc2670c1ac6b82d8d4
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:3ec282813d6d67bddb0be845c01ddecb9ca8fc8a
+          image: ghcr.io/gjcourt/vibrato:9634a44c3f6671812efb5ccc2670c1ac6b82d8d4
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `9634a44c`, batching three PRs: **#57** verified menu-open + clean-start unwind + `lead`→2; **#58** scrollable rolling brew chart (auto-follow live, drag/wheel pan, History scrub); **#59** write = reconcile (sync Execute PI/shot toggles + clear empty phases to match the Vibrato profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)