### PR TITLE
feat(homeassistant): Tinted refine — Kitchen layout + group tint

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -711,6 +711,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -726,6 +728,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -741,6 +745,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -774,6 +780,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -809,6 +817,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -823,6 +833,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -837,6 +849,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -871,6 +885,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -886,6 +902,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -920,6 +938,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -935,6 +955,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -971,6 +993,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -986,6 +1010,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1001,6 +1027,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1016,6 +1044,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1050,6 +1080,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1065,6 +1097,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1098,6 +1132,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1131,6 +1167,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1165,6 +1203,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1180,6 +1220,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1214,6 +1256,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1229,6 +1273,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1262,6 +1308,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1295,6 +1343,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1329,6 +1379,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1344,6 +1396,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1378,6 +1432,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1393,6 +1449,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1427,10 +1485,9 @@ views:
   subview: true
   icon: mdi:silverware-fork-knife
   type: sections
-  max_columns: 2
+  max_columns: 1
   sections:
   - type: grid
-    column_span: 1
     cards:
     - type: heading
       heading: Kitchen Lights
@@ -1449,6 +1506,15 @@ views:
           - light.kitchen_main_lights
           - light.kitchen_under_cabinet
           - light.kitchen_island_pendants
+      card_mod:
+        style: |
+          ha-card {
+            max-width: 520px;
+            margin: 0 auto;
+            border-radius: 22px;
+            border: none;
+            background: {% if ['light.kitchen_main_lights', 'light.kitchen_under_cabinet', 'light.kitchen_island_pendants'] | select('is_state', 'on') | list | count > 0 %}linear-gradient(150deg, rgba(255, 184, 56, 0.28), rgba(255, 150, 40, 0.16)), var(--card-background-color){% else %}var(--card-background-color){% endif %};
+          }
     - type: custom:mushroom-light-card
       entity: light.kitchen_main_lights
       name: Main
@@ -1458,6 +1524,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1473,6 +1541,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);
@@ -1488,6 +1558,8 @@ views:
       card_mod:
         style: |
           ha-card {
+            max-width: 520px;
+            margin: 0 auto;
             border-radius: 22px;
             border: none;
             box-shadow: 0 1px 2px rgba(30, 50, 90, 0.06);


### PR DESCRIPTION
Single-column Kitchen subview (kills masonry offset), room cards capped 520px centered, tinted group card. Iterating the Tinted look via the screenshot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)