### PR TITLE
deploy(vibrato): additive profile steps (#67)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:5b02c7713bef8b91a4de0692465719e0bea8c745
+          image: ghcr.io/gjcourt/vibrato:39bdbee1e727357cf3a8a20ec8a45602974d632c
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps the **production** vibrato image `5b02c771` → `39bdbee1` ([gjcourt/vibrato#67](https://github.com/gjcourt/vibrato/pull/67)).

## What ships

The profile editor becomes **purely additive in the time domain**:
- Each step carries a **duration (Δt)** after the previous one instead of an absolute time — cumulative sum means steps **can never overlap**.
- Every phase has a **Start point pinned at t=0**, so a lone "8 s @ 2 bar" step renders as a continuous line from zero instead of a first datapoint at t=8.
- Steps are a **drag-reorderable list**; reordering is UI-only and reaches the ITO only on *Write to machine*.
- Coincident/overlapping points are structurally impossible on every edit path (0.1 s minimum gap), matching the firmware's monotonic `(time, pressure)` point model. Ramp semantics preserved, so the chart matches the machine.

## Scope / risk

- **Editor-only change** — the stored/wire model stays absolute-time points, so the machine-write path, chart, persistence, and all existing saved profiles are unchanged (no migration).
- Legacy phases whose first point isn't at t=0 are normalized on load.
- Production only, matching the prior deploy (#1258). Staging stays on its current pin (it runs `LEVA_TRANSPORT=sim`).

## Verification

- vibrato #67: CI green, 321/321 tests, prettier/eslint/tsc clean; one adversarial critique round applied (fixed a stale-closure bug where a second field edit reverted the first).
- Image `ghcr.io/gjcourt/vibrato:39bdbee1e727357cf3a8a20ec8a45602974d632c` built + pushed on merge to main.
- `kustomize build apps/production/vibrato` passes and renders the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)