### PR TITLE
fix(homeassistant): restore 3-day forecast in weather bar

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -31,6 +31,11 @@ views:
         forecast_type: daily
         show_current: true
         show_forecast: true
+        # Give the card enough height so the 3-day forecast rows render (the
+        # wide/short bar was clipping them to current-conditions only).
+        card_mod:
+          style: |
+            ha-card { min-height: 200px; }
       - type: custom:mushroom-template-card
         primary: All Lights Off
         secondary: "{{ states('sensor.lights_on') }} on"


### PR DESCRIPTION
min-height on the weather card so the Mon/Tue/Wed forecast renders in the wide bar again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)