### PR TITLE
feat(mealie): migrate to food.burntbytes.com + BASE_URL + SMTP email

### DIFF
--- a/apps/production/authelia/configuration.yaml
+++ b/apps/production/authelia/configuration.yaml
@@ -89,6 +89,10 @@ identity_providers:
         authorization_policy: two_factor
         token_endpoint_auth_method: client_secret_basic
         redirect_uris:
+          # New primary hostname (food.burntbytes.com). The mealie.burntbytes.com
+          # entries are kept during the 301-redirect transition and removed in cleanup.
+          - https://food.burntbytes.com/login
+          - https://food.burntbytes.com/login?direct=1
           - https://mealie.burntbytes.com/login
           - https://mealie.burntbytes.com/login?direct=1
         scopes:

--- a/apps/production/homepage/config/services.yaml
+++ b/apps/production/homepage/config/services.yaml
@@ -65,9 +65,9 @@
         siteMonitor: https://links.burntbytes.com
     - Mealie:
         icon: mealie.png
-        href: https://mealie.burntbytes.com
+        href: https://food.burntbytes.com
         description: Recipe management
-        siteMonitor: https://mealie.burntbytes.com
+        siteMonitor: https://food.burntbytes.com
     - Vitals:
         icon: mdi-heart-pulse
         href: https://vitals.burntbytes.com

--- a/apps/production/mealie/configmap-env.yaml
+++ b/apps/production/mealie/configmap-env.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mealie-env-config
+  namespace: mealie
+  labels:
+    app: mealie
+    env: production
+data:
+  # Server-generated links (invites, password reset, notification emails) are
+  # built from BASE_URL. Setting it fixes the "Server Side Base URL is still the
+  # default" warning in Site Settings. Points at the new primary hostname.
+  BASE_URL: "https://food.burntbytes.com"
+  # SMTP via Gmail submission (STARTTLS on 587) — mirrors the fleet pattern
+  # (infra/controllers/renovate-automerge, alertmanager). Mealie uses
+  # SMTP_AUTH_STRATEGY=TLS for STARTTLS. Credentials live in secret-smtp.yaml (SOPS).
+  SMTP_HOST: "smtp.gmail.com"
+  SMTP_PORT: "587"
+  SMTP_AUTH_STRATEGY: "TLS"
+  SMTP_FROM_NAME: "Mealie"
+  SMTP_FROM_EMAIL: "gjcourt@gmail.com"

--- a/apps/production/mealie/deployment-patch.yaml
+++ b/apps/production/mealie/deployment-patch.yaml
@@ -19,5 +19,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: mealie-oidc-config
+            - configMapRef:
+                name: mealie-env-config
             - secretRef:
                 name: mealie-oidc-secret
+            - secretRef:
+                name: mealie-smtp-secret

--- a/apps/production/mealie/httproute.yaml
+++ b/apps/production/mealie/httproute.yaml
@@ -1,3 +1,6 @@
+# Production routing for Mealie.
+# Primary hostname is food.burntbytes.com; the legacy mealie.burntbytes.com
+# 301-redirects to it (hostname migration 2026-07-28).
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
@@ -5,6 +8,7 @@ metadata:
   namespace: mealie-prod
 spec:
   hostnames:
+    - food.burntbytes.com
     - mealie.burntbytes.com
   parentRefs:
     - name: app-gateway-production
@@ -24,7 +28,7 @@ metadata:
   namespace: mealie-prod
 spec:
   hostnames:
-    - mealie.burntbytes.com
+    - food.burntbytes.com
   parentRefs:
     - name: app-gateway-production
       namespace: default
@@ -33,4 +37,23 @@ spec:
     - backendRefs:
         - name: mealie
           port: 9000
-
+---
+# Legacy hostname -> new hostname: permanent redirect, preserves path.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: mealie-redirect
+  namespace: mealie-prod
+spec:
+  hostnames:
+    - mealie.burntbytes.com
+  parentRefs:
+    - name: app-gateway-production
+      namespace: default
+      sectionName: https
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: food.burntbytes.com
+            statusCode: 301

--- a/apps/production/mealie/kustomization.yaml
+++ b/apps/production/mealie/kustomization.yaml
@@ -4,8 +4,12 @@ namespace: mealie-prod
 resources:
   - ../../base/mealie/
   - configmap-oidc.yaml
+  - configmap-env.yaml
   - httproute.yaml
   - secret-oidc.yaml
+  # secret-smtp.yaml is created from secret-smtp.yaml.example by the operator
+  # (SOPS-encrypted). kustomize build / CI fails until it exists — intended gate.
+  - secret-smtp.yaml
 
 labels:
   - pairs:

--- a/apps/production/mealie/secret-smtp.yaml
+++ b/apps/production/mealie/secret-smtp.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-smtp-secret
+  namespace: mealie
+  labels:
+    app: mealie
+    env: production
+type: Opaque
+stringData:
+  SMTP_USER: ENC[AES256_GCM,data:FzAXD8IqovK93f7c0MRiLQP45CTMDQpOuWCjba3SvDeF,iv:qrD9gu7n8q66nUwX73d69lHzn0fp5DS+ya/mFEo4YnM=,tag:9UyuwaZ77qqC87gqdNgOAA==,type:str]
+  SMTP_PASSWORD: ENC[AES256_GCM,data:5PU94lmPbJc5cTYfuRnOVQ==,iv:08BPhhN0IlqNNKuwkeKfclfFZ90KoVi/qWtsCxSEzKg=,tag:+z2pa+i0w7deLlt+vX6zMw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNcExLdy95NVloSGpoU2p0
+        WFRqUm1PeFNOeWtQVi9ybVlCbUZSUEVIdEhZCmZ6OXFXM2F2T1ZoODYyRW9kN1hr
+        WHdWdVNXNi94Qnd5eTJjTE5DWHBuMTQKLS0tIDhxVHBoYnIzem9oYnE0OThSaEM2
+        NnpMeTFFVDFEL2MydERlUFVvcWNkTkEKDo+J+qGoImYpxdfVp1adgPPFtzTvPcGf
+        Og2kYP37W9r85Fi6lBp73/sG7fL1bW4NIbcL1T4QgaXGdFrX7BWLGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-28T23:57:20Z"
+  mac: ENC[AES256_GCM,data:zrhJgKrTmOOoxJVxi/3fXnVIXWlOa2ceONkIi4ZwGWkRg/EkOjKh7FPjRrmNMzoY0UtY7CM8EoNT0RWw6adluFBXbd0/ou1iyfwjtHMjah27wBH6w/7EmEQfxplPNTdjtalVJwMZnPYxHq8Oi7TQrfbymsDDZ7H330MzBqcBCNE=,iv:WGsiev523Hg53XQRTRYysQTzS0ri4bFIep3iagPeKhQ=,tag:hj4Lb1y9Sw9E4Cgj8WgY9g==,type:str]
+  version: 3.13.1

--- a/apps/production/mealie/secret-smtp.yaml.example
+++ b/apps/production/mealie/secret-smtp.yaml.example
@@ -1,0 +1,30 @@
+# TEMPLATE — operator action required.
+#
+# Mealie authenticates to Gmail SMTP with a Gmail app password to send invites,
+# password-reset, and notification emails. Secrets are namespace-scoped, so this
+# lives in the mealie-prod namespace. The value is the SAME Gmail app password
+# already stored in apps/production/authelia/secret-authelia.yaml
+# (AUTHELIA_NOTIFIER_SMTP_PASSWORD) and the alertmanager SMTP secret.
+#
+# To activate:
+#   cp secret-smtp.yaml.example secret-smtp.yaml
+#   # paste the Gmail app password into stringData.SMTP_PASSWORD
+#   sops -e -i secret-smtp.yaml     # .sops.yaml rule apps/production/.*secret.*\.yaml$ encrypts it
+#   git add secret-smtp.yaml && git commit
+#
+# secret-smtp.yaml is already wired into kustomization.yaml + the deployment
+# envFrom, so `kustomize build` (and CI) fails until the encrypted file exists —
+# that is the intended gate. The apps-production Flux Kustomization has SOPS
+# decryption enabled, so no further wiring is needed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-smtp-secret
+  namespace: mealie
+  labels:
+    app: mealie
+    env: production
+type: Opaque
+stringData:
+  SMTP_USER: "gjcourt@gmail.com"
+  SMTP_PASSWORD: "REPLACE_WITH_GMAIL_APP_PASSWORD"

--- a/apps/staging/mealie/configmap-env.yaml
+++ b/apps/staging/mealie/configmap-env.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mealie-env-config
+  namespace: mealie-stage
+  labels:
+    app: mealie
+    env: staging
+data:
+  # Fixes the "Server Side Base URL default" warning on staging too; staging
+  # keeps its own hostname (not renamed to food).
+  BASE_URL: "https://mealie.stage.burntbytes.com"
+  # SMTP via Gmail submission (STARTTLS on 587). Credentials in secret-smtp.yaml (SOPS).
+  SMTP_HOST: "smtp.gmail.com"
+  SMTP_PORT: "587"
+  SMTP_AUTH_STRATEGY: "TLS"
+  SMTP_FROM_NAME: "Mealie (staging)"
+  SMTP_FROM_EMAIL: "gjcourt@gmail.com"

--- a/apps/staging/mealie/deployment-patch.yaml
+++ b/apps/staging/mealie/deployment-patch.yaml
@@ -19,5 +19,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: mealie-oidc-config
+            - configMapRef:
+                name: mealie-env-config
             - secretRef:
                 name: mealie-oidc-secret
+            - secretRef:
+                name: mealie-smtp-secret

--- a/apps/staging/mealie/kustomization.yaml
+++ b/apps/staging/mealie/kustomization.yaml
@@ -4,8 +4,12 @@ namespace: mealie-stage
 resources:
   - ../../base/mealie/
   - configmap-oidc.yaml
+  - configmap-env.yaml
   - httproute.yaml
   - secret-oidc.yaml
+  # secret-smtp.yaml is created from secret-smtp.yaml.example by the operator
+  # (SOPS-encrypted). kustomize build / CI fails until it exists — intended gate.
+  - secret-smtp.yaml
 
 labels:
   - pairs:

--- a/apps/staging/mealie/secret-smtp.yaml
+++ b/apps/staging/mealie/secret-smtp.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-smtp-secret
+  namespace: mealie-stage
+  labels:
+    app: mealie
+    env: staging
+type: Opaque
+stringData:
+  SMTP_USER: ENC[AES256_GCM,data:QPs0Z3OWKAF0XF8mliiMmQHQ8YPkd5pzMNANOy04,iv:5uBu8SJ6esOCyDVOLEgsF95BcD8Ex8dYqrofvX6aRuw=,tag:Oa/6gF9ynrHqq2BNFqc7ag==,type:str]
+  SMTP_PASSWORD: ENC[AES256_GCM,data:gwLXY/qWjPnzPnorKhvP3A==,iv:KKqdXvZBcpD22YfgkxXDNn3/75/e7VHOwpGljLbh6dI=,tag:5ugom6zd8Y8O8H5cv3uyAg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBucmtSK2FJY1Z1NVU4bGhY
+        WFBYUFhLNU0xcEloby94dVRzWnh6NFZRcWt3CndJT25wN09jTTVBdGpWdzlaUmJl
+        R0M3bGV3Y3BJd0ZLU3VpYXprV2N5cFUKLS0tIEErRU1MZnJxeUhVZTdvVGRFMHVV
+        N2FUSDgxbUoydy9ZTFVPOTdoR0szejAKi+RvZGwW0jRqzmhPdRjaBepT9+YmXyFz
+        P5ZlpGf3wGH1b7DQEuLOSruV/1NQc1zBthDft9eOFQ7xVaLE6WSe4w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1lnrpvnhtkmzhfhelxse4798f67l86nct2rjahryvt4rgyfu8zg7samjjuw
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-28T23:57:20Z"
+  mac: ENC[AES256_GCM,data:ZibND0jYuhvK1iM2+Fv8A9HEKI4JAZ0Zh3VNVg8Vvam5vN4oTnK0P0lW6bmF89wVPJrXGXgEjKREKcjzQumB1/fPzxuftReaLVL3Hd+yTlcwZSICvIy2+xPcJ7q5aoVn8ax3PkWToo4LWjKgGBOSEdcHbOM8Vu3GU+hfnYrTxF0=,iv:/WdLn1Niu6RwwYEBLA5BkIPfi7geNcuq4in+H1m9lKY=,tag:0F46K2tl8zNcgSAu6oZhlA==,type:str]
+  version: 3.13.1

--- a/apps/staging/mealie/secret-smtp.yaml.example
+++ b/apps/staging/mealie/secret-smtp.yaml.example
@@ -1,0 +1,26 @@
+# TEMPLATE — operator action required (staging).
+#
+# Same Gmail app password as production (apps/production/mealie/secret-smtp.yaml)
+# and the rest of the fleet. Namespace-scoped, so staging needs its own copy in
+# the mealie-stage namespace.
+#
+# To activate:
+#   cp secret-smtp.yaml.example secret-smtp.yaml
+#   # paste the Gmail app password into stringData.SMTP_PASSWORD
+#   sops -e -i secret-smtp.yaml     # .sops.yaml rule apps/staging/.*secret.*\.yaml$ encrypts it
+#   git add secret-smtp.yaml && git commit
+#
+# Wired into kustomization.yaml + deployment envFrom; kustomize build / CI fails
+# until the encrypted file exists — intended gate.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-smtp-secret
+  namespace: mealie-stage
+  labels:
+    app: mealie
+    env: staging
+type: Opaque
+stringData:
+  SMTP_USER: "gjcourt@gmail.com"
+  SMTP_PASSWORD: "REPLACE_WITH_GMAIL_APP_PASSWORD"

--- a/docs/operations/apps/mealie.md
+++ b/docs/operations/apps/mealie.md
@@ -6,18 +6,25 @@ Mealie is a self-hosted recipe manager and meal planner with a REST API backend 
 ## 2. Architecture
 Mealie is deployed as a Kubernetes `Deployment` with a single replica in the `mealie-prod` (and `mealie-stage`) namespace.
 - **Database**: Uses SQLite, stored within the application's data directory.
-- **Storage**: Uses a PersistentVolumeClaim (`mealie-data-pvc`) backed by the `synology-iscsi` storage class for storing the SQLite database, recipes, and images.
+- **Storage**: Uses a PersistentVolumeClaim (`mealie-data-pvc`) backed by the `truenas-iscsi` storage class for storing the SQLite database, recipes, and images.
 - **Networking**: Exposed via Cilium Gateway API (`HTTPRoute`).
 
 ## 3. URLs
 - **Staging**: https://mealie.stage.burntbytes.com
-- **Production**: https://mealie.burntbytes.com
+- **Production**: https://food.burntbytes.com — the legacy https://mealie.burntbytes.com 301-redirects here (migration 2026-07-28). LAN-only (served by the `*.burntbytes.com` wildcard gateway; not exposed via the Cloudflare tunnel).
 
 ## 4. Configuration
 - **Environment Variables**:
-  - OIDC configuration is provided via the `mealie-oidc-config` ConfigMap.
+  - OIDC config: `mealie-oidc-config` ConfigMap.
+  - App/email config: `mealie-env-config` ConfigMap — `BASE_URL` (must equal the public URL so
+    server-generated email/notification links are correct) and the non-secret SMTP settings
+    (`SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`, `SMTP_AUTH_STRATEGY=TLS`, `SMTP_FROM_*`).
 - **ConfigMaps/Secrets**:
-  - `mealie-oidc-secret` (Secret): Contains the OIDC client secret for Authelia integration (SOPS encrypted).
+  - `mealie-oidc-secret` (Secret, SOPS): OIDC client secret for Authelia.
+  - `mealie-smtp-secret` (Secret, SOPS): `SMTP_USER` + `SMTP_PASSWORD` (Gmail app password — the same
+    one used across the fleet). Created from `secret-smtp.yaml.example` by the operator (`sops -e -i`).
+- **OIDC redirect URIs**: registered in `apps/production/authelia/configuration.yaml` (mealie client).
+  When the hostname changes, these MUST be updated to match or SSO login breaks.
 - **SSO Integration**: Uses `hostAliases` to resolve `auth.burntbytes.com` to the Gateway API IP (`10.42.2.40`) from within the pod, allowing it to communicate with Authelia for OIDC authentication.
 
 ## 5. Usage Instructions
@@ -40,9 +47,13 @@ To verify Mealie is working:
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:
-  - The `mealie-data-pvc` (which contains the SQLite database and all media) is backed up via Synology Snapshot Replication.
+  - The `mealie-data-pvc` (SQLite database + all media) lives on TrueNAS (`truenas-iscsi`) and is
+    covered by TrueNAS ZFS snapshots.
+  - Mealie also has an in-app backup (Admin → Backups) that exports a portable archive — take one
+    before version upgrades.
 - **Restore Procedure**:
-  1. Restore the `mealie-data-pvc` LUN via Synology DSM if necessary.
+  1. Restore the `mealie-data-pvc` zvol from a TrueNAS ZFS snapshot if necessary, or restore an
+     in-app backup archive via Admin → Backups.
   2. Re-deploy the Mealie manifests.
 
 ## 9. Troubleshooting

--- a/docs/plans/2026-07-28-mealie-food-migration.md
+++ b/docs/plans/2026-07-28-mealie-food-migration.md
@@ -1,0 +1,61 @@
+---
+status: in-progress
+last_modified: 2026-07-28
+summary: "Rename Mealie mealie.burntbytes.com -> food.burntbytes.com (301 old->new, LAN-only) and fix Site Settings: v3.22.0, BASE_URL, SMTP email, OIDC redirect URIs"
+---
+
+# Migrate Mealie to `food.burntbytes.com` + fix Site Settings
+
+## Context
+
+Mealie (recipe manager) is served at `mealie.burntbytes.com`; we're moving it to a cleaner
+`food.burntbytes.com` and clearing the health warnings on its Site Settings page: out-of-date
+version (v3.19.2 → v3.22.0), unset `BASE_URL` (breaks server-generated email/notification links),
+and no SMTP config ("Email Not Ready"). LDAP is unused (ignorable); OIDC is healthy but its redirect
+URIs embed the old hostname and must move with the rename.
+
+Decisions: old host gets a **301 redirect** to the new one; app stays **LAN-only** (already covered by
+the `*.burntbytes.com` wildcard gateway listener, wildcard TLS cert, and AdGuard wildcard — no
+gateway/cert/DNS/tunnel changes). Internal names (`mealie-prod` namespace, PVC, repo dirs) stay
+`mealie`; only the public hostname changes, so there is **no data/namespace migration**.
+
+## Changes
+
+Split into two PRs so the version bump can be validated on staging independently of the rename.
+
+**PR A — version bump** (`chore/mealie-v3.22.0`): `apps/base/mealie/deployment.yaml` image
+v3.19.2 → v3.22.0 (digest-pinned). Alembic auto-migrates SQLite on startup; `Recreate` = brief downtime.
+
+**PR B — hostname + config** (`feat/mealie-food-migration`):
+- `apps/production/mealie/httproute.yaml` — serve `food.burntbytes.com`; new `mealie-redirect` route
+  301s `mealie.burntbytes.com` → `food` (Gateway API `RequestRedirect` with `hostname:`).
+- `apps/production/mealie/configmap-env.yaml` (new) — `BASE_URL=https://food.burntbytes.com` + non-secret
+  SMTP (`smtp.gmail.com:587`, `SMTP_AUTH_STRATEGY=TLS`, `SMTP_FROM_*`), mirroring the fleet Gmail pattern.
+- `apps/production/mealie/secret-smtp.yaml` (SOPS, operator-created from `.example`) — `SMTP_USER` +
+  `SMTP_PASSWORD` (the shared Gmail app password). Wired via `deployment-patch.yaml` `envFrom` +
+  `kustomization.yaml`; CI fails until encrypted — the intended gate.
+- `apps/production/authelia/configuration.yaml` — add `food.burntbytes.com/login[?direct=1]` to the mealie
+  client `redirect_uris` (keep the old two during transition; requires an Authelia rollout restart).
+- `apps/production/homepage/config/services.yaml` — tile → `food.burntbytes.com`.
+- Staging parity: `apps/staging/mealie/{configmap-env,secret-smtp.yaml.example,deployment-patch,kustomization}`
+  get `BASE_URL` (stage host) + SMTP; staging hostname is **not** renamed.
+- `docs/operations/apps/mealie.md` updated (URLs, `truenas-iscsi`, new config/secrets, backup notes).
+
+## Operator steps (SOPS is operator-only)
+1. Before merging PR A: Mealie Admin → Backups export + a TrueNAS ZFS snapshot of `mealie-data-pvc`.
+2. For PR B: `cp secret-smtp.yaml.example secret-smtp.yaml`, paste the Gmail app password into
+   `SMTP_PASSWORD`, `sops -e -i secret-smtp.yaml`, commit — for **both** `apps/production/mealie/` and
+   `apps/staging/mealie/`.
+3. After merge: `flux reconcile kustomization apps-production --with-source -n flux-system`;
+   `kubectl -n authelia rollout restart deploy/authelia` (load new redirect URIs).
+
+## Verification
+- `kustomize build apps/production` and `apps/staging` pass once the secrets are encrypted.
+- Staging on v3.22.0 healthy first; then prod pod Running, `/api/app/about` = v3.22.0.
+- `https://food.burntbytes.com` loads on-LAN; **OIDC login via Authelia succeeds on the new host**.
+- `https://mealie.burntbytes.com/...` → **301 → food** (path preserved).
+- Site Settings: Server Side Base URL ✓, Email ✓ Ready, in-app **Test** email delivers; version ✓.
+- Homepage tile → `food.burntbytes.com`, uptime monitor green.
+
+## Cleanup (follow-up PR, after cutover confirmed)
+Remove the old `mealie.burntbytes.com` `redirect_uris` from Authelia. Keep the 301 route as long as desired.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,10 +60,11 @@ see `scripts/plans-index/`).
 
 <!-- BEGIN PLANS INDEX -->
 
-### In progress (13)
+### In progress (14)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-07-28-mealie-food-migration.md](2026-07-28-mealie-food-migration.md) | 2026-07-28 | Rename Mealie mealie.burntbytes.com -> food.burntbytes.com (301 old->new, LAN-only) and fix Site Settings: v3.22.0, BASE_URL, SMTP email, OIDC redirect URIs |
 | [2026-07-13-immich-photos-images-to-media.md](2026-07-13-immich-photos-images-to-media.md) | 2026-07-13 | Consolidate the Immich photo library from family/images/photos onto the canonical family/media/photos (all media under family/media/ per the assimilation plan); retire family/images/* |
 | [2026-07-04-homelabscope.md](2026-07-04-homelabscope.md) | 2026-07-04 | homelabscope — one Prometheus metric family (homelabscope_job_last_success_seconds{job}) + textfile collector + cronjob recording rules + templated staleness/absence alerts + Grafana table monitoring EVERY scheduled homelab job; fixes the orphaned (unscraped) immich-backup metric |
 | [2026-07-04-alcatraz-photos-pull.md](2026-07-04-alcatraz-photos-pull.md) | 2026-07-04 | Retire the impossible hestia→alcatraz rsync push-back; alcatraz pulls from hestia as local root via a DSM Task Scheduler job |


### PR DESCRIPTION
Migrates Mealie from `mealie.burntbytes.com` → **`food.burntbytes.com`** and fixes the Site Settings health warnings. Pairs with #1244 (version bump).

## ⚠️ CI will be RED until you encrypt the SMTP secret — this is the intended gate
`kustomize build` fails because `secret-smtp.yaml` is referenced but only the `.example` template is committed (SOPS is operator-only). To make it green:
```bash
# for BOTH apps/production/mealie and apps/staging/mealie:
cp secret-smtp.yaml.example secret-smtp.yaml
# paste the shared Gmail app password into stringData.SMTP_PASSWORD
sops -e -i secret-smtp.yaml
git add secret-smtp.yaml && git commit --amend --no-edit && git push -f   # or a follow-up commit
```

## What changed
| Site Settings issue | Fix |
|---|---|
| Wrong hostname | `httproute.yaml`: serve `food.burntbytes.com`; new `mealie-redirect` route 301s `mealie` → `food` (path preserved) |
| Server Side Base URL default ⚠️ | `configmap-env.yaml` (new) → `BASE_URL=https://food.burntbytes.com` |
| Email Not Ready ⚠️ | SMTP via Gmail 587/STARTTLS (`mealie-env-config`) + SOPS `mealie-smtp-secret` |
| OIDC (hidden dependency) | Authelia mealie client gains `food.burntbytes.com/login[?direct=1]` redirect URIs (old kept for transition) |
| LDAP Not Ready | ignored — unused |

Also: homepage tile → `food`, runbook refreshed (URLs, `truenas-iscsi`, config/secrets, backups), and a `docs/plans/` entry.

**Scope:** LAN-only — the `*.burntbytes.com` wildcard gateway listener, wildcard TLS cert, and AdGuard wildcard already resolve `food`, so **no gateway/cert/DNS/tunnel changes** and no data/namespace migration. Staging keeps its own hostname; it only gets `BASE_URL`(stage) + SMTP for parity.

## After merge
```
flux reconcile kustomization apps-production --with-source -n flux-system
kubectl -n authelia rollout restart deploy/authelia   # load new redirect URIs
```
Then verify: `food.burntbytes.com` loads + OIDC login works; `mealie.burntbytes.com` 301s to it; Site Settings BASE_URL ✓ + Email ✓ (send a Test email); homepage tile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)