### PR TITLE
feat(homeassistant): dashboard reorg — Overview landing, room volume, auto Lights

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -217,6 +217,30 @@ views:
     column_span: 3
     cards:
     - type: heading
+      heading: Music — Room Volume
+      heading_style: title
+    - type: tile
+      entity: media_player.living_room_snapcast_client
+      name: Living Room
+      icon: mdi:sofa
+      features:
+      - type: media-player-volume-slider
+    - type: tile
+      entity: media_player.kitchen_snapcast_client
+      name: Kitchen
+      icon: mdi:silverware-fork-knife
+      features:
+      - type: media-player-volume-slider
+    - type: tile
+      entity: media_player.snap_test_snapcast_client
+      name: Office
+      icon: mdi:desk
+      features:
+      - type: media-player-volume-slider
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
       heading: Audio / Visual Remotes
       heading_style: title
     - type: markdown

--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -1,4 +1,59 @@
 views:
+- title: Overview
+  path: overview
+  icon: mdi:home
+  type: sections
+  max_columns: 3
+  sections:
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Music — Room Volume
+      heading_style: title
+    - type: tile
+      entity: media_player.living_room_snapcast_client
+      name: Living Room
+      icon: mdi:sofa
+      features:
+      - type: media-player-volume-slider
+    - type: tile
+      entity: media_player.kitchen_snapcast_client
+      name: Kitchen
+      icon: mdi:silverware-fork-knife
+      features:
+      - type: media-player-volume-slider
+    - type: tile
+      entity: media_player.snap_test_snapcast_client
+      name: Office
+      icon: mdi:desk
+      features:
+      - type: media-player-volume-slider
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Key Rooms
+      heading_style: title
+    - type: button
+      name: All Lights Off
+      icon: mdi:lightbulb-group-off
+      tap_action:
+        action: call-service
+        service: light.turn_off
+        target:
+          entity_id: all
+    - type: area
+      area: front_foyer
+    - type: area
+      area: kitchen
+    - type: area
+      area: hallway
+    - type: area
+      area: master_bedroom
+    - type: area
+      area: master_bathroom
+    # TODO: add `hallway_landing` area card once that Area is created in HA.
 - title: Control
   type: sections
   max_columns: 3
@@ -543,3 +598,51 @@ views:
     - type: tile
       entity: button.ir_blaster_topping_c2
       name: C2
+- title: Lights
+  path: lights
+  icon: mdi:lightbulb-group
+  type: sections
+  max_columns: 3
+  sections:
+  - type: grid
+    column_span: 3
+    cards:
+    - type: heading
+      heading: Lights by Room
+      heading_style: title
+    - type: markdown
+      content: 'Room cards auto-populate from HA Areas — new lights appear in their room automatically. Replaces the old hand-maintained Switchboard.'
+  - type: grid
+    column_span: 3
+    cards:
+    - type: area
+      area: living_room
+    - type: area
+      area: kitchen
+    - type: area
+      area: dining_room
+    - type: area
+      area: front_foyer
+    - type: area
+      area: hallway
+    - type: area
+      area: butler_pantry
+    - type: area
+      area: master_bedroom
+    - type: area
+      area: master_bathroom
+    - type: area
+      area: niccolo_bedroom
+    - type: area
+      area: nursery_bedroom
+    - type: area
+      area: hall_bathroom
+    - type: area
+      area: powder_bathroom
+    - type: area
+      area: office
+    - type: area
+      area: laundry_room
+    - type: area
+      area: exterior
+    # TODO: add `hallway_landing` once that Area is created in HA.


### PR DESCRIPTION
## What

Phase-1 reorganization of the git-managed `Control` dashboard so the most-used controls are first-order, per the plan discussed:

- **Overview** (new landing view): **room-volume sliders** (Living Room / Kitchen / Office Snapcast) + the **5 key rooms** as area cards (Front Foyer, Kitchen, Hallway, Master Bedroom, Master Bathroom) + an **All Lights Off** button.
- **Lights** (new view): per-room **area cards** that auto-populate from HA Areas — new lights show up in their room automatically. **Replaces the hand-maintained Switchboard** (which was 15 manual cards ≈ what these auto-generate).
- **Audio / Visual**: room volume added above the IR remotes (from the first commit).
- **Control**: unchanged (fans, laundry, nightlight).

Tab order: **Overview · Control · Audio/Visual · Lights**.

## Design notes

- Uses built-in `tile` (with `media-player-volume-slider`) and `area` cards — no HACS.
- `area` cards are the GitOps sweet spot for "lights by room": version-controlled *and* self-populating within each area (vs. hand-listing every light).
- All 29 lights are already assigned to Areas (17 areas), so the room cards are fully populated.

## Owner follow-ups (not git — `.storage`/UI)

- **Create the `Hallway Landing` Area** (Settings → Areas & Zones) — the 4-way junction (hallway / hall bath / primary + secondary bedrooms); assign its light + future presence sensor. Then uncomment the two `hallway_landing` `# TODO` area cards.
- **Set this dashboard as your default** (Profile → set default dashboard) so Overview is the true landing.
- After merge + Flux reconcile: `kubectl rollout restart deployment/homeassistant -n homeassistant-prod` to pick up the new dashboard file.
- Optional cleanup: retire Switchboard; rename the stray `office-presence` area and the `snap_test` Office media_player id.

## Validation

`kustomize build` clean for prod + staging; YAML parses to 4 views; 20 area cards render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet
