### PR TITLE
fix(homeassistant): weather forecast (flex-grow not flex-basis:0)

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -24,18 +24,13 @@ views:
       # Weather ~2/3, All Lights Off ~1/3 (horizontal-stack is 50/50 by default).
       card_mod:
         style: |
-          #root > *:first-child { flex: 2 !important; }
+          #root > *:first-child { flex-grow: 2 !important; flex-basis: 60% !important; }
       cards:
       - type: weather-forecast
         entity: weather.forecast_home
         forecast_type: daily
         show_current: true
         show_forecast: true
-        # Give the card enough height so the 3-day forecast rows render (the
-        # wide/short bar was clipping them to current-conditions only).
-        card_mod:
-          style: |
-            ha-card { min-height: 200px; }
       - type: custom:mushroom-template-card
         primary: All Lights Off
         secondary: "{{ states('sensor.lights_on') }} on"


### PR DESCRIPTION
flex:2 zeroed the basis and tripped the weather card into current-only. Use flex-grow:2 + flex-basis:60%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)