### PR TITLE
deploy(vibrato): fix Clear-confirm read (#61)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:945661bdb0b63447d1e4822846e58a32007c8305
+          image: ghcr.io/gjcourt/vibrato:ead5b3714aa530f43cc521b0f027f1a1870a23e5
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:945661bdb0b63447d1e4822846e58a32007c8305
+          image: ghcr.io/gjcourt/vibrato:ead5b3714aa530f43cc521b0f027f1a1870a23e5
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `ead5b371` (vibrato #61). Fixes the reconcile Clear confirm: it read the yes/no state from `cursorText` (the depth/title row, which carries no brackets) and threw `couldn't select [yes]` despite the machine clearing — now reads `displayText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)