### PR TITLE
fix(immich): db-init uses VectorChord, not removed pgvecto.rs

### DIFF
--- a/apps/base/immich/job-db-init.yaml
+++ b/apps/base/immich/job-db-init.yaml
@@ -18,8 +18,22 @@ spec:
           # postgres 18-alpine
           image: postgres@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
           command: ["/bin/sh", "-c"]
+          # Immich uses VectorChord (`vchord`, which pulls in `vector`) as of the
+          # pgvecto.rs -> VectorChord migration. The old `vectors` (pgvecto.rs)
+          # extension is no longer shipped by the CNPG image, so `CREATE EXTENSION
+          # vectors` fails (this is exactly what broke immich-stage db-init on
+          # 2026-07-20). CREATE EXTENSION requires superuser, so this job runs as
+          # postgres to create the extensions and hand ownership to the immich
+          # role. Idempotent: safe to re-run against an already-provisioned DB.
+          # Per-env DB connection (PGPASSWORD/PGHOST) is supplied by the overlay
+          # patch; the script here is shared so prod and staging can't drift.
           args:
-            - echo "Patch me"
+            - |
+              until pg_isready -h "$PGHOST"; do echo "Waiting for database..."; sleep 2; done;
+              psql -U postgres -d immich -v ON_ERROR_STOP=1 \
+                -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;" \
+                -c "CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;" \
+                -c "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_roles WHERE rolname = 'immich') WHERE extname IN ('vchord', 'vector', 'earthdistance', 'cube');"
           env:
             - name: PGPASSWORD
             - name: PGHOST

--- a/apps/production/immich/job-patch.yaml
+++ b/apps/production/immich/job-patch.yaml
@@ -9,6 +9,9 @@ spec:
     spec:
       containers:
         - name: db-init
+          # Only the per-env DB connection is patched here; the extension-setup
+          # script lives in apps/base/immich/job-db-init.yaml (shared, so prod
+          # and staging can't drift — see that file's comment).
           env:
             - name: PGPASSWORD
               valueFrom:
@@ -17,14 +20,3 @@ spec:
                   key: password
             - name: PGHOST
               value: immich-db-prod-cnpg-v3-rw
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              until pg_isready -h $PGHOST; do echo "Waiting for database..."; sleep 2; done;
-              psql -U postgres -d immich -c "CREATE EXTENSION IF NOT EXISTS vectors CASCADE;"
-              psql -U postgres -d immich -c "CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;"
-              psql -U postgres -d immich -c "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_roles WHERE rolname = 'immich') WHERE extname = 'vectors';"
-              psql -U postgres -d immich -c "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_roles WHERE rolname = 'immich') WHERE extname = 'earthdistance';"
-              psql -U postgres -d immich -c "GRANT ALL ON SCHEMA vectors TO immich;"
-              psql -U postgres -d immich -c "GRANT ALL ON ALL TABLES IN SCHEMA vectors TO immich;"
-              psql -U postgres -d immich -c "ALTER DEFAULT PRIVILEGES IN SCHEMA vectors GRANT ALL ON TABLES TO immich;"

--- a/apps/staging/immich/job-patch.yaml
+++ b/apps/staging/immich/job-patch.yaml
@@ -9,6 +9,9 @@ spec:
     spec:
       containers:
         - name: db-init
+          # Only the per-env DB connection is patched here; the extension-setup
+          # script lives in apps/base/immich/job-db-init.yaml (shared, so prod
+          # and staging can't drift — see that file's comment).
           env:
             - name: PGPASSWORD
               valueFrom:
@@ -17,14 +20,3 @@ spec:
                   key: password
             - name: PGHOST
               value: immich-db-staging-cnpg-v1-rw
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              until pg_isready -h $PGHOST; do echo "Waiting for database..."; sleep 2; done;
-              psql -U postgres -d immich -c "CREATE EXTENSION IF NOT EXISTS vectors CASCADE;"
-              psql -U postgres -d immich -c "CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;"
-              psql -U postgres -d immich -c "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_roles WHERE rolname = 'immich') WHERE extname = 'vectors';"
-              psql -U postgres -d immich -c "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_roles WHERE rolname = 'immich') WHERE extname = 'earthdistance';"
-              psql -U postgres -d immich -c "GRANT ALL ON SCHEMA vectors TO immich;"
-              psql -U postgres -d immich -c "GRANT ALL ON ALL TABLES IN SCHEMA vectors TO immich;"
-              psql -U postgres -d immich -c "ALTER DEFAULT PRIVILEGES IN SCHEMA vectors GRANT ALL ON TABLES TO immich;"


### PR DESCRIPTION
## Why
`immich-db-init` runs `CREATE EXTENSION IF NOT EXISTS vectors` (pgvecto.rs), but Immich migrated to **VectorChord**. The CNPG image no longer ships `vectors`; both DBs now run `vchord 0.4.2` (+ `vector 0.8.0`) + `earthdistance`. The first statement errors → the job fails (`BackoffLimitExceeded`).

That's exactly what broke **immich-stage** db-init on 2026-07-20 (`KubeJobFailed`). Prod's job had `Complete`d earlier — it ran while `vectors` was still available, then Immich migrated it — so only staging alerted. But **both** overlay patches still carried the stale script, a latent bug for either env on a fresh DB.

## What
- Script now: `CREATE EXTENSION vchord CASCADE` (pulls in `vector`) + `earthdistance`, and reassigns ownership of `vchord`/`vector`/`earthdistance`/`cube` to the `immich` role. Drops the obsolete pgvecto.rs `vectors`-schema grants (VectorChord lives in `public`). Adds `ON_ERROR_STOP=1` so a real failure surfaces instead of being masked.
- **DRY:** the shared script moves into `apps/base/immich/job-db-init.yaml`; the staging/production patches now supply only their per-env DB connection — so the two envs can't drift again (that drift is *why* staging broke while prod didn't).

## Test
- Ran the exact corrected script against the **live staging DB**: exit 0, idempotent (extensions already present → no-op; ownership set to `immich`).
- `kustomize build` clean for both overlays; rendered job verified to carry the right per-env `PGHOST`/`PGPASSWORD` + the vchord script.
- Post-merge: reconcile `apps-staging` **and** `apps-production`; both jobs force-recreate (the `force` annotation is on both) and run green → the `KubeJobFailed` alert clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)