### PR TITLE
feat(tunnel): make the public surface deliberate — +memos +food, -overture

### DIFF
--- a/apps/production/cloudflare-tunnel/README.md
+++ b/apps/production/cloudflare-tunnel/README.md
@@ -13,7 +13,7 @@ under `apps/production/`).
 
 Reason: the tunnel is bound to a specific Cloudflare account, tunnel ID, and
 DNS records (`auth.burntbytes.com`, `links.burntbytes.com`,
-`overture.burntbytes.com`, etc.). Staging traffic in this homelab is not
+`memos.burntbytes.com`, etc.). Staging traffic in this homelab is not
 publicly exposed — staging hostnames resolve internally via the cluster
 gateway. Running a second `cloudflared` instance for staging would require
 provisioning a separate tunnel ID and credentials in Cloudflare, plus DNS
@@ -27,3 +27,56 @@ through a PR. Cloudflare exposes tunnel health under
 external traffic recovers. If a config change might break ingress, gate it
 behind a temporary hostname first and validate via `cloudflared tunnel info`
 before flipping production hosts.
+
+## The public surface
+
+`config.yaml`'s `ingress:` list **is** the cluster's entire inbound surface from
+the internet. There is no other public path — everything else resolves only on
+the LAN via the `*.burntbytes.com` wildcard and the AdGuard rewrite. Adding a
+hostname here publishes it; removing one makes it LAN-only again.
+
+Currently published:
+
+| Hostname | App | Why public | Auth |
+|---|---|---|---|
+| `auth.burntbytes.com` | Authelia | Required — every OIDC redirect below terminates here | `one_factor` |
+| `links.burntbytes.com` | Linkding | "Local cloud" — bookmarks from anywhere | OIDC, `two_factor` |
+| `memos.burntbytes.com` | Memos | "Local cloud" — notes from anywhere | OIDC, `two_factor` |
+| `food.burntbytes.com` | Mealie | "Local cloud" — recipes from anywhere | OIDC, `two_factor` |
+| `burntbytes.com` + `-origin` | Blog | Public by definition | none |
+| `cadence.burntbytes.com` | — | **Orphan** — see the note in `config.yaml` | none |
+
+### Bar for adding a hostname
+
+Authelia's `default_policy` is `bypass`, and these hostnames are **not**
+gateway-protected by a forward-auth rule — the apps above authenticate
+*in-app* as OIDC clients. So an app that does not enforce its own login is
+wide open the moment it is added here.
+
+Before adding an entry:
+
+1. Confirm the app is an Authelia OIDC client with
+   `authorization_policy: two_factor` in
+   `apps/production/authelia/configuration.yaml`, **and** that the hostname you
+   are publishing appears in that client's `redirect_uris`.
+2. Confirm a production HTTPRoute actually serves the hostname (otherwise you
+   publish a hostname with no backend — see the cadence note).
+3. Add the Cloudflare DNS `CNAME` → `<tunnel-uuid>.cfargotunnel.com`.
+   **DNS is not managed in this repo** and there is no external-dns; the record
+   is created by hand in the Cloudflare dashboard. Without it the tunnel entry
+   is inert.
+
+No manual restart is needed: the `configMapGenerator` content-hashes the
+ConfigMap name, so any change to `config.yaml` renames it, rewrites the
+Deployment's volume reference, and Flux rolls the pods. (cloudflared does not
+hot-reload its ingress config, which is why the hash suffix exists.)
+
+### Residual risk on the OIDC apps
+
+Enabling OIDC does not necessarily *disable* local password login. Neither
+Memos nor Mealie has an explicit "local login disabled" setting in this repo,
+and Mealie sets `OIDC_AUTO_REDIRECT: "false"`, so its login page offers both
+paths. The consequence of publishing them is that a password form is reachable
+from the internet and is brute-forceable independently of Authelia's 2FA. If
+that matters, disable local auth in the app or put the hostname behind an
+Authelia forward-auth rule instead of relying on in-app OIDC alone.

--- a/apps/production/cloudflare-tunnel/config.yaml
+++ b/apps/production/cloudflare-tunnel/config.yaml
@@ -9,24 +9,47 @@ no-autoupdate: true
 
 # Route all traffic to the production gateway
 # The gateway handles routing based on hostname
+#
+# THIS LIST IS THE ENTIRE PUBLIC ATTACK SURFACE. Everything not named here is
+# LAN-only — the cluster has no other inbound path from the internet. Adding a
+# hostname here publishes it, so the bar for entry is: the app must enforce its
+# own authentication, because Authelia's `default_policy` is `bypass` and a
+# forward-auth rule does NOT apply to these (the OIDC apps below authenticate
+# in-app, they are not gateway-protected).
+#
+# Before adding an entry, confirm the app is an Authelia OIDC client with
+# `authorization_policy: two_factor` in apps/production/authelia/configuration.yaml,
+# and add the matching Cloudflare DNS CNAME (see README — DNS is NOT in GitOps).
 ingress:
-  # Authelia
+  # Authelia — the SSO endpoint itself; must be publicly reachable for every
+  # OIDC redirect below to complete.
   - hostname: auth.burntbytes.com
     service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
     originRequest:
       originServerName: auth.burntbytes.com
 
-  # Linkding
+  # ── "Local cloud" — the three apps intended to be reachable from anywhere.
+  # All three are Authelia OIDC clients at authorization_policy: two_factor.
+
+  # Linkding — bookmarks. LD_ENABLE_OIDC=True.
   - hostname: links.burntbytes.com
     service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
     originRequest:
       originServerName: links.burntbytes.com
 
-  # Overture
-  - hostname: overture.burntbytes.com
+  # Memos — notes. OIDC via Authelia (see memos deployment-patch.yaml).
+  - hostname: memos.burntbytes.com
     service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
     originRequest:
-      originServerName: overture.burntbytes.com
+      originServerName: memos.burntbytes.com
+
+  # Mealie — recipes. OIDC_AUTH_ENABLED=true. Note the app answers on both
+  # food. and mealie.; only food. is published, and it is already a registered
+  # OIDC redirect_uri. mealie.burntbytes.com stays LAN-only.
+  - hostname: food.burntbytes.com
+    service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
+    originRequest:
+      originServerName: food.burntbytes.com
 
   # burntbytes blog — hidden origin hostname for pre-cutover validation.
   # Inert off-LAN until a Cloudflare DNS record points it at the tunnel;
@@ -43,9 +66,16 @@ ingress:
     originRequest:
       originServerName: burntbytes.com
 
-  # Cadence — self-hosted Shopify app (agent-payment discovery demo). Routes to the
-  # production gateway; the app-side HTTPRoute (cadence.burntbytes.com -> cadence
-  # Service) lands with the app deploy. TLS covered by the *.burntbytes.com wildcard.
+  # Cadence — self-hosted Shopify app (agent-payment discovery demo).
+  #
+  # ⚠️ ORPHAN as of 2026-08-12: this hostname is published but there is NO
+  # production HTTPRoute for it — #1261 landed the tunnel route ahead of the app,
+  # and the app PR (#1262) is blocked on three findings, one of which is that it
+  # would expose an unauthenticated merchant dashboard (no Authelia rule, and
+  # default_policy is bypass). It therefore does not meet the bar stated at the
+  # top of this file. Left in place pending the #1262 decision — remove it if
+  # that PR is closed, and re-land it together with the app (and its auth
+  # posture) if it proceeds.
   - hostname: cadence.burntbytes.com
     service: https://cilium-gateway-app-gateway-production.default.svc.cluster.local
     originRequest:


### PR DESCRIPTION
## What's actually public today

Audited from GitOps. The tunnel's `ingress:` list is the cluster's **entire** inbound surface — there is no other path in. It had drifted from intent in both directions.

| Hostname | App | Auth | Change |
|---|---|---|---|
| `auth.burntbytes.com` | Authelia | `one_factor` | — |
| `links.burntbytes.com` | Linkding | OIDC `two_factor` | — |
| `memos.burntbytes.com` | Memos | OIDC `two_factor` | **+ added** |
| `food.burntbytes.com` | Mealie | OIDC `two_factor` | **+ added** |
| `burntbytes.com` + `-origin` | Blog | none (public by definition) | — |
| `overture.burntbytes.com` | Overture | bypass | **− removed** |
| `cadence.burntbytes.com` | *nothing* | none | ⚠️ flagged, left |

**16 apps stay LAN-only** — golinks, vitals, flashcards, jellyfin, hass, adguard, navidrome, openwebui, homepage, excalidraw, audiobookshelf, snapcast, vibrato, changes, mealie's `mealie.` alias, memos' internal route.

## Why each change

**− overture:** the Deployment is scaled `0/0` and its CNPG cluster is hibernated deliberately. It published a hostname that can only return 503.

**+ memos, + food:** the "local cloud" set. Both clear the same bar linkding already met, verified explicitly:

| | Authelia OIDC client | policy | hostname in `redirect_uris` | production HTTPRoute |
|---|---|---|---|---|
| memos | ✅ `memos` | `two_factor` | ✅ `/auth/callback` | ✅ |
| mealie | ✅ `mealie` | `two_factor` | ✅ `food.../login` | ✅ |

Mealie answers on both `food.` and `mealie.`; only `food.` is published, and it's the registered redirect. `mealie.burntbytes.com` stays LAN-only.

## Two things worth knowing before merge

**These hostnames are not gateway-protected.** Authelia's `default_policy` is `bypass` and there is no forward-auth rule for any of them — the apps authenticate *in-app* as OIDC clients. That's why the bar above is about the app's own auth. An app that doesn't enforce its own login would be wide open the moment it's added here. Now documented in the README so the next addition doesn't get this wrong.

**OIDC does not necessarily disable local password login.** Neither memos nor mealie has a local-auth-disabled setting in this repo, and mealie sets `OIDC_AUTO_REDIRECT: "false"` so its login page offers both paths. Net effect of this PR: a password form for each becomes internet-reachable and brute-forceable independently of Authelia's 2FA. Acceptable if that's the tradeoff you want for anywhere-access; if not, the fix is disabling local auth in-app or adding a forward-auth rule.

## Flagged, deliberately not changed

`cadence.burntbytes.com` is published with **no production HTTPRoute behind it**. #1261 landed the tunnel route ahead of the app; #1262 is blocked on three findings, one being that it would expose an unauthenticated merchant dashboard. It's the one entry failing the documented bar. Left in place with an inline note pending the #1262 decision — say the word and I'll drop it.

## Operator step — DNS is not in GitOps

There's no external-dns. Each new hostname needs a Cloudflare `CNAME` → `<tunnel-uuid>.cfargotunnel.com`, created by hand. **Until those exist, the `memos.` and `food.` entries are inert** — merging this alone does not publish them.

## Verification

- `kustomize build apps/production/cloudflare-tunnel` ✓
- ConfigMap hash rotates `cloudflared-7dm7m62dkt` → `cloudflared-f7b98c4kcf`, so Flux rolls the pods automatically — no manual `rollout restart` (cloudflared doesn't hot-reload ingress config, which is why that generator exists)
- Every published hostname checked against: has an HTTPRoute + is in its OIDC client's `redirect_uris`. All pass except the flagged cadence orphan.

Post-merge:
```bash
kubectl -n cloudflare-tunnel rollout status deploy/cloudflared
kubectl -n cloudflare-tunnel get pods   # both replicas ready
# then create the two CNAMEs and confirm memos/food resolve off-LAN
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUJaWoFvk7o67BbqxkQiE3