### PR TITLE
chore(renovate): rotate expired GitHub token

### DIFF
--- a/infra/controllers/renovate/secret.yaml
+++ b/infra/controllers/renovate/secret.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: secret-renovate-container-env
-    namespace: renovate
+  name: secret-renovate-container-env
+  namespace: renovate
 data:
-    RENOVATE_TOKEN: ENC[AES256_GCM,data:bDzmoavBUa5WHoyPwuj3QmHvUmani5XNGG5Qh0cNBtUraEIeiQ5PgGx5NLJrmXA9cIZl1HtmovI=,iv:C1HhnJr8Aw2yUWXAzBuuihhXuNViR8G6RliR4sMPQlA=,tag:B6jWJ7Nk5NtZzNnWVn6Cyg==,type:str]
+  RENOVATE_TOKEN: ENC[AES256_GCM,data:7N+9tz7xXMsYuqPX3udvIpviCr3CRhlMx3w9Q3X+pSdQwju32lO1HdnWuDtP7l6akRWC/nHVbNk=,iv:IALQSj6IzZ/tXiS3LOU9o42lDSsAQala+GMgQ5+DMpo=,tag:7vWOyYvB3hju9TVtEWvFjQ==,type:str]
 sops:
-    age:
-        - recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRUkp6aDJWNU44YlU3KzF6
-            OEdFamk0ZU55L0p0NVd5Q09BUmVyeHIzU25zCnI0NGh3NEw1NVdsNGpoNDhzWTNz
-            RXIrMTAyM05MZ1F6d1NQckM2UFBMd0kKLS0tIFRZMXRMMktmeFRTSmhveFZQYTBh
-            OEN2VU1raE5uOEEwcEdtZVZ6SHlyUFEKm7/+9OIdRrmQNWSrjB1Vdw952HGnXS+H
-            cmz/C2Y9gO3WyTwD6WkCRXmMrBx7eigbfT02S1m5e0vLqGhy9+v0JQ==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-26T03:02:42Z"
-    mac: ENC[AES256_GCM,data:biIJmPSqQZW1EqQ1vIDPClMj0oPDYUQ+SmLvIQiTlVg6cKtVUDxPNzm9fAqoCozPyKtkba8/gfFMtXxM3q+sPxELTNnuMkYdrSiab+4Uk91dZG1QU+sfIJ4fEMRrj+tV4FkqKx7vlKZ3afc62yqkNJEIOjRJHHYQDlJ8/iZFuAQ=,iv:lZyVx7QyprryWCPfFkMlKRoJkCsFqOI6EDnpzxeQVG4=,tag:Rwyz9AtrOvkyTW0JD4eOww==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    version: 3.10.2
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRUkp6aDJWNU44YlU3KzF6
+        OEdFamk0ZU55L0p0NVd5Q09BUmVyeHIzU25zCnI0NGh3NEw1NVdsNGpoNDhzWTNz
+        RXIrMTAyM05MZ1F6d1NQckM2UFBMd0kKLS0tIFRZMXRMMktmeFRTSmhveFZQYTBh
+        OEN2VU1raE5uOEEwcEdtZVZ6SHlyUFEKm7/+9OIdRrmQNWSrjB1Vdw952HGnXS+H
+        cmz/C2Y9gO3WyTwD6WkCRXmMrBx7eigbfT02S1m5e0vLqGhy9+v0JQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-27T06:20:06Z"
+  mac: ENC[AES256_GCM,data:7z3MxRzvpqx2v/opQ7kfYO+sahQnZc3VoNjnmP45Ic5CBIAk1FZzenTV0mDFj4zv3lqTOTjrtuFhdjt0XA2OAlIulk1yfhtJnxNaZ2zaPRS6ZApqsJ3iMUVwT4mLl2Q5Z7LxCaPscQDIxwtldRy1F36fxiJNg6h4Ed4apZ8iGeY=,iv:4DI3MwGU1cP9GcLy2S76zX62HZVI1KWVQF/glV76anA=,tag:ocftp3x+l0+DslfYWvrIjg==,type:str]
+  version: 3.10.2


### PR DESCRIPTION
## Why
Renovate's GitHub PAT (`RENOVATE_TOKEN` in `secret-renovate-container-env`) expired ~1 year after issue (`lastmodified: 2025-07-26`). Every scheduled run since ~07-13 failed init with `github.com token 401 unauthorized` → `Authentication failure`, so no dependency PRs were opened or merged — firing both `HomelabscopeJobStale` criticals.

`renovate-automerge` shares this same credential (`GITHUB_TOKEN` → `secret-renovate-container-env` key `RENOVATE_TOKEN`), so this one rotation fixes both jobs.

## What
- Rotates `RENOVATE_TOKEN` to a fresh PAT (`repo` + `workflow`).
- Re-encrypted with current sops, which also clears a **MAC-version drift** (the file was written by an older sops; the 3.13.1 CLI MAC-failed on read until this rewrite — `sops -d` now verifies cleanly).

## Test
- `sops -d` verifies without `--ignore-mac` (drift resolved).
- Recipient + `encrypted_regex` unchanged; value remains `ENC[…]`.
- Post-merge: reconcile `infra-controllers`, trigger a manual `renovate` run, confirm 401 is gone and both stale alerts clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)