### PR TITLE
fix(homeassistant): smart all-lights toggle

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -102,6 +102,9 @@ spec:
             - name: config-file
               mountPath: /config/automations.yaml
               subPath: automations.yaml
+            - name: config-file
+              mountPath: /config/scripts.yaml
+              subPath: scripts.yaml
             # Lovelace YAML-mode dashboards. ConfigMap data keys cannot
             # contain `/`, so the dashboard file is stored as a flat key
             # (dashboards_control.yaml) and subPath-mounted into the

--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -696,9 +696,9 @@ views:
       icon_color: "{{ 'amber' if ['light.kitchen_main_lights', 'light.kitchen_under_cabinet', 'light.kitchen_island_pendants'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.kitchen_main_lights
           - light.kitchen_under_cabinet
           - light.kitchen_island_pendants
@@ -767,9 +767,9 @@ views:
       icon_color: "{{ 'amber' if ['light.living_room_sconces'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.living_room_sconces
     - type: custom:mushroom-light-card
       entity: light.living_room_sconces
@@ -802,9 +802,9 @@ views:
       icon_color: "{{ 'amber' if ['light.dining_room_sconces', 'light.0xa4c138b55dac7973', 'light.0xa4c138a9f6011cac'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.dining_room_sconces
           - light.0xa4c138b55dac7973
           - light.0xa4c138a9f6011cac
@@ -871,9 +871,9 @@ views:
       icon_color: "{{ 'amber' if ['light.front_foyer_chandelier', 'light.front_foyer_spot_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.front_foyer_chandelier
           - light.front_foyer_spot_lights
     - type: custom:mushroom-light-card
@@ -924,9 +924,9 @@ views:
       icon_color: "{{ 'amber' if ['light.hallway_long', 'light.hallway_landing'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.hallway_long
           - light.hallway_landing
     - type: custom:mushroom-light-card
@@ -977,9 +977,9 @@ views:
       icon_color: "{{ 'amber' if ['light.master_bedroom_main_lights', 'light.master_bedroom_entry', 'light.master_bedroom_sconce_north', 'light.master_bedroom_sconce_south'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.master_bedroom_main_lights
           - light.master_bedroom_entry
           - light.master_bedroom_sconce_north
@@ -1066,9 +1066,9 @@ views:
       icon_color: "{{ 'amber' if ['light.master_bathroom_vanity', 'light.master_bathroom_ceiling'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.master_bathroom_vanity
           - light.master_bathroom_ceiling
     - type: custom:mushroom-light-card
@@ -1119,9 +1119,9 @@ views:
       icon_color: "{{ 'amber' if ['light.office_main_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.office_main_lights
     - type: custom:mushroom-light-card
       entity: light.office_main_lights
@@ -1154,9 +1154,9 @@ views:
       icon_color: "{{ 'amber' if ['light.niccolo_bedroom_main_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.niccolo_bedroom_main_lights
     - type: custom:mushroom-light-card
       entity: light.niccolo_bedroom_main_lights
@@ -1189,9 +1189,9 @@ views:
       icon_color: "{{ 'amber' if ['light.nursery_bedroom_main_lights', 'light.nursery_bedroom_closet_light'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.nursery_bedroom_main_lights
           - light.nursery_bedroom_closet_light
     - type: custom:mushroom-light-card
@@ -1242,9 +1242,9 @@ views:
       icon_color: "{{ 'amber' if ['light.hall_bathroom_main_lights', 'light.hall_bathroom_vanity_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.hall_bathroom_main_lights
           - light.hall_bathroom_vanity_lights
     - type: custom:mushroom-light-card
@@ -1295,9 +1295,9 @@ views:
       icon_color: "{{ 'amber' if ['light.powder_bathroom_chandelier'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.powder_bathroom_chandelier
     - type: custom:mushroom-light-card
       entity: light.powder_bathroom_chandelier
@@ -1330,9 +1330,9 @@ views:
       icon_color: "{{ 'amber' if ['light.butler_pantry_main_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.butler_pantry_main_lights
     - type: custom:mushroom-light-card
       entity: light.butler_pantry_main_lights
@@ -1365,9 +1365,9 @@ views:
       icon_color: "{{ 'amber' if ['light.laundry_room_main_lights', 'light.laundry_room_cove'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.laundry_room_main_lights
           - light.laundry_room_cove
     - type: custom:mushroom-light-card
