### PR TITLE
fix(homeassistant): weather 50/50 so forecast renders

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -21,10 +21,6 @@ views:
     - type: horizontal-stack
       grid_options:
         columns: full
-      # Weather ~2/3, All Lights Off ~1/3 (horizontal-stack is 50/50 by default).
-      card_mod:
-        style: |
-          #root > *:first-child { flex-grow: 2 !important; flex-basis: 60% !important; }
       cards:
       - type: weather-forecast
         entity: weather.forecast_home


### PR DESCRIPTION
HA weather card drops the day forecast when wide. Revert to 50/50 where Mon/Tue/Wed renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)