### PR TITLE
feat(cert-manager): scrape metrics + alert on stalled renewal

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,7 +5,7 @@
 > this page links out. **Update this file in the same PR whenever** a plan's
 > status changes, an incident postmortem lands, or hardware/topology changes.
 >
-> Last updated: 2026-07-06
+> Last updated: 2026-08-05
 
 ## Cluster at a glance
 
@@ -59,6 +59,7 @@ Planned, not yet started:
 
 ## Known issues / blocked
 
+- **`*.burntbytes.com` wildcard expired 2026-08-05 — resolved same day, but it was silently broken for 30 days.** cert-manager's DNS-01 propagation self-check queried cluster DNS (CoreDNS → AdGuard), which serves a split-horizon view and returns `ANSWER: 0` for `_acme-challenge.burntbytes.com`, so the ACME Order sat `pending` from 2026-07-06 until the old cert lapsed. Cloudflare had published the records correctly the whole time. Fixed with `--dns01-recursive-nameservers` ([#1274](https://github.com/gjcourt/homelab/pull/1274)); cert-manager metrics are now scraped and alerted on ([#1275](https://github.com/gjcourt/homelab/pull/1275)) — there was previously **no ServiceMonitor**, so no expiry alert was possible at all. The Certificate reported `Ready=True` throughout, which was true and useless. Full postmortem: [incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md](operations/incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md). **Open follow-up:** audit which other Helm charts default `serviceMonitor.enabled: false` and are therefore unmonitored.
 - **No on-prem LLM inference.** The 2× RTX 4090 were sold 2026-05-16. The `llms/` and GPU-`monitoring/` Custom Apps on hestia are archived. Restoring inference needs new GPU hardware or a hosted-API backend.
 - **`hermes` / `hermes-callee` (Signal bots) and `signal-cli` decommissioned 2026-06-17.** Removed from `apps/{base,production,staging}/` and garbage-collected by Flux (`prune: true`). They had no model backend after the GPUs were sold and were already scaled to 0. Signal-based critical-alert routing is dead as a result — see the obsoleted Phase 2 in [plans/2026-05-09-monitoring-enhancement.md](plans/2026-05-09-monitoring-enhancement.md).
 - **`.22` (talos-v2l-hng) decommissioned 2026-06-19** — bad DIMM (reads 30.6 GiB vs ~62), did not return after the 2026-06-18 maintenance. Removed from etcd and the cluster; **`.23` was promoted to control-plane in its place**, restoring fault-tolerant 3-member etcd (now a 4-node cluster). See the [control-plane promotion runbook](operations/2026-06-19-talos-controlplane-promotion.md) and [plan/execution record](plans/2026-06-19-promote-talos-25-to-controlplane.md). `.22` hardware verdict (DIMM/board/RMA) and `.24` re-entry still pending. **Topology (verified 2026-06-19):** all 4 nodes share one **Rack Switch (USWED42)** and one **USP PDU Pro** (separate outlets) — so the switch + PDU are **accepted single points of failure** (a 3-member etcd survives a node/outlet loss, not a whole-switch/PDU loss). Highest-value mitigation: put the Rack Switch + PDU on a UPS.

