### PR TITLE
docs: promote 29 operational gotchas into runbooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ The historical `docs/apps/`, `docs/guides/`, `docs/incidents/`, and `docs/infra/
 
 - [Adding a new app](operations/2026-05-02-adding-an-app.md)
 - [Flux debugging — common patterns](operations/2026-05-02-flux-debugging.md)
+- [Gotchas index](operations/2026-08-15-gotchas-index.md) — behaviour that already cost real time once
 - [CNPG backup and disaster recovery](operations/2026-05-02-cnpg-backup-recovery.md)
 - How-to guides (grandfathered names): [Making changes](operations/making-changes.md), [Flux and deployments](operations/flux-and-deployments.md), [Staging workflow](operations/staging-workflow.md), [Synology iSCSI operations](operations/synology-iscsi-operations.md)
 

--- a/docs/operations/2026-08-15-cluster-gotchas.md
+++ b/docs/operations/2026-08-15-cluster-gotchas.md
@@ -15,25 +15,42 @@ Node topology, kubectl selector traps, and Flux behaviours that differ from what
 
 ## talos shelf correlated failure
 
-**melodic-muse node physical topology + the correlated-failure trap behind the 2026-06-18 quorum-loss outage**
+**Physical topology, the correlated-failure trap behind the 2026-06-18 quorum loss, and where power
+independence actually stops**
 
-melodic-muse (Talos cluster) physical layout, learned during the 2026-06-18 maintenance:
-**`.22`+`.23` share one shelf; `.24`+`.25` share another; `.20`/`.21` are separate.**
-4 independent PSUs, but the shelf mechanically couples its two nodes (pulling the shelf to
-service one node takes both down). `.21` and `.25` also share a switch/power path with the
-maintenance shelves.
+**Every node has its own PSU. They all plug into one PDU (USP PDU Pro) and one switch (USWED42).**
+So per-node power redundancy is real and it buys you nothing above the node — the PDU and the switch
+are shared single points of failure for the entire cluster, on separate outlets but one device each.
+This was verified 2026-06-19 and it supersedes an earlier reading that treated per-node PSUs as
+failure independence. See
+[Talos control-plane promotion](./2026-06-19-talos-controlplane-promotion.md).
 
-**Why:** During the `.22` DIMM work, an action on the shared switch/power path dropped
-`.21` (a control-plane survivor that was supposed to be untouched) **and** `.25` at once —
-not 5 independent failures, one infra fault. With `.22` already down, losing `.21` left
-etcd at 1/3 → **full control-plane outage** (`etcdserver: no leader`, apiserver `etcd failed`).
-The "2/3 quorum is safe" assumption was wrong because the survivors weren't failure-independent.
+**Shelves couple pairs mechanically.** Pulling a shelf to service one node takes both of its
+occupants down. That is a handling and thermal coupling, separate from the power path above.
 
-**How to apply:** During any cluster op, treat `.20`/`.21` **and the switch/PSU/shelf they
-share** as off-limits — confirm survivor independence before relying on quorum. Don't uncordon
-maintenance nodes until the operator confirms physical work is fully done and nodes are staying
-up (mid-work uncordon churned workloads onto `.23`, which then dropped again). See
-[[feedback_flux_suspend_during_cluster_ops]], [[project_homelab_cluster]].
+**Why it mattered.** During the 2026-06-18 DIMM work, an action on the shared path dropped a
+control-plane survivor that was supposed to be untouched, plus a worker, at the same time — not
+independent failures, one infra fault. With another node already down, etcd fell to 1/3 and the
+control plane went out entirely (`etcdserver: no leader`, apiserver `etcd failed`). **The "2/3 quorum
+is safe" assumption was wrong because the survivors were never failure-independent.**
+
+**How to apply.**
+
+- **Never assume quorum survives a physical operation.** Confirm survivor independence first — and
+ on this cluster, above the node level, there isn't any. One switch, one PDU.
+- **Don't take down two nodes on the same shelf** in a single operation.
+- **Don't uncordon maintenance nodes** until physical work is confirmed finished and the nodes are
+ staying up. Mid-work uncordon churned workloads onto a node that then dropped again.
+- See [Flux suspend during cluster ops](#flux-suspend-during-cluster-ops).
+
+**Current cluster (as of 2026-08):** 4 nodes — **3 control-plane (`.20`, `.21`, `.23`) + 1 worker
+(`.25`)**. `.22` was decommissioned 2026-06-19 for a bad DIMM and `.23` promoted to control-plane in
+its place; `.24` is out. Earlier notes describing a six-node layout with `.22`/`.24` are historical.
+**Check `docs/STATUS.md` for the live list — it moves.**
+
+**Related:** `.20` has no BMC, so recovering a hung control-plane node needs a physical power-cycle —
+and `.20`/`.21` share that switch and PDU. See
+[incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md](./incidents/2026-06-24-cp-node-hang-cilium-k8sservicehost-spof.md).
 
 ---
 
@@ -41,16 +58,16 @@ up (mid-work uncordon churned workloads onto `.23`, which then dropped again). S
 
 **Talos/containerd masks /sys/devices/virtual/powercap with an empty tmpfs; reading RAPL in a pod needs a non-/sys hostPath mount + walking the device tree, not /sys/class symlinks**
 
-Reading **RAPL energy** (`/sys/class/powercap/intel-rapl:*/energy_uj`) from a pod on the Talos cluster fails in a non-obvious way: containerd stacks an **empty read-only tmpfs over `/sys/devices/virtual/powercap`** (default sysfs masking). The `/sys/class/powercap/intel-rapl:*` entries are **relative symlinks** into `../../devices/virtual/powercap/...`, so they resolve *through* the mask → ENOENT for both shell `cat` and Go `os.ReadFile` inside the long-running pod.
+Reading **RAPL energy** (`/sys/class/powercap/intel-rapl:*/energy_uj`) from a pod on the Talos cluster fails in a non-obvious way: containerd stacks an **empty read-only tmpfs over `/sys/devices/virtual/powercap`** (default sysfs masking). The `/sys/class/powercap/intel-rapl:*` entries are **relative symlinks** into `././devices/virtual/powercap/..`, so they resolve *through* the mask → ENOENT for both shell `cat` and Go `os.ReadFile` inside the long-running pod.
 
 **Why it's a trap:** a fresh single-mount busybox probe reads RAPL fine (its mount overlays the mask), so manual verification passes while the deployed agent gets nothing. Diagnosed live on thermalscope 2026-06-16 after the collector showed `power_up=1` (ReadDir of the class dir succeeds) but **zero energy series** (every per-domain read returned empty).
 
 **How to do it right (works):**
-- Mount the hostPath `/sys/devices/virtual/powercap` at a **non-`/sys` path** in the container (e.g. `/host/sys/powercap`). Anything remounted under `/sys/...` gets re-masked.
-- Point the collector at that path (thermalscope: `THERMALSCOPE_POWERCAP_ROOT=/host/sys/powercap`) and **walk the device tree** (real dirs, nested `intel-rapl/intel-rapl:0/` = package-0, `.../intel-rapl:0:0/` = core), not the flat `/sys/class/powercap` symlinks. De-dup domains by `name` so the `intel-rapl-mmio` mirror doesn't double-count.
+- Mount the hostPath `/sys/devices/virtual/powercap` at a **non-`/sys` path** in the container (e.g. `/host/sys/powercap`). Anything remounted under `/sys/..` gets re-masked.
+- Point the collector at that path (thermalscope: `THERMALSCOPE_POWERCAP_ROOT=/host/sys/powercap`) and **walk the device tree** (real dirs, nested `intel-rapl/intel-rapl:0/` = package-0, `../intel-rapl:0:0/` = core), not the flat `/sys/class/powercap` symlinks. De-dup domains by `name` so the `intel-rapl-mmio` mirror doesn't double-count.
 - RAPL `energy_uj` is **root-gated** (Platypus mitigation); the agent must run `runAsUser: 0` (node-exporter runs non-root, which is why `node_rapl_*` is absent in the cluster — verified). Expose energy as a monotonic counter; `rate()/1e6` = watts. Verified sane on the APU nodes: package-0 ≈ 2–6 W.
 
-**Why it matters:** cost a 3-round deploy-verify saga. Contrast hwmon, which works with a plain `/sys/class/hwmon` mount because its symlink targets are *real PCI devices* the container's base sysfs exposes — only the *virtual* powercap subtree is masked. Same family of "verify on the real node" lesson as [[feedback_homelab_lan_access]]; the netscope BPF lockdown bug the same day is the analog for tracing programs.
+**Why it matters:** cost a 3-round deploy-verify saga. Contrast hwmon, which works with a plain `/sys/class/hwmon` mount because its symlink targets are *real PCI devices* the container's base sysfs exposes — only the *virtual* powercap subtree is masked. Same family of "verify on the real node" lesson as [homelab lan access](./2026-08-15-operating-principles.md#homelab-lan-access); the netscope BPF lockdown bug the same day is the analog for tracing programs.
 
 ---
 
@@ -60,7 +77,7 @@ Reading **RAPL energy** (`/sys/class/powercap/intel-rapl:*/energy_uj`) from a po
 
 The Kubernetes label-selector grammar for `notin` evaluates against the key's value, but the special case of "pod doesn't have the key at all" is also treated as "not in the listed values." Result: a delete with `--selector='job-name notin (restore-foo, restore-bar)'` intended to clean squatter Deployment pods will ALSO delete every CNPG / StatefulSet / cron-job-created pod in the namespace that has no `job-name` label whatsoever.
 
-**Why:** Burned by this in the alcatraz → hestia preserve-7 migration (2026-05-23). Wrote a broad `notin (restore-*)` selector to force-delete app pods that had grabbed the freshly-recreated PVCs (see [[flux-suspend-during-cluster-ops]]). Accidentally killed `immich-db-staging-cnpg-v1-5` and `v1-6` postgres pods because they didn't have a `job-name` label. CNPG operator recovered them via rebootstrap, but it was an avoidable 2-minute outage for the cluster's primary postgres.
+**Why:** Burned by this in the alcatraz → hestia preserve-7 migration (2026-05-23). Wrote a broad `notin (restore-*)` selector to force-delete app pods that had grabbed the freshly-recreated PVCs (see [flux suspend during cluster ops](#flux-suspend-during-cluster-ops)). Accidentally killed `immich-db-staging-cnpg-v1-5` and `v1-6` postgres pods because they didn't have a `job-name` label. CNPG operator recovered them via rebootstrap, but it was an avoidable 2-minute outage for the cluster's primary postgres.
 
 **How to apply:**
 
@@ -92,7 +109,7 @@ The bare `app` term means "has the key" — so the selector now matches only pod
 - Cilium NetworkPolicy `endpointSelector` with `NotIn` — same gotcha
 
 **Related cross-references:**
-- [[flux-suspend-during-cluster-ops]] — the upstream cause; suspending Flux would have prevented the squatter-pod problem and made the broad selector unnecessary
+- [flux suspend during cluster ops](#flux-suspend-during-cluster-ops) — the upstream cause; suspending Flux would have prevented the squatter-pod problem and made the broad selector unnecessary
 
 ---
 
@@ -102,7 +119,7 @@ The bare `app` term means "has the key" — so the selector now matches only pod
 
 When a migration plan involves "scale workload to 0 → delete PVC → wait for recreation → run rsync data-restore Job → scale workload back up," Flux's default 10-minute reconciliation interval will race with the manual steps. The reconciler sees `replicas: 1` in the source manifest and scales the deployment back up, the workload pod grabs the freshly-recreated PVC (RWO), and your restore-rsync Job is stuck in `ContainerCreating` with `Multi-Attach error for volume X: Volume is already used by pod(s) <app-pod>`.
 
-**Why:** Hit this in production during the alcatraz → hestia preserve-7 migration (2026-05-23). Six of seven restore-rsync Jobs sat in ContainerCreating for 21 minutes because Flux scaled the deployments back up after I'd scaled them to 0. Cost: a manual force-delete sweep that accidentally killed CNPG postgres pods too (see [[kubectl-selector-notin-pitfall]]).
+**Why:** Hit this in production during the alcatraz → hestia preserve-7 migration (2026-05-23). Six of seven restore-rsync Jobs sat in ContainerCreating for 21 minutes because Flux scaled the deployments back up after I'd scaled them to 0. Cost: a manual force-delete sweep that accidentally killed CNPG postgres pods too (see [kubectl selector notin pitfall](#kubectl-selector-notin-pitfall)).
 
 **How to apply:**
 
@@ -125,8 +142,8 @@ Same pattern for `apps-production` when doing Phase 1.2 prod migrations. Be expl
 - If the migration touches resources outside the Kustomization's scope (e.g., a manual PVC not in the manifests), suspension may be unnecessary — Flux won't re-create what it doesn't know about.
 
 **Related cross-references:**
-- [[pvc-storage-class-migration]] — the underlying migration pattern that triggers this race
-- [[cnpg-promote-pg-resetwal]] — CNPG-specific recovery that ALSO benefits from suspending the operator's reconcile loop (`cnpg.io/reconciliationLoop=disabled` annotation)
+- [pvc storage class migration](./2026-08-15-storage-gotchas.md#pvc-storage-class-migration) — the underlying migration pattern that triggers this race
+- [cnpg promote pg resetwal](./2026-08-15-services-gotchas.md#cnpg-promote-pg-resetwal) — CNPG-specific recovery that ALSO benefits from suspending the operator's reconcile loop (`cnpg.io/reconciliationLoop=disabled` annotation)
 
 ---
 
@@ -161,14 +178,14 @@ sleep 2
 
 # 2. Set claimRef to namespace + name only (no UID)
 kubectl patch pv $PV --type=merge -p '{
-  "spec": {
-    "claimRef": {
-      "apiVersion": "v1",
-      "kind": "PersistentVolumeClaim",
-      "namespace": "'$NS'",
-      "name": "'$PVC'"
-    }
-  }
+ "spec": {
+ "claimRef": {
+ "apiVersion": "v1",
+ "kind": "PersistentVolumeClaim",
+ "namespace": "'$NS'",
+ "name": "'$PVC'"
+ }
+ }
 }'
 
 # 3. Apply the PVC manifest WITHOUT volumeName (let Flux's manifest stand)
@@ -176,26 +193,26 @@ kubectl apply -f - <<YAML
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: $PVC
-  namespace: $NS
+ name: $PVC
+ namespace: $NS
 spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: <whatever the manifest says>
-  resources:
-    requests:
-      storage: $SIZE
+ accessModes: [ReadWriteOnce]
+ storageClassName: <whatever the manifest says>
+ resources:
+ requests:
+ storage: $SIZE
 YAML
 # The binder will see the PV's matching claimRef and bind without volumeName being set by the manifest.
 ```
 
 **Why the patch-then-remove dance:** if you only patch `claimRef.uid: null` on a PV that has a stale UID, strategic merge keeps the old UID — the binder rejects the bind silently and the storageclass provisioner provisions a fresh empty PV (DATA LOSS risk). Remove claimRef entirely first.
 
-**Storage-class admission gotcha:** If your manifest has no `storageClassName`, the default-storage-class admission plugin sets it to the cluster's default at PVC creation time. The resulting cluster PVC has `storageClassName: synology-iscsi` (or whatever default) even though the manifest had nothing. If a later Flux apply has a different value (or null), it's a strategic-merge-patch mismatch. **Best practice: always pin `storageClassName` explicitly in PVC manifests** to avoid drift between cluster state and Git.
+**Storage-class admission gotcha:** If your manifest has no `storageClassName`, the default-storage-class admission plugin sets it to the cluster's default at PVC creation time. The resulting cluster PVC has `storageClassName: truenas-iscsi` (or whatever default) even though the manifest had nothing. If a later Flux apply has a different value (or null), it's a strategic-merge-patch mismatch. **Best practice: always pin `storageClassName` explicitly in PVC manifests** to avoid drift between cluster state and Git.
 
 **Related cross-references:**
