### PR TITLE
fix(snapcast): persist server.json so restarts keep client volumes

### DIFF
--- a/apps/base/snapcast/deployment.yaml
+++ b/apps/base/snapcast/deployment.yaml
@@ -124,13 +124,15 @@ spec:
               drop:
                 - ALL
           env:
+            # server.json (client VOLUMES + MACs, group/stream assignments) must
+            # survive restarts. snapserver writes it to $HOME/.config/snapserver/
+            # and does NOT honor XDG_CONFIG_HOME — a prior attempt pointed XDG at
+            # the PVC but state still landed on the ephemeral /tmp emptyDir, so
+            # every restart reset all clients to 100% (kitchen/living-room blast).
+            # Point HOME at the spotify-state PVC (mounted at /var/lib/snapserver);
+            # go-librespot files live at the PVC root, snapserver under .config/ —
+            # no conflict.
             - name: HOME
-              value: /tmp
-            # State file (server.json: client MACs, group/stream assignments) is
-            # persisted to the spotify-state PVC so pod restarts don't lose stream
-            # assignments. go-librespot files live at the PVC root; snapserver
-            # writes to the snapserver/ subdirectory — no conflict.
-            - name: XDG_CONFIG_HOME
               value: /var/lib/snapserver
           ports:
             - name: stream


### PR DESCRIPTION
## Incident
Restarting the snapcast pod (2026-07-30) blasted **kitchen and living-room to 100%** and desynced HA volume control. Root cause: snapserver's `server.json` (client volumes, MACs, group/stream assignments) was landing on the **ephemeral `/tmp` emptyDir**, so every restart wiped it → all clients default to 100%.

## Why
The manifest *intended* to persist state — it set `XDG_CONFIG_HOME=/var/lib/snapserver` (the `spotify-state` PVC). But **snapserver ignores `XDG_CONFIG_HOME`** and writes to `$HOME/.config/snapserver/`, and `HOME` was `/tmp`. Confirmed live: the state file sat at `/tmp/.config/snapserver/server.json`, and `Server.GetStatus` showed both rooms reset to 100% after the restart.

## Fix
Point `HOME` at the `spotify-state` PVC (`/var/lib/snapserver`) and drop the ineffective `XDG_CONFIG_HOME`. snapserver then writes `server.json` under `/var/lib/snapserver/.config/snapserver/` (persistent). go-librespot's state lives at the PVC root; snapserver's under `.config/` — no collision.

## Validation
- `kustomize build apps/production/snapcast` ✓
- `kustomize build apps/staging/snapcast` ✓
- rendered snapserver env: `HOME=/var/lib/snapserver`, no `XDG_CONFIG_HOME`
- no plaintext secrets

## Deploy note
To avoid one *final* reset on the deploy restart, I'll pre-seed the PVC with the current (corrected) `server.json` before the reconcile, so the new pod comes up with the right volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)