### PR TITLE
feat(homeassistant): fill Today row (horizontal-stack)

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -22,31 +22,31 @@ views:
       grid_options:
         columns: full
       cards:
-        - type: weather-forecast
-          entity: weather.forecast_home
-          forecast_type: daily
-          show_current: true
-          show_forecast: true
-        - type: custom:mushroom-template-card
-          primary: All Lights Off
-          secondary: "{{ states('sensor.lights_on') }} on"
-          icon: mdi:lightbulb-group-off
-          icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
-          layout: vertical
-          fill_container: true
-          tap_action:
-            action: perform-action
-            perform_action: light.turn_off
-            target:
-              entity_id: all
-          card_mod:
-            style: |
-              ha-card {
-                height: 100%;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-              }
+      - type: weather-forecast
+        entity: weather.forecast_home
+        forecast_type: daily
+        show_current: true
+        show_forecast: true
+      - type: custom:mushroom-template-card
+        primary: All Lights Off
+        secondary: "{{ states('sensor.lights_on') }} on"
+        icon: mdi:lightbulb-group-off
+        icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
+        layout: vertical
+        fill_container: true
+        tap_action:
+          action: perform-action
+          perform_action: light.turn_off
+          target:
+            entity_id: all
+        card_mod:
+          style: |
+            ha-card {
+              height: 100%;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
   # Volume ordered by how the rooms are used: Kitchen, Living Room, Office.
   - type: grid
     column_span: 3

--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -15,26 +15,38 @@ views:
     - type: heading
       heading: Today
       heading_style: title
-    - type: weather-forecast
-      entity: weather.forecast_home
-      forecast_type: daily
-      show_current: true
-      show_forecast: true
+    # horizontal-stack forces a true 50/50 fill (grid_options columns won't
+    # stretch cards in a sections grid). Weather left, a big All Lights Off
+    # killswitch right that fills its half to match the weather height.
+    - type: horizontal-stack
       grid_options:
-        columns: 7
-    - type: custom:mushroom-template-card
-      primary: All Lights Off
-      secondary: "{{ states('sensor.lights_on') }} on"
-      icon: mdi:lightbulb-group-off
-      icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
-      tap_action:
-        action: perform-action
-        perform_action: light.turn_off
-        target:
-          entity_id: all
-      fill_container: true
-      grid_options:
-        columns: 5
+        columns: full
+      cards:
+        - type: weather-forecast
+          entity: weather.forecast_home
+          forecast_type: daily
+          show_current: true
+          show_forecast: true
+        - type: custom:mushroom-template-card
+          primary: All Lights Off
+          secondary: "{{ states('sensor.lights_on') }} on"
+          icon: mdi:lightbulb-group-off
+          icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
+          layout: vertical
+          fill_container: true
+          tap_action:
+            action: perform-action
+            perform_action: light.turn_off
+            target:
+              entity_id: all
+          card_mod:
+            style: |
+              ha-card {
+                height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+              }
   # Volume ordered by how the rooms are used: Kitchen, Living Room, Office.
   - type: grid
     column_span: 3


### PR DESCRIPTION
Wrap weather + All Lights Off in a horizontal-stack for a true 50/50 fill, cutting the Today-row dead space. Iterating the Overview toward the mockup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)