-- [[audit-pvc-before-lossy-destroy]] — verify before destroying so you don't need this recovery
-- [[pv-retain-recovery-pattern]] — the lower-level mechanism; this is the Flux-compatible variant
-- [[pvc-storage-class-migration]] — the higher-level migration pattern that triggers the need to rebind
+- [audit pvc before lossy destroy](./2026-08-15-storage-gotchas.md#audit-pvc-before-lossy-destroy) — verify before destroying so you don't need this recovery
+- [pv retain recovery pattern](./2026-08-15-storage-gotchas.md#pv-retain-recovery-pattern) — the lower-level mechanism; this is the Flux-compatible variant
+- [pvc storage class migration](./2026-08-15-storage-gotchas.md#pvc-storage-class-migration) — the higher-level migration pattern that triggers the need to rebind
 
 ---
 
@@ -207,6 +224,6 @@ GA Flux controllers (helm-controller v1.x, kustomize-controller v1.x, source-con
 
 **Per-object readiness comes from kube-state-metrics instead** (the upstream `flux2-monitoring-example` pattern): a `customResourceState` config makes ksm emit `gotk_resource_info{customresource_kind, exported_namespace, name, ready, suspended, revision}` (an Info gauge, value always 1). Alert on `gotk_resource_info{customresource_kind="Kustomization", ready="False"} == 1`. Note the namespace label is **`exported_namespace`**, not `namespace`.
 
-Implemented in homelab PRs #937 (PodMonitor for controller metrics) + #940 (ksm CRS config + rewritten rules). Config lives in `infra/controllers/kube-prometheus-stack/values.yaml` under `kube-state-metrics.customResourceState` + `rbac.extraRules` (list/watch on the Flux API groups). Served CRD versions when built: Kustomization v1, HelmRelease v2, GitRepository v1 — verify with `kubectl get crd <x> -o jsonpath='{.spec.versions[?(@.served==true)].name}'` before pinning. This was Phase 3 of the homelab monitoring-enhancement plan (`docs/plans/2026-05-09-monitoring-enhancement.md`). Relates to [[feedback_verify_api_versions]].
+Implemented in homelab PRs #937 (PodMonitor for controller metrics) + #940 (ksm CRS config + rewritten rules). Config lives in `infra/controllers/kube-prometheus-stack/values.yaml` under `kube-state-metrics.customResourceState` + `rbac.extraRules` (list/watch on the Flux API groups). Served CRD versions when built: Kustomization v1, HelmRelease v2, GitRepository v1 — verify with `kubectl get crd <x> -o jsonpath='{.spec.versions[?(@.served==true)].name}'` before pinning. This was Phase 3 of the homelab monitoring-enhancement plan (`docs/plans/2026-05-09-monitoring-enhancement.md`). Relates to [verify api versions](./2026-08-15-operating-principles.md#verify-api-versions).
 
 ---

--- a/docs/operations/2026-08-15-cluster-gotchas.md
+++ b/docs/operations/2026-08-15-cluster-gotchas.md
@@ -1,0 +1,212 @@
+---
+title: Cluster gotchas — Talos, kubectl, Flux
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, talos, kubectl, flux, gotchas]
+---
+
+# Cluster gotchas — Talos, kubectl, Flux
+
+Node topology, kubectl selector traps, and Flux behaviours that differ from what the manifests imply. Promoted 2026-08-15.
+
+---
+
+## talos shelf correlated failure
+
+**melodic-muse node physical topology + the correlated-failure trap behind the 2026-06-18 quorum-loss outage**
+
+melodic-muse (Talos cluster) physical layout, learned during the 2026-06-18 maintenance:
+**`.22`+`.23` share one shelf; `.24`+`.25` share another; `.20`/`.21` are separate.**
+4 independent PSUs, but the shelf mechanically couples its two nodes (pulling the shelf to
+service one node takes both down). `.21` and `.25` also share a switch/power path with the
+maintenance shelves.
+
+**Why:** During the `.22` DIMM work, an action on the shared switch/power path dropped
+`.21` (a control-plane survivor that was supposed to be untouched) **and** `.25` at once —
+not 5 independent failures, one infra fault. With `.22` already down, losing `.21` left
+etcd at 1/3 → **full control-plane outage** (`etcdserver: no leader`, apiserver `etcd failed`).
+The "2/3 quorum is safe" assumption was wrong because the survivors weren't failure-independent.
+
+**How to apply:** During any cluster op, treat `.20`/`.21` **and the switch/PSU/shelf they
+share** as off-limits — confirm survivor independence before relying on quorum. Don't uncordon
+maintenance nodes until the operator confirms physical work is fully done and nodes are staying
+up (mid-work uncordon churned workloads onto `.23`, which then dropped again). See
+[[feedback_flux_suspend_during_cluster_ops]], [[project_homelab_cluster]].
+
+---
+
+## talos sysfs powercap mask
+
+**Talos/containerd masks /sys/devices/virtual/powercap with an empty tmpfs; reading RAPL in a pod needs a non-/sys hostPath mount + walking the device tree, not /sys/class symlinks**
+
+Reading **RAPL energy** (`/sys/class/powercap/intel-rapl:*/energy_uj`) from a pod on the Talos cluster fails in a non-obvious way: containerd stacks an **empty read-only tmpfs over `/sys/devices/virtual/powercap`** (default sysfs masking). The `/sys/class/powercap/intel-rapl:*` entries are **relative symlinks** into `../../devices/virtual/powercap/...`, so they resolve *through* the mask → ENOENT for both shell `cat` and Go `os.ReadFile` inside the long-running pod.
+
+**Why it's a trap:** a fresh single-mount busybox probe reads RAPL fine (its mount overlays the mask), so manual verification passes while the deployed agent gets nothing. Diagnosed live on thermalscope 2026-06-16 after the collector showed `power_up=1` (ReadDir of the class dir succeeds) but **zero energy series** (every per-domain read returned empty).
+
+**How to do it right (works):**
+- Mount the hostPath `/sys/devices/virtual/powercap` at a **non-`/sys` path** in the container (e.g. `/host/sys/powercap`). Anything remounted under `/sys/...` gets re-masked.
+- Point the collector at that path (thermalscope: `THERMALSCOPE_POWERCAP_ROOT=/host/sys/powercap`) and **walk the device tree** (real dirs, nested `intel-rapl/intel-rapl:0/` = package-0, `.../intel-rapl:0:0/` = core), not the flat `/sys/class/powercap` symlinks. De-dup domains by `name` so the `intel-rapl-mmio` mirror doesn't double-count.
+- RAPL `energy_uj` is **root-gated** (Platypus mitigation); the agent must run `runAsUser: 0` (node-exporter runs non-root, which is why `node_rapl_*` is absent in the cluster — verified). Expose energy as a monotonic counter; `rate()/1e6` = watts. Verified sane on the APU nodes: package-0 ≈ 2–6 W.
+
+**Why it matters:** cost a 3-round deploy-verify saga. Contrast hwmon, which works with a plain `/sys/class/hwmon` mount because its symlink targets are *real PCI devices* the container's base sysfs exposes — only the *virtual* powercap subtree is masked. Same family of "verify on the real node" lesson as [[feedback_homelab_lan_access]]; the netscope BPF lockdown bug the same day is the analog for tracing programs.
+
+---
+
+## kubectl selector notin pitfall
+
+**A `--selector='key notin (a,b,c)'` matches pods that have the key with any other value AND pods that DON'T HAVE THE KEY AT ALL. Will sweep up unrelated pods (e.g., CNPG postgres pods that don't carry the `job-name` label) on broad delete operations.**
+
+The Kubernetes label-selector grammar for `notin` evaluates against the key's value, but the special case of "pod doesn't have the key at all" is also treated as "not in the listed values." Result: a delete with `--selector='job-name notin (restore-foo, restore-bar)'` intended to clean squatter Deployment pods will ALSO delete every CNPG / StatefulSet / cron-job-created pod in the namespace that has no `job-name` label whatsoever.
+
+**Why:** Burned by this in the alcatraz → hestia preserve-7 migration (2026-05-23). Wrote a broad `notin (restore-*)` selector to force-delete app pods that had grabbed the freshly-recreated PVCs (see [[flux-suspend-during-cluster-ops]]). Accidentally killed `immich-db-staging-cnpg-v1-5` and `v1-6` postgres pods because they didn't have a `job-name` label. CNPG operator recovered them via rebootstrap, but it was an avoidable 2-minute outage for the cluster's primary postgres.
+
+**How to apply:**
+
+Prefer the **positive selector** that lists exactly what you want to delete:
+
+```bash
+# Bad: sweeps everything in the namespace without job-name label
+kubectl delete pods -n <ns> --selector='job-name notin (restore-foo)' --force --grace-period=0
+
+# Good: explicit `in` set
+kubectl delete pods -n <ns> --selector='app in (mealie, audiobookshelf, jellyfin)' --force --grace-period=0
+
+# Also good: name-targeted
+kubectl delete pod -n <ns> <specific-pod-name> --force --grace-period=0
+```
+
+If you must use `notin` (e.g., "delete everything except the migration Jobs"), add a second selector that restricts the result to a known label class:
+
+```bash
+# Restrict notin to pods that have the `app` label set at all
+kubectl delete pods -n <ns> --selector='app,job-name notin (restore-foo)' --force --grace-period=0
+```
+
+The bare `app` term means "has the key" — so the selector now matches only pods that have an `app` label AND a job-name not in the exclusion list. CNPG/STS pods without `app` are excluded.
+
+**Same pitfall in other Kubernetes APIs:**
+- `kubectl get pods --selector='env notin (prod)'` includes pods without `env` set
+- `client-go` LabelSelector with `Operator: NotIn` has the same semantics
+- Cilium NetworkPolicy `endpointSelector` with `NotIn` — same gotcha
+
+**Related cross-references:**
+- [[flux-suspend-during-cluster-ops]] — the upstream cause; suspending Flux would have prevented the squatter-pod problem and made the broad selector unnecessary
+
+---
+
+## flux suspend during cluster ops
+
+**Before delete-and-recreate PVC migrations, suspend the affected Flux Kustomization. Otherwise Flux re-applies the Deployment spec mid-flight and the workload pod grabs the new PVC before your data-restore Job can mount it (Multi-Attach error).**
+
+When a migration plan involves "scale workload to 0 → delete PVC → wait for recreation → run rsync data-restore Job → scale workload back up," Flux's default 10-minute reconciliation interval will race with the manual steps. The reconciler sees `replicas: 1` in the source manifest and scales the deployment back up, the workload pod grabs the freshly-recreated PVC (RWO), and your restore-rsync Job is stuck in `ContainerCreating` with `Multi-Attach error for volume X: Volume is already used by pod(s) <app-pod>`.
+
+**Why:** Hit this in production during the alcatraz → hestia preserve-7 migration (2026-05-23). Six of seven restore-rsync Jobs sat in ContainerCreating for 21 minutes because Flux scaled the deployments back up after I'd scaled them to 0. Cost: a manual force-delete sweep that accidentally killed CNPG postgres pods too (see [[kubectl-selector-notin-pitfall]]).
+
+**How to apply:**
+
+Before starting any migration that involves deleting+recreating PVCs, suspend the Flux Kustomization that manages those workloads:
+
+```bash
+# Suspend
+flux suspend kustomization apps-staging -n flux-system
+
+# Do the migration work: scale to 0, delete PVCs, restore data, etc.
+
+# Resume only after restore Job has bound the dest PVC AND finished
+flux resume kustomization apps-staging -n flux-system
+```
+
+Same pattern for `apps-production` when doing Phase 1.2 prod migrations. Be explicit about which Kustomization owns which workloads — `flux get kustomizations -A` shows the mapping.
+
+**When NOT to suspend:**
+- If the migration is short enough (< 1 minute end-to-end) and the Kustomization's reconcile interval is longer (default 10m), the race window may be small enough to skip suspension. But "small enough" is a guess; suspend is cheap insurance.
+- If the migration touches resources outside the Kustomization's scope (e.g., a manual PVC not in the manifests), suspension may be unnecessary — Flux won't re-create what it doesn't know about.
+
+**Related cross-references:**
+- [[pvc-storage-class-migration]] — the underlying migration pattern that triggers this race
+- [[cnpg-promote-pg-resetwal]] — CNPG-specific recovery that ALSO benefits from suspending the operator's reconcile loop (`cnpg.io/reconciliationLoop=disabled` annotation)
+
+---
+
+## flux pvc volumename anti pattern
+
+**Don't use `volumeName` in the spec of Flux-managed PVCs to bind to a specific PV. Flux SSA tries to unset volumeName because the manifest doesn't include it, producing 'spec is immutable' errors. Use PV `claimRef` pre-binding instead.**
+
+When statically binding a PVC to an existing PV (e.g., after a PV-Retain recovery or storage migration), there are two binding patterns:
+
+1. **PVC-side**: set `pvc.spec.volumeName: <pv-name>` — works for kubectl-applied PVCs
+2. **PV-side**: set `pv.spec.claimRef: {namespace, name}` (no UID) — binds the PV to the future PVC of that name
+
+**For Flux-managed PVCs, only the PV-side `claimRef` pattern works.**
+
+**Why:** Burned on this in the alcatraz → hestia migration (2026-05-24). After migrating 13 production preserve PVCs, I rebound each PVC via `kubectl apply` with `volumeName: pvc-XXX` set. Flux's strategic-merge-patch dry-run then showed:
+
+```
+- "VolumeName": "pvc-XXX-truenas",
++ "VolumeName": "",
+```
+
+Flux's manifest doesn't include volumeName, so its SSA computes "would set to empty string." Kubernetes rejects with `spec is immutable after creation`. Flux Kustomization stays `ReconciliationFailed` indefinitely.
+
+**How to apply:**
+
+When you need to bind a Flux-managed PVC to a pre-existing PV:
+
+```bash
+# 1. Reset the PV's claimRef (remove old UID so binding is "wildcard")
+kubectl patch pv $PV --type=json -p '[{"op":"remove","path":"/spec/claimRef"}]'
+sleep 2
+
+# 2. Set claimRef to namespace + name only (no UID)
+kubectl patch pv $PV --type=merge -p '{
+  "spec": {
+    "claimRef": {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "namespace": "'$NS'",
+      "name": "'$PVC'"
+    }
+  }
+}'
+
+# 3. Apply the PVC manifest WITHOUT volumeName (let Flux's manifest stand)
+kubectl apply -f - <<YAML
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $PVC
+  namespace: $NS
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: <whatever the manifest says>
+  resources:
+    requests:
+      storage: $SIZE
+YAML
+# The binder will see the PV's matching claimRef and bind without volumeName being set by the manifest.
+```
+
+**Why the patch-then-remove dance:** if you only patch `claimRef.uid: null` on a PV that has a stale UID, strategic merge keeps the old UID — the binder rejects the bind silently and the storageclass provisioner provisions a fresh empty PV (DATA LOSS risk). Remove claimRef entirely first.
+
+**Storage-class admission gotcha:** If your manifest has no `storageClassName`, the default-storage-class admission plugin sets it to the cluster's default at PVC creation time. The resulting cluster PVC has `storageClassName: synology-iscsi` (or whatever default) even though the manifest had nothing. If a later Flux apply has a different value (or null), it's a strategic-merge-patch mismatch. **Best practice: always pin `storageClassName` explicitly in PVC manifests** to avoid drift between cluster state and Git.
+
+**Related cross-references:**
+- [[audit-pvc-before-lossy-destroy]] — verify before destroying so you don't need this recovery
+- [[pv-retain-recovery-pattern]] — the lower-level mechanism; this is the Flux-compatible variant
+- [[pvc-storage-class-migration]] — the higher-level migration pattern that triggers the need to rebind
+
+---
+
+## flux ga no reconcile condition
+
+**GA Flux controllers don't emit gotk_reconcile_condition; use kube-state-metrics gotk_resource_info for readiness alerts**
+
+GA Flux controllers (helm-controller v1.x, kustomize-controller v1.x, source-controller v1.x on melodic-muse) **do not expose the `gotk_reconcile_condition` gauge** — it was removed from the v2 GA line. The controllers emit `gotk_reconcile_duration_seconds`, `gotk_event_http_*`, `controller_runtime_*`, but nothing carrying per-object Ready state. Any alert rule referencing `gotk_reconcile_condition` is inert (loads as `health=ok` but never fires — no series to match).
+
+**Per-object readiness comes from kube-state-metrics instead** (the upstream `flux2-monitoring-example` pattern): a `customResourceState` config makes ksm emit `gotk_resource_info{customresource_kind, exported_namespace, name, ready, suspended, revision}` (an Info gauge, value always 1). Alert on `gotk_resource_info{customresource_kind="Kustomization", ready="False"} == 1`. Note the namespace label is **`exported_namespace`**, not `namespace`.
+
+Implemented in homelab PRs #937 (PodMonitor for controller metrics) + #940 (ksm CRS config + rewritten rules). Config lives in `infra/controllers/kube-prometheus-stack/values.yaml` under `kube-state-metrics.customResourceState` + `rbac.extraRules` (list/watch on the Flux API groups). Served CRD versions when built: Kustomization v1, HelmRelease v2, GitRepository v1 — verify with `kubectl get crd <x> -o jsonpath='{.spec.versions[?(@.served==true)].name}'` before pinning. This was Phase 3 of the homelab monitoring-enhancement plan (`docs/plans/2026-05-09-monitoring-enhancement.md`). Relates to [[feedback_verify_api_versions]].
+
+---

--- a/docs/operations/2026-08-15-gotchas-index.md
+++ b/docs/operations/2026-08-15-gotchas-index.md
@@ -1,0 +1,34 @@
+---
+title: Gotchas index
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, gotchas, index]
+---
+
+# Gotchas index
+
+Hard-won operational behaviour that isn't obvious from the manifests or the upstream docs — the
+things that cost real debugging time once and shouldn't cost it twice.
+
+These were accumulated as working notes outside the repo. Promoted here 2026-08-15 so they're
+available to whoever is actually debugging at 2am, rather than only inside a tooling session.
+
+| Runbook | Covers |
+| ------------------------------------------------------------ | ------------------------------------------------- |
+| [Networking](./2026-08-15-networking-gotchas.md) | Cilium netpol for Gateway API, LoadBalancer SNAT |
+| [Storage](./2026-08-15-storage-gotchas.md) | PVC/PV immutability, Retain recovery, ZFS busy, TrueNAS, Synology |
+| [Cluster](./2026-08-15-cluster-gotchas.md) | Talos topology and sysfs, kubectl selectors, Flux |
+| [Services](./2026-08-15-services-gotchas.md) | CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy |
+| [Operating principles](./2026-08-15-operating-principles.md) | Staging, registries, cluster access, API versions |
+
+**Read the storage runbook before destroying anything.** Several entries there are data-loss
+adjacent — PVCs holding SQLite databases that look empty, PVs whose Retain policy is the only thing
+standing between you and a rebuild, ZFS datasets that report busy for a reason you won't guess.
+
+## Adding to these
+
+A gotcha earns a place here when it (a) cost real time, (b) is not discoverable from the manifest or
+the upstream docs, and (c) will recur. If it's a one-off caused by a specific broken state, it
+belongs in the incident write-up, not here.

--- a/docs/operations/2026-08-15-gotchas-index.md
+++ b/docs/operations/2026-08-15-gotchas-index.md
@@ -20,7 +20,7 @@ available to whoever is actually debugging at 2am, rather than only inside a too
 | [Networking](./2026-08-15-networking-gotchas.md) | Cilium netpol for Gateway API, LoadBalancer SNAT |
 | [Storage](./2026-08-15-storage-gotchas.md) | PVC/PV immutability, Retain recovery, ZFS busy, TrueNAS, Synology |
 | [Cluster](./2026-08-15-cluster-gotchas.md) | Talos topology and sysfs, kubectl selectors, Flux |
-| [Services](./2026-08-15-services-gotchas.md) | CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy |
+| [Services](./2026-08-15-services-gotchas.md) | CNPG, SOPS, mosquitto, Spotify, Mopidy |
 | [Operating principles](./2026-08-15-operating-principles.md) | Staging, registries, cluster access, API versions |
 
 **Read the storage runbook before destroying anything.** Several entries there are data-loss

--- a/docs/operations/2026-08-15-networking-gotchas.md
+++ b/docs/operations/2026-08-15-networking-gotchas.md
@@ -21,14 +21,14 @@ For apps exposed via Cilium Gateway API on a multi-node cluster with VXLAN tunne
 
 ```yaml
 ingress:
-  - fromEntities:
-      - host        # Envoy and pod on the same node
-      - remote-node # Envoy and pod on different nodes (VXLAN cross-node)
-      - ingress     # Cilium proxy source IP (reserved identity 8)
-    toPorts:
-      - ports:
-          - port: "8080"
-            protocol: TCP
+ - fromEntities:
+ - host # Envoy and pod on the same node
+ - remote-node # Envoy and pod on different nodes (VXLAN cross-node)
+ - ingress # Cilium proxy source IP (reserved identity 8)
+ toPorts:
+ - ports:
+ - port: "8080"
+ protocol: TCP
 ```
 
 **Why:** Cilium's Gateway API Envoy binds upstream connections to a dedicated proxy IP (e.g. `10.244.x.15`) that Cilium classifies as reserved identity 8 (`ingress`), not `host` or `remote-node`. Without `ingress`, all Envoy→pod connections fail even though direct `/dev/tcp` from the same pod works. Confirmed by checking `cilium bpf ipcache list` on the destination node: the Envoy source IP shows `identity=8`. Also: `remote-node` is needed when Envoy and the pod are on different nodes (VXLAN cross-node). All three are required.

--- a/docs/operations/2026-08-15-networking-gotchas.md
+++ b/docs/operations/2026-08-15-networking-gotchas.md
@@ -1,0 +1,61 @@
+---
+title: Networking gotchas — Cilium, LoadBalancer, gateways
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, cilium, networking, gotchas]
+---
+
+# Networking gotchas — Cilium, LoadBalancer, gateways
+
+Hard-won Cilium behaviour that is not obvious from the docs and has cost real debugging time. Promoted from working notes 2026-08-15.
+
+---
+
+## cilium gateway netpol
+
+**How to write CiliumNetworkPolicy ingress rules for apps behind the Gateway API on a multi-node VXLAN cluster**
+
+For apps exposed via Cilium Gateway API on a multi-node cluster with VXLAN tunneling, the ingress rule must allow **all three** entities: `host`, `remote-node`, AND `ingress`:
+
+```yaml
+ingress:
+  - fromEntities:
+      - host        # Envoy and pod on the same node
+      - remote-node # Envoy and pod on different nodes (VXLAN cross-node)
+      - ingress     # Cilium proxy source IP (reserved identity 8)
+    toPorts:
+      - ports:
+          - port: "8080"
+            protocol: TCP
+```
+
+**Why:** Cilium's Gateway API Envoy binds upstream connections to a dedicated proxy IP (e.g. `10.244.x.15`) that Cilium classifies as reserved identity 8 (`ingress`), not `host` or `remote-node`. Without `ingress`, all Envoy→pod connections fail even though direct `/dev/tcp` from the same pod works. Confirmed by checking `cilium bpf ipcache list` on the destination node: the Envoy source IP shows `identity=8`. Also: `remote-node` is needed when Envoy and the pod are on different nodes (VXLAN cross-node). All three are required.
+
+`fromEndpoints: {namespace: default}` and `fromEndpoints: {namespace: kube-system}` are both wrong — hostNetwork pods don't carry namespace-based pod identities.
+
+**How to diagnose:** Check Envoy admin socket: if `upstream_cx_connect_fail` equals `upstream_cx_total` and `upstream_rq_total=0`, and `/dev/tcp` from within the Envoy pod succeeds, the missing entity is `ingress`.
+
+**How to apply:** Any time writing or reviewing a CiliumNetworkPolicy ingress rule for a gateway-facing app, use `[host, remote-node, ingress]`. Applies to adguard and excalidraw too (same bug).
+
+---
+
+## cilium lb snat pattern
+
+**fromCIDR doesn't work for LAN clients hitting Kubernetes LoadBalancer services due to SNAT; use fromEntities:world instead**
+
+`fromCIDR` rules do NOT work for external LAN clients connecting through a Kubernetes `LoadBalancer` service with `externalTrafficPolicy: Cluster` (the default).
+
+Cilium SNATs the source IP to a node IP (e.g. `10.244.0.168`) before the packet reaches the pod. The pod sees the node IP (classified as `world` identity), not the original LAN IP. `cilium monitor --type drop` shows:
+```
+drop (Policy denied) identity world->12962: 10.244.0.168:33114 -> 10.244.1.72:1704
+```
+
+**Why `externalTrafficPolicy: Local` doesn't help**: Cilium's L2 announcement lease does not transfer to the node running the pod when the policy changes. The old lease holder (wrong node) keeps renewing it, causing `Connection refused` from correct-node-only traffic routing.
+
+**Fix**: Use `fromEntities: world` for ports that need external/LAN access. The security boundary is the L2 VLAN — the VIP is only reachable on VLAN 2, so permitting `world` at the CNP level is appropriate.
+
+**How to apply**: For any LAN-accessible LoadBalancer service (snapcast, future audio/IoT services), use `fromEntities: world` in the CNP ingress rules instead of `fromCIDR`. Confirmed fixed in PR #494 for snapcast ports 1704/1705/1780.
+
+---

--- a/docs/operations/2026-08-15-operating-principles.md
+++ b/docs/operations/2026-08-15-operating-principles.md
@@ -17,9 +17,9 @@ Standing decisions about how this cluster is operated, as distinct from how any 
 
 **staging envs (esp. CNPG DBs) should be fixed-size stable mirrors of prod so they're a real rehearsal testbed**
 
-George wants **staging environments to be fixed-size, stable mirrors of prod** so they function as a real rehearsal testbed — not drifted, half-broken clones.
+the operator wants **staging environments to be fixed-size, stable mirrors of prod** so they function as a real rehearsal testbed — not drifted, half-broken clones.
 
-**Why:** discovered 2026-07-03 while rehearsing the Immich v3 migration on staging: `immich-db-staging-cnpg-v1` had drifted to **20Gi** (prod is **10Gi** after the [[project_democratic_csi_api_driver_blocked]] expansion) AND had a replica (`-6`) wedged on a WAL-segment gap and crashlooping for 9 days. A degraded, wrong-sized staging DB undermines its value as a pre-prod rehearsal for risky ops.
+**Why:** discovered 2026-07-03 while rehearsing the Immich v3 migration on staging: `immich-db-staging-cnpg-v1` had drifted to **20Gi** (prod is **10Gi** after the expansion) AND had a replica (`-6`) wedged on a WAL-segment gap and crashlooping for 9 days. A degraded, wrong-sized staging DB undermines its value as a pre-prod rehearsal for risky ops.
 
 **How to apply:** when touching staging manifests, size staging DB/PVCs to mirror prod's shape (or a deliberate fraction), keep them healthy, and treat staging as a first-class rehearsal env. Follow-up work item: normalize `apps/staging/immich` (and other CNPG staging clusters) to a fixed size aligned with prod, and add health monitoring so staging degradation is caught early. Relates to the "do staging fully first" rule in the Immich v3 upgrade runbook.
 
@@ -33,14 +33,14 @@ A staging/preview environment must **not** connect to a single-connection physic
 production also uses. Point staging at a **simulator/mock** transport instead; **prod owns the
 device exclusively**.
 
-**Why:** Discovered on Vibrato 2026-07-18 ([[project_leva_controller]]). Both staging + prod set
+**Why:** Discovered on Vibrato 2026-07-18 (). Both staging + prod set
 `LEVA_HOST=10.42.7.11` (the one physical ito espresso controller, limited TCP slots). Two failures:
 1. **Contention** — after the connection self-heal (watchdog + re-handshake) deployed to both, staging
-   actively re-grabbed the ito's single telemetry stream every ~20s and **starved prod** (prod Monitor
-   went blank; scaling staging to 0 instantly restored prod's stream).
+ actively re-grabbed the ito's single telemetry stream every ~20s and **starved prod** (prod Monitor
+ went blank; scaling staging to 0 instantly restored prod's stream).
 2. **Safety** — a staging PR-preview wired to the real machine can **send it commands** (trigger a
-   shot / actuate hardware). Preview envs rebuild from every open PR, so untrusted/in-progress code
-   would drive real hardware.
+ shot / actuate hardware). Preview envs rebuild from every open PR, so untrusted/in-progress code
+ would drive real hardware.
 
 **How to apply:** In the staging overlay, set the transport to sim/mock (e.g. Vibrato:
 `LEVA_TRANSPORT=sim` on `apps/staging/<app>/deployment-patch.yaml`). Staging still validates the full
@@ -61,23 +61,23 @@ When adding a new first-party container image to gjcourt/homelab:
 
 The two legacy images on Docker Hub — `gjcourt/snapcast`, `gjcourt/go-librespot` — are forks of upstream projects kept on Docker Hub for backwards compatibility. They are **not** the precedent for new images. The snapcast deployment references them as-is for compat, but new sidecars should use ghcr.io.
 
-**Why:** This session, I told an agent to push the new mopidy image to docker.io because the snapcast deployment had docker.io siblings. The agent's PR worked but required setting up `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets — friction the user shouldn't have to deal with. I had to push a fix commit (#436 retag → ghcr.io) before the workflow could run.
+**Why:** Historically, an attempt to push the new mopidy image to docker.io because the snapcast deployment had docker.io siblings. The agent's PR worked but required setting up `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets — friction the user shouldn't have to deal with. I had to push a fix commit (#436 retag → ghcr.io) before the workflow could run.
 
 **How to apply:** When spawning an agent to add a new image + build workflow:
 
 - Explicitly tell them ghcr.io is the registry, not docker.io.
-- Reference the existing `.github/workflows/build-signal-bridge.yml` as the canonical pattern (GITHUB_TOKEN auth, date-tagged: `YYYY-MM-DD`, fallback `YYYY-MM-DD-N`, multi-arch `linux/amd64,linux/arm64` via QEMU + buildx).
+- Reference the existing `.github/workflows/build-mopidy.yml` as the canonical pattern (GITHUB_TOKEN auth, date-tagged: `YYYY-MM-DD`, fallback `YYYY-MM-DD-N`, multi-arch `linux/amd64,linux/arm64` via QEMU + buildx).
 - Don't let the agent infer the registry from `apps/base/snapcast/deployment.yaml` — those are the legacy forks.
 
-**★ GHCR "repo:null" 403 GOTCHA (2026-07-25).** A GHA `GITHUB_TOKEN` push gets `403 Forbidden` (`unexpected status from HEAD request … 403`) when the target GHCR package **already exists but is NOT linked to a repo** — i.e. it was first created by a manual PAT push (`make image`). Check with `gh api user/packages/container/<name> --jq .repository.full_name` → `null` = unlinked. **Fix: delete the stale package so the next GHA push re-creates it auto-linked (+ public):** `gh api --method DELETE user/packages/container/<name>` (needs `delete:packages` scope → `gh auth refresh -h github.com -s delete:packages` first; and Claude's auto-mode classifier BLOCKS the DELETE — have George run it via `! …`). Non-destructive alt = package Settings → *Manage Actions access* → add the repo with **Write**. After either, `gh run rerun <id>`. **2026-07-25: migrated golinks, changes, vitals, soundbyte from manual `make image` to GHA `image.yml`** (push to default branch + workflow_dispatch; tags `YYYY-MM-DD`, `YYYY-MM-DD-<sha7>`, `latest`; the immutable `date-sha` is the one to pin in homelab). golinks deployed `2026-07-26-57ffc01` (golinks-prod ns; host go.burntbytes.com; unknown shortcode now 302→`/admin?new=<code>`). Repos already on GHA (left alone): vibrato, pingo, flashcards, burntbytes, modemscope, netscope, thermalscope, ladder, tempo-interview. cadence skipped (killed venture).
+**★ GHCR "repo:null" 403 GOTCHA (2026-07-25).** A GHA `GITHUB_TOKEN` push gets `403 Forbidden` (`unexpected status from HEAD request … 403`) when the target GHCR package **already exists but is NOT linked to a repo** — i.e. it was first created by a manual PAT push (`make image`). Check with `gh api user/packages/container/<name> --jq .repository.full_name` → `null` = unlinked. **Fix: delete the stale package so the next GHA push re-creates it auto-linked (+ public):** `gh api --method DELETE user/packages/container/<name>` (needs `delete:packages` scope → `gh auth refresh -h github.com -s delete:packages` first; and Some tooling blocks interactive DELETEs; run it directly if so.). Non-destructive alt = package Settings → *Manage Actions access* → add the repo with **Write**. After either, `gh run rerun <id>`. **2026-07-25: migrated golinks, changes, vitals, soundbyte from manual `make image` to GHA `image.yml`** (push to default branch + workflow_dispatch; tags `YYYY-MM-DD`, `YYYY-MM-DD-<sha7>`, `latest`; the immutable `date-sha` is the one to pin in homelab). golinks deployed `2026-07-26-57ffc01` (golinks-prod ns; host go.burntbytes.com; unknown shortcode now 302→`/admin?new=<code>`). Repos already on GHA (left alone): vibrato, pingo, flashcards, burntbytes, modemscope, netscope, thermalscope, ladder, tempo-interview. cadence skipped (killed venture).
 
 ---
 
 ## homelab lan access
 
-**kubectl commands to the homelab cluster work from this Mac — confirmed in session fd65b62a. Stale "no LAN access" note was wrong.**
+**kubectl commands to the homelab cluster work from this Mac — Stale "no LAN access" note was wrong.**
 
-**kubectl works on this Mac** against the homelab cluster (`https://10.42.2.20:6443`). The earlier "no LAN access" note was from a different session or network state. The user confirmed: "you can run that yourself" when I offered to wait for them to run kubectl commands.
+**kubectl works on this Mac** against the homelab cluster (`https://10.42.2.20:6443`). The earlier "no LAN access" note was from a different session or network state.  when I offered to wait for them to run kubectl commands.
 
 `ping` and `ssh` to `10.42.2.x` may still require VPN or not — don't assume either way. Use kubectl for cluster diagnostics; it has been confirmed working.
 

--- a/docs/operations/2026-08-15-operating-principles.md
+++ b/docs/operations/2026-08-15-operating-principles.md
@@ -1,0 +1,104 @@
+---
+title: Operating principles — staging, registries, access, API versions
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, practice, staging, gotchas]
+---
+
+# Operating principles — staging, registries, access, API versions
+
+Standing decisions about how this cluster is operated, as distinct from how any one component behaves. Promoted 2026-08-15.
+
+---
+
+## staging fixed size testbed
+
+**staging envs (esp. CNPG DBs) should be fixed-size stable mirrors of prod so they're a real rehearsal testbed**
+
+George wants **staging environments to be fixed-size, stable mirrors of prod** so they function as a real rehearsal testbed — not drifted, half-broken clones.
+
+**Why:** discovered 2026-07-03 while rehearsing the Immich v3 migration on staging: `immich-db-staging-cnpg-v1` had drifted to **20Gi** (prod is **10Gi** after the [[project_democratic_csi_api_driver_blocked]] expansion) AND had a replica (`-6`) wedged on a WAL-segment gap and crashlooping for 9 days. A degraded, wrong-sized staging DB undermines its value as a pre-prod rehearsal for risky ops.
+
+**How to apply:** when touching staging manifests, size staging DB/PVCs to mirror prod's shape (or a deliberate fraction), keep them healthy, and treat staging as a first-class rehearsal env. Follow-up work item: normalize `apps/staging/immich` (and other CNPG staging clusters) to a fixed size aligned with prod, and add health monitoring so staging degradation is caught early. Relates to the "do staging fully first" rule in the Immich v3 upgrade runbook.
+
+---
+
+## staging no shared physical device
+
+**Never point a homelab staging/preview overlay at a single-connection physical device shared with prod — use the simulator/mock; prod owns the device.**
+
+A staging/preview environment must **not** connect to a single-connection physical device that
+production also uses. Point staging at a **simulator/mock** transport instead; **prod owns the
+device exclusively**.
+
+**Why:** Discovered on Vibrato 2026-07-18 ([[project_leva_controller]]). Both staging + prod set
+`LEVA_HOST=10.42.7.11` (the one physical ito espresso controller, limited TCP slots). Two failures:
+1. **Contention** — after the connection self-heal (watchdog + re-handshake) deployed to both, staging
+   actively re-grabbed the ito's single telemetry stream every ~20s and **starved prod** (prod Monitor
+   went blank; scaling staging to 0 instantly restored prod's stream).
+2. **Safety** — a staging PR-preview wired to the real machine can **send it commands** (trigger a
+   shot / actuate hardware). Preview envs rebuild from every open PR, so untrusted/in-progress code
+   would drive real hardware.
+
+**How to apply:** In the staging overlay, set the transport to sim/mock (e.g. Vibrato:
+`LEVA_TRANSPORT=sim` on `apps/staging/<app>/deployment-patch.yaml`). Staging still validates the full
+app stack (UI, WS, chart) on canned frames. Leave the real-device egress netpol in place (harmless
+when unused) so flipping one env to real-hardware for a specific test stays easy. This generalizes to
+any shared single-owner resource a preview env shouldn't mutate.
+
+---
+
+## homelab image registry
+
+**New gjcourt/* images use ghcr.io (auto-auth via GITHUB_TOKEN). The legacy gjcourt/snapcast and gjcourt/go-librespot on Docker Hub are vestigial forks; don't use them as the precedent for new images.**
+
+When adding a new first-party container image to gjcourt/homelab:
+
+- **Push to `ghcr.io/gjcourt/<name>`** — confirmed in `AGENTS.md` ("ghcr.io | Container image registry (`gjcourt/<app>`)") and matches every new image: vitals, golinks, overture, signal-bridge, pingo, mopidy.
+- **Authenticate via `${{ secrets.GITHUB_TOKEN }}`** with `permissions: { packages: write }`. No operator-set Docker Hub creds required.
+
+The two legacy images on Docker Hub — `gjcourt/snapcast`, `gjcourt/go-librespot` — are forks of upstream projects kept on Docker Hub for backwards compatibility. They are **not** the precedent for new images. The snapcast deployment references them as-is for compat, but new sidecars should use ghcr.io.
+
+**Why:** This session, I told an agent to push the new mopidy image to docker.io because the snapcast deployment had docker.io siblings. The agent's PR worked but required setting up `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets — friction the user shouldn't have to deal with. I had to push a fix commit (#436 retag → ghcr.io) before the workflow could run.
+
+**How to apply:** When spawning an agent to add a new image + build workflow:
+
+- Explicitly tell them ghcr.io is the registry, not docker.io.
+- Reference the existing `.github/workflows/build-signal-bridge.yml` as the canonical pattern (GITHUB_TOKEN auth, date-tagged: `YYYY-MM-DD`, fallback `YYYY-MM-DD-N`, multi-arch `linux/amd64,linux/arm64` via QEMU + buildx).
+- Don't let the agent infer the registry from `apps/base/snapcast/deployment.yaml` — those are the legacy forks.
+
+**★ GHCR "repo:null" 403 GOTCHA (2026-07-25).** A GHA `GITHUB_TOKEN` push gets `403 Forbidden` (`unexpected status from HEAD request … 403`) when the target GHCR package **already exists but is NOT linked to a repo** — i.e. it was first created by a manual PAT push (`make image`). Check with `gh api user/packages/container/<name> --jq .repository.full_name` → `null` = unlinked. **Fix: delete the stale package so the next GHA push re-creates it auto-linked (+ public):** `gh api --method DELETE user/packages/container/<name>` (needs `delete:packages` scope → `gh auth refresh -h github.com -s delete:packages` first; and Claude's auto-mode classifier BLOCKS the DELETE — have George run it via `! …`). Non-destructive alt = package Settings → *Manage Actions access* → add the repo with **Write**. After either, `gh run rerun <id>`. **2026-07-25: migrated golinks, changes, vitals, soundbyte from manual `make image` to GHA `image.yml`** (push to default branch + workflow_dispatch; tags `YYYY-MM-DD`, `YYYY-MM-DD-<sha7>`, `latest`; the immutable `date-sha` is the one to pin in homelab). golinks deployed `2026-07-26-57ffc01` (golinks-prod ns; host go.burntbytes.com; unknown shortcode now 302→`/admin?new=<code>`). Repos already on GHA (left alone): vibrato, pingo, flashcards, burntbytes, modemscope, netscope, thermalscope, ladder, tempo-interview. cadence skipped (killed venture).
+
+---
+
+## homelab lan access
+
+**kubectl commands to the homelab cluster work from this Mac — confirmed in session fd65b62a. Stale "no LAN access" note was wrong.**
+
+**kubectl works on this Mac** against the homelab cluster (`https://10.42.2.20:6443`). The earlier "no LAN access" note was from a different session or network state. The user confirmed: "you can run that yourself" when I offered to wait for them to run kubectl commands.
+
+`ping` and `ssh` to `10.42.2.x` may still require VPN or not — don't assume either way. Use kubectl for cluster diagnostics; it has been confirmed working.
+
+**How to apply:** Run `kubectl` commands directly. Do not ask the user to paste kubectl output just because of this old memory.
+
+---
+
+## verify api versions
+
+**Before writing a manifest with an alpha/beta API version, confirm served=true on the cluster**
+
+Before using any non-`v1` API version (e.g. `v1alpha3`, `v1beta1`) in a manifest, verify it's actually served:
+
+```bash
+kubectl get crd <name> -o jsonpath='{range .spec.versions[*]}{.name}{" served="}{.served}{"\n"}{end}'
+```
+
+A CRD can list a version in its spec while having `served=false` — Flux dry-run will fail with "no matches for kind X in version Y" and block ALL reconciliation for that kustomization until fixed.
+
+**Why:** Used `gateway.networking.k8s.io/v1alpha3` for `BackendTLSPolicy` — it appeared in the CRD spec but `served=false`. Flux was completely blocked for ~45 min, preventing unrelated fixes (openwebui netpol) from applying.
+
+**How to apply:** Whenever writing a CRD-backed resource with an alpha/experimental apiVersion, run the served check above first. Prefer the highest served stable version.
+
+---

--- a/docs/operations/2026-08-15-services-gotchas.md
+++ b/docs/operations/2026-08-15-services-gotchas.md
@@ -1,0 +1,273 @@
+---
+title: Service gotchas — CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, cnpg, sops, mqtt, gotchas]
+---
+
+# Service gotchas — CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy
+
+Per-service traps: containerisation surprises, secret mounting, silent process death, and discovery protocols that do not cross VLANs. Promoted 2026-08-15.
+
+---
+
+## cnpg promote pg resetwal
+
+**When a CNPG `promote` gets stuck because the standby can't apply WAL beyond a certain LSN (often due to S3 WAL archive corruption), use pg_resetwal inside a fenced pod to force-promote with on-disk WAL only. Lossy at the LSN boundary; OK for staging.**
+
+CNPG `promote` requires the target standby to reach a consistent recovery state before it can transition to primary. If the WAL archive has stale/wrong-system-id files from a previous cluster lineage, the standby's `restore_command` fetches them, fails the system-id check, and loops forever in "shut down in recovery" state. The cluster stays in `phase=Failing over` indefinitely.
+
+**Why:** Burned by this on linkding-db-staging-cnpg-v1 during the alcatraz → hestia CNPG migration (2026-05-21). The S3 archive at `s3://gjcourt-homelab-backup/staging/linkding/v1/` had WAL files from before the May 7 cluster bootstrap, with database system ID 7590465003792736283 — mismatched against the current cluster's 7614059988316004375. The promote was invisible damage until the moment v1-1 was destroyed.
+
+**How to apply:**
+
+When you see `WAL file is from different database system: WAL file database system identifier is X, pg_control database system identifier is Y` and `cluster state: shut down in recovery` in the standby's logs:
+
+```bash
+# 1. Fence the instance so CNPG/instance-manager stops fighting you
+kubectl cnpg fencing on <cluster> <id> -n <ns>
+kubectl annotate cluster -n <ns> <cluster> \
+  cnpg.io/reconciliationLoop=disabled --overwrite
+
+# 2. pg_resetwal inside the fenced pod
+kubectl exec -n <ns> <cluster>-<id> -c postgres -- bash -c '
+  /usr/lib/postgresql/17/bin/pg_ctl stop -D /var/lib/postgresql/data/pgdata -m immediate 2>&1 || true
+  sleep 2
+  /usr/lib/postgresql/17/bin/pg_resetwal -f /var/lib/postgresql/data/pgdata
+  rm -f /var/lib/postgresql/data/pgdata/standby.signal
+  rm -f /var/lib/postgresql/data/pgdata/recovery.signal
+  rm -f /var/lib/postgresql/data/pgdata/backup_label.old
+  /usr/lib/postgresql/17/bin/pg_controldata /var/lib/postgresql/data/pgdata | grep -E "state|TimeLine"
+'
+
+# 3. Unfence + re-enable reconciliation
+kubectl cnpg fencing off <cluster> <id> -n <ns>
+kubectl annotate cluster -n <ns> <cluster> cnpg.io/reconciliationLoop-
+
+# 4. Force CNPG reconcile so the operator sees the new primary
+kubectl annotate cluster -n <ns> <cluster> \
+  cnpg.io/reconciliation-trigger="$(date +%s)" --overwrite
+```
+
+**Cost:** Lossy at the LSN boundary. You lose any transactions written after pg_basebackup completed but before the standby's local WAL caught up. For us in linkding-stage that was ~minutes of writes; acceptable for staging.
+
+**Don't do this in prod** without first auditing the WAL archive (see [[cnpg-wal-archive-failing]] for which clusters are at risk) and confirming the data loss window is acceptable. For prod, prefer fixing the archive corruption and retrying the standard promote.
+
+**Direct-PVC workaround for in-pod safety checks:** kubectl's auto-mode permission classifier will block `pg_resetwal` calls because they're destructive. You may need to run the kubectl-exec command yourself or explicitly re-authorize via AskUserQuestion (the answer doesn't always propagate to the classifier).
+
+---
+
+## sops mac drift 313
+
+**Editing homelab SOPS secrets errors \"MAC mismatch\" (sops 3.13 CLI vs older-encrypted files); fix = sops set --ignore-mac**
+
+Editing an existing homelab SOPS secret (e.g. `sops --set` / `sops set` / `sops -i`) can fail with
+**`MAC mismatch. File has X, computed Y`** (exit 51) even though the key and file are fine.
+
+**Why:** the files were written by an older sops (metadata `version: 3.10.2`), and George's local
+CLI is **sops 3.13.1**. The data key decrypts fine and values decrypt fine (`sops -d --ignore-mac`
+→ exit 0), but the two versions compute the MAC differently, so plain read/verify fails. Flux
+decrypts in-cluster fine regardless — this is a **local-CLI-only** snag. NOT a wrong key, NOT
+corruption. (Confirmed 2026-07-27: file byte-identical to origin, `.sops.yaml` + file config agree,
+recipient matches George's key.)
+
+**Fix — re-encrypt with the current CLI (recomputes a fresh, self-consistent MAC), swapping the
+value in the same step.** For a k8s Secret whose value is under `data:` (base64), pass the value via
+stdin so the token never hits the process list:
+
+```
+printf '"%s"' "$(printf %s 'NEWVALUE' | base64 | tr -d '\n')" \
+  | sops set --ignore-mac --value-stdin path/to/secret.yaml '["data"]["KEYNAME"]'
+```
+
+After this, plain `sops -d` verifies cleanly (drift fixed for that file going forward). `--ignore-mac`
+only relaxes the *read* check; sops always writes a fresh MAC. Env note: George's key is
+`SOPS_AGE_KEY_FILE=~/.sops/homelab-staging.agekey` — despite the "staging" name it's the single age
+recipient (`age1lnrpvnhtkmzhfhelxse…`) used for prod/staging/infra alike in `.sops.yaml`.
+
+Per [[feedback_sops_modifications_operator_only]], George runs the encrypt; Claude stages the branch
++ hands the one-liner, then commits/PRs/banks/reconciles. See [[project_renovate_homelab]] (first use).
+
+---
+
+## sops modifications operator only
+
+**Both `sops -e -i`, `sops --set`, and direct file edits to SOPS-encrypted secrets are denied by the permission system. Don't try; design for operator handoff instead.**
+
+The user's permission system blocks all of these against existing SOPS-encrypted Secrets:
+
+- `sops -e -i <file>` (encrypt in place)
+- `sops --set '...' <file>` (update a single field, even non-encrypted metadata)
+- Direct text edits to the file (would invalidate the SOPS MAC anyway by default — `mac_only_encrypted: true` is not set in `.sops.yaml`)
+- `sops --decrypt` (would expose plaintext to the transcript)
+
+**Why:** Touching production-adjacent secrets is operator-only by policy. Even cosmetic metadata fixes (e.g., updating `metadata.namespace` from `vitals` to `vitals-stage`) are out of scope from agent sessions.
+
+**How to apply:** When a plan requires modifying a SOPS-encrypted secret:
+
+1. **Don't try.** Don't run any of the commands above.
+2. **Stage everything else** (config, deployment manifests, plain ConfigMaps).
+3. **Provide a `.yaml.example` template** alongside the missing secret file (clear PLACEHOLDER values, no real creds).
+4. **Reference the secret in `kustomization.yaml`**. CI will fail until the operator materializes the encrypted version — that failure is the **gate signal**.
+5. **Open the PR as DRAFT** with an explicit "Operator unblock checklist": copy `.example` → `.yaml`, fill creds, `sops -e -i`, commit, mark ready, merge.
+
+Reference patterns: PR #418 (authelia SMTP password) and PR #426 (navidrome credentials) — both shipped this way and are the canonical template for this workflow.
+
+Note: `kustomize build` will fail with `evalsymlink failure` until the secret file exists. That's intentional — it forces the operator to encrypt before merge.
+
+---
+
+## mosquitto secret subpath
+
+**mosquitto password_file from a k8s secret must be mounted via subPath, not a directory mount (symlink)**
+
+mosquitto 2.1.2 crashloops with `password-file: Error: Unable to open pwfile` when its `password_file` is a Kubernetes secret-projected **symlink**. A whole-secret directory mount (`mountPath: /mosquitto/auth`) projects each key as `passwordfile -> ..data/passwordfile`; mosquitto refuses to open the symlink even though the file is world-readable (a read as uid 1883 succeeds — so it is NOT a permissions issue).
+
+**Why:** k8s secret/configMap directory mounts use the `..data` atomic-swap symlink layout. Apps that open config-referenced files strictly (mosquitto's pwfile loader) fail on the symlink, not on perms.
+
+**How to apply:** Mount each secret key via `subPath` (`mountPath: /mosquitto/auth/passwordfile` + `subPath: passwordfile`) so it lands as a real file. Tradeoff: subPath mounts don't auto-update on secret change — fine for a password file (pod restart picks it up). Caused a z2m/HA MQTT outage 2026-06-24 (homelab PR #976 → fixed in #985). Generalizes to any app that won't follow the secret symlink. Related: [[feedback_sops_modifications_operator_only]].
+
+---
+
+## signal cli zombie
+
+**signal-cli JVM goes zombie on OOM — process stays Running, port :7583 dead — and signal-bridge/hermes crashloop downstream. PR #568 added livenessProbe.**
+
+When debugging signal-cli outages on the homelab cluster (`signal-cli` namespace), check for the **JVM zombie state** before assuming a fresh issue:
+
+- The signal-cli daemon throws `OutOfMemoryError: Java heap space` in the `daemon-listener` thread under socket-connection load. The thread dies, but the JVM process stays running, so kubelet sees `Running` indefinitely and never restarts it.
+- Symptom shape: `signal-cli` container `Running` with restart count 0 but `Ready: False`; readiness probe fails with `dial tcp …:7583: i/o timeout`; `signal-bridge` sidecar in CrashLoopBackOff with hundreds of restarts; `hermes-{prod,callee-prod,stage,callee-stage}` all CrashLoopBackOff downstream.
+
+**Why:** Triggered the 2026-05-04 → 2026-05-09 outage (4d16h). Without a livenessProbe on the JVM container, k8s never recovers because the cgroup never OOMKills the process — the heap caps at `-Xmx2048m` while the cgroup limit is 3Gi, so non-heap allocations fit fine. PR #568 added a TCP livenessProbe on `:7583` (60s initialDelay, 30s period, failureThreshold 3) so the same class of failure now self-heals in ~2 minutes.
+
+**How to apply:**
+- If signal-cli is misbehaving, first check `kubectl get pod -n signal-cli` for "Running but NotReady" — that's the zombie shape, not a fresh OOM. Restart with `kubectl delete pod -n signal-cli -l app=signal-cli` and signal-bridge + hermes will recover on their own.
+- Hermes uses upstream `nousresearch/hermes-agent` so retry/backoff there is not in our control — Kubernetes' CrashLoopBackOff (capped at 5min) is the only knob. To recover hermes faster after fixing signal-cli, `kubectl delete pod -l app=hermes` in each hermes namespace instead of waiting out the backoff.
+- Heap tuning history: `-Xmx1.5g`/2Gi limit (one account) → `-Xmx2048m`/3Gi limit (two accounts, PR #470). Bump both in lockstep if a third account is linked.
+- All four hermes deployments (`hermes-prod`, `hermes-stage`, `hermes-callee-prod`, `hermes-callee-stage`) connect through the prod signal-cli (PR #477 pointed staging at prod after signal-cli-stage was scaled down).
+
+---
+
+## spotify connect ephemeral port
+
+**Spotify Connect discovery is two-stage — mDNS announcement THEN a TCP handshake to the device's advertised port. librespot/go-librespot picks an ephemeral high port by default; cross-VLAN firewall rules that allow only the \"obvious\" media ports (80/AirPlay/Snapcast) silently drop the handshake and the device never appears in Spotify's picker. Pin the port via config and add it to the allow-list.**
+
+### Rule
+
+When adding cross-VLAN firewall rules so a guest/IoT network can reach a Spotify Connect endpoint (HifiBerry with go-librespot/librespot/raspotify, custom librespot containers, etc.), do all three:
+
+1. **Pin librespot's zeroconf port** to a fixed value. For go-librespot, add to `/etc/go-librespot/config.yml`:
+   ```yaml
+   zeroconf_port: 4070
+   ```
+   For librespot-rust: `--zeroconf-port 4070`. For raspotify: edit `/etc/raspotify/conf` `LIBRESPOT_ZEROCONF_PORT=4070`.
+
+2. **Add the chosen port to the firewall allow-list** alongside the obvious media ports (AirPlay 7000, Snapcast 1704/1705/1780, web UI 80).
+
+3. **Verify with `dns-sd -L "<device-name>" _spotify-connect._tcp local.`** from a host on the restricted VLAN. Output should show `:4070` (not a random high port). If it still shows a random port, librespot didn't pick up the config — restart the service.
+
+### Why
+
+Spotify Connect discovery is a two-stage handshake:
+
+1. **mDNS announcement** on `_spotify-connect._tcp` — the client sees `<name>.local.:<port>` via standard zeroconf.
+2. **TCP fetch** to `<host>:<port>/zc?action=getInfo` — the client GETs device capabilities (auth modes, codec support) before adding it to the picker.
+
+If step 2 is dropped by the firewall, the client silently treats the device as undiscoverable — no error, no log line, just absent from the picker. Looks identical to "mDNS isn't reaching this VLAN" even when it is.
+
+librespot picks `:0` (OS-assigned ephemeral) by default, which lands in the 32768–60999 range on Linux. Every reboot picks a different port. No realistic firewall allow-list catches a range that wide without effectively opening all high ports — which defeats the point of isolation.
+
+Observed 2026-06-09 in the homelab Chamber-of-Secrets (Guest VLAN, `10.42.6.0/24`) → HifiBerries (`10.42.2.38/.39`) flow. AirPlay (port 7000) and Snapcast (1704/1705/1780) were allowed; Spotify Connect was supposed to "just work" alongside but didn't. dns-sd from the Mac on Guest VLAN saw `_spotify-connect._tcp` advertising `:43077` (kitchen) and `:43991` (living-room) — both blocked by UniFi isolation. After pinning both to `:4070` and adding 4070 to the allow-list, iOS Spotify discovers them basically instantly.
+
+### How to apply
+
+For any new librespot-based device added to a network isolation boundary:
+
+1. SSH to the device, identify how librespot is configured (config file, systemd drop-in, env var).
+2. Pin `zeroconf_port` to a stable, repo-documented value (we use **4070** for the homelab).
+3. Restart the service.
+4. From a same-VLAN client: `dns-sd -L "<device>" _spotify-connect._tcp local.` → confirm pinned port.
+5. Update the firewall policy on the gateway to allow that port to the device's IP.
+6. From the restricted VLAN: toggle Wi-Fi off/on to clear iOS mDNSResponder, then open Spotify — device should appear in the picker within a few seconds.
+
+### Symptom triage
+
+If "Spotify shows the device on the trusted VLAN but not the restricted VLAN":
+- Wrong diagnosis: assuming it's mDNS. Test with `dns-sd -B _spotify-connect._tcp local.` from the restricted VLAN. If the device shows up there, mDNS is fine.
+- Right diagnosis: check `dns-sd -L "<device>" _spotify-connect._tcp local.` for the advertised port, compare to the firewall allow-list. If port mismatch, that's the gap.
+
+### Related
+
+- [[cilium-gateway-netpol]] — different flavor of the same pattern: discovery-via-mDNS + unicast-via-CNP. Two enforcement points; both must permit the unicast leg.
+- See also: `docs/plans/2026-05-07-guest-vlan-dns-and-hifiberry-access.md` (the Phase C plan this trap surfaced in).
+
+---
+
+## mopidy container gstreamer
+
+**Containerizing Mopidy can't be done on a python:slim base — Mopidy needs GStreamer's GObject-introspection bindings (the `gi` Python module + gir typelibs) which are NOT pip-installable. Use a Debian base + apt python3-gi + a --system-site-packages venv. Also needs setuptools<81 for pkg_resources.**
+
+### Rule
+
+The homelab Mopidy image (`images/mopidy/`, → `ghcr.io/gjcourt/mopidy`, used by
+the snapcast pod's MPD/Subsonic sidecar) **must be Debian-based**, not
+`python:slim`. Mopidy imports GStreamer via PyGObject (`import gi`), and those
+GObject-introspection bindings + typelibs come ONLY from system apt packages —
+they cannot be pip-installed (Mopidy's own docs say so).
+
+Working Dockerfile shape:
+```dockerfile
+FROM debian:bookworm-slim
+RUN apt-get install -y --no-install-recommends \
+      python3 python3-venv \
+      python3-gi python3-gi-cairo \
+      gir1.2-glib-2.0 gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
+      gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-tools \
+      libcairo2 gettext-base
+# Debian python3 is externally managed (PEP 668); venv with system site
+# packages so pip-installed mopidy can import the apt-provided gi/Gst.
+RUN python3 -m venv --system-site-packages /opt/mopidy-venv
+ENV PATH="/opt/mopidy-venv/bin:$PATH"
+RUN pip install "setuptools<81" mopidy==3.4.2 mopidy-mpd mopidy-subidy mopidy-local
+```
+
+### Why
+
+The original image was `FROM python:3.14-slim` and crashlooped through TWO
+layers on first real deploy (2026-06-11, shipping snapcast PR #895):
+
+1. `ModuleNotFoundError: No module named 'pkg_resources'` — Mopidy 3.4.2 imports
+   the legacy pkg_resources; pip stopped bundling setuptools on Python 3.12+,
+   and Python 3.14 was never a supported Mopidy runtime. Fix: `setuptools<81`
+   (newer setuptools is removing pkg_resources) + a supported Python.
+2. `ERROR: A GObject based library was not found. No module named 'gi'` — the
+   GStreamer bindings. python:slim can't provide them. Fix: Debian + python3-gi.
+
+### How to apply
+
+When touching the mopidy image or debugging the snapcast mopidy sidecar:
+- Keep the Debian base; don't "simplify" to python:slim.
+- Validate startup on snapcast-stage before prod — the sidecar logs
+  `MPD server running at [::]:6600` + `Audio output set to ...navidrome.fifo`
+  when healthy.
+
+### Related cross-service wiring (snapcast ↔ navidrome)
+
+For the mopidy→Navidrome Subsonic path to work, THREE policies must align
+(all hit during the #895 ship):
+- snapcast CNP egress allows `navidrome-prod:4533` (+ MPD ingress on 6600).
+- navidrome CNP ingress allows `app=snapcast` from snapcast-{prod,stage}.
+- The mopidy PVC (`snapcast-mopidy-state`) needs `storageClassName: truenas-iscsi`
+  (no default SC → unschedulable).
+- NAVIDROME_URL is an in-cluster literal (`navidrome.navidrome-prod.svc:4533`),
+  not the public hairpin — only the blog is on the tunnel. Creds are a
+  dedicated low-priv Navidrome user (`snapcast-bot`), SOPS-encrypted.
+
+### Related
+
+- [[spotify-connect-ephemeral-port]] — sibling snapcast/HifiBerry audio wiring.
+- Plan: `gjcourt/homelab` docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
+
+---

--- a/docs/operations/2026-08-15-services-gotchas.md
+++ b/docs/operations/2026-08-15-services-gotchas.md
@@ -1,5 +1,5 @@
 ---
-title: Service gotchas — CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy
+title: Service gotchas — CNPG, SOPS, mosquitto, Spotify, Mopidy
 status: Stable
 created: 2026-08-15
 updated: 2026-08-15
@@ -7,7 +7,7 @@ updated_by: gjcourt
 tags: [operations, cnpg, sops, mqtt, gotchas]
 ---
 
-# Service gotchas — CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy
+# Service gotchas — CNPG, SOPS, mosquitto, Spotify, Mopidy
 
 Per-service traps: containerisation surprises, secret mounting, silent process death, and discovery protocols that do not cross VLANs. Promoted 2026-08-15.
 
@@ -29,17 +29,17 @@ When you see `WAL file is from different database system: WAL file database syst
 # 1. Fence the instance so CNPG/instance-manager stops fighting you
 kubectl cnpg fencing on <cluster> <id> -n <ns>
 kubectl annotate cluster -n <ns> <cluster> \
-  cnpg.io/reconciliationLoop=disabled --overwrite
+ cnpg.io/reconciliationLoop=disabled --overwrite
 
 # 2. pg_resetwal inside the fenced pod
 kubectl exec -n <ns> <cluster>-<id> -c postgres -- bash -c '
-  /usr/lib/postgresql/17/bin/pg_ctl stop -D /var/lib/postgresql/data/pgdata -m immediate 2>&1 || true
-  sleep 2
-  /usr/lib/postgresql/17/bin/pg_resetwal -f /var/lib/postgresql/data/pgdata
-  rm -f /var/lib/postgresql/data/pgdata/standby.signal
-  rm -f /var/lib/postgresql/data/pgdata/recovery.signal
-  rm -f /var/lib/postgresql/data/pgdata/backup_label.old
-  /usr/lib/postgresql/17/bin/pg_controldata /var/lib/postgresql/data/pgdata | grep -E "state|TimeLine"
+ /usr/lib/postgresql/17/bin/pg_ctl stop -D /var/lib/postgresql/data/pgdata -m immediate 2>&1 || true
+ sleep 2
+ /usr/lib/postgresql/17/bin/pg_resetwal -f /var/lib/postgresql/data/pgdata
+ rm -f /var/lib/postgresql/data/pgdata/standby.signal
+ rm -f /var/lib/postgresql/data/pgdata/recovery.signal
+ rm -f /var/lib/postgresql/data/pgdata/backup_label.old
+ /usr/lib/postgresql/17/bin/pg_controldata /var/lib/postgresql/data/pgdata | grep -E "state|TimeLine"
 '
 
 # 3. Unfence + re-enable reconciliation
@@ -48,14 +48,14 @@ kubectl annotate cluster -n <ns> <cluster> cnpg.io/reconciliationLoop-
 
 # 4. Force CNPG reconcile so the operator sees the new primary
 kubectl annotate cluster -n <ns> <cluster> \
-  cnpg.io/reconciliation-trigger="$(date +%s)" --overwrite
+ cnpg.io/reconciliation-trigger="$(date +%s)" --overwrite
 ```
 
 **Cost:** Lossy at the LSN boundary. You lose any transactions written after pg_basebackup completed but before the standby's local WAL caught up. For us in linkding-stage that was ~minutes of writes; acceptable for staging.
 
-**Don't do this in prod** without first auditing the WAL archive (see [[cnpg-wal-archive-failing]] for which clusters are at risk) and confirming the data loss window is acceptable. For prod, prefer fixing the archive corruption and retrying the standard promote.
+**Don't do this in prod** without first auditing the WAL archive (see see the CNPG WAL archiving entry under Known issues in `docs/STATUS.md` for which clusters are at risk) and confirming the data loss window is acceptable. For prod, prefer fixing the archive corruption and retrying the standard promote.
 
-**Direct-PVC workaround for in-pod safety checks:** kubectl's auto-mode permission classifier will block `pg_resetwal` calls because they're destructive. You may need to run the kubectl-exec command yourself or explicitly re-authorize via AskUserQuestion (the answer doesn't always propagate to the classifier).
+**Direct-PVC workaround for in-pod safety checks:** Some tooling blocks this command; run it directly if so. You may need to run the kubectl-exec command yourself or explicitly re-authorize via AskUserQuestion (the answer doesn't always propagate to the classifier).
 
 ---
 
@@ -66,12 +66,12 @@ kubectl annotate cluster -n <ns> <cluster> \
 Editing an existing homelab SOPS secret (e.g. `sops --set` / `sops set` / `sops -i`) can fail with
 **`MAC mismatch. File has X, computed Y`** (exit 51) even though the key and file are fine.
 
-**Why:** the files were written by an older sops (metadata `version: 3.10.2`), and George's local
+**Why:** the files were written by an older sops (metadata `version: 3.10.2`), and the operator's local
 CLI is **sops 3.13.1**. The data key decrypts fine and values decrypt fine (`sops -d --ignore-mac`
 → exit 0), but the two versions compute the MAC differently, so plain read/verify fails. Flux
 decrypts in-cluster fine regardless — this is a **local-CLI-only** snag. NOT a wrong key, NOT
 corruption. (Confirmed 2026-07-27: file byte-identical to origin, `.sops.yaml` + file config agree,
-recipient matches George's key.)
+recipient matches the operator's key.)
 
 **Fix — re-encrypt with the current CLI (recomputes a fresh, self-consistent MAC), swapping the
 value in the same step.** For a k8s Secret whose value is under `data:` (base64), pass the value via
@@ -79,16 +79,16 @@ stdin so the token never hits the process list:
 
 ```
 printf '"%s"' "$(printf %s 'NEWVALUE' | base64 | tr -d '\n')" \
-  | sops set --ignore-mac --value-stdin path/to/secret.yaml '["data"]["KEYNAME"]'
+ | sops set --ignore-mac --value-stdin path/to/secret.yaml '["data"]["KEYNAME"]'
 ```
 
 After this, plain `sops -d` verifies cleanly (drift fixed for that file going forward). `--ignore-mac`
-only relaxes the *read* check; sops always writes a fresh MAC. Env note: George's key is
+only relaxes the *read* check; sops always writes a fresh MAC. Env note: the operator's key is
 `SOPS_AGE_KEY_FILE=~/.sops/homelab-staging.agekey` — despite the "staging" name it's the single age
 recipient (`age1lnrpvnhtkmzhfhelxse…`) used for prod/staging/infra alike in `.sops.yaml`.
 
-Per [[feedback_sops_modifications_operator_only]], George runs the encrypt; Claude stages the branch
-+ hands the one-liner, then commits/PRs/banks/reconciles. See [[project_renovate_homelab]] (first use).
+Per [sops modifications operator only](#sops-modifications-operator-only), the operator runs the encrypt; Claude stages the branch
++ hands the one-liner, then commits/PRs/banks/reconciles. See (first use).
 
 ---
 
@@ -99,7 +99,7 @@ Per [[feedback_sops_modifications_operator_only]], George runs the encrypt; Clau
 The user's permission system blocks all of these against existing SOPS-encrypted Secrets:
 
 - `sops -e -i <file>` (encrypt in place)
-- `sops --set '...' <file>` (update a single field, even non-encrypted metadata)
+- `sops --set '..' <file>` (update a single field, even non-encrypted metadata)
 - Direct text edits to the file (would invalidate the SOPS MAC anyway by default — `mac_only_encrypted: true` is not set in `.sops.yaml`)
 - `sops --decrypt` (would expose plaintext to the transcript)
 
@@ -123,32 +123,26 @@ Note: `kustomize build` will fail with `evalsymlink failure` until the secret fi
 
 **mosquitto password_file from a k8s secret must be mounted via subPath, not a directory mount (symlink)**
 
-mosquitto 2.1.2 crashloops with `password-file: Error: Unable to open pwfile` when its `password_file` is a Kubernetes secret-projected **symlink**. A whole-secret directory mount (`mountPath: /mosquitto/auth`) projects each key as `passwordfile -> ..data/passwordfile`; mosquitto refuses to open the symlink even though the file is world-readable (a read as uid 1883 succeeds — so it is NOT a permissions issue).
+mosquitto 2.1.2 crashloops with `password-file: Error: Unable to open pwfile` when its `password_file` is a Kubernetes secret-projected **symlink**. A whole-secret directory mount (`mountPath: /mosquitto/auth`) projects each key as `passwordfile -> .data/passwordfile`; mosquitto refuses to open the symlink even though the file is world-readable (a read as uid 1883 succeeds — so it is NOT a permissions issue).
 
-**Why:** k8s secret/configMap directory mounts use the `..data` atomic-swap symlink layout. Apps that open config-referenced files strictly (mosquitto's pwfile loader) fail on the symlink, not on perms.
+**Why:** k8s secret/configMap directory mounts use the `.data` atomic-swap symlink layout. Apps that open config-referenced files strictly (mosquitto's pwfile loader) fail on the symlink, not on perms.
 
-**How to apply:** Mount each secret key via `subPath` (`mountPath: /mosquitto/auth/passwordfile` + `subPath: passwordfile`) so it lands as a real file. Tradeoff: subPath mounts don't auto-update on secret change — fine for a password file (pod restart picks it up). Caused a z2m/HA MQTT outage 2026-06-24 (homelab PR #976 → fixed in #985). Generalizes to any app that won't follow the secret symlink. Related: [[feedback_sops_modifications_operator_only]].
-
----
-
-## signal cli zombie
-
-**signal-cli JVM goes zombie on OOM — process stays Running, port :7583 dead — and signal-bridge/hermes crashloop downstream. PR #568 added livenessProbe.**
-
-When debugging signal-cli outages on the homelab cluster (`signal-cli` namespace), check for the **JVM zombie state** before assuming a fresh issue:
-
-- The signal-cli daemon throws `OutOfMemoryError: Java heap space` in the `daemon-listener` thread under socket-connection load. The thread dies, but the JVM process stays running, so kubelet sees `Running` indefinitely and never restarts it.
-- Symptom shape: `signal-cli` container `Running` with restart count 0 but `Ready: False`; readiness probe fails with `dial tcp …:7583: i/o timeout`; `signal-bridge` sidecar in CrashLoopBackOff with hundreds of restarts; `hermes-{prod,callee-prod,stage,callee-stage}` all CrashLoopBackOff downstream.
-
-**Why:** Triggered the 2026-05-04 → 2026-05-09 outage (4d16h). Without a livenessProbe on the JVM container, k8s never recovers because the cgroup never OOMKills the process — the heap caps at `-Xmx2048m` while the cgroup limit is 3Gi, so non-heap allocations fit fine. PR #568 added a TCP livenessProbe on `:7583` (60s initialDelay, 30s period, failureThreshold 3) so the same class of failure now self-heals in ~2 minutes.
-
-**How to apply:**
-- If signal-cli is misbehaving, first check `kubectl get pod -n signal-cli` for "Running but NotReady" — that's the zombie shape, not a fresh OOM. Restart with `kubectl delete pod -n signal-cli -l app=signal-cli` and signal-bridge + hermes will recover on their own.
-- Hermes uses upstream `nousresearch/hermes-agent` so retry/backoff there is not in our control — Kubernetes' CrashLoopBackOff (capped at 5min) is the only knob. To recover hermes faster after fixing signal-cli, `kubectl delete pod -l app=hermes` in each hermes namespace instead of waiting out the backoff.
-- Heap tuning history: `-Xmx1.5g`/2Gi limit (one account) → `-Xmx2048m`/3Gi limit (two accounts, PR #470). Bump both in lockstep if a third account is linked.
-- All four hermes deployments (`hermes-prod`, `hermes-stage`, `hermes-callee-prod`, `hermes-callee-stage`) connect through the prod signal-cli (PR #477 pointed staging at prod after signal-cli-stage was scaled down).
+**How to apply:** Mount each secret key via `subPath` (`mountPath: /mosquitto/auth/passwordfile` + `subPath: passwordfile`) so it lands as a real file. Tradeoff: subPath mounts don't auto-update on secret change — fine for a password file (pod restart picks it up). Caused a z2m/HA MQTT outage 2026-06-24 (homelab PR #976 → fixed in #985). Generalizes to any app that won't follow the secret symlink. Related: [sops modifications operator only](#sops-modifications-operator-only).
 
 ---
+
+## signal cli zombie — historical (service decommissioned 2026-06-17)
+
+> **`signal-cli` and the `hermes` bots were decommissioned 2026-06-17** and garbage-collected by
+> Flux. The namespace and workloads no longer exist, so nothing here is actionable — it is kept for
+> the transferable lesson only.
+
+**The lesson, which generalises to any JVM workload:** a JVM whose worker thread dies of OOM can stay
+`Running` with the process alive and the port still listening. A readiness probe that only checks the
+port passes forever, so Kubernetes never restarts it and the workload is silently dead.
+
+**Add a `livenessProbe`, not just a `readinessProbe`**, and make it exercise something the worker
+thread owns rather than something the JVM answers regardless.
 
 ## spotify connect ephemeral port
 
@@ -159,10 +153,10 @@ When debugging signal-cli outages on the homelab cluster (`signal-cli` namespace
 When adding cross-VLAN firewall rules so a guest/IoT network can reach a Spotify Connect endpoint (HifiBerry with go-librespot/librespot/raspotify, custom librespot containers, etc.), do all three:
 
 1. **Pin librespot's zeroconf port** to a fixed value. For go-librespot, add to `/etc/go-librespot/config.yml`:
-   ```yaml
-   zeroconf_port: 4070
-   ```
-   For librespot-rust: `--zeroconf-port 4070`. For raspotify: edit `/etc/raspotify/conf` `LIBRESPOT_ZEROCONF_PORT=4070`.
+ ```yaml
+ zeroconf_port: 4070
+ ```
+ For librespot-rust: `--zeroconf-port 4070`. For raspotify: edit `/etc/raspotify/conf` `LIBRESPOT_ZEROCONF_PORT=4070`.
 
 2. **Add the chosen port to the firewall allow-list** alongside the obvious media ports (AirPlay 7000, Snapcast 1704/1705/1780, web UI 80).
 
@@ -200,7 +194,7 @@ If "Spotify shows the device on the trusted VLAN but not the restricted VLAN":
 
 ### Related
 
-- [[cilium-gateway-netpol]] — different flavor of the same pattern: discovery-via-mDNS + unicast-via-CNP. Two enforcement points; both must permit the unicast leg.
+- [cilium gateway netpol](./2026-08-15-networking-gotchas.md#cilium-gateway-netpol) — different flavor of the same pattern: discovery-via-mDNS + unicast-via-CNP. Two enforcement points; both must permit the unicast leg.
 - See also: `docs/plans/2026-05-07-guest-vlan-dns-and-hifiberry-access.md` (the Phase C plan this trap surfaced in).
 
 ---
@@ -221,11 +215,11 @@ Working Dockerfile shape:
 ```dockerfile
 FROM debian:bookworm-slim
 RUN apt-get install -y --no-install-recommends \
-      python3 python3-venv \
-      python3-gi python3-gi-cairo \
-      gir1.2-glib-2.0 gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
-      gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-tools \
-      libcairo2 gettext-base
+ python3 python3-venv \
+ python3-gi python3-gi-cairo \
+ gir1.2-glib-2.0 gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 \
+ gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-tools \
+ libcairo2 gettext-base
 # Debian python3 is externally managed (PEP 668); venv with system site
 # packages so pip-installed mopidy can import the apt-provided gi/Gst.
 RUN python3 -m venv --system-site-packages /opt/mopidy-venv
@@ -239,19 +233,19 @@ The original image was `FROM python:3.14-slim` and crashlooped through TWO
 layers on first real deploy (2026-06-11, shipping snapcast PR #895):
 
 1. `ModuleNotFoundError: No module named 'pkg_resources'` — Mopidy 3.4.2 imports
-   the legacy pkg_resources; pip stopped bundling setuptools on Python 3.12+,
-   and Python 3.14 was never a supported Mopidy runtime. Fix: `setuptools<81`
-   (newer setuptools is removing pkg_resources) + a supported Python.
+ the legacy pkg_resources; pip stopped bundling setuptools on Python 3.12+,
+ and Python 3.14 was never a supported Mopidy runtime. Fix: `setuptools<81`
+ (newer setuptools is removing pkg_resources) + a supported Python.
 2. `ERROR: A GObject based library was not found. No module named 'gi'` — the
-   GStreamer bindings. python:slim can't provide them. Fix: Debian + python3-gi.
+ GStreamer bindings. python:slim can't provide them. Fix: Debian + python3-gi.
 
 ### How to apply
 
 When touching the mopidy image or debugging the snapcast mopidy sidecar:
 - Keep the Debian base; don't "simplify" to python:slim.
 - Validate startup on snapcast-stage before prod — the sidecar logs
-  `MPD server running at [::]:6600` + `Audio output set to ...navidrome.fifo`
-  when healthy.
+ `MPD server running at [::]:6600` + `Audio output set to ..navidrome.fifo`
+ when healthy.
 
 ### Related cross-service wiring (snapcast ↔ navidrome)
 
@@ -260,14 +254,14 @@ For the mopidy→Navidrome Subsonic path to work, THREE policies must align
 - snapcast CNP egress allows `navidrome-prod:4533` (+ MPD ingress on 6600).
 - navidrome CNP ingress allows `app=snapcast` from snapcast-{prod,stage}.
 - The mopidy PVC (`snapcast-mopidy-state`) needs `storageClassName: truenas-iscsi`
-  (no default SC → unschedulable).
+ (no default SC → unschedulable).
 - NAVIDROME_URL is an in-cluster literal (`navidrome.navidrome-prod.svc:4533`),
-  not the public hairpin — only the blog is on the tunnel. Creds are a
-  dedicated low-priv Navidrome user (`snapcast-bot`), SOPS-encrypted.
+ not the public hairpin — only the blog is on the tunnel. Creds are a
+ dedicated low-priv Navidrome user (`snapcast-bot`), SOPS-encrypted.
 
 ### Related
 
-- [[spotify-connect-ephemeral-port]] — sibling snapcast/HifiBerry audio wiring.
+- [spotify connect ephemeral port](#spotify-connect-ephemeral-port) — sibling snapcast/HifiBerry audio wiring.
 - Plan: `gjcourt/homelab` docs/plans/2026-03-14-navidrome-snapcast-mopidy.md.
 
 ---

--- a/docs/operations/2026-08-15-storage-gotchas.md
+++ b/docs/operations/2026-08-15-storage-gotchas.md
@@ -1,0 +1,402 @@
+---
+title: Storage gotchas — PVCs, PVs, ZFS, TrueNAS, Synology
+status: Stable
+created: 2026-08-15
+updated: 2026-08-15
+updated_by: gjcourt
+tags: [operations, storage, pvc, zfs, truenas, synology, gotchas]
+---
+
+# Storage gotchas — PVCs, PVs, ZFS, TrueNAS, Synology
+
+Everything that has bitten us on persistent storage: immutable fields, destructive migrations, reclaim policies, and NAS-side surprises. Several of these are data-loss-adjacent — read before destroying anything. Promoted 2026-08-15.
+
+---
+
+## audit pvc before lossy destroy
+
+**Before destroying a PVC as 'lossy', exec into the running pod and `ls -la $mountpath` + `du -sh`. App names like 'adguard-config' and 'navidrome-data' SOUND lossy but hold sqlite DBs, sessions, automations — destroying them wipes user-visible state.**
+
+The "lossy vs preserve" classification of small Deploy/STS PVCs in the alcatraz→hestia migration was wrong for almost everything I called lossy. Real per-pod content audit on 2026-05-23:
+
+| PVC | Bytes | Content found | Actually lossy? |
+|---|---|---|---|
+| audiobookshelf-data-pvc | 476K | absdatabase.sqlite (library state, progress, users) | **NO — preserve** |
+| audiobookshelf-meta-data-pvc | 68K | empty backups/cache/logs/streams dirs | yes |
+| authelia-data | 340K | db.sqlite3 (sessions, MFA), configuration.yaml, users.yml | **NO — preserve** |
+| homeassistant-config-pvc | 107M | .storage/, automations.yaml — ALL automations + integrations | **NO — critical** |
+| jellyfin-cache-pvc | 25M | transcodes/omdb cache | yes |
+| jellyfin-config-pvc | 364M | watch progress, library DB, users, plugins | **NO — preserve** |
+| linkding-data-pvc | 48K | empty (DB is in CNPG postgres) | yes |
+| mealie-data-pvc | 29M | mealie.db — RECIPES + log files | **NO — preserve** |
+| memos-data-pvc | 0K | empty (DB is in CNPG postgres) | yes |
+| navidrome-data-pvc | 9.3M | navidrome.db (play history, playlists, users) | **NO — preserve** |
+| snapcast-spotify-state | 20K | state.json | yes (regen on first play) |
+| adguard config/work (STS VCT) | ~10K | AdGuardHome.yaml — all blocklists, clients, rewrites | **NO — wiping = household DNS down** |
+
+Bigger insight: **adguard-prod config PVC was on the original "lossy" list and got destroyed → household DNS went down**. Saved by old PV being on `Retain` policy — restored via rsync from `pvc-2d7d6f58...` (see [[pv-retain-recovery-pattern]]).
+
+**Why:** I trusted an earlier classification ("lossy" tag from migration plan) without verifying actual contents. The plan said "data PVC" but small data PVCs in tiny apps often hold their entire sqlite + configuration.
+
+**How to apply:**
+
+Before any `kubectl delete pvc` for a "lossy" cutover:
+
+```bash
+# 1. Find a running pod that mounts the PVC
+pod=$(kubectl get pods -n $NS -o json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for p in d['items']:
+    for v in p['spec'].get('volumes',[]):
+        if v.get('persistentVolumeClaim',{}).get('claimName')=='$PVC':
+            for c in p['spec']['containers']:
+                for m in c.get('volumeMounts',[]):
+                    if m['name']==v['name']:
+                        print(p['metadata']['name'], c['name'], m['mountPath'])
+                        sys.exit(0)
+")
+
+# 2. Look at sizes + file types
+kubectl exec -n $NS $POD -c $CONTAINER -- sh -c "du -sh $MOUNT; ls -la $MOUNT" 
+
+# 3. RED FLAGS for "lossy":
+#    - any .sqlite / .db file > 0 bytes (user data)
+#    - .yaml/.json config (state)
+#    - .storage/ directory (Home Assistant)
+#    - files >1MB total
+#    - mtime within last 7 days (active use)
+```
+
+**Heuristic:** "X-cache" or "X-transcodes" or "X-state" PVCs are usually lossy. "X-data" or "X-config" or just "X" without a qualifier are usually preserve. Empty dirs (0K) are obviously lossy.
+
+**For staging vs prod:** staging is fine to lose. **Prod requires per-PVC verification** even if staging was wiped — production data has different blast radius.
+
+**Related cross-references:**
+- [[flux-suspend-during-cluster-ops]] — suspend Flux first so the workload doesn't re-grab the PVC
+- [[pvc-storage-class-migration]] — destroy-and-recreate pattern (assumes you've correctly classified as lossy)
+- [[pv-retain-recovery-pattern]] — if you destroy and regret it, Retain policy is your safety net
+
+---
+
+## pvc storage class migration
+
+**PVCs are immutable on storageClassName. Migrating across storage classes requires destroy-and-recreate, with different patterns for StatefulSet templates vs standalone Deployment PVCs.**
+
+`spec.storageClassName` is one of the immutable PVC fields. Kustomize/Helm/Flux can't change it on an existing PVC — they patch and silently fail. To actually migrate, you have to delete the PVC and let Flux recreate it on the new class.
+
+**Why:** Learned this the hard way across the alcatraz → hestia migration (PRs #742, #747, #753, #754). A manifest spec change alone is a no-op for already-bound PVCs; the cluster stays on the old SC and Flux logs immutable-field warnings forever.
+
+**How to apply:**
+
+| PVC source | Migration mechanics |
+|---|---|
+| **Standalone PVC** (referenced by Deployment) | Scale workload to 0 → delete PVC → reconcile Flux → new empty PVC on new SC → scale up. |
+| **StatefulSet `volumeClaimTemplates`** (Loki, Adguard) | STS templates are also immutable. Scale STS to 0 → `kubectl delete sts X --cascade=orphan` → delete PVCs → reconcile (Helm/Flux recreates STS) → new STS with new template + fresh PVCs. |
+| **CNPG cluster PVCs** | Operator-managed: edit `spec.storage.storageClass` in the Cluster CR, then `kubectl cnpg destroy <cluster> <id>` one replica at a time. CNPG re-bootstraps via pg_basebackup from primary. |
+
+**Gotchas:**
+- **Flux gets stuck on the immutable-field error and stops reconciling downstream resources** — must clear ALL stuck PVCs in one batch, not one at a time, or Flux blocks itself.
+- **Terminating PVCs hang when a Pending pod still references them.** Force-delete Pending pods (`kubectl delete pod X --force --grace-period=0`) to clear the finalizer chain.
+- **Lossy migrations wipe app state** — adguard ends up in "first launch" mode, crashlooping on probes that check the production port instead of the wizard port 3000. Either scale to 0 until you reconfigure, or use [[cnpg-promote-pg-resetwal]]-style operator-only recovery if the manifest defaults insist on a running pod.
+
+For data-preserving migrations across storage classes, use `kubectl pv-migrate` with a temp PVC (orig → tmp on new SC → delete orig → recreate empty on new SC → tmp → orig). PVC names can't be renamed, so this 2-step copy is unavoidable when you want to keep the original PVC name.
+
+---
+
+## pv retain recovery pattern
+
+**When a PV has `persistentVolumeReclaimPolicy: Retain` and goes to phase=Released after PVC deletion, the underlying volume is still intact. Recover by clearing claimRef + creating a new PVC with volumeName pointing to the old PV.**
+
+If a "lossy" PVC destroy turned out to wipe real data (see [[audit-pvc-before-lossy-destroy]]), and the old PV had `Retain` reclaim policy, the data is still on the storage backend. Recovery is mechanical.
+
+**Why:** Burned and recovered from this on 2026-05-23 destroying adguard-prod config PVC. Old PV `pvc-2d7d6f58-6293-4a0f-8e29-d13ddf47ea6e` was phase=Released with Retain, underlying Synology iSCSI LUN still had AdGuardHome.yaml. Without that backstop, the household DNS resolver would have needed a full re-setup.
+
+**How to apply:**
+
+```bash
+# 1. Find the old Released PV
+kubectl get pv -o json | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+for pv in d['items']:
+    cr = pv['spec'].get('claimRef', {})
+    if cr.get('namespace')=='$NS' and cr.get('name')=='$OLD_PVC_NAME':
+        print(pv['metadata']['name'], pv['status']['phase'], pv['spec']['persistentVolumeReclaimPolicy'])
+"
+
+# 2. Clear claimRef so it becomes Available
+kubectl patch pv $OLD_PV_NAME --type=merge -p '{"spec":{"claimRef":null}}'
+
+# 3. Create a temp PVC bound to the old PV
+cat <<YAML | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${OLD_PVC_NAME}-recovery-source
+  namespace: $NS
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: $OLD_STORAGE_CLASS   # e.g. synology-iscsi (must match the PV's class)
+  resources:
+    requests:
+      storage: $SIZE
+  volumeName: $OLD_PV_NAME              # binds to specific PV
+YAML
+
+# 4. Scale workload to 0 (release the new PVC)
+
+# 5. Run a Job that mounts BOTH old + new PVCs, rsync/cp old -> new
+#    (use a permissive image like alpine + rsync, OR the same app image
+#     to avoid ImagePullBackOff if cluster DNS is impaired)
+
+# 6. Scale workload back up
+# 7. Clean up: delete the recovery-source PVC. Old PV goes back to Released (or Available depending on reclaim).
+```
+
+**Notes:**
+- Must match the PV's `storageClassName` exactly when creating the temp PVC, or binding fails silently.
+- If cluster DNS is impaired (e.g., the workload you destroyed WAS the DNS resolver), pick a container image that's already cached on the nodes — busybox/alpine pulls will fail. Adguard's own image worked because nodes already had it.
+- The PV's underlying volume (iSCSI LUN / NFS export / ZFS dataset) must not have been deleted by the storage operator. With Retain, that won't happen automatically, but if you've explicitly issued a `synology-csi`/`democratic-csi` delete or rm'd the dataset, this trick won't help.
+
+**Related cross-references:**
+- [[audit-pvc-before-lossy-destroy]] — the upstream cause; verify before destroying so this recovery is rare
+- [[pvc-storage-class-migration]] — the migration pattern this protects against
+
+---
+
+## immutable pv staging preview wedge
+
+**Changing an immutable PV field (nfs.path/server) in a homelab base/overlay hits the STAGING preview at PR-open (not merge) and wedges the whole apps-staging Kustomization until the -staging PVs are recreated.**
+
+Homelab `staging` is an auto-preview env rebuilt by CI (`staging-deploy.yaml`) from `master + open PRs` the moment a PR's checks go green — so a manifest change lands on the LIVE staging cluster **before merge**.
+
+**Why:** if that change edits an **immutable PV field** (`spec.nfs.path`, `spec.nfs.server`, any `persistentvolumesource`), Flux's server-side apply is rejected (`spec.persistentvolumesource is immutable after creation`). Because `apps-staging` is ONE Kustomization over ~24 apps with no `dependsOn`, the failed PV apply drives the whole thing `Ready=False`, retrying every 1m, blocking every other staging app from converging — triggered by merely OPENING the PR. `kustomize build` CI can't catch it (client-side render; immutability is admission-time), so the auto-merge gate stays green.
+
+**How to apply:** when a PR changes an immutable PV field, expect to recreate the `-staging` PVs/PVCs as part of landing it (same one-time delete/recreate the `-prod` ones needed). Recreate procedure (staging, read-only NFS, `Retain` → no data loss), confirmed 2026-07-17 on jellyfin (PR #1136):
+```
+flux suspend kustomization apps-staging -n flux-system
+kubectl scale deploy <app> -n <ns>-stage --replicas=0            # release PVC mounts; wait pod gone
+kubectl delete pvc -n <ns>-stage <pvc>...                        # then
+kubectl delete pv  <pv>-staging...                               # Retain PV, data untouched
+flux resume kustomization apps-staging -n flux-system
+flux reconcile kustomization apps-staging -n flux-system --with-source   # recreates at new path + scales app back up
+```
+Prod (`apps-production`) does NOT auto-apply open PRs, so prod only needs the recreate at actual merge — and only if the prod render's PV path actually changes (a base change that prod already overlays to the same value = no-op). Related: [[feedback_flux_suspend_during_cluster_ops]], [[feedback_pvc_storage_class_migration]], [[feedback_flux_pvc_volumename_anti_pattern]], [[project_jellyfin_library_cleanup]].
+
+---
+
+## zfs destroy busy container mount
+
+**ZFS "dataset is busy" on destroy despite unmounted — caused by hestia containers bind-mounting a parent dir capturing child-dataset submounts; + TrueNAS altroot mountpoint gotcha**
+
+Retiring a ZFS dataset on hestia (TrueNAS SCALE 26.x, pool `main` altroot `/mnt`).
+Three traps, in order of how much time each burned:
+
+**1. `zfs destroy` "dataset is busy" while `mounted=no` + not in `/proc/mounts` =
+a container holds a STALE submount in its own mount namespace.** hestia docker
+containers (`immich-photos-backup`, `homelabscope-heartbeat`) bind-mount a PARENT
+dir (`/mnt/main/family`). A ZFS *child* dataset mounted under it (e.g.
+`family/images/photos-staging-30d`) gets copied into the container's mount ns at
+container-start. Later unmounting the child on the HOST does NOT remove the
+container's private copy → it pins the dataset. Survives host unmount, `exportfs
+-f`, nfsd cache flush, AND a full NFS service restart (mount namespaces are
+independent). **Fix: `docker restart <container>`** to rebuild its ns cleanly
+(safe once the child is host-unmounted — nothing left to recapture).
+**Why:** don't trust `zfs get mounted` / `/proc/1/mounts` alone; scan ALL
+namespaces: `for f in /proc/[0-9]*/mountinfo; do grep -l "<path>" $f; done`, then
+map PID→container via `/proc/<pid>/cgroup`. `docker inspect .Mounts` won't show it
+(the bind is the parent, the submount is implicit).
+
+**2. `showmount -a` can show a PHANTOM client** (`10.42.2.25:/...images...`) that
+has NO real mount (verified with a privileged hostPID probe pod reading
+`/proc/1/mounts` on that Talos node). It's stale mountd bookkeeping, unrelated to
+the busy state. Red herring — don't chase it or restart NFS for it.
+
+**3. TrueNAS altroot mountpoint gotcha.** Pool `main` has `altroot=/mnt`. Creating
+a dataset with `zfs create -o mountpoint=/mnt/main/...` DOUBLE-prefixes →
+`/mnt/mnt/main/...`, and any rsync to the intended path silently lands in a plain
+dir on the PARENT dataset instead of the new dataset. **Set mountpoint WITHOUT the
+`/mnt` prefix:** `zfs set mountpoint=/main/family/media/photos-staging-30d` →
+resolves to `/mnt/main/family/...`. Move staged data aside first so the (re)mount
+doesn't shadow it.
+
+**How to apply:** before any hestia `zfs destroy`, expect a container/app to hold
+the dataset via a parent bind-mount; restart the holders (cheap, low-risk) rather
+than restarting NFS (blips prod). Verify redundancy with a path+size manifest diff
+(`find -printf "%P\t%s\n" | sort` + `comm -23`) before destroying. Context:
+[[project_immich_photos_images_to_media]], [[project_truenas_api]],
+[[feedback_bash_arrays_in_harness]].
+
+---
+
+## truenas apps
+
+**For hestia-resident services, prefer TrueNAS Custom App (paste compose into SCALE UI) over raw docker-compose + systemd**
+
+For services running on TrueNAS hestia (`truenas_admin@10.42.2.10`), prefer **TrueNAS Custom Apps** over raw `docker compose` invocation, even though it adds a manual copy/paste step.
+
+**Why:** The user values TrueNAS's managed-lifecycle features — auto-restart on reboot, status/log surface in the SCALE UI, ZFS snapshot integration, and built-in app upgrade flow — more than fully-automated git-driven sync. The trade-off (operator copies the compose YAML from the homelab repo into the SCALE UI Custom App wizard when changes happen) is acceptable.
+
+**How to apply:** When proposing a TrueNAS-resident service, default the deployment surface to **TrueNAS Custom App**. The compose YAML in the homelab repo (under `hosts/hestia/<app>/`) is the canonical source; operator pastes it into SCALE UI to deploy or update. Do not propose systemd units or raw `docker compose up -d` workflows for hestia services unless the user explicitly opts out of TrueNAS Apps.
+
+**Gotchas to call out in plans:**
+- TrueNAS Custom App does not support `build:` directives — images must be pre-built and pulled from a registry.
+- Secrets/tokens belong in the SCALE UI's env-var section (masked input), not in the YAML pasted into git.
+- TrueNAS prefixes container names with `ix-<app-name>-`. Compose YAML stays clean; expect the prefix when running `docker ps` / `docker inspect`.
+- Custom volume host paths (e.g., `/mnt/tank/apps/<svc>/data`) are supported and recommended for data that should survive app deletion.
+- Drift risk: someone could edit the compose in SCALE UI without updating git. Document the canonical-source rule in each `hosts/hestia/<app>/README.md`.
+
+---
+
+## synology 0700 default and group bit
+
+**\"Synology DSM started saving new photo uploads with POSIX mode 0700 sometime around 2025-12-31. Files owned by user:users with mode `rwx**
+
+---` look readable to a service account in the admin group, but they aren't: gid=100(users) matches the file group, and the group bit `---` denies BEFORE Unix falls through to 'other'. Fix is `chmod g+rX,o+rX`, not just `o+rX`."
+metadata:
+  node_type: memory
+  type: feedback
+---
+
+### Rule
+
+When a Synology DSM share rsync silently misses files dated after ~2026-01-01:
+
+1. The Synology Photos / DSM Drive default file-mode template flipped from `0644` (rw-r--r--) to `0700` (rwx------) around 2025-12-31. New uploads since then are owner-only.
+2. Adding `chmod o+rX` alone does NOT fix it for a service account that's in the **owning file's group** (typically `users` / gid=100). POSIX checks the group bit before "other"; if you're in the file's group and the group bit denies, you never reach the "other" bit.
+3. The fix is `chmod -R g+rX,o+rX` (or just `chmod -R go+rX`).
+
+### Why
+
+Symptom this presents as: rsync says `success` with `Number of regular files transferred: 0` for files that obviously aren't on the destination. Or rsync exits 23 with `send_files failed to open ... Permission denied (13)` despite the share-level ACL granting Read access.
+
+Reproduced 2026-06-02 on alcatraz (Synology DSM):
+- `truenas-backup` user (uid 1031, **gid 100 = users**, also in admin group 101)
+- Files `-rwx------ 1 mara users IMG_XXXX.HEIC` (mode 0700, gid 100 = `users`)
+- truenas-backup IS in `users`, so group check applies → denied → never reaches "other"
+- `chmod o+rX` made files `0705` (`-rwx---r-x`), but truenas-backup still got denied (group still `---`)
+- `chmod g+rX,o+rX` made files `0755` (`-rwxr-xr-x`), truenas-backup reads fine
+
+This is a classic Unix gotcha (group-bit-evaluated-before-other) showing up in a homelab-rsync context. Cost ~30 min before noticing the obvious mode `705` was missing the `g+r`.
+
+### How to apply
+
+When debugging "rsync silently skips Synology-owned files":
+- `ssh truenas-backup@<alcatraz> 'stat -c "%a %U:%G" /volume1/homes/<user>/Photos/<recent-file>'`
+- If the mode is `700` or any pattern where `group` is more restrictive than `other`, and the service account is in the file's group:
+  - `ssh <dsm_admin>@<alcatraz>; sudo chmod -R g+rX,o+rX /volume1/homes/<user>/Photos/...`
+
+For the homelab Synology specifically, this is alcatraz at `10.42.2.11`. DSM admin user that can sudo: **`manager`** (confirmed 2026-06-09).
+
+### Recurrence log
+
+- 2026-06-02 — first surfaced; manual chmod applied to existing files. Long-term hardening deferred.
+- 2026-06-09 — recurred exactly as predicted. New uploads since 2026-06-02 went straight to mode 0700 again. Sync failed for all of george's 2026/06 files; mara unaffected (no new uploads).
+- **2026-06-09 — durable fix landed**: PR #881 added `--rsync-path="sudo -n /bin/chmod -R g+rX,o+rX /volume1/homes/<user>/Photos && rsync"` to the immich-photos-backup script. Image `2026-06-09@sha256:93a52aa2…`, deployed via PR #882. Operator installed `/etc/sudoers.d/immich-photos-backup` on alcatraz (NOPASSWD for `truenas-backup` on the exact chmod commands). Validated end-to-end: catch-up run pulled 88M of new uploads cleanly. PR #885 follow-up replaces the original `visudo -cf` pre-validation gate (DSM doesn't ship visudo) with `sudo -n true` + `sudo -l -U` post-install sanity.
+
+Next failure mode to watch for (not yet observed):
+- DSM upgrade wipes `/etc/sudoers.d/` — the chmod fails → rsync exits 12 → cron logs "FAILED" loudly → metric stays stale → `ImmichPhotoBackupStale` alert fires after 36h. Re-add the sudoers file from README §3a.
+- DSM upgrade sets `Defaults requiretty` — NOPASSWD+`-n` rejected on non-tty ssh; same loud failure mode.
+
+### Long-term hardening
+
+`chmod -R` is one-shot — it doesn't cover **future** uploads, which Synology will keep writing with mode 0700. Options for a permanent fix (not done as of 2026-06-02):
+
+1. Cron job on alcatraz that runs `chmod -R g+rX,o+rX /volume1/homes/{george,mara}/Photos` nightly BEFORE the hestia 04:00 rsync pulls.
+2. Add the chmod as a remote `--rsync-path` shim in the immich-photos-backup script (runs on alcatraz before each rsync invocation).
+3. Find and revert the Synology Photos / DSM Drive setting that flipped the default to 0700 (operator detective work — DSM Photos Settings? Mobile app upload settings? Synology Knowledge Base?).
+4. Have hestia rsync as a user that's NOT in the `users` group, so "other" bit applies. Would require a new account on alcatraz with no group membership in `users`.
+
+### Related
+
+- [[synology-per-user-photo-symlinks]] — sibling Synology permission trap on `family/images/photos/<user>` symlinks. Different mechanism (symlink ACL), same outcome (silent rsync skip).
+- [[rsync-verify-destination]] — generic rule: always verify destination after a low-bytes rsync; both Synology traps masquerade as "clean" rsync runs.
+- [[hestia-photos-sot]] — the migration that surfaced this trap. Caused Immich to silently miss all 2026 photos until 2026-06-02.
+
+---
+
+## synology per user photo symlinks
+
+**On Synology DSM, /volume1/family/images/photos/<user>/ paths are symlinks into /volume1/homes/<user>/Photos/ (Synology Photos personal space). The family-side path has per-file ACLs from each user's account that deny non-owners file open, even when a shared service user has share-level Read. Sync from the homes path.**
+
+### Rule
+
+When rsync'ing photos off a Synology DSM box as a service user (e.g. `truenas-backup`), read from `/volume1/homes/<user>/Photos/` directly — never from `/volume1/family/images/photos/<user>/`.
+
+### Why
+
+On Synology Photos (and the older Photo Station), each user's personal photo collection lives in their home folder. The "family" share's `images/photos/<user>/` paths are symlinks (or bind mounts that look like symlinks to userspace tools) into each user's home. The file bytes are real; the apparent location under family is a view.
+
+Per-file ACLs on those files come from the original uploader's Synology account, and Synology's filesystem ACL layer applies them at file open regardless of the path used to traverse. A service user (`truenas-backup`) granted Read on the `family` share can:
+- List directories under `family/images/photos/<user>/` (directory ACL allows traversal)
+- See file names and sizes (stat works via the parent dir's ACL)
+- **NOT open the files** (file-level ACL only includes the owner)
+
+Rsync's failure mode is specifically `send_files failed to open "...": Permission denied (13)` with exit code 23. The DSM "Apply to this folder, sub-folders and files" recursive-ACL apply on the `family` share **does not traverse into the symlinked targets** — you have to apply it on the underlying `homes` share, and even then file-level ACLs from the user's account can override.
+
+The reliable workaround is to source from the canonical path: `truenas-backup@host:/volume1/homes/<user>/Photos/`. As long as `truenas-backup` has Read on the `homes` share, file ACLs from the user account include the share-level grant via the standard inheritance, and file open succeeds.
+
+### How to apply
+
+When writing or modifying any rsync that pulls per-user photos off Synology:
+
+1. Source: `truenas-backup@<host>:/volume1/homes/<user>/Photos/` (loop over users)
+2. Destination: whatever the canonical layout is on the receiver (e.g. `/mnt/main/family/images/photos/<user>/` on hestia per the 2026-06-01 SOT plan)
+3. Never source from `/volume1/family/images/photos/<user>/` — even if it "feels" like the canonical path, it's a symlink with ACL traps
+
+The `immich-photos-backup` script (`images/immich-photos-backup/immich-photos-backup.sh` in gjcourt/homelab) is the reference implementation. Loops over `USERS=(george mara)` and runs one rsync per user.
+
+### Diagnostic signature
+
+If rsync hits this and you forget the rule:
+- exit code 23
+- stderr full of `send_files failed to open "/volume1/family/images/photos/<user>/<YYYY>/<MM>/...": Permission denied (13)` for files older than a certain date AND newest files
+- `du -sh` as the service user shows real sizes on the family path (directory ACL works)
+- BUT `cat` on any individual file returns Permission denied
+
+Reproduced 2026-06-01 in the hestia-SOT bulk seed (Phase 3 of [[hestia-photos-sot]]). Wasted ~2 hours of retries before the user surfaced the symlink fact.
+
+### Related
+
+- [[immich-photo-backup-setup]] — uses this pattern in production
+- [[hestia-photos-sot]] — the plan that hit this trap during Phase 3 bulk seed
+
+---
+
+## rsync verify destination
+
+**Don't trust rsync's 'low bytes sent/received + high speedup' summary as proof the sync worked. A high speedup means rsync DECIDED to skip files (either matched or perm-denied with --ignore-errors); empty destination + same summary means everything failed silently. Always verify destination has actual content.**
+
+### Rule
+
+After any rsync, verify the destination directly. Don't read success from rsync's summary line alone — verify with `du -sh <dest>`, `ls -la <dest>`, or `find <dest> | wc -l`. Especially when `--ignore-errors` or `--partial` is in play.
+
+### Why
+
+Rsync's final summary looks the same whether:
+- (a) all source files already matched destination → no transfer needed → success
+- (b) all source files were perm-denied at open and skipped under `--ignore-errors` → silent failure
+
+Both produce: `sent 196 bytes received 2.01K bytes; total size is X; speedup is Y` with no `rsync error:` suffix. Exit code may still be 0 with `--ignore-errors`. The difference only shows up when you look at the destination.
+
+Burned 2026-06-01 on hestia-SOT Phase 3 Stream C: `/volume1/homes/` → `/mnt/main/homes/`. Summary line matched the "already in place" pattern; declared clean. User later asked "where does that data live?" → discovered `/mnt/main/homes/` was 205 bytes (empty ZFS dataset metadata only). Truenas-backup hit the same per-user ACL trap as photos (see [[synology-per-user-photo-symlinks]]), and `--ignore-errors` swallowed every Permission denied silently.
+
+### How to apply
+
+After every non-trivial rsync, run at minimum:
+```bash
+du -sh <dest>
+ls -la <dest> | head
+```
+
+Compare to expected order of magnitude. If destination size ≈ "few KB ZFS metadata" or "0M" when source was supposed to land hundreds of MB / GB, something failed silently. Read the stderr log.
+
+When using `--ignore-errors` or `--partial`, always pipe stderr to a file (`2>/tmp/rsync-errs.log`) and check `wc -l` after — even if exit was 0, a long log means files were skipped.
+
+### Related
+
+- [[synology-per-user-photo-symlinks]] — the specific ACL trap that produced the silent skip in the hestia-SOT case
+- [[hestia-photos-sot]] — the plan where this misread happened
+
+---

--- a/docs/operations/2026-08-15-storage-gotchas.md
+++ b/docs/operations/2026-08-15-storage-gotchas.md
@@ -34,7 +34,7 @@ The "lossy vs preserve" classification of small Deploy/STS PVCs in the alcatraz�
 | snapcast-spotify-state | 20K | state.json | yes (regen on first play) |
 | adguard config/work (STS VCT) | ~10K | AdGuardHome.yaml — all blocklists, clients, rewrites | **NO — wiping = household DNS down** |
 
-Bigger insight: **adguard-prod config PVC was on the original "lossy" list and got destroyed → household DNS went down**. Saved by old PV being on `Retain` policy — restored via rsync from `pvc-2d7d6f58...` (see [[pv-retain-recovery-pattern]]).
+Bigger insight: **adguard-prod config PVC was on the original "lossy" list and got destroyed → household DNS went down**. Saved by old PV being on `Retain` policy — restored via rsync from `pvc-2d7d6f58..` (see [pv retain recovery pattern](#pv-retain-recovery-pattern)).
 
 **Why:** I trusted an earlier classification ("lossy" tag from migration plan) without verifying actual contents. The plan said "data PVC" but small data PVCs in tiny apps often hold their entire sqlite + configuration.
 
@@ -48,24 +48,24 @@ pod=$(kubectl get pods -n $NS -o json | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
 for p in d['items']:
-    for v in p['spec'].get('volumes',[]):
-        if v.get('persistentVolumeClaim',{}).get('claimName')=='$PVC':
-            for c in p['spec']['containers']:
-                for m in c.get('volumeMounts',[]):
-                    if m['name']==v['name']:
-                        print(p['metadata']['name'], c['name'], m['mountPath'])
-                        sys.exit(0)
+ for v in p['spec'].get('volumes',[]):
+ if v.get('persistentVolumeClaim',{}).get('claimName')=='$PVC':
+ for c in p['spec']['containers']:
+ for m in c.get('volumeMounts',[]):
+ if m['name']==v['name']:
+ print(p['metadata']['name'], c['name'], m['mountPath'])
+ sys.exit(0)
 ")
 
 # 2. Look at sizes + file types
 kubectl exec -n $NS $POD -c $CONTAINER -- sh -c "du -sh $MOUNT; ls -la $MOUNT" 
 
 # 3. RED FLAGS for "lossy":
-#    - any .sqlite / .db file > 0 bytes (user data)
-#    - .yaml/.json config (state)
-#    - .storage/ directory (Home Assistant)
-#    - files >1MB total
-#    - mtime within last 7 days (active use)
+# - any .sqlite / .db file > 0 bytes (user data)
+# - .yaml/.json config (state)
+# - .storage/ directory (Home Assistant)
+# - files >1MB total
+# - mtime within last 7 days (active use)
 ```
 
 **Heuristic:** "X-cache" or "X-transcodes" or "X-state" PVCs are usually lossy. "X-data" or "X-config" or just "X" without a qualifier are usually preserve. Empty dirs (0K) are obviously lossy.
@@ -73,9 +73,9 @@ kubectl exec -n $NS $POD -c $CONTAINER -- sh -c "du -sh $MOUNT; ls -la $MOUNT"
 **For staging vs prod:** staging is fine to lose. **Prod requires per-PVC verification** even if staging was wiped — production data has different blast radius.
 
 **Related cross-references:**
-- [[flux-suspend-during-cluster-ops]] — suspend Flux first so the workload doesn't re-grab the PVC
-- [[pvc-storage-class-migration]] — destroy-and-recreate pattern (assumes you've correctly classified as lossy)
-- [[pv-retain-recovery-pattern]] — if you destroy and regret it, Retain policy is your safety net
+- [flux suspend during cluster ops](./2026-08-15-cluster-gotchas.md#flux-suspend-during-cluster-ops) — suspend Flux first so the workload doesn't re-grab the PVC
+- [pvc storage class migration](#pvc-storage-class-migration) — destroy-and-recreate pattern (assumes you've correctly classified as lossy)
+- [pv retain recovery pattern](#pv-retain-recovery-pattern) — if you destroy and regret it, Retain policy is your safety net
 
 ---
 
@@ -98,7 +98,7 @@ kubectl exec -n $NS $POD -c $CONTAINER -- sh -c "du -sh $MOUNT; ls -la $MOUNT"
 **Gotchas:**
 - **Flux gets stuck on the immutable-field error and stops reconciling downstream resources** — must clear ALL stuck PVCs in one batch, not one at a time, or Flux blocks itself.
 - **Terminating PVCs hang when a Pending pod still references them.** Force-delete Pending pods (`kubectl delete pod X --force --grace-period=0`) to clear the finalizer chain.
-- **Lossy migrations wipe app state** — adguard ends up in "first launch" mode, crashlooping on probes that check the production port instead of the wizard port 3000. Either scale to 0 until you reconfigure, or use [[cnpg-promote-pg-resetwal]]-style operator-only recovery if the manifest defaults insist on a running pod.
+- **Lossy migrations wipe app state** — adguard ends up in "first launch" mode, crashlooping on probes that check the production port instead of the wizard port 3000. Either scale to 0 until you reconfigure, or use [cnpg promote pg resetwal](./2026-08-15-services-gotchas.md#cnpg-promote-pg-resetwal)-style operator-only recovery if the manifest defaults insist on a running pod.
 
 For data-preserving migrations across storage classes, use `kubectl pv-migrate` with a temp PVC (orig → tmp on new SC → delete orig → recreate empty on new SC → tmp → orig). PVC names can't be renamed, so this 2-step copy is unavoidable when you want to keep the original PVC name.
 
@@ -108,7 +108,7 @@ For data-preserving migrations across storage classes, use `kubectl pv-migrate` 
 
 **When a PV has `persistentVolumeReclaimPolicy: Retain` and goes to phase=Released after PVC deletion, the underlying volume is still intact. Recover by clearing claimRef + creating a new PVC with volumeName pointing to the old PV.**
 
-If a "lossy" PVC destroy turned out to wipe real data (see [[audit-pvc-before-lossy-destroy]]), and the old PV had `Retain` reclaim policy, the data is still on the storage backend. Recovery is mechanical.
+If a "lossy" PVC destroy turned out to wipe real data (see [audit pvc before lossy destroy](#audit-pvc-before-lossy-destroy)), and the old PV had `Retain` reclaim policy, the data is still on the storage backend. Recovery is mechanical.
 
 **Why:** Burned and recovered from this on 2026-05-23 destroying adguard-prod config PVC. Old PV `pvc-2d7d6f58-6293-4a0f-8e29-d13ddf47ea6e` was phase=Released with Retain, underlying Synology iSCSI LUN still had AdGuardHome.yaml. Without that backstop, the household DNS resolver would have needed a full re-setup.
 
@@ -120,9 +120,9 @@ kubectl get pv -o json | python3 -c "
 import json,sys
 d = json.load(sys.stdin)
 for pv in d['items']:
-    cr = pv['spec'].get('claimRef', {})
-    if cr.get('namespace')=='$NS' and cr.get('name')=='$OLD_PVC_NAME':
-        print(pv['metadata']['name'], pv['status']['phase'], pv['spec']['persistentVolumeReclaimPolicy'])
+ cr = pv['spec'].get('claimRef', {})
+ if cr.get('namespace')=='$NS' and cr.get('name')=='$OLD_PVC_NAME':
+ print(pv['metadata']['name'], pv['status']['phase'], pv['spec']['persistentVolumeReclaimPolicy'])
 "
 
 # 2. Clear claimRef so it becomes Available
@@ -133,22 +133,22 @@ cat <<YAML | kubectl apply -f -
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ${OLD_PVC_NAME}-recovery-source
-  namespace: $NS
+ name: ${OLD_PVC_NAME}-recovery-source
+ namespace: $NS
 spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: $OLD_STORAGE_CLASS   # e.g. synology-iscsi (must match the PV's class)
-  resources:
-    requests:
-      storage: $SIZE
-  volumeName: $OLD_PV_NAME              # binds to specific PV
+ accessModes: [ReadWriteOnce]
+ storageClassName: $OLD_STORAGE_CLASS # e.g. truenas-iscsi (must match the PV's class)
+ resources:
+ requests:
+ storage: $SIZE
+ volumeName: $OLD_PV_NAME # binds to specific PV
 YAML
 
 # 4. Scale workload to 0 (release the new PVC)
 
 # 5. Run a Job that mounts BOTH old + new PVCs, rsync/cp old -> new
-#    (use a permissive image like alpine + rsync, OR the same app image
-#     to avoid ImagePullBackOff if cluster DNS is impaired)
+# (use a permissive image like alpine + rsync, OR the same app image
+# to avoid ImagePullBackOff if cluster DNS is impaired)
 
 # 6. Scale workload back up
 # 7. Clean up: delete the recovery-source PVC. Old PV goes back to Released (or Available depending on reclaim).
@@ -160,8 +160,8 @@ YAML
 - The PV's underlying volume (iSCSI LUN / NFS export / ZFS dataset) must not have been deleted by the storage operator. With Retain, that won't happen automatically, but if you've explicitly issued a `synology-csi`/`democratic-csi` delete or rm'd the dataset, this trick won't help.
 
 **Related cross-references:**
-- [[audit-pvc-before-lossy-destroy]] — the upstream cause; verify before destroying so this recovery is rare
-- [[pvc-storage-class-migration]] — the migration pattern this protects against
+- [audit pvc before lossy destroy](#audit-pvc-before-lossy-destroy) — the upstream cause; verify before destroying so this recovery is rare
+- [pvc storage class migration](#pvc-storage-class-migration) — the migration pattern this protects against
 
 ---
 
@@ -176,13 +176,13 @@ Homelab `staging` is an auto-preview env rebuilt by CI (`staging-deploy.yaml`) f
 **How to apply:** when a PR changes an immutable PV field, expect to recreate the `-staging` PVs/PVCs as part of landing it (same one-time delete/recreate the `-prod` ones needed). Recreate procedure (staging, read-only NFS, `Retain` → no data loss), confirmed 2026-07-17 on jellyfin (PR #1136):
 ```
 flux suspend kustomization apps-staging -n flux-system
-kubectl scale deploy <app> -n <ns>-stage --replicas=0            # release PVC mounts; wait pod gone
-kubectl delete pvc -n <ns>-stage <pvc>...                        # then
-kubectl delete pv  <pv>-staging...                               # Retain PV, data untouched
+kubectl scale deploy <app> -n <ns>-stage --replicas=0 # release PVC mounts; wait pod gone
+kubectl delete pvc -n <ns>-stage <pvc>.. # then
+kubectl delete pv <pv>-staging.. # Retain PV, data untouched
 flux resume kustomization apps-staging -n flux-system
-flux reconcile kustomization apps-staging -n flux-system --with-source   # recreates at new path + scales app back up
+flux reconcile kustomization apps-staging -n flux-system --with-source # recreates at new path + scales app back up
 ```
-Prod (`apps-production`) does NOT auto-apply open PRs, so prod only needs the recreate at actual merge — and only if the prod render's PV path actually changes (a base change that prod already overlays to the same value = no-op). Related: [[feedback_flux_suspend_during_cluster_ops]], [[feedback_pvc_storage_class_migration]], [[feedback_flux_pvc_volumename_anti_pattern]], [[project_jellyfin_library_cleanup]].
+Prod (`apps-production`) does NOT auto-apply open PRs, so prod only needs the recreate at actual merge — and only if the prod render's PV path actually changes (a base change that prod already overlays to the same value = no-op). Related: [flux suspend during cluster ops](./2026-08-15-cluster-gotchas.md#flux-suspend-during-cluster-ops), [pvc storage class migration](#pvc-storage-class-migration), [flux pvc volumename anti pattern](./2026-08-15-cluster-gotchas.md#flux-pvc-volumename-anti-pattern).
 
 ---
 
@@ -208,25 +208,24 @@ namespaces: `for f in /proc/[0-9]*/mountinfo; do grep -l "<path>" $f; done`, the
 map PID→container via `/proc/<pid>/cgroup`. `docker inspect .Mounts` won't show it
 (the bind is the parent, the submount is implicit).
 
-**2. `showmount -a` can show a PHANTOM client** (`10.42.2.25:/...images...`) that
+**2. `showmount -a` can show a PHANTOM client** (`10.42.2.25:/..images..`) that
 has NO real mount (verified with a privileged hostPID probe pod reading
 `/proc/1/mounts` on that Talos node). It's stale mountd bookkeeping, unrelated to
 the busy state. Red herring — don't chase it or restart NFS for it.
 
 **3. TrueNAS altroot mountpoint gotcha.** Pool `main` has `altroot=/mnt`. Creating
-a dataset with `zfs create -o mountpoint=/mnt/main/...` DOUBLE-prefixes →
-`/mnt/mnt/main/...`, and any rsync to the intended path silently lands in a plain
+a dataset with `zfs create -o mountpoint=/mnt/main/..` DOUBLE-prefixes →
+`/mnt/mnt/main/..`, and any rsync to the intended path silently lands in a plain
 dir on the PARENT dataset instead of the new dataset. **Set mountpoint WITHOUT the
 `/mnt` prefix:** `zfs set mountpoint=/main/family/media/photos-staging-30d` →
-resolves to `/mnt/main/family/...`. Move staged data aside first so the (re)mount
+resolves to `/mnt/main/family/..`. Move staged data aside first so the (re)mount
 doesn't shadow it.
 
 **How to apply:** before any hestia `zfs destroy`, expect a container/app to hold
 the dataset via a parent bind-mount; restart the holders (cheap, low-risk) rather
 than restarting NFS (blips prod). Verify redundancy with a path+size manifest diff
 (`find -printf "%P\t%s\n" | sort` + `comm -23`) before destroying. Context:
-[[project_immich_photos_images_to_media]], [[project_truenas_api]],
-[[feedback_bash_arrays_in_harness]].
+, .
 
 ---
 
@@ -251,13 +250,7 @@ For services running on TrueNAS hestia (`truenas_admin@10.42.2.10`), prefer **Tr
 
 ## synology 0700 default and group bit
 
-**\"Synology DSM started saving new photo uploads with POSIX mode 0700 sometime around 2025-12-31. Files owned by user:users with mode `rwx**
-
----` look readable to a service account in the admin group, but they aren't: gid=100(users) matches the file group, and the group bit `---` denies BEFORE Unix falls through to 'other'. Fix is `chmod g+rX,o+rX`, not just `o+rX`."
-metadata:
-  node_type: memory
-  type: feedback
----
+**Synology DSM started saving new photo uploads with POSIX mode 0700 (`rwx------`) around 2025-12-31. A service account in the file's group (gid=100 `users`) is denied by the group bit before Unix falls through to "other" — so the fix is `chmod g+rX,o+rX`, not `o+rX`.**
 
 ### Rule
 
@@ -269,7 +262,7 @@ When a Synology DSM share rsync silently misses files dated after ~2026-01-01:
 
 ### Why
 
-Symptom this presents as: rsync says `success` with `Number of regular files transferred: 0` for files that obviously aren't on the destination. Or rsync exits 23 with `send_files failed to open ... Permission denied (13)` despite the share-level ACL granting Read access.
+Symptom this presents as: rsync says `success` with `Number of regular files transferred: 0` for files that obviously aren't on the destination. Or rsync exits 23 with `send_files failed to open .. Permission denied (13)` despite the share-level ACL granting Read access.
 
 Reproduced 2026-06-02 on alcatraz (Synology DSM):
 - `truenas-backup` user (uid 1031, **gid 100 = users**, also in admin group 101)
@@ -285,7 +278,7 @@ This is a classic Unix gotcha (group-bit-evaluated-before-other) showing up in a
 When debugging "rsync silently skips Synology-owned files":
 - `ssh truenas-backup@<alcatraz> 'stat -c "%a %U:%G" /volume1/homes/<user>/Photos/<recent-file>'`
 - If the mode is `700` or any pattern where `group` is more restrictive than `other`, and the service account is in the file's group:
-  - `ssh <dsm_admin>@<alcatraz>; sudo chmod -R g+rX,o+rX /volume1/homes/<user>/Photos/...`
+ - `ssh <dsm_admin>@<alcatraz>; sudo chmod -R g+rX,o+rX /volume1/homes/<user>/Photos/..`
 
 For the homelab Synology specifically, this is alcatraz at `10.42.2.11`. DSM admin user that can sudo: **`manager`** (confirmed 2026-06-09).
 
@@ -310,9 +303,9 @@ Next failure mode to watch for (not yet observed):
 
 ### Related
 
-- [[synology-per-user-photo-symlinks]] — sibling Synology permission trap on `family/images/photos/<user>` symlinks. Different mechanism (symlink ACL), same outcome (silent rsync skip).
-- [[rsync-verify-destination]] — generic rule: always verify destination after a low-bytes rsync; both Synology traps masquerade as "clean" rsync runs.
-- [[hestia-photos-sot]] — the migration that surfaced this trap. Caused Immich to silently miss all 2026 photos until 2026-06-02.
+- [synology per user photo symlinks](#synology-per-user-photo-symlinks) — sibling Synology permission trap on `family/images/photos/<user>` symlinks. Different mechanism (symlink ACL), same outcome (silent rsync skip).
+- [rsync verify destination](#rsync-verify-destination) — generic rule: always verify destination after a low-bytes rsync; both Synology traps masquerade as "clean" rsync runs.
+- see [the hestia photos plan](./plans/2026-06-01-hestia-photos-sot.md) — the migration that surfaced this trap. Caused Immich to silently miss all 2026 photos until 2026-06-02.
 
 ---
 
@@ -333,7 +326,7 @@ Per-file ACLs on those files come from the original uploader's Synology account,
 - See file names and sizes (stat works via the parent dir's ACL)
 - **NOT open the files** (file-level ACL only includes the owner)
 
-Rsync's failure mode is specifically `send_files failed to open "...": Permission denied (13)` with exit code 23. The DSM "Apply to this folder, sub-folders and files" recursive-ACL apply on the `family` share **does not traverse into the symlinked targets** — you have to apply it on the underlying `homes` share, and even then file-level ACLs from the user's account can override.
+Rsync's failure mode is specifically `send_files failed to open "..": Permission denied (13)` with exit code 23. The DSM "Apply to this folder, sub-folders and files" recursive-ACL apply on the `family` share **does not traverse into the symlinked targets** — you have to apply it on the underlying `homes` share, and even then file-level ACLs from the user's account can override.
 
 The reliable workaround is to source from the canonical path: `truenas-backup@host:/volume1/homes/<user>/Photos/`. As long as `truenas-backup` has Read on the `homes` share, file ACLs from the user account include the share-level grant via the standard inheritance, and file open succeeds.
 
@@ -351,16 +344,16 @@ The `immich-photos-backup` script (`images/immich-photos-backup/immich-photos-ba
 
 If rsync hits this and you forget the rule:
 - exit code 23
-- stderr full of `send_files failed to open "/volume1/family/images/photos/<user>/<YYYY>/<MM>/...": Permission denied (13)` for files older than a certain date AND newest files
+- stderr full of `send_files failed to open "/volume1/family/images/photos/<user>/<YYYY>/<MM>/..": Permission denied (13)` for files older than a certain date AND newest files
 - `du -sh` as the service user shows real sizes on the family path (directory ACL works)
 - BUT `cat` on any individual file returns Permission denied
 
-Reproduced 2026-06-01 in the hestia-SOT bulk seed (Phase 3 of [[hestia-photos-sot]]). Wasted ~2 hours of retries before the user surfaced the symlink fact.
+Reproduced 2026-06-01 in the hestia-SOT bulk seed (Phase 3 of see [the hestia photos plan](./plans/2026-06-01-hestia-photos-sot.md)). Wasted ~2 hours of retries before the user surfaced the symlink fact.
 
 ### Related
 
-- [[immich-photo-backup-setup]] — uses this pattern in production
-- [[hestia-photos-sot]] — the plan that hit this trap during Phase 3 bulk seed
+- — uses this pattern in production
+- see [the hestia photos plan](./plans/2026-06-01-hestia-photos-sot.md) — the plan that hit this trap during Phase 3 bulk seed
 
 ---
 
@@ -380,7 +373,7 @@ Rsync's final summary looks the same whether:
 
 Both produce: `sent 196 bytes received 2.01K bytes; total size is X; speedup is Y` with no `rsync error:` suffix. Exit code may still be 0 with `--ignore-errors`. The difference only shows up when you look at the destination.
 
-Burned 2026-06-01 on hestia-SOT Phase 3 Stream C: `/volume1/homes/` → `/mnt/main/homes/`. Summary line matched the "already in place" pattern; declared clean. User later asked "where does that data live?" → discovered `/mnt/main/homes/` was 205 bytes (empty ZFS dataset metadata only). Truenas-backup hit the same per-user ACL trap as photos (see [[synology-per-user-photo-symlinks]]), and `--ignore-errors` swallowed every Permission denied silently.
+Burned 2026-06-01 on hestia-SOT Phase 3 Stream C: `/volume1/homes/` → `/mnt/main/homes/`. Summary line matched the "already in place" pattern; declared clean. User later asked "where does that data live?" → discovered `/mnt/main/homes/` was 205 bytes (empty ZFS dataset metadata only). Truenas-backup hit the same per-user ACL trap as photos (see [synology per user photo symlinks](#synology-per-user-photo-symlinks)), and `--ignore-errors` swallowed every Permission denied silently.
 
 ### How to apply
 
@@ -396,7 +389,7 @@ When using `--ignore-errors` or `--partial`, always pipe stderr to a file (`2>/t
 
 ### Related
 
-- [[synology-per-user-photo-symlinks]] — the specific ACL trap that produced the silent skip in the hestia-SOT case
-- [[hestia-photos-sot]] — the plan where this misread happened
+- [synology per user photo symlinks](#synology-per-user-photo-symlinks) — the specific ACL trap that produced the silent skip in the hestia-SOT case
+- see [the hestia photos plan](./plans/2026-06-01-hestia-photos-sot.md) — the plan where this misread happened
 
 ---


### PR DESCRIPTION
These accumulated as working notes outside the repo and were only reachable from inside a tooling session. **Someone debugging Cilium at 2am has this repo, not that session.**

## What lands

| Runbook | Entries |
| --- | --- |
| Networking - Cilium netpol for Gateway API, LoadBalancer SNAT | 2 |
| Storage - PVC/PV immutability, Retain recovery, ZFS busy, TrueNAS, Synology | 9 |
| Cluster - Talos topology and sysfs, kubectl selectors, Flux | 6 |
| Services - CNPG, SOPS, mosquitto, signal-cli, Spotify, Mopidy | 7 |
| Operating principles - staging, registries, access, API versions | 5 |

Plus an index. Grouped by subsystem rather than one file per lesson.

## A few worth calling out

- **Cilium Gateway API needs all three of `host`, `remote-node`, `ingress`** in fromEntities. Envoy binds to a proxy IP with reserved identity 8; without `ingress` every Envoy-to-pod connection fails while direct `/dev/tcp` works.
- **PV Retain recovery** - the sequence to clear claimRef and rebind after a destroyed PVC.
- **ZFS dataset busy despite unmounted** - a hestia bind-mount is holding it.
- **Audit PVCs before destroying them as lossy** - small Deployment PVCs hold SQLite and configs.

The index warns to read storage before destroying anything, because several entries are data-loss adjacent.

## Not in this PR

The source notes stay where they are. They become pointer stubs in a follow-up **after** this lands, so nothing is lost if this is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sdWWB7AnP1Ya1AqLHUN1X