### PR TITLE
deploy(vibrato): sticky chart + beans-per-shot (#62,#63)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:ead5b3714aa530f43cc521b0f027f1a1870a23e5
+          image: ghcr.io/gjcourt/vibrato:8716b107758bdd0e88ea6a0d0a097533c9d4017d
           env:
             - name: LEVA_NODE_ID
               value: "espresso"

--- a/apps/staging/vibrato/deployment-patch.yaml
+++ b/apps/staging/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:ead5b3714aa530f43cc521b0f027f1a1870a23e5
+          image: ghcr.io/gjcourt/vibrato:8716b107758bdd0e88ea6a0d0a097533c9d4017d
           env:
             - name: LEVA_NODE_ID
               value: "vibrato-stage"


### PR DESCRIPTION
Bumps prod + staging vibrato to `8716b107`. Sticky brew chart (persists last pull across tab-switches/reloads until a new pull or Clear) + beans-per-shot capture (name/roaster/roast date, shown in History for profile rating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)