### PR TITLE
deploy(vibrato): two-column Brew layout, un-clipped chart

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:8716b107758bdd0e88ea6a0d0a097533c9d4017d
+          image: ghcr.io/gjcourt/vibrato:5b02c7713bef8b91a4de0692465719e0bea8c745
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps production **vibrato** image `8716b107` → `5b02c771` — [gjcourt/vibrato#66](https://github.com/gjcourt/vibrato/pull/66).

Brew tab is now **two columns** (info left, chart right), telemetry tiles folded into the left column as a 2×2, and the chart no longer clips off the bottom on a laptop. Image built + pushed by vibrato CI on the merge to main.

- `kustomize build apps/production/vibrato` ✓
- Full-SHA pin, matching vibrato's existing convention; forward of the deployed `8716b107`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)