### PR TITLE
deploy(golinks): 404→create-link (#46), first GHA-built image

### DIFF
--- a/apps/base/golinks/deployment.yaml
+++ b/apps/base/golinks/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: golinks
-          image: ghcr.io/gjcourt/golinks:2026-07-04
+          image: ghcr.io/gjcourt/golinks:2026-07-26-57ffc01
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Bumps golinks to `2026-07-26-57ffc01` — the first image built by golinks's new GitHub Actions workflow (#47). Ships #46: a missing shortcode now 302s to `/admin?new=<code>` (create form pre-filled) instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)