### PR TITLE
feat(cloudflare-tunnel): route cadence.burntbytes.com to the gateway

### DIFF
--- a/apps/production/cloudflare-tunnel/config.yaml
+++ b/apps/production/cloudflare-tunnel/config.yaml
@@ -43,5 +43,13 @@ ingress:
     originRequest:
       originServerName: burntbytes.com
 
+  # Cadence — self-hosted Shopify app (agent-payment discovery demo). Routes to the
+  # production gateway; the app-side HTTPRoute (cadence.burntbytes.com -> cadence
+  # Service) lands with the app deploy. TLS covered by the *.burntbytes.com wildcard.
+  - hostname: cadence.burntbytes.com
+    service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
+    originRequest:
+      originServerName: cadence.burntbytes.com
+
   # Catch-all returns 404
   - service: http_status:404


### PR DESCRIPTION
Step 2 of exposing the self-hosted Cadence Shopify app at `cadence.burntbytes.com` (for the agent-payment discovery demo).

Adds a production tunnel ingress rule: `cadence.burntbytes.com` → the Cilium gateway — same target + `originServerName` pattern as every other `*.burntbytes.com` hostname, so the gateway presents the `*.burntbytes.com` wildcard cert (no new cert needed).

- **Step 1 (DNS route)** already done: `cloudflared tunnel route dns production cadence.burntbytes.com` — verified live via DoH (Status 0, matches `links.burntbytes.com`).
- **Step 3 (after merge):** `kubectl -n cloudflare-tunnel rollout restart deploy/cloudflared` — the ConfigMap has no hot-reload.
- **App side (later):** the HTTPRoute `cadence.burntbytes.com → cadence Service` lands with the Cadence app deploy. Until then the hostname resolves but the gateway returns 404 — expected while staging the tunnel ahead of the app.

`kustomize build apps/production/cloudflare-tunnel` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)