@@ -1418,9 +1418,9 @@ views:
       icon_color: "{{ 'amber' if ['light.exterior_east', 'light.exterior_west'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.exterior_east
           - light.exterior_west
     - type: custom:mushroom-light-card
@@ -1481,9 +1481,9 @@ views:
       icon_color: "{{ 'amber' if ['light.front_foyer_chandelier', 'light.front_foyer_spot_lights'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.front_foyer_chandelier
           - light.front_foyer_spot_lights
       grid_options:
@@ -1555,9 +1555,9 @@ views:
       icon_color: "{{ 'amber' if ['light.kitchen_main_lights', 'light.kitchen_under_cabinet', 'light.kitchen_island_pendants'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.kitchen_main_lights
           - light.kitchen_under_cabinet
           - light.kitchen_island_pendants
@@ -1649,9 +1649,9 @@ views:
       icon_color: "{{ 'amber' if ['light.hallway_long', 'light.hallway_landing'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.hallway_long
           - light.hallway_landing
       grid_options:
@@ -1723,9 +1723,9 @@ views:
       icon_color: "{{ 'amber' if ['light.master_bedroom_main_lights', 'light.master_bedroom_entry', 'light.master_bedroom_sconce_north', 'light.master_bedroom_sconce_south'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.master_bedroom_main_lights
           - light.master_bedroom_entry
           - light.master_bedroom_sconce_north
@@ -1837,9 +1837,9 @@ views:
       icon_color: "{{ 'amber' if ['light.master_bathroom_vanity', 'light.master_bathroom_ceiling'] | select('is_state', 'on') | list | count > 0 else 'disabled' }}"
       tap_action:
         action: perform-action
-        perform_action: light.toggle
-        target:
-          entity_id:
+        perform_action: script.smart_light_toggle
+        data:
+          entities:
           - light.master_bathroom_vanity
           - light.master_bathroom_ceiling
       grid_options:

--- a/apps/base/homeassistant/files/scripts.yaml
+++ b/apps/base/homeassistant/files/scripts.yaml
@@ -1,0 +1,31 @@
+# Git-managed HA scripts (script: !include scripts.yaml in configuration.yaml).
+# Mounted read-only from the homeassistant-config ConfigMap.
+
+# Smart group toggle for a set of lights, used by the "All <Room> Lights" cards.
+# Fixes the light.toggle-per-entity bug (mixed state scrambled instead of
+# unifying). Logic:
+#   - if ANY light in the set is on  -> turn them ALL off
+#   - if ALL are off                 -> turn them ALL on
+# turn_on is called without a brightness, so lights with brightness memory
+# (most Zigbee/Hue) return to their last level ("remember last state").
+smart_light_toggle:
+  alias: Smart Light Group Toggle
+  mode: parallel
+  max: 25
+  icon: mdi:lightbulb-group
+  fields:
+    entities:
+      description: The light entities to toggle together (list).
+      example: "[light.kitchen_main_lights, light.kitchen_island_pendants]"
+  sequence:
+    - if:
+        - condition: template
+          value_template: "{{ expand(entities) | selectattr('state', 'eq', 'on') | list | count > 0 }}"
+      then:
+        - action: light.turn_off
+          target:
+            entity_id: "{{ entities }}"
+      else:
+        - action: light.turn_on
+          target:
+            entity_id: "{{ entities }}"

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -22,6 +22,7 @@ configMapGenerator:
       - configuration.yaml=files/configuration.yaml
       - automations.yaml=files/automations.yaml
       - binary_sensors.yaml=files/binary_sensors.yaml
+      - scripts.yaml=files/scripts.yaml
       # Lovelace dashboards bundled as flat keys (K8s ConfigMap data keys
       # cannot contain `/`). The Deployment mounts each via subPath into
       # /config/dashboards/<name>.yaml so HA finds them at the path declared


### PR DESCRIPTION
Fix the 'All <Room> Lights' toggle: light.toggle-per-entity scrambled mixed states. New git-managed script.smart_light_toggle does any-on->all-off / all-off->all-on; turn_on omits brightness so lights restore their last level. Repoints all 20 group cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)