### PR TITLE
deploy(vibrato): Profiles layout + History latest-shot (#68)

### DIFF
--- a/apps/production/vibrato/deployment-patch.yaml
+++ b/apps/production/vibrato/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: vibrato
-          image: ghcr.io/gjcourt/vibrato:39bdbee1e727357cf3a8a20ec8a45602974d632c
+          image: ghcr.io/gjcourt/vibrato:860974309807f48df3816adce399e1c5ff3f7559
           env:
             - name: LEVA_NODE_ID
               value: "espresso"


### PR DESCRIPTION
Bumps the **production** vibrato image `39bdbee1` → `86097430` ([gjcourt/vibrato#68](https://github.com/gjcourt/vibrato/pull/68)).

## What ships

- **Profiles matches Brew** — config column left, larger curve canvas right. It was the only tab with the canvas on the left.
- **Curve card capped at the viewport**, same treatment as `.brew-chart-col`. The canvas was `aspect-ratio:1/1`, so widening its column made it *taller* (870×870 → 1010×1010) and pushed the chart off a laptop screen; it now flex-grows into the available height (1010×505, page no longer scrolls).
- **History opens the most recent shot** on arrival — the replay chart is populated without a click.
- **Fix — curve overlay was misaligned with its own axes.** The Profiles tab draws its editable curve on top of the grid rendered by `chart.js`, but hardcoded its own plot padding (`{l:34,r:40,t:14,b:26}` vs the renderer's `{l:44,r:46,t:22,b:30}`). Every overlay coordinate was 10px left / 8px high of the axes: the t=0 point rendered *outside* the plot area, and `tOf()`/`barOf()` inverted the same wrong transform, so drag and double-click-to-add were miscalibrated by that offset. `PAD` is now exported and shared by all three call sites.
- **Fix** — shots with no beans rendered a literal `"null"` in the detail pane (raw `Element.append(null)` stringifies; `h()` would have skipped it).

## Verification

- vibrato #68: CI green, 321/321 tests, prettier/eslint/tsc clean; one adversarial critique round applied (it caught the canvas-height regression and the missing `disposed` guard).
- Layout re-measured in a headless browser at 375 / 768 / 1440 — zero horizontal overflow, no vertical overflow at 1440×900, curve hoisted above the config cards when stacked.
- `kustomize build apps/production/vibrato` passes and renders the new tag.
- Production only, matching the prior two vibrato deploys. Staging stays on its pin (`LEVA_TRANSPORT=sim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)