### PR TITLE
fix(homeassistant): canonical Snapcast entity ids after cleanup

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -18,13 +18,13 @@ views:
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.kitchen_snapcast_client_2
+      entity: media_player.kitchen_snapcast_client
       name: Kitchen
       icon: mdi:silverware-fork-knife
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.snap_test_snapcast_client
+      entity: media_player.office_snapcast_client
       name: Office
       icon: mdi:desk
       features:
@@ -281,13 +281,13 @@ views:
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.kitchen_snapcast_client_2
+      entity: media_player.kitchen_snapcast_client
       name: Kitchen
       icon: mdi:silverware-fork-knife
       features:
       - type: media-player-volume-slider
     - type: tile
-      entity: media_player.snap_test_snapcast_client
+      entity: media_player.office_snapcast_client
       name: Office
       icon: mdi:desk
       features:


### PR DESCRIPTION
Repoints the dashboard to the canonical Snapcast entity ids after the registry cleanup: `kitchen_snapcast_client` (live eth0 client; the orphaned old-MAC entity was deleted and `_2` renamed to canonical) and `office_snapcast_client` (renamed from `snap_test_snapcast_client`). kustomize build clean prod+staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfkRErMrPyNuft1RbpzMet