### PR TITLE
feat(homeassistant): smart toggle remembers last state (scene snapshot)

### DIFF
--- a/apps/base/homeassistant/files/scripts.yaml
+++ b/apps/base/homeassistant/files/scripts.yaml
@@ -3,11 +3,21 @@
 
 # Smart group toggle for a set of lights, used by the "All <Room> Lights" cards.
 # Fixes the light.toggle-per-entity bug (mixed state scrambled instead of
-# unifying). Logic:
-#   - if ANY light in the set is on  -> turn them ALL off
-#   - if ALL are off                 -> turn them ALL on
-# turn_on is called without a brightness, so lights with brightness memory
-# (most Zigbee/Hue) return to their last level ("remember last state").
+# unifying) AND remembers the room's last brightness/colour.
+#
+# Logic:
+#   - if ANY light is on  -> snapshot the current state into a per-room scene,
+#                            then turn them ALL off
+#   - if ALL are off      -> restore that scene (exact last brightness/colour);
+#                            if none saved yet (e.g. after an HA restart) just
+#                            turn them all on
+#
+# Lutron Caséta dimmers do NOT honour "restore last level" on a bare turn_on
+# (they jump to full), so the scene snapshot is what makes "remember last
+# state" work here. The scene id is derived from the entity list, so every
+# group card works with no per-card config. Scenes created via scene.create
+# are in-memory and reset on an HA restart (first turn-on then falls back to
+# plain on).
 smart_light_toggle:
   alias: Smart Light Group Toggle
   mode: parallel
@@ -17,15 +27,31 @@ smart_light_toggle:
     entities:
       description: The light entities to toggle together (list).
       example: "[light.kitchen_main_lights, light.kitchen_island_pendants]"
+  variables:
+    scene_id: "restore_{{ entities[0].split('.')[1] }}"
   sequence:
     - if:
         - condition: template
           value_template: "{{ expand(entities) | selectattr('state', 'eq', 'on') | list | count > 0 }}"
       then:
+        # Some are on -> remember the current state, then turn everything off.
+        - action: scene.create
+          data:
+            scene_id: "{{ scene_id }}"
+            snapshot_entities: "{{ entities }}"
         - action: light.turn_off
           target:
             entity_id: "{{ entities }}"
       else:
-        - action: light.turn_on
-          target:
-            entity_id: "{{ entities }}"
+        # All off -> restore the remembered state, or plain-on if none saved.
+        - if:
+            - condition: template
+              value_template: "{{ states('scene.' ~ scene_id) not in ['unknown', 'unavailable'] }}"
+          then:
+            - action: scene.turn_on
+              target:
+                entity_id: "scene.{{ scene_id }}"
+          else:
+            - action: light.turn_on
+              target:
+                entity_id: "{{ entities }}"


### PR DESCRIPTION
Caséta dimmers don't restore last level on bare turn_on. Add scene snapshot on the way off + restore on the way on, so the room comes back at its exact last brightness. Script-only; derives a per-room scene id from the entity list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)