### PR TITLE
feat(homeassistant): Tinted theme + Overview polish

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -105,6 +105,9 @@ spec:
             - name: config-file
               mountPath: /config/scripts.yaml
               subPath: scripts.yaml
+            - name: config-file
+              mountPath: /config/themes/tinted.yaml
+              subPath: themes_tinted.yaml
             # Lovelace YAML-mode dashboards. ConfigMap data keys cannot
             # contain `/`, so the dashboard file is stored as a flat key
             # (dashboards_control.yaml) and subPath-mounted into the

--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -1,5 +1,6 @@
 views:
 - title: Overview
+  theme: Tinted
   path: overview
   icon: mdi:home
   type: sections
@@ -20,7 +21,7 @@ views:
       show_current: true
       show_forecast: true
       grid_options:
-        columns: 6
+        columns: 7
     - type: custom:mushroom-template-card
       primary: All Lights Off
       secondary: "{{ states('sensor.lights_on') }} on"
@@ -33,7 +34,7 @@ views:
           entity_id: all
       fill_container: true
       grid_options:
-        columns: 6
+        columns: 5
   # Volume ordered by how the rooms are used: Kitchen, Living Room, Office.
   - type: grid
     column_span: 3
@@ -130,6 +131,7 @@ views:
         action: navigate
         navigation_path: av
 - title: Control
+  theme: Tinted
   type: sections
   max_columns: 3
   sections:
@@ -338,6 +340,7 @@ views:
       entity: input_number.nightlight_offset_today
       name: Jitter (today)
 - title: Audio / Visual
+  theme: Tinted
   path: av
   icon: mdi:remote
   type: sections
@@ -674,6 +677,7 @@ views:
       entity: button.ir_blaster_topping_c2
       name: C2
 - title: Lights
+  theme: Tinted
   path: lights
   icon: mdi:lightbulb-group
   type: sections
@@ -1462,6 +1466,7 @@ views:
 # layout: every light is a mushroom-light-card with a brightness slider
 # and card_mod that washes the card warm when the light is on.
 - title: Front Foyer
+  theme: Tinted
   path: area-front-foyer
   subview: true
   icon: mdi:door
@@ -1536,6 +1541,7 @@ views:
             transition: background 0.3s ease;
           }
 - title: Kitchen
+  theme: Tinted
   path: area-kitchen
   subview: true
   icon: mdi:silverware-fork-knife
@@ -1630,6 +1636,7 @@ views:
             transition: background 0.3s ease;
           }
 - title: Hallway
+  theme: Tinted
   path: area-hallway
   subview: true
   icon: mdi:door-sliding
@@ -1704,6 +1711,7 @@ views:
             transition: background 0.3s ease;
           }
 - title: Master Bedroom
+  theme: Tinted
   path: area-master-bedroom
   subview: true
   icon: mdi:bed
@@ -1818,6 +1826,7 @@ views:
             transition: background 0.3s ease;
           }
 - title: Master Bathroom
+  theme: Tinted
   path: area-master-bathroom
   subview: true
   icon: mdi:shower

--- a/apps/base/homeassistant/files/themes/tinted.yaml
+++ b/apps/base/homeassistant/files/themes/tinted.yaml
@@ -1,0 +1,40 @@
+# Git-managed HA theme (frontend.themes: !include_dir_merge_named themes).
+# Applied per-view via `theme: Tinted`. Soft, rounded, borderless cards to
+# match the "Tinted" design direction, in both light and dark.
+Tinted:
+  # Shared (both modes)
+  ha-card-border-radius: "18px"
+  ha-card-border-width: "0px"
+  card-mod-theme: Tinted
+
+  modes:
+    light:
+      primary-color: "#0aa2e6"
+      accent-color: "#0aa2e6"
+      primary-background-color: "#eef1f5"
+      secondary-background-color: "#eef1f5"
+      card-background-color: "#ffffff"
+      ha-card-background: "#ffffff"
+      primary-text-color: "#1b2026"
+      secondary-text-color: "#5f6b76"
+      disabled-text-color: "#9aa4b2"
+      divider-color: "rgba(20, 30, 60, 0.06)"
+      ha-card-box-shadow: "0 1px 2px rgba(20,30,60,0.05), 0 4px 16px rgba(20,30,60,0.06)"
+      # mushroom
+      mush-border-radius: "18px"
+      mush-card-primary-font-weight: "600"
+
+    dark:
+      primary-color: "#38bdf8"
+      accent-color: "#38bdf8"
+      primary-background-color: "#0e1116"
+      secondary-background-color: "#0e1116"
+      card-background-color: "#1b1f27"
+      ha-card-background: "#1b1f27"
+      primary-text-color: "#e6e9ee"
+      secondary-text-color: "#9aa4b2"
+      disabled-text-color: "#6b7482"
+      divider-color: "rgba(255, 255, 255, 0.07)"
+      ha-card-box-shadow: "0 1px 2px rgba(0,0,0,0.4), 0 6px 20px rgba(0,0,0,0.35)"
+      mush-border-radius: "18px"
+      mush-card-primary-font-weight: "600"

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -23,6 +23,7 @@ configMapGenerator:
       - automations.yaml=files/automations.yaml
       - binary_sensors.yaml=files/binary_sensors.yaml
       - scripts.yaml=files/scripts.yaml
+      - themes_tinted.yaml=files/themes/tinted.yaml
       # Lovelace dashboards bundled as flat keys (K8s ConfigMap data keys
       # cannot contain `/`). The Deployment mounts each via subPath into
       # /config/dashboards/<name>.yaml so HA finds them at the path declared


### PR DESCRIPTION
Git-managed Tinted theme (rounded/borderless/soft-shadow, light+dark) applied to the Control dashboard; rebalance the Today row. Iterating the Overview toward the design mockup via the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)