### PR TITLE
fix(homeassistant): responsive Today row (mobile)

### DIFF
--- a/apps/base/homeassistant/files/dashboards/control.yaml
+++ b/apps/base/homeassistant/files/dashboards/control.yaml
@@ -15,44 +15,40 @@ views:
     - type: heading
       heading: Today
       heading_style: title
-    # horizontal-stack forces a true 50/50 fill (grid_options columns won't
-    # stretch cards in a sections grid). Weather left, a big All Lights Off
-    # killswitch right that fills its half to match the weather height.
-    - type: horizontal-stack
+    # Weather + All Lights Off as SEPARATE section cards (not a horizontal-
+    # stack, which forced side-by-side and clipped the wide weather card on
+    # mobile). grid_options columns 9/3 = ~3/4 : ~1/4 side-by-side on desktop;
+    # on a phone the section reflows to one column so they STACK cleanly.
+    # clock-weather-card stretches to fill its column (unlike the native card).
+    - type: custom:clock-weather-card
+      entity: weather.forecast_home
+      forecast_rows: 3
+      hide_clock: false
+      hide_date: false
       grid_options:
-        columns: full
-      # Weather ~3/4, All Lights Off ~1/4.
+        columns: 9
+    - type: custom:mushroom-template-card
+      primary: All Lights Off
+      secondary: "{{ states('sensor.lights_on') }} on"
+      icon: mdi:lightbulb-group-off
+      icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
+      layout: vertical
+      fill_container: true
+      tap_action:
+        action: perform-action
+        perform_action: light.turn_off
+        target:
+          entity_id: all
+      grid_options:
+        columns: 3
       card_mod:
         style: |
-          #root > *:first-child { flex-grow: 3 !important; flex-basis: 74% !important; }
-      cards:
-      # clock-weather-card renders a wide weather panel WITH a horizontal-ish
-      # daily forecast (the native weather card drops the forecast when wide).
-      - type: custom:clock-weather-card
-        entity: weather.forecast_home
-        forecast_rows: 3
-        hide_clock: false
-        hide_date: false
-      - type: custom:mushroom-template-card
-        primary: All Lights Off
-        secondary: "{{ states('sensor.lights_on') }} on"
-        icon: mdi:lightbulb-group-off
-        icon_color: "{{ 'amber' if states('sensor.lights_on') | int(0) > 0 else 'disabled' }}"
-        layout: vertical
-        fill_container: true
-        tap_action:
-          action: perform-action
-          perform_action: light.turn_off
-          target:
-            entity_id: all
-        card_mod:
-          style: |
-            ha-card {
-              height: 100%;
-              display: flex;
-              align-items: center;
-              justify-content: center;
-            }
+          ha-card {
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
   # Volume ordered by how the rooms are used: Kitchen, Living Room, Office.
   - type: grid
     column_span: 3


### PR DESCRIPTION
Drop horizontal-stack for grid_options cards so the Today row stacks on mobile instead of clipping the wide weather card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)