### PR TITLE
fix(jellyfin): add free-space floor to transcode-janitor

### DIFF
--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -99,10 +99,21 @@ spec:
         # Sidecar: periodically sweep orphaned transcode files. Jellyfin only
         # removes transcodes on a clean session-stop or at startup; abnormally
         # ended sessions (client/network drops) orphan them, and over long
-        # uptime they accumulate until /cache fills — which crashes FFmpeg and
-        # breaks playback + image rendering. This is the periodic cleanup
-        # Jellyfin has no scheduled task for. No probe by design: the janitor's
-        # health must not gate Jellyfin's pod readiness.
+        # uptime they accumulate until /cache fills. As of Jellyfin 10.11 this
+        # is fatal, not just slow: startup aborts with "path `/cache` has
+        # insufficient free space (Required: 2GiB)" (seen 2026-07-26), and
+        # because that check runs before the task scheduler, Jellyfin can never
+        # run its own cleanup to recover — it crashloops. This sidecar is an
+        # independent process that cleans even while Jellyfin is down, doing
+        # the periodic reap Jellyfin has no scheduled task for. Two-stage:
+        #   1. age sweep — reap transcodes older than 4h (routine housekeeping).
+        #   2. free-space floor — if <4GiB free (comfortably above the 2GiB
+        #      startup gate), delete oldest transcodes regardless of age until
+        #      back over the line. This is what makes the sweep robust: age
+        #      alone loses the race when a burst of concurrent 4K transcodes
+        #      fills /cache faster than the 4h window. df -P prints 1K blocks;
+        #      4194304 = 4GiB. No probe by design: the janitor's health must
+        #      not gate Jellyfin's pod readiness.
         - name: transcode-janitor
           image: busybox:1.37.0
           command:
@@ -111,6 +122,11 @@ spec:
             - |
               while true; do
                 find /cache/transcodes -mindepth 1 -type f -mmin +240 -exec rm -f {} + 2>/dev/null || true
+                while [ "$(df -P /cache | awk 'NR==2{print $4}')" -lt 4194304 ]; do
+                  oldest=$(ls -tr /cache/transcodes/* 2>/dev/null | head -1)
+                  [ -z "$oldest" ] && break
+                  rm -f "$oldest" 2>/dev/null || true
+                done
                 find /cache/transcodes -mindepth 1 -depth -type d -exec rmdir {} + 2>/dev/null || true
                 sleep 1800
               done

--- a/docs/operations/incidents/2026-07-26-jellyfin-cache-refill-transcodes.md
+++ b/docs/operations/incidents/2026-07-26-jellyfin-cache-refill-transcodes.md
@@ -1,7 +1,7 @@
 # Incident: Jellyfin `/cache` refilled with orphaned transcodes (recurrence)
 
 **Date:** 2026-07-26
-**Status:** **Mitigated** — `/cache/transcodes` cleared (20 G → 121 M), service restored; durable fix (transcode-janitor sidecar) in review ([#1212](https://github.com/gjcourt/homelab/pull/1212))
+**Status:** **Resolved** — `/cache/transcodes` cleared (20 G → 121 M), service restored; transcode-janitor sidecar merged ([#1212](https://github.com/gjcourt/homelab/pull/1212)) and hardened with a free-space floor after a same-day recurrence (see [Update 2026-07-26](#update-2026-07-26--jellyfin-1011-startup-gate-turned-a-full-cache-into-a-crashloop))
 **Severity:** Medium — user-facing degradation (broken thumbnails, laggy/broken playback, flaky resume) across devices; no data loss, no outage
 **Environments affected:** `jellyfin-prod`
 **Authors:** George Courtsunis
@@ -93,11 +93,52 @@ was the volume being 4× larger (20 Gi vs 5 Gi) — it just took longer to refil
 
 ## Remaining follow-ups
 
-- [ ] Merge #1212 (via staging validation).
+- [x] Merge #1212 (transcode-janitor sidecar).
+- [x] Harden the janitor with a free-space floor after the 10.11 startup-gate recurrence
+      (see [Update 2026-07-26](#update-2026-07-26--jellyfin-1011-startup-gate-turned-a-full-cache-into-a-crashloop)).
 - [ ] **Verify the `KubePersistentVolumeFillingUp` alert fired for this fill and is
       routed/visible** — 2026-07-02 was caught by the alert *before* user impact; this one
-      reached users first, suggesting the alert was missed, silenced, or not routed.
+      reached users first, suggesting the alert was missed, silenced, or not routed. The
+      10.11 startup gate makes this more urgent: a full cache now crashloops the server.
 - [ ] Optional: move transcodes to an `emptyDir` (defense-in-depth, above).
+
+## Update 2026-07-26 — Jellyfin 10.11 startup gate turned a full cache into a crashloop
+
+Hours after #1212 merged, Jellyfin **crashlooped** (`1/2`, `CrashLoopBackOff`). The janitor
+sidecar was up, but the main container died at boot:
+
+```
+[FTL] Main: Unhandled Exception
+System.InvalidOperationException: The path `/cache` has insufficient free space.
+Available: 140KiB, Required: 2GiB.
+   at StorageHelper.TestCommonPathsForStorageCapacity(...)
+   at Program.StartApp(...)
+```
+
+**New failure mode vs. the original incident.** Jellyfin **10.11** added a hard startup
+storage check requiring **≥2 GiB free on `/cache`**. Two consequences:
+
+1. A full cache is now **fatal at boot**, not merely slow — the same slow orphan-fill that
+   previously only degraded playback now refuses to start the server.
+2. The check runs inside `StartApp`, **before the scheduled-task host starts**, so Jellyfin
+   can never run its *own* transcode cleanup to recover — it's a chicken-and-egg crashloop.
+   Only an independent process (the sidecar) can clean `/cache` in this state.
+
+**Trigger:** the cache was already at 100% (140 KiB free) from ongoing orphan accumulation;
+the PR-driven pod rolls (#1212 + the concurrent HA/dashboard merges) restarted the pod into
+the new 10.11 gate. The janitor's 4 h age threshold meant not enough was old enough to reap
+at that instant, so it couldn't rescue the boot.
+
+**Immediate:** `rm -rf /cache/transcodes/*` via the sidecar container → `/cache` 100% → 1%
+(19.5 G free) → Jellyfin booted `2/2`.
+
+**Durable hardening ([#TBD]):** added a **free-space floor** to the janitor loop. In addition
+to the 4 h age sweep, if `/cache` drops below **4 GiB free** (comfortably above the 2 GiB
+startup gate) it deletes the *oldest* transcode files regardless of age until back over the
+line. Age-based cleanup alone loses the race when a burst of concurrent 4K transcodes fills
+the volume faster than the 4 h window; the free-space floor makes the 30-min sweep a genuine
+guarantee against the startup gate — **without** growing the PVC (kept at 20 Gi; a larger
+volume only raises the ceiling it eventually fills to, it doesn't remove the failure mode).
 
 ## References
 


### PR DESCRIPTION
## Why

Hours after #1212 (transcode-janitor sidecar) merged, Jellyfin **crashlooped**:

```
[FTL] Main: Unhandled Exception
System.InvalidOperationException: The path `/cache` has insufficient free space.
Available: 140KiB, Required: 2GiB.
   at StorageHelper.TestCommonPathsForStorageCapacity(...)
```

Jellyfin **10.11** added a hard startup check requiring **≥2 GiB free on `/cache`**. Two consequences:
1. A full cache is now **fatal at boot**, not just slow.
2. The check runs *before* the task scheduler, so Jellyfin can't run its own cleanup to recover — chicken-and-egg crashloop. Only an independent process (the sidecar) can clean `/cache` in that state.

The janitor's **age-based** sweep (reap >4h old, every 30m) loses the race when a burst of concurrent 4K transcodes fills `/cache` faster than the 4h window — so it couldn't rescue that boot.

## What

Add a **free-space floor** to the janitor loop (on top of the existing 4h age sweep): if `/cache` drops below **4 GiB free** (comfortably above the 2 GiB startup gate), delete the *oldest* transcodes regardless of age until back over the line. `df -P` prints 1K blocks; `4194304 = 4 GiB`.

This makes the 30-min sweep a genuine guarantee against the startup gate **without growing the PVC** (kept at 20 Gi — a bigger volume only raises the ceiling it eventually fills to; it doesn't remove the failure mode).

Also documents the escalation + fix in the [2026-07-26 incident report](../blob/master/docs/operations/incidents/2026-07-26-jellyfin-cache-refill-transcodes.md).

## Test
- `kustomize build apps/{production,staging}/jellyfin` pass.
- Rendered janitor command verified.
- Live: mitigated the crashloop by clearing `/cache/transcodes` (100% → 1%); Jellyfin booted `2/2`. This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)