### PR TITLE
fix(cert-manager): point DNS-01 self-check at public resolvers (wildcard cert expired)

### DIFF
--- a/infra/controllers/cert-manager/values.yaml
+++ b/infra/controllers/cert-manager/values.yaml
@@ -14,6 +14,27 @@ config:
   # Enables gateway api to manage certs
   enableGatewayAPI: true
 
+# DNS-01 self-check MUST bypass cluster DNS.
+#
+# Before validating with Let's Encrypt, cert-manager checks that the challenge
+# TXT record has propagated. By default it asks the cluster resolver, which
+# chains CoreDNS -> the node's resolv.conf -> AdGuard (10.42.2.43). AdGuard runs
+# a split-horizon view of burntbytes.com and answers NOERROR/ANSWER:0 for
+# _acme-challenge.burntbytes.com, so the self-check can never pass — even though
+# Cloudflare has published the record and public resolvers serve it fine.
+#
+# That silently stalled the *.burntbytes.com renewal for 30 days (Order pending
+# since 2026-07-06) until the certificate expired on 2026-08-05, taking every
+# production host down with an expired-cert browser error. The Certificate
+# reported Ready=True throughout, because the OLD cert was still valid; the real
+# signal was Issuing=True/Renewing sitting unchanged for a month.
+#
+# Pointing the self-check at public recursive resolvers is the documented remedy
+# for split-horizon DNS. `-only` stops it falling back to the cluster resolver.
+extraArgs:
+  - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
+  - --dns01-recursive-nameservers-only
+
 # Enable the default approver
 # This automatically approves certificate requests from cert-manager
 approveSignerNames:


### PR DESCRIPTION
## Incident

**The `*.burntbytes.com` wildcard expired 2026-08-05 05:22 GMT.** Every production host is serving an expired certificate — browsers show it as insecure and `curl` refuses the connection. Surfaced as "Home Assistant is broken"; it is not, the pod is `1/1 Running` with 0 restarts.

## Root cause

Renewal was scheduled for **2026-07-06** and did fire. The ACME Order has been `pending` for **30 days**.

Cloudflare published the DNS-01 TXT records correctly — they are live in public DNS right now:

```
dig +short TXT _acme-challenge.burntbytes.com @1.1.1.1
"MCL2XKaR2Kh1WGbLOifBcRD9hFj__unrJsLh5_HTs0s"
"cRtiB_eOUoS11wC_RMwGGd0G4xOsqM-8yG80MDYqnLQ"
```

What failed is cert-manager's **own propagation self-check**, which runs before it asks Let's Encrypt to validate. With no `--dns01-recursive-nameservers` set, that check uses the cluster resolver:

```
cert-manager -> CoreDNS -> node resolv.conf -> AdGuard (10.42.2.43)
```

AdGuard serves a split-horizon view of `burntbytes.com` and answers `NOERROR / ANSWER: 0` for `_acme-challenge.burntbytes.com`. The self-check therefore could never pass, and the Order sat pending until the old certificate ran out.

## Fix

```yaml
extraArgs:
  - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
  - --dns01-recursive-nameservers-only
```

The documented remedy for split-horizon DNS. `-only` prevents falling back to the cluster resolver.

## Why nobody was warned

Two independent gaps, both worth fixing separately:

1. The Certificate reported `Ready=True` for the entire month — technically true, the *old* cert had not expired. The real signal was the second condition, `Issuing=True / Renewing`, unchanged since July 6.
2. **There is no cert-manager ServiceMonitor**, so `certmanager_certificate_expiration_timestamp_seconds` is never scraped and no alert could fire. The 8 certificate-related alert rules in the cluster are all kubelet/apiserver internals — nothing watches public certs.

## Blast radius

Production wildcard and the staging wildcard (`*.stage.burntbytes.com`) are stuck in the identical state; staging should recover the same way.

## After merge

The 30-day-old Orders almost certainly hold expired ACME authorizations and need deleting to force fresh ones. Let's Encrypt failed-validation rate limits may also apply after a month of retries — if issuance doesn't complete, that's a wait rather than a config problem.

## Verification

- `kustomize build infra/controllers` green
- Rendered `cert-manager-helm-values` ConfigMap carries both args; all other values keys intact

## Follow-up

Add the cert-manager ServiceMonitor + a certificate-expiry alert. This failed silently for a month; that's the part worth fixing permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)