### PR TITLE
deploy(vibrato): fix reconcile nav (#60)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:9634a44c3f6671812efb5ccc2670c1ac6b82d8d4
+          image: ghcr.io/gjcourt/vibrato:945661bdb0b63447d1e4822846e58a32007c8305
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:9634a44c3f6671812efb5ccc2670c1ac6b82d8d4
+          image: ghcr.io/gjcourt/vibrato:945661bdb0b63447d1e4822846e58a32007c8305
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `945661bd` (vibrato #60). Fixes the reconcile write's navigation: after syncing the Execute PI/shot toggles the cursor was stranded below `Edit` and `scrollTo` (down-only, no wrap) couldn't reach it — so the toggle flipped but the phase-clear never ran. Now re-homes by re-entering the Profiles menu before descending into Edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)