--- a/docs/operations/incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md
+++ b/docs/operations/incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md
@@ -1,0 +1,133 @@
+# Incident: `*.burntbytes.com` wildcard expired — DNS-01 self-check blocked by split-horizon DNS
+
+**Date:** 2026-08-05
+**Status:** **Resolved** — new certificate issued (valid to 2026-11-03), all production hosts serving valid TLS. Root cause fixed in [#1274](https://github.com/gjcourt/homelab/pull/1274); detection gap closed in [#1275](https://github.com/gjcourt/homelab/pull/1275)
+**Severity:** High — total production TLS outage. Every `*.burntbytes.com` host served an expired certificate; browsers blocked with a security interstitial, `curl` refused the connection outright
+**Environments affected:** production (`*.burntbytes.com`) and staging (`*.stage.burntbytes.com`)
+**Authors:** George Courtsunis
+
+---
+
+> **The failure lasted 30 days before anyone could see it.** The renewal broke on
+> 2026-07-06 and produced no signal a human would notice until the old certificate
+> lapsed a month later. The outage is the cheap part of this incident; the
+> month of silence is the expensive part.
+
+## Summary
+
+The `*.burntbytes.com` wildcard expired **2026-08-05 05:22:11 GMT**, taking TLS down on
+every production host at once. It surfaced as "something is wrong with Home Assistant" —
+Home Assistant was fine (`1/1 Running`, 0 restarts, 4d uptime); it was simply the first
+host someone happened to open.
+
+cert-manager had scheduled renewal for **2026-07-06** and did start it. The ACME Order
+then sat `pending` for **30 days** and never completed.
+
+Cloudflare published the DNS-01 challenge TXT records correctly — they were live in
+public DNS the entire time:
+
+```
+dig +short TXT _acme-challenge.burntbytes.com @1.1.1.1
+"MCL2XKaR2Kh1WGbLOifBcRD9hFj__unrJsLh5_HTs0s"
+"cRtiB_eOUoS11wC_RMwGGd0G4xOsqM-8yG80MDYqnLQ"
+```
+
+What failed was cert-manager's **own propagation self-check**, which runs *before* it asks
+Let's Encrypt to validate. With no `--dns01-recursive-nameservers` configured, that check
+uses the cluster resolver:
+
+```
+cert-manager → CoreDNS → node /etc/resolv.conf → AdGuard (10.42.2.43)
+```
+
+AdGuard serves a split-horizon view of `burntbytes.com` and answers
+`NOERROR / ANSWER: 0` for `_acme-challenge.burntbytes.com`. The self-check could therefore
+never pass, no matter how correct the published records were. Renewal stalled; the old
+certificate ran out.
+
+## Timeline
+
+| When | What |
+|---|---|
+| 2026-07-06 05:22 | Renewal scheduled and started. Order created, DNS-01 challenges issued |
+| 2026-07-06 → 08-05 | Order `pending`. Self-check queries AdGuard, gets `ANSWER: 0`, retries. 30 days |
+| 2026-08-05 05:22 | Certificate expires. All production hosts begin serving it expired |
+| 2026-08-05 ~16:00 | Reported as "Home Assistant is broken" |
+| 2026-08-05 ~16:10 | Diagnosed: expired wildcard, not an app fault. Stored and served certs identical (same serial), so not a stale-cache issue |
+| 2026-08-05 ~16:30 | [#1274](https://github.com/gjcourt/homelab/pull/1274) merged: `--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53` + `-only` |
+| 2026-08-05 ~16:45 | 30-day-old CertificateRequests deleted to force fresh ACME authorizations (the old ones had expired) |
+| 2026-08-05 16:00:38 | New certificate issued, valid to 2026-11-03. Challenge went `pending` → `valid :: Successfully authorized domain` |
+| 2026-08-05 ~17:00 | All hosts verified 200/302. Staging recovered by the same path with no separate action |
+
+## Why nobody was warned
+
+Two independent gaps. Either alone would have caught this.
+
+**1. `Ready=True` is not a health signal for renewal.** The Certificate reported
+`Ready=True` for the entire month, and it was *correct* — the existing certificate had not
+expired yet. Readiness describes the current certificate, not whether renewal is working.
+The honest signal was the second condition, `Issuing=True / Renewing`, unchanged since
+2026-07-06, and `status.renewalTime` pinned a month in the past. Nothing watched either.
+
+**2. cert-manager metrics were never scraped.** There was no ServiceMonitor, so
+`certmanager_certificate_expiration_timestamp_seconds` did not exist in Prometheus at all.
+No expiry alert was possible even in principle. The cluster's eight certificate-related
+alert rules are all kubelet/apiserver internals — **nothing watched the public certificates
+users actually hit.**
+
+## Fixes
+
+**Root cause — [#1274](https://github.com/gjcourt/homelab/pull/1274)**
+`infra/controllers/cert-manager/values.yaml`:
+
+```yaml
+extraArgs:
+  - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
+  - --dns01-recursive-nameservers-only
+```
+
+The documented remedy for split-horizon DNS. `-only` prevents falling back to the cluster
+resolver.
+
+**Detection — [#1275](https://github.com/gjcourt/homelab/pull/1275)**
+Enables the chart's ServiceMonitor and adds `infra/configs/alerts/cert-manager-rules.yaml`.
+The load-bearing alert is `CertManagerRenewalOverdue`: `renewalTime` sits in the future on
+a healthy certificate and jumps forward on each successful renewal, so a value in the past
+means renewal is due and has not completed. It would have fired **2026-07-07** — four weeks
+before a browser error did.
+
+Two traps found while writing that PR, both worth remembering:
+
+- The chart labels its ServiceMonitor `prometheus: default`, but this cluster's Prometheus
+  selects on `release: kube-prometheus-stack`. Enabling the ServiceMonitor without adding
+  that label creates an object Prometheus silently ignores — monitoring that doesn't
+  monitor, which is the same class of bug as the incident itself.
+- With the default `honorLabels: false`, prometheus-operator overwrites the metric's
+  `namespace` label with the *target's* namespace (always `security`), so every alert
+  annotation would have named the wrong namespace and the runbook line would have printed
+  the wrong `kubectl -n`.
+
+## Prevent recurrence
+
+- [x] DNS-01 self-check bypasses cluster DNS (#1274)
+- [x] cert-manager metrics scraped; expiry + stalled-renewal alerts (#1275)
+- [x] `CertManagerDown` uses `absent()`, not just `up == 0`, so the watcher failing is
+      itself detectable — a bare `up == 0` stops evaluating when the series vanishes,
+      which is precisely the pre-incident state
+- [ ] Consider the same split-horizon check for any future ACME solver added to the cluster
+- [ ] Broader question this raises: **what else is monitored only by a metric nobody
+      scrapes?** cert-manager was silently unmonitored for the cluster's entire lifetime.
+      An audit of Helm charts whose `serviceMonitor.enabled` defaults to `false` would
+      likely find more.
+
+## Lessons
+
+**A "Ready" condition that describes current state says nothing about whether renewal is
+working.** Any resource that self-renews needs an alert on the *renewal* path, not the
+readiness of the artifact it last produced. This generalises well beyond certificates.
+
+**A month of retries produced no escalation.** cert-manager retried the self-check for 30
+days without ever surfacing differently than a transient failure. Retry without a
+time-boxed escalation is indistinguishable from silence.
+
+**The first symptom was a user opening a browser.** That is the monitoring of last resort.

--- a/docs/reference/cert-manager.md
+++ b/docs/reference/cert-manager.md
@@ -47,7 +47,21 @@ kubectl get clusterissuer letsencrypt-production -o wide
 The `ClusterIssuer` should show a `Ready` status of `True`.
 
 ## 7. Monitoring & Alerting
-- **Metrics**: Cert-Manager exposes Prometheus metrics. Key metrics include `certmanager_certificate_expiration_timestamp_seconds` to monitor expiring certificates.
+
+- **Metrics**: scraped via the chart's ServiceMonitor (`prometheus.servicemonitor.enabled`
+  in `infra/controllers/cert-manager/values.yaml`). Two settings there are load-bearing:
+  `labels.release: kube-prometheus-stack` (this cluster's Prometheus selects on it — without
+  it the ServiceMonitor is created and silently ignored) and `honorLabels: true` (otherwise
+  the certificate's `namespace` label is overwritten with the target's, always `security`).
+  Enabled 2026-08-05; before that cert-manager was **not scraped at all**.
+- **Alerts**: `infra/configs/alerts/cert-manager-rules.yaml` —
+  `CertManagerRenewalOverdue` (critical, `renewalTime` in the past >24h),
+  `CertManagerCertExpiringSoon` (<21d) / `Critical` (<7d), `CertManagerCertNotReady`,
+  `CertManagerDown`.
+- **`Ready=True` is not a renewal health signal.** It describes the certificate you already
+  have, not whether renewal is succeeding. A stalled renewal keeps `Ready=True` right up
+  until the old cert expires — this is exactly how the 2026-08-05 outage stayed invisible
+  for 30 days. Watch `status.renewalTime` and the `Issuing` condition instead.
 - **Logs**: Check controller logs using `kubectl logs -n security deploy/cert-manager`.
 
 ## 8. Disaster Recovery
@@ -60,4 +74,16 @@ The `ClusterIssuer` should show a `Ready` status of `True`.
   - Check the `Challenge` resource: `kubectl describe challenge <name>`
   - Verify the Cloudflare API token is valid and has the correct permissions.
   - Ensure the DNS TXT record is propagating correctly.
+- **Order stuck `pending` for days, but `dig @1.1.1.1 TXT _acme-challenge.<domain>` shows
+  the record is live**: this is the 2026-08-05 failure mode. cert-manager runs its own
+  propagation self-check *before* asking Let's Encrypt to validate, and by default that
+  check uses cluster DNS (CoreDNS → AdGuard), which serves a split-horizon view of
+  `burntbytes.com` and returns `NOERROR / ANSWER: 0` for the challenge record. The fix is
+  already applied — `--dns01-recursive-nameservers` in `values.yaml` — so if you see this
+  again, confirm those args survived a chart upgrade. Note the certificate will report
+  `Ready=True` throughout. Full writeup:
+  [incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md](../operations/incidents/2026-08-05-wildcard-cert-expiry-dns01-split-horizon.md).
+- **Authorizations older than ~30 days are dead.** A long-stalled Order holds expired ACME
+  authorizations and will never recover on its own; delete the CertificateRequest to force
+  cert-manager to rebuild the chain.
 - **Webhook errors**: If you see errors related to the cert-manager webhook, ensure the webhook pod is running and reachable by the Kubernetes API server.

--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -25,7 +25,7 @@ The monitoring stack is deployed in the `monitoring` namespace via Flux using of
   - `infra/controllers/promtail/values.yaml`
   - `infra/controllers/vector/values.yaml`
 - **Loki Alerting Rules** (LogQL, evaluated by Loki ruler): `infra/controllers/loki/alerting-rules.yaml`
-- **Prometheus Alerting Rules** (PromQL): `infra/configs/alerts/prometheus-rules.yaml`
+- **Prometheus Alerting Rules** (PromQL): `infra/configs/alerts/prometheus-rules.yaml` and `infra/configs/alerts/cert-manager-rules.yaml`
 - **Grafana Dashboards**: Pre-configured dashboards are included in the `kube-prometheus-stack` chart. Additional custom dashboards can be added via ConfigMaps.
 - **Loki Data Source**: Grafana is configured to use Loki as a data source for log querying.
 

--- a/infra/configs/alerts/cert-manager-rules.yaml
+++ b/infra/configs/alerts/cert-manager-rules.yaml
@@ -15,8 +15,9 @@
 # The cluster's 8 pre-existing certificate alerts are all kubelet/apiserver
 # internals. Nothing watched the public certs users actually hit.
 #
-# Discovered via ruleNamespaceSelector: {} plus the release label below
-# (serviceMonitorSelectorNilUsesHelmValues=true also governs rule selection).
+# Discovery: ruleNamespaceSelector is {} and ruleSelector matches
+# `release: kube-prometheus-stack` (via ruleSelectorNilUsesHelmValues), which is
+# why the label below is required — same as the sibling prometheus-rules.yaml.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -40,7 +41,16 @@ spec:
         # listening to. 24h of grace absorbs a normal retry; a month does not.
         # ---------------------------------------------------------------------
         - alert: CertManagerRenewalOverdue
-          expr: certmanager_certificate_renewal_timestamp_seconds < time()
+          # `> 0` guard: the collector initialises renewalTime to 0.0 and only
+          # overwrites it when status.RenewalTime is non-nil, which the readiness
+          # controller clears whenever the Secret is missing/undecodable. Without
+          # the guard, 0 < time() is trivially true and every never-issued cert
+          # pages critical — including right after someone deletes a Secret to
+          # force reissuance, a plausible move while recovering from this very
+          # incident. CertManagerCertNotReady covers never-issued certs instead.
+          expr: >
+            certmanager_certificate_renewal_timestamp_seconds > 0
+            and certmanager_certificate_renewal_timestamp_seconds < time()
           for: 24h
           labels:
             severity: critical
@@ -57,7 +67,14 @@ spec:
         # renewalTime looking sane. 21d gives three weeks of daylight on a
         # 90-day Let's Encrypt cert that renews at 30 days remaining.
         - alert: CertManagerCertExpiringSoon
-          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 21
+          # `> 0` guard as above. Upper-bounded at 7d so this does not fire
+          # alongside CertManagerCertExpiringCritical — Alertmanager's inhibit
+          # rules key on `equal: [namespace, alertname]`, so differing alertnames
+          # are never deduped and one cert would otherwise send three emails.
+          expr: >
+            certmanager_certificate_expiration_timestamp_seconds > 0
+            and (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 21
+            and (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 >= 7
           for: 1h
           labels:
             severity: warning
@@ -69,7 +86,9 @@ spec:
 
         # Paging tier: under a week means the renewal path is broken, not slow.
         - alert: CertManagerCertExpiringCritical
-          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
+          expr: >
+            certmanager_certificate_expiration_timestamp_seconds > 0
+            and (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
           for: 1h
           labels:
             severity: critical
@@ -99,10 +118,18 @@ spec:
         # looks like health. That is the failure mode this whole file exists to
         # prevent, so watch the watcher.
         - alert: CertManagerDown
-          expr: up{job=~".*cert-manager.*"} == 0
+          # `absent()` is the whole point. `up == 0` only evaluates while the
+          # target still EXISTS; if the ServiceMonitor is deleted, the release
+          # label regresses on a chart upgrade, or the Service labels change,
+          # the series disappears and a bare `up == 0` silently stops firing —
+          # which is exactly the pre-2026-08-05 state: nothing scraped, nothing
+          # alerting, everything green. Critical, not warning: warnings route to
+          # +alerts@ whose Gmail filter skips the inbox, so the meta-alert
+          # guarding this entire file would land where nobody looks.
+          expr: up{job=~".*cert-manager.*"} == 0 or absent(up{job="cert-manager"})
           for: 15m
           labels:
-            severity: warning
+            severity: critical
           annotations:
             summary: "cert-manager metrics endpoint is down"
             description: >

--- a/infra/configs/alerts/cert-manager-rules.yaml
+++ b/infra/configs/alerts/cert-manager-rules.yaml
@@ -1,0 +1,110 @@
+# Certificate lifecycle alerts.
+#
+# Written after the 2026-08-05 outage: the *.burntbytes.com wildcard expired and
+# every production host started serving an expired cert. The renewal had been
+# stalled for THIRTY DAYS (ACME Order pending since 2026-07-06, DNS-01 self-check
+# querying split-horizon cluster DNS). Nothing alerted, for two reasons:
+#
+#   1. The Certificate reported Ready=True the entire time. That was true and
+#      useless — the OLD cert had not expired yet. Readiness says nothing about
+#      whether renewal is succeeding.
+#   2. cert-manager's metrics were never scraped at all (no ServiceMonitor), so
+#      certmanager_certificate_expiration_timestamp_seconds did not exist in
+#      Prometheus. Enabled in infra/controllers/cert-manager/values.yaml.
+#
+# The cluster's 8 pre-existing certificate alerts are all kubelet/apiserver
+# internals. Nothing watched the public certs users actually hit.
+#
+# Discovered via ruleNamespaceSelector: {} plus the release label below
+# (serviceMonitorSelectorNilUsesHelmValues=true also governs rule selection).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: cert-manager
+      rules:
+        # ---------------------------------------------------------------------
+        # THE ONE THAT WOULD HAVE CAUGHT 2026-08-05.
+        #
+        # renewalTime is when cert-manager intends to renew. On a healthy cert it
+        # sits in the FUTURE, and jumps forward each time renewal succeeds. If it
+        # is in the past, renewal was due and has not completed.
+        #
+        # During the incident this was pinned at 2026-07-06 for 30 straight days
+        # while Ready stayed True — a loud, unambiguous signal that nobody was
+        # listening to. 24h of grace absorbs a normal retry; a month does not.
+        # ---------------------------------------------------------------------
+        - alert: CertManagerRenewalOverdue
+          expr: certmanager_certificate_renewal_timestamp_seconds < time()
+          for: 24h
+          labels:
+            severity: critical
+          annotations:
+            summary: "cert-manager renewal overdue for {{ $labels.namespace }}/{{ $labels.name }}"
+            description: >
+              Renewal for {{ $labels.namespace }}/{{ $labels.name }} was scheduled
+              over 24h ago and has not completed. The certificate may still be
+              valid and Ready=True — that is exactly how the 2026-08-05 wildcard
+              expiry went unnoticed for a month. Check for a stuck ACME Order:
+              kubectl -n {{ $labels.namespace }} get order,challenge
+
+        # Expiry backstop, in case renewal fails in a way that leaves
+        # renewalTime looking sane. 21d gives three weeks of daylight on a
+        # 90-day Let's Encrypt cert that renews at 30 days remaining.
+        - alert: CertManagerCertExpiringSoon
+          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 21
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "TLS cert {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | printf \"%.0f\" }}d"
+            description: >
+              {{ $labels.namespace }}/{{ $labels.name }} expires in
+              {{ $value | printf "%.0f" }} days and has not been renewed.
+
+        # Paging tier: under a week means the renewal path is broken, not slow.
+        - alert: CertManagerCertExpiringCritical
+          expr: (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 7
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "TLS cert {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | printf \"%.0f\" }}d"
+            description: >
+              {{ $labels.namespace }}/{{ $labels.name }} expires in
+              {{ $value | printf "%.0f" }} days. Renewal has had weeks to succeed
+              and has not. Expect browser TLS errors on every host this cert
+              serves when it lapses.
+
+        # Ready=False is a weaker signal than the two above (it was True
+        # throughout the incident), but a cert that never issues at all — a new
+        # app, or a wildcard after a hard failure — only shows up here.
+        - alert: CertManagerCertNotReady
+          expr: certmanager_certificate_ready_status{condition="True"} == 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+            description: >
+              {{ $labels.namespace }}/{{ $labels.name }} has been not-Ready for
+              over an hour. If this is a new certificate it has never issued.
+
+        # If cert-manager stops being scraped, every alert above goes silent and
+        # looks like health. That is the failure mode this whole file exists to
+        # prevent, so watch the watcher.
+        - alert: CertManagerDown
+          expr: up{job=~".*cert-manager.*"} == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "cert-manager metrics endpoint is down"
+            description: >
+              Prometheus cannot scrape cert-manager. Every certificate-expiry
+              alert is blind while this is true.

--- a/infra/configs/alerts/kustomization.yaml
+++ b/infra/configs/alerts/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - prometheus-rules.yaml
+  - cert-manager-rules.yaml

--- a/infra/controllers/cert-manager/values.yaml
+++ b/infra/controllers/cert-manager/values.yaml
@@ -41,20 +41,32 @@ approveSignerNames:
   - "issuers.cert-manager.io/*"
   - "clusterissuers.cert-manager.io/*"
 
-# Metrics scraping. The chart creates the ServiceMonitor but labels it only
-# `prometheusInstance: default`; this cluster's Prometheus selects on
-# `release: kube-prometheus-stack` (serviceMonitorSelectorNilUsesHelmValues=true),
-# so WITHOUT the label below the ServiceMonitor would be created and then
-# silently ignored — scraped by nothing, alerting on nothing.
-#
-# Why this exists: the *.burntbytes.com wildcard expired 2026-08-05 after a
-# renewal stalled for 30 days, and nothing noticed because
+# Metrics scraping. Why this exists: the *.burntbytes.com wildcard expired
+# 2026-08-05 after a renewal stalled for 30 days, and nothing noticed because
 # certmanager_certificate_expiration_timestamp_seconds was never scraped. The
 # alerts this feeds live in infra/configs/alerts/cert-manager-rules.yaml.
+#
+# Two settings below are load-bearing; without either, this is monitoring that
+# doesn't monitor:
+#
+#   labels.release — the chart labels its ServiceMonitor `prometheus: default`
+#     only. This cluster's Prometheus selects on `release:
+#     kube-prometheus-stack` (serviceMonitorSelectorNilUsesHelmValues=true), so
+#     without this the ServiceMonitor is created and then silently ignored.
+#
+#   honorLabels — prometheus-operator sets `namespace` on every scraped series
+#     from the TARGET's namespace (always `security` here). With the default
+#     honorLabels=false the target wins and the certificate's own namespace is
+#     renamed `exported_namespace`, so every alert annotation would report
+#     `security` regardless of where the cert lives — and the runbook line
+#     would print the wrong `kubectl -n`. honorLabels=true keeps the metric's
+#     own namespace/name, which IS the subject of these alerts. Same pattern
+#     kube-prometheus-stack uses for kube-state-metrics.
 prometheus:
   enabled: true
   servicemonitor:
     enabled: true
+    honorLabels: true
     labels:
       release: kube-prometheus-stack
 

--- a/infra/controllers/cert-manager/values.yaml
+++ b/infra/controllers/cert-manager/values.yaml
@@ -41,6 +41,23 @@ approveSignerNames:
   - "issuers.cert-manager.io/*"
   - "clusterissuers.cert-manager.io/*"
 
+# Metrics scraping. The chart creates the ServiceMonitor but labels it only
+# `prometheusInstance: default`; this cluster's Prometheus selects on
+# `release: kube-prometheus-stack` (serviceMonitorSelectorNilUsesHelmValues=true),
+# so WITHOUT the label below the ServiceMonitor would be created and then
+# silently ignored — scraped by nothing, alerting on nothing.
+#
+# Why this exists: the *.burntbytes.com wildcard expired 2026-08-05 after a
+# renewal stalled for 30 days, and nothing noticed because
+# certmanager_certificate_expiration_timestamp_seconds was never scraped. The
+# alerts this feeds live in infra/configs/alerts/cert-manager-rules.yaml.
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+
 webhook:
   hostNetwork: false
   # Use the host's DNS


### PR DESCRIPTION
Follow-up to #1274. That PR fixed **why** the 2026-08-05 wildcard expiry happened. This one fixes **why nobody knew for 30 days**.

## Two gaps, both closed

**1. cert-manager metrics were never scraped.** No ServiceMonitor existed, so `certmanager_certificate_expiration_timestamp_seconds` was not in Prometheus at all and no expiry alert was even possible.

> ⚠️ **Load-bearing detail:** the chart labels its ServiceMonitor only `prometheusInstance: default`, but this cluster's Prometheus selects on `release: kube-prometheus-stack` (`serviceMonitorSelectorNilUsesHelmValues: true`). Flipping `servicemonitor.enabled: true` *without* adding that label creates an object Prometheus **silently ignores** — monitoring that doesn't monitor, which is precisely the failure this PR exists to fix. `servicemonitor.labels` sets it.

**2. Nothing alerted on public certificate lifecycle.** The cluster's 8 existing certificate rules are all kubelet/apiserver internals.

## New alerts

| Alert | Severity | Fires when |
|---|---|---|
| **`CertManagerRenewalOverdue`** | critical | `renewalTime` in the past for **24h** |
| `CertManagerCertExpiringSoon` | warning | < 21 days remaining |
| `CertManagerCertExpiringCritical` | critical | < 7 days remaining |
| `CertManagerCertNotReady` | warning | not Ready for 1h |
| `CertManagerDown` | warning | metrics unscrapeable for 15m |

**`CertManagerRenewalOverdue` is the one that would have caught this.** `renewalTime` sits in the future on a healthy certificate and jumps forward each time renewal succeeds. If it's in the past, renewal was due and hasn't completed. During the incident it was pinned at **2026-07-06 for a solid month** while `Ready` stayed `True` — a loud, unambiguous signal that nothing was listening to. It would have paged on **July 7**, four weeks before users saw a browser error.

Deliberately **not** keyed on `Ready`: it was `True` for the entire outage. Readiness describes the current certificate, not whether renewal is working. That conflation is what made this invisible.

`CertManagerDown` exists because if scraping stops, every alert above goes quiet and looks like health — the same shape of failure. Watch the watcher.

## Verification

- `kustomize build` green for `infra/configs` and `infra/controllers`
- `promtool check rules` → **SUCCESS: 5 rules found**
- Rendered `PrometheusRule` carries `release: kube-prometheus-stack`
- **Rebased on `6b622ec1`** so #1274's `--dns01-recursive-nameservers` args are preserved — a stale local `origin/master` initially produced a branch that would have silently reverted them

## After merge

Confirm the target actually appears, rather than assuming:

```bash
kubectl -n security get servicemonitor
# Prometheus → Status → Targets should list a cert-manager job
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)