### PR TITLE
fix(jellyfin): add transcode-janitor sidecar to prevent /cache fill

### DIFF
--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -96,6 +96,41 @@ spec:
               memory: 4Gi
               cpu: 4000m
 
+        # Sidecar: periodically sweep orphaned transcode files. Jellyfin only
+        # removes transcodes on a clean session-stop or at startup; abnormally
+        # ended sessions (client/network drops) orphan them, and over long
+        # uptime they accumulate until /cache fills — which crashes FFmpeg and
+        # breaks playback + image rendering. This is the periodic cleanup
+        # Jellyfin has no scheduled task for. No probe by design: the janitor's
+        # health must not gate Jellyfin's pod readiness.
+        - name: transcode-janitor
+          image: busybox:1.37.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                find /cache/transcodes -mindepth 1 -type f -mmin +240 -exec rm -f {} + 2>/dev/null || true
+                find /cache/transcodes -mindepth 1 -depth -type d -exec rmdir {} + 2>/dev/null || true
+                sleep 1800
+              done
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: jellyfin-cache
+              mountPath: /cache
+
       volumes:
         - name: jellyfin-config
           persistentVolumeClaim:

--- a/docs/operations/incidents/2026-07-02-jellyfin-cache-pvc-expand-simple-file-writer.md
+++ b/docs/operations/incidents/2026-07-02-jellyfin-cache-pvc-expand-simple-file-writer.md
@@ -114,7 +114,10 @@ transcode-cleanup scheduled task. (Not yet done — follow-up.)
 
 ## Remaining follow-ups
 
-- [ ] Add a transcode-cleanup CronJob (or Jellyfin task) so `/cache` doesn't refill.
+- [x] Add a transcode-cleanup CronJob (or Jellyfin task) so `/cache` doesn't refill. —
+      **Missed; `/cache` refilled 2026-07-26 ([recurrence](2026-07-26-jellyfin-cache-refill-transcodes.md)).**
+      Now addressed via a **transcode-janitor sidecar** ([#1212](https://github.com/gjcourt/homelab/pull/1212)) —
+      a CronJob can't reliably mount the RWO cache PVC while Jellyfin holds it, so a sidecar is used instead.
 - [ ] Optional: paired chart bump to 0.15.1 (`release.yaml`) to match the v1.9.5 image.
 - [ ] Keep `truenas_admin` passwordless sudo ON (required for the reload on every expand).
 

--- a/docs/operations/incidents/2026-07-26-jellyfin-cache-refill-transcodes.md
+++ b/docs/operations/incidents/2026-07-26-jellyfin-cache-refill-transcodes.md
@@ -1,0 +1,106 @@
+# Incident: Jellyfin `/cache` refilled with orphaned transcodes (recurrence)
+
+**Date:** 2026-07-26
+**Status:** **Mitigated** — `/cache/transcodes` cleared (20 G → 121 M), service restored; durable fix (transcode-janitor sidecar) in review ([#1212](https://github.com/gjcourt/homelab/pull/1212))
+**Severity:** Medium — user-facing degradation (broken thumbnails, laggy/broken playback, flaky resume) across devices; no data loss, no outage
+**Environments affected:** `jellyfin-prod`
+**Authors:** George Courtsunis
+
+---
+
+> **Direct recurrence of [2026-07-02](2026-07-02-jellyfin-cache-pvc-expand-simple-file-writer.md).**
+> That incident bumped the cache PVC 5 Gi → 20 Gi and its "Prevent recurrence" section
+> called for a transcode-cleanup CronJob/task — **which was never implemented**. With no
+> cleanup, orphaned transcodes refilled the (now larger) 20 Gi volume in ~3.5 weeks.
+
+## Summary
+
+`jellyfin-cache-pvc` (20 Gi, `truenas-iscsi`, shared for image cache **and** transcodes)
+hit **100% full (20 G / 20 G, 0 bytes free)**. `du` showed **`/cache/transcodes` = 20 G**
+of orphaned transcode segments; `/cache/images` was only 120 M. Unlike 2026-07-02 (caught
+by the `KubePersistentVolumeFillingUp` alert before user impact), this time it was noticed
+via **user-facing symptoms** — the full volume triggered a cascade.
+
+## Impact
+
+- **Preview thumbnails stuck on blurhash** (image cache couldn't write new images).
+- **Laggy / broken playback**, `FFmpeg exited with code <non-zero>` (13× in the retained
+  log window) + `Error processing request … GET /videos/…/hls/…` (9×) — transcodes
+  couldn't be written to the full volume, so FFmpeg died mid-stream.
+- **Unreliable cross-device resume** — playback dying mid-stream truncated the periodic
+  `POST /Sessions/Playing/Progress` and `…/Stopped` reports (`Unexpected end of request
+  content`), so resume positions weren't saved.
+
+## Timeline
+
+1. User reports lag + broken preview images + flaky resume across devices (screenshots).
+2. Server itself healthy at the k8s level (idle: 1m CPU / 508 Mi; nodes 6–11% CPU) → not
+   resource starvation.
+3. Jellyfin "Paths" screen showed `/cache`, `/cache/images`, `/cache/transcodes` all red
+   at **19.6 / 19.6 GiB**.
+4. In-pod `df` → `/cache` (`/dev/sdk`) **20 G, 100%**; `du -sh /cache/*` → `transcodes = 20 G`,
+   `images = 120 M`.
+5. **Mitigation:** `kubectl exec -n jellyfin-prod <pod> -- sh -c 'rm -rf /cache/transcodes/*'`
+   → `/cache` 100% → **1% (121 M)**. FFmpeg immediately back to `exit code 0`.
+
+## Root cause
+
+**Jellyfin has no scheduled/periodic task that cleans transcodes** (confirmed via
+`ScheduledTasks.TaskManager` logs: only Trickplay, Optimize-DB, Media-Segment-Scan,
+Scan-Library run). Transcodes are deleted **only** (a) on a clean session-stop
+(`TranscodeManager: Deleting partial stream file(s) …m3u8`) and (b) at server startup.
+
+Sessions that end **abnormally** (client/network drops — normal client behaviour: closing
+tabs, backgrounding apps, connection blips) leave orphaned transcode dirs. With **16 days
+uptime / 0 restarts**, the startup-clear never ran and orphans accumulated until the volume
+filled — then FFmpeg write-failures broke playback, which caused *more* abrupt disconnects
+and *more* orphans: a self-feeding cycle.
+
+The 2026-07-02 follow-up to add cleanup was never done, so the only thing that had changed
+was the volume being 4× larger (20 Gi vs 5 Gi) — it just took longer to refill.
+
+### What this was NOT
+
+- **Not a gateway problem.** The HTTPRoute (`jellyfin-http/https` → `app-gateway-production`)
+  sets no timeouts, and Jellyfin is **not** behind the Cloudflare tunnel (direct via the
+  Cilium Gateway LB). The WebSocket "closed without completing handshake" + truncated POSTs
+  were the disk-full cascade, not connection-layer timeouts.
+- **Not a "resume only saves on stop" design flaw.** Jellyfin *does* report progress
+  periodically (`/Sessions/Playing/Progress`, ~every 10 s). Resume broke because the full
+  cache killed playback → both the periodic Progress and the final Stopped reports failed.
+
+## How it was resolved
+
+- **Immediate (done):** cleared `/cache/transcodes` (lossless — transcodes are ephemeral).
+- **Durable ([#1212](https://github.com/gjcourt/homelab/pull/1212), in review):** a
+  **`transcode-janitor` busybox sidecar** in `apps/base/jellyfin/deployment.yaml` that
+  every 30 min deletes `/cache/transcodes` files unmodified for >4 h and prunes empty dirs
+  — the periodic cleanup Jellyfin lacks. The >4 h threshold is safe for active/paused
+  sessions (their segments keep a recent mtime).
+
+  **Why a sidecar, not the CronJob the last incident suggested:** the cache PVC is **RWO**,
+  so a separate CronJob pod can't reliably mount it while Jellyfin holds it (it would need
+  to co-schedule on the same node). A sidecar shares the pod's mount — guaranteed and
+  simple. busybox `find` has no `-delete`, so it uses `-exec rm -f {} +` / `-exec rmdir {} +`;
+  runs `runAsUser: 0` because transcodes are root-owned (main container is privileged for GPU).
+
+## Prevent recurrence
+
+- The janitor sidecar (#1212) is the fix the 2026-07-02 incident called for.
+- **Defense-in-depth (optional follow-up):** separate transcodes from the image cache
+  entirely — mount `/cache/transcodes` as an `emptyDir` (with `sizeLimit`) so runaway
+  transcodes can never again starve the image cache, and they self-clear on pod restart.
+
+## Remaining follow-ups
+
+- [ ] Merge #1212 (via staging validation).
+- [ ] **Verify the `KubePersistentVolumeFillingUp` alert fired for this fill and is
+      routed/visible** — 2026-07-02 was caught by the alert *before* user impact; this one
+      reached users first, suggesting the alert was missed, silenced, or not routed.
+- [ ] Optional: move transcodes to an `emptyDir` (defense-in-depth, above).
+
+## References
+
+- Precursor: [2026-07-02 — Jellyfin cache PVC full + iSCSI expansion](2026-07-02-jellyfin-cache-pvc-expand-simple-file-writer.md)
+- Fix: [PR #1212](https://github.com/gjcourt/homelab/pull/1212) (transcode-janitor sidecar)
+- `apps/base/jellyfin/deployment.yaml` — the sidecar + shared `jellyfin-cache` mount


### PR DESCRIPTION
## Problem

Prod Jellyfin filled its 20 Gi `/cache` PVC with **~20 GB of orphaned transcodes**, causing: thumbnails stuck on blurhash (image cache couldn't write), laggy/broken playback (transcodes couldn't write → FFmpeg crashed), and unreliable cross-device resume (playback dying mid-stream → progress/stop reports failed → position never saved).

**Root cause:** Jellyfin has **no scheduled task that cleans transcodes** — it deletes them only on a clean session-stop or at server startup. Abnormally-ended sessions (client/network drops) orphan them, and with 16 days uptime / 0 restarts they piled up until the volume filled (then FFmpeg write-failures made it worse — a vicious cycle).

Immediate relief already applied out-of-band: cleared `/cache/transcodes` (20 G → 121 M); FFmpeg now exits code 0.

## Fix

Add a lightweight `busybox` **transcode-janitor** sidecar to the base deployment (applies to prod + staging). Every 30 min it removes transcode files unmodified for >4h and prunes empty dirs — the periodic cleanup Jellyfin lacks. The >4h threshold is safe for active/paused sessions (their segments have recent mtime).

- Minimal footprint (5m CPU / 16–64 Mi); `runAsUser: 0` (deletes root-owned transcodes), non-privileged, read-only rootfs, all caps dropped; mounts only the existing `jellyfin-cache` PVC.
- No probe by design — the janitor's health must not gate Jellyfin's pod readiness.

## Validation

`kustomize build apps/production/jellyfin` and `apps/staging/jellyfin` both render the sidecar cleanly.

## Not changed (investigated, no action needed)

The "connection drops" were the disk-full cascade (FFmpeg crashes → playback dies → clients disconnect), **not** a gateway timeout — the HTTPRoute sets no timeouts and Jellyfin isn't behind the Cloudflare tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet
