### PR TITLE
chore(mealie): bump v3.19.2 → v3.22.0

### DIFF
--- a/apps/base/mealie/deployment.yaml
+++ b/apps/base/mealie/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: mealie
       automountServiceAccountToken: false
       # App runs as the upstream `abc` user (UID/GID 911) per the Mealie
-      # Dockerfile (https://github.com/mealie-recipes/mealie/blob/v3.16.0/docker/Dockerfile).
+      # Dockerfile (https://github.com/mealie-recipes/mealie/blob/v3.22.0/docker/Dockerfile).
       # When the entrypoint sees it is already running as 911 it skips the
       # root-only chown branch and execs straight into the app, so a hard
       # securityContext here is safe.
@@ -34,8 +34,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        # mealie v3.16.0
-        - image: ghcr.io/mealie-recipes/mealie:v3.19.2@sha256:f68e959bf66f4f458893ea58facac71690fe6f2ac7a31466b5cecb41b4e99c02
+        # mealie v3.22.0
+        - image: ghcr.io/mealie-recipes/mealie:v3.22.0@sha256:36c28f0642fb6c75fae8997a2d55994631b9b4bcffba3016c208fc132a4c1e69
           name: mealie
           ports:
             - containerPort: 9000


### PR DESCRIPTION
## What
Bumps Mealie from **v3.19.2 → v3.22.0** (digest-pinned) in `apps/base/mealie/deployment.yaml`, and fixes the stale `v3.16.0` comments.

Addresses the **"Application Version out of date"** warning on the Mealie Site Settings page.

## Why now
Part 1 of the `mealie.burntbytes.com → food.burntbytes.com` migration. The version bump is hostname-independent, so it ships separately and can be validated on **staging first**.

## Notes / rollout
- Base bump reaches **both** prod (`mealie-prod`) and staging (`mealie-stage`). Reconcile `apps-staging` first, verify healthy (`/api/app/about` returns v3.22.0, UI loads), then `apps-production`.
- Alembic auto-migrates the SQLite DB on startup; `strategy: Recreate` = brief downtime.
- **Before merge:** take a Mealie Admin → Backups export **and** a ZFS snapshot of `mealie-data-pvc` (rollback parachute). Skim the 3.20/3.21/3.22 changelogs.

## Verify
```
flux reconcile kustomization apps-staging --with-source -n flux-system
kubectl -n mealie-stage rollout status deploy/mealie
# then production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)