### PR TITLE
fix(homeassistant): repoint kitchen room-volume to live Snapcast entity

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -18,7 +18,7 @@ views:
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.kitchen_snapcast_client
+      entity: media_player.kitchen_snapcast_client_2
       name: Kitchen
       icon: mdi:silverware-fork-knife
       features:
@@ -281,7 +281,7 @@ views:
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.kitchen_snapcast_client
+      entity: media_player.kitchen_snapcast_client_2
       name: Kitchen
       icon: mdi:silverware-fork-knife
       features:


### PR DESCRIPTION
The kitchen wired cutover flipped its snapclient MAC (wlan0→eth0) → new Snapcast client id → HA made `media_player.kitchen_snapcast_client_2` (eth0 `…1f:af`, live/idle) and the old `kitchen_snapcast_client` (`…1b:7d`) went unavailable. Repoints the Overview + A/V kitchen volume cards to the live entity. Caught by the post-deploy live-state check against the HA recorder DB.

**Optional cleanup (UI):** delete the orphaned `media_player.kitchen_snapcast_client` + rename `_2`→`kitchen_snapcast_client` (and `snap_test`→`office`) for clean ids; I'd then repoint back to the canonical id.

kustomize build clean for prod + staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet