### PR TITLE
fix(homeassistant): split www ConfigMap under 1 MiB

### DIFF
--- a/apps/base/homeassistant/deployment.yaml
+++ b/apps/base/homeassistant/deployment.yaml
@@ -120,10 +120,10 @@ spec:
             - name: www-file
               mountPath: /config/www/mushroom.js
               subPath: mushroom.js
-            - name: www-file
+            - name: www-file2
               mountPath: /config/www/card-mod.js
               subPath: card-mod.js
-            - name: www-file
+            - name: www-file2
               mountPath: /config/www/clock-weather-card.js
               subPath: clock-weather-card.js
       volumes:
@@ -136,3 +136,6 @@ spec:
         - name: www-file
           configMap:
             name: homeassistant-www
+        - name: www-file2
+          configMap:
+            name: homeassistant-www2

--- a/apps/base/homeassistant/kustomization.yaml
+++ b/apps/base/homeassistant/kustomization.yaml
@@ -32,10 +32,16 @@ configMapGenerator:
   # Vendored custom frontend cards (Mushroom v5.1.1). Kept in git (not a HACS
   # runtime download) so the resource is reproducible. Mounted to /config/www
   # and loaded via `frontend.extra_module_url: /local/mushroom.js`.
+  # Split across two ConfigMaps: a single one holding all three vendored cards
+  # exceeds the 1 MiB etcd/ConfigMap limit (mushroom 712K + card-mod 99K +
+  # clock 306K). mushroom alone in one, the smaller two in another.
   - name: homeassistant-www
     namespace: homeassistant
     files:
       - mushroom.js=files/www/mushroom.js
+  - name: homeassistant-www2
+    namespace: homeassistant
+    files:
       - card-mod.js=files/www/card-mod.js
       - clock-weather-card.js=files/www/clock-weather-card.js
 


### PR DESCRIPTION
The combined www ConfigMap exceeded the 1 MiB etcd limit and wedged apps-production. Split into two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)