### PR TITLE
fix(renovate): authenticate ghcr.io lookups

### DIFF
--- a/infra/controllers/renovate/cronjob.yaml
+++ b/infra/controllers/renovate/cronjob.yaml
@@ -28,6 +28,23 @@ spec:
                 - gjcourt/soundbyte
                 - gjcourt/python-nginx-signing
 
+              env:
+                # Re-expose the platform token by name so it can be interpolated
+                # into RENOVATE_HOST_RULES below (envFrom vars are NOT available
+                # for k8s $(VAR) expansion).
+                - name: RENOVATE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: secret-renovate-container-env
+                      key: RENOVATE_TOKEN
+                # Authenticate the Docker datasource against ghcr.io. Without a
+                # token, anonymous ghcr lookups hit the rate limit (-> "no-result"
+                # for public third-party images like Immich/Navidrome/Home Assistant/
+                # Audiobookshelf/Homepage/CNPG/open-webui, so no update PRs are ever
+                # opened) and 403 on private gjcourt/* packages. k8s expands
+                # $(RENOVATE_TOKEN) at runtime, so no secret value lives in this file.
+                - name: RENOVATE_HOST_RULES
+                  value: '[{"matchHost":"ghcr.io","hostType":"docker","token":"$(RENOVATE_TOKEN)"}]'
               envFrom:
                 - configMapRef:
                     name: renovate-container-env


### PR DESCRIPTION
## Problem
The daily Renovate run logs `Package lookup failures` — every `ghcr.io` image returns `no-result`. Renovate's config has only `RENOVATE_TOKEN` (for opening PRs), **no `hostRules` for the ghcr registry**. Verified live:
- public `immich-app/immich-server` lists tags anonymously for a single request, but under a bulk run Renovate hits ghcr's **anonymous rate limit** → `no-result`
- private `gjcourt/*` packages → hard **403** anonymously

**Net effect:** Renovate opens **zero update PRs** for every ghcr.io-hosted app — Immich, Navidrome, Home Assistant, Audiobookshelf, Homepage, CNPG, open-webui, etc. Docker Hub + lscr.io + GitHub Actions updates were unaffected (that's why it looked like Renovate was "working").

## Fix
Add `RENOVATE_HOST_RULES` authenticating `ghcr.io` with the **existing** `RENOVATE_TOKEN`, re-exposed as a named env so k8s `$(VAR)` expansion interpolates it at runtime. **No new secret, no token value in the manifest, no operator step.**

## Scope note
Any valid GitHub token raises the ghcr rate limit for **public** images (the real gap). The private `gjcourt/*` images are date-sha tagged and updated by the build→pin workflow, not Renovate — so covering them (would need `read:packages` on the PAT) is optional and low-value.

## Verify after merge
Reconcile `infra-controllers`, trigger a run (`kubectl -n renovate create job --from=cronjob/renovate renovate-manual`), and confirm the `Package lookup failures` WARNs are gone and update PRs appear for the ghcr apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)