### PR TITLE
docs(plans): hestia deploy monitoring gap and sshd refused-connection diagnosis

### DIFF
--- a/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
+++ b/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
@@ -1,0 +1,235 @@
+---
+status: planned
+last_modified: 2026-08-18
+summary: "hestia has no per-container metrics and no signal when the GitHub runner dies, so deploys failed silently for days; close it with an off-cluster canary, post-apply verification, and a container probe on the heartbeat that already exists"
+---
+
+# Plan: close the hestia deploy blind spot
+
+## Context — the incident that exposed it
+
+On 2026-08-18 a merge to `master` touching `hosts/hestia/**` produced a
+`deploy-hestia.yml` run that sat **queued indefinitely**. The self-hosted runner
+on hestia was crash-looping:
+
+```
+Current runner version: '2.334.0'
+An error occurred: Runner version v2.334.0 is deprecated and cannot receive messages.
+RestartCount = 11894
+```
+
+The runner registered with GitHub successfully every time, was told its version
+was too old, exited, and was restarted by `unless-stopped`. GitHub reported it
+`status=offline`. An earlier Renovate deploy run had been sitting queued,
+unnoticed, since well before that.
+
+**Nothing alerted.** Not the crash loop, not the offline runner, not the queued
+run, not the fact that the deployed image had drifted several digests behind
+`master`.
+
+## The blind spot is four gaps, not one
+
+Every layer that could have caught this was scoped to Kubernetes or to
+scheduled jobs.
+
+**1. Monitoring on hestia is per-process, not per-container.** There are exactly
+four Prometheus scrape targets on hestia — node-exporter (`:9100`), netscope
+(`:9101`), thermalscope (`:9102`), ipmi-exporter (`:9290`). Verified live,
+`count({__name__=~"container_.*", instance="hestia"})` returns an **empty
+vector**. There is no cAdvisor and no docker exporter. The node-exporter runs
+`--collector.disable-defaults --collector.textfile`, so there are not even
+`node_*` series for hestia — it is a textfile courier, deliberately.
+
+**2. The Kubernetes-shaped alerts create false confidence.**
+`ContainerCrashLoopBackOff`, `ContainerOOMKilled` and `ContainerHighCPU` exist
+in `infra/configs/alerts/prometheus-rules.yaml` and work correctly — for pods.
+Their `expr` is `kube_pod_container_status_*` / `container_cpu_usage_seconds_total`,
+i.e. kube-state-metrics and cAdvisor. hestia is not a node in this cluster. The
+alert *names* read as coverage the cluster does not have.
+
+**3. homelabscope's model does not fit an event-driven pipeline.** The
+`homelabscope_job_*` family is "last success plus a max-age budget", which is
+exactly right for the 11 scheduled jobs it covers. `deploy-hestia.yml` fires on
+push: no cadence, no expected freshness, no natural `max_age` to compare
+against. The deploy path was structurally ineligible for the one general
+mechanism that would otherwise have covered it.
+
+**4. A queued run is not a failed run.** GitHub emails on workflow *failure*. A
+run nobody picks up never fails and never notifies. Runner `status=offline` is
+visible only in a Settings UI that nothing polls. GitHub's own tooling is
+structurally silent about precisely this state.
+
+### The failure was self-concealing
+
+`DISABLE_AUTO_UPDATE: "true"` means the runner cannot upgrade past GitHub's
+minimum version on its own. The fix is a digest bump, which Renovate does open
+and merge — but `hosts/hestia/actions-runner/` is **unconditionally excluded**
+from `deploy-hestia.yml`. So the repair for the broken deploy path was itself
+gated behind a manual step nobody was nagged about, and the runner could not
+deploy its own fix.
+
+### Drift is already real, and already invisible
+
+`thermalscope` carries `x-deploy.archived: true` in
+`hosts/hestia/monitoring/docker-compose.yml` — archived 2026-05-16 with the note
+"will crash-loop without nvidia-smi". It is **`up=1` and being scraped right
+now.** Repo state and box state have already diverged. Nothing noticed. This
+also means `x-deploy.archived` is not a trustworthy source for any
+"should-be-running" watchlist.
+
+## Proposal
+
+Three mechanisms for three genuinely different detection problems.
+
+### A. A hestia container is down or crash-looping
+
+Extend **`homelabscope-heartbeat`**, which already runs on hestia as a
+`privileged: true` bash loop writing `.prom` textfiles. Mount
+`/var/run/docker.sock:ro` and add a probe emitting a new family alongside the
+existing one:
+
+```
+homelabscope_container_running{name}
+homelabscope_container_restarts_total{name}
+homelabscope_container_health{name}
+```
+
+Then one alert pair in `infra/configs/homelabscope/prometheus-rule.yaml`,
+structurally identical to the existing `Stale` / `MetricAbsent` pair:
+`running == 0 for 10m`, and `increase(restarts_total[1h]) > 5`. Both
+**`severity: critical`**.
+
+Why extend rather than add an exporter: the heartbeat container is already
+privileged with `/dev/zfs`, so the socket mount raises no privilege bar; it is
+already scraped, already alerted on, and the Grafana dashboard is generic over
+the family so new series appear with zero dashboard work. Most importantly
+**the watcher is already watched** — if the heartbeat dies, the existing
+`HomelabscopeJobMetricAbsent` guard on the ZFS snapshot jobs it writes will
+fire. A new exporter would need its own liveness story built from scratch.
+
+An `absent()` guard over an explicit must-exist list is required: a *removed*
+container emits nothing at all, and `== 0` cannot see that. This is the same
+lesson `HomelabscopeJobMetricAbsent` already encodes.
+
+Would have caught this incident: **yes** — 11894 restarts trips the restart-rate
+arm within the hour. Covers `libation` and every future hestia container for
+free.
+
+### B. The runner is offline or a run is stuck queued
+
+A new **hourly canary workflow**: `on: schedule`, one job on
+`runs-on: [self-hosted, hestia]`, whose only step is a `curl` to a second
+healthchecks.io check (Period 1h, Grace 1h).
+
+This is strictly stronger than "the container is running" — it proves GitHub can
+dispatch, the runner picks up, and the runner executes: the entire path that was
+broken. It is also the only proposal here that lives **off-cluster**, so it
+survives the 2026-08-13 failure mode where Prometheus kept evaluating while
+ingesting nothing and every in-cluster alert froze.
+
+Would have caught this incident: **yes** — red within ~2h.
+
+**Rejected alternative:** polling `GET /actions/runs?status=queued` and
+`/actions/runners` into a textfile. It needs `actions:read` and
+`administration:read`; the existing hestia PAT is fine-grained `Contents:
+read-only`. That is a new high-privilege credential with a 1-year expiry tail,
+bought to detect "queued while the runner is healthy" — a case that barely
+exists, because a healthy runner drains the queue.
+
+### C. A deploy reported success and did nothing
+
+**C1 — post-apply verification in `scripts/truenas-update-app.sh`.** After
+`app.update` returns `SUCCESS`, poll `docker inspect` on the target container
+and assert the running image matches the compose. Exit non-zero on mismatch.
+The script already runs inside the runner container, which already has
+`/var/run/docker.sock` mounted — no new access needed.
+
+This matters because the silent no-op is a *known, documented* bug
+(`docs/operations/2026-05-14-truenas-app-update-quirk.md`): `app.update` returns
+`SUCCESS` without taking effect against a crash-looping container. C1 converts
+that into a **red workflow run, which GitHub does email about** — reusing a
+notification path that already works.
+
+Needs a bounded poll (~60–120s), not a single check, to absorb the race between
+`app.update` returning and TrueNAS finishing the recreate.
+
+**C2 — drift check, appended to the canary workflow.** Extend
+`truenas-update-app.sh --dry-run` to exit non-zero on a non-empty diff, run
+hourly across all apps. Two distinct drifts must both be covered:
+
+- repo → `app.config` — catches merged-but-never-applied changes (the queued
+  Renovate deploy)
+- `app.config` → `docker inspect` — catches the no-op
+
+`--dry-run` never calls `app.update`, so it is safe to run against
+`hosts/hestia/actions-runner/` **even though that path is excluded from apply**
+— include it, and the manual runner upgrade finally gets nagged.
+
+Main implementation risk: benign normalisation differences between repo YAML and
+what the Apps subsystem stores (key ordering, injected defaults). Without a
+normalising comparison this cries wolf hourly and gets ignored, which is worse
+than not having it.
+
+## Recommended order
+
+**Precondition: the runner must be healthy first**, or step 1's check is born
+red. That is a manual redeploy at the current pinned digest — the runner cannot
+deploy its own fix.
+
+1. **Canary workflow** — `.github/workflows/runner-canary.yml`, a second
+   healthchecks.io check, ping URL as a repo secret. Update
+   `docs/reference/monitoring.md` §7 and `hosts/hestia/actions-runner/README.md`.
+   Smallest change, biggest coverage, off-cluster.
+2. **Post-apply verification** — `scripts/truenas-update-app.sh`. Cross-reference
+   from the app-update-quirk runbook so it stops being manual folklore.
+3. **Container probe** — heartbeat image, compose, prometheus-rule. Ships as two
+   PRs per the established pattern: build the image, then pin the digest and add
+   the `absent()` guards once the series are confirmed live. Guarding a
+   not-yet-present series is a guaranteed false critical.
+4. **Drift check** — last, highest false-positive risk, and it wants (2)'s
+   comparison logic proven first.
+5. `docs/STATUS.md` — Known issues entry and follow-ups.
+
+## Explicitly not doing
+
+- **cAdvisor on hestia.** A heavy scrape target with known cardinality problems,
+  to answer up/down/restarts for ~8 containers. Prometheus here has 10d
+  retention on iSCSI storage that has already gone read-only once (2026-08-13).
+  A 30-line bash probe answers the question at a fraction of the series count.
+- **Enabling node-exporter default collectors on hestia.** Different concern
+  (host metrics), doubles the scrape, the disable is a deliberate documented
+  choice, and it would not have caught this. Its own PR if wanted.
+- **Shipping hestia docker logs to Loki.** It would have matched the literal
+  deprecation string, but it is a new agent and pipeline on hestia, and
+  string-matching alerts rot the moment upstream rewords the message. Restart
+  count is a far more durable invariant than a log line.
+- **A dedicated GitHub Actions Prometheus exporter.** New component, new
+  credential, new upgrade surface, for a case the canary already covers.
+- **Alerting on Docker `unhealthy` alone.** The runner *had* a healthcheck
+  (`pgrep -f Runner.Listener`, 60s) and it bought nothing — nothing queries it.
+  Worse, a crash-looping container reports `starting` or vanishes rather than
+  `unhealthy`, so the one signal it emits is the wrong one.
+- **Any of this at `severity: warning`.** Warnings route to `+alerts@` behind a
+  skip-inbox filter this repo documents as effectively unread, on a 24h repeat.
+  The deploy path being dead is critical or it is nothing. Note also the default
+  route receiver is `null` — an alert with no `severity` label is silently
+  discarded.
+
+## Open questions
+
+- **`DISABLE_AUTO_UPDATE: "true"` — keep or flip?** Keeping it is deterministic
+  and Renovate-pinnable but **guarantees this recurs** at the next deprecation.
+  Flipping it self-heals but makes the runner permanently diverge from its
+  pinned digest, turning the C2 drift check into permanent noise for that app.
+  These conflict; pick one and write down which.
+- **Should `hosts/hestia/actions-runner/` stay excluded from auto-apply?**
+  Recommended: keep manual, rely on the C2 nag. The alternative is a two-phase
+  detached self-deploy with a real risk of bricking the deploy path.
+- **Watchlist for A.** Which containers are "must be running"? `x-deploy.archived`
+  is not trustworthy — see thermalscope above. Explicit list, or reconcile the
+  archived flags first?
+- **healthchecks.io concentration.** The canary and the existing Watchdog check
+  would share one free account. A lapsed account silently kills the deadman with
+  nothing in-cluster noticing; two checks doubles that blast radius.
+- **Does alcatraz's runner get the same canary now**, or wait for its operator
+  bootstrap? It has the identical blind spot by construction.

--- a/docs/plans/2026-08-18-hestia-sshd-refused-diagnosis.md
+++ b/docs/plans/2026-08-18-hestia-sshd-refused-diagnosis.md
@@ -1,0 +1,270 @@
+---
+status: planned
+last_modified: 2026-08-18
+summary: "hestia's sshd intermittently refuses port 22 while every other service stays up; the MaxStartups theory carried across sessions is disproven, so collect wedged-state evidence before changing any setting"
+blocked_on: "Evidence from the wedged state, which has been destroyed 4-5 times by restarting the service before capturing it. Next wedge: capture from the TrueNAS web Shell over 443 BEFORE restarting."
+---
+
+# Plan: hestia sshd refuses port 22 — diagnose before treating
+
+## Signature
+
+```
+ICMP ping        0% loss
+TCP 80/443/3260  OPEN
+TCP 22           REFUSED
+```
+
+The data plane is entirely healthy throughout — 161 pods running, iSCSI fine.
+Only sshd is affected. Recovery is a manual TrueNAS UI → System Settings →
+Services → SSH → restart; it does not self-heal.
+
+Observed triggers: it wedged after roughly **4 short-lived SSH sessions in ~2
+minutes**, and again after 5 short invocations fired in quick succession. It has
+also re-wedged ~15 minutes after a restart with 6 users connected. **A single
+long session reliably survives where several short ones do not.**
+
+## The standing hypothesis is disproven
+
+Prior sessions recorded this as *"sessions accumulating and not being reaped"*
+and pointed at `MaxSessions` / `MaxStartups`. Two independent lines of evidence
+say that is the wrong tree.
+
+**`MaxStartups` cannot produce `ECONNREFUSED`.** Its check runs in sshd's
+`drop_connection()` path, *after* the kernel has completed the three-way
+handshake and `accept()` has returned a socket. The client sees the TCP connect
+succeed and then get closed —
+`kex_exchange_identification: read: Connection reset by peer` or
+`Connection closed by remote host`. Never "Connection refused".
+([`sshd_config(5)`](https://man.openbsd.org/sshd_config), OpenSSH `sshd.c`.)
+It also self-clears as unauthenticated connections drain, which is incompatible
+with a fault that persists until a service restart.
+
+**`MaxSessions` is further off still.** It limits shell/exec/subsystem *channels
+within one already-authenticated connection*. It cannot affect a new TCP
+connect, and it would make the "one long session" workaround worse, not better —
+the opposite of what we observe. The hypothesis on file conflates channel count
+with connection count.
+
+A genuine `ECONNREFUSED` is a kernel-level RST at SYN. That narrows the field
+sharply.
+
+## Competing explanations
+
+Ranked by fit to the observed signature.
+
+**H — systemd socket activation tripping a trigger limit. Leading candidate.**
+If sshd is fronted by `ssh.socket` and it trips `TriggerLimitBurst` /
+`StartLimitBurst`, the socket unit enters `failed`, the kernel has no listener,
+and every subsequent connect is refused — and only a service restart re-arms it.
+This fits **all four observations simultaneously**: refused rather than filtered,
+triggered by a burst of short connections, harmless to one long connection, and
+recoverable only by restart. *Confirm:* `systemctl status ssh.socket` shows
+`failed` with `Result=trigger-limit-hit` or `start-limit-hit`, `NRefused`
+non-zero. *Rule out:* `ssh.socket` does not exist or is not enabled.
+
+**A — the sshd master is simply gone.** Debian's stock `ssh.service`
+historically carries no `Restart=`, so a crash leaves the unit dead with nothing
+listening until someone restarts it. *Confirm:* no listener in
+`ss -ltnp 'sport = :22'`, unit `failed`/`inactive`, `NRestarts` incremented.
+*Rule out:* a listener present while connections are still refused.
+
+**E — resource exhaustion in the accept loop.** fd/task limits causing sshd to
+stop calling `accept()`. Normally yields *filtered*, not refused — **unless**
+`net.ipv4.tcp_abort_on_overflow=1`, which converts backlog overflow into RST.
+That sysctl is the only thing reconciling E with this signature, so check it
+explicitly.
+
+**F — a packet filter REJECTs port 22.** Docker 29.4 under TrueNAS Apps rewrites
+nft rules on container churn. *Confirm:* a `reject` rule matching dport 22
+present only when wedged. *Rule out:* identical ruleset healthy vs wedged.
+
+**G — middleware regenerating `sshd_config` and failing to restart.**
+*Confirm:* `/var/log/middlewared.log` shows an ssh config write or
+`service.control` call just before the wedge; `sshd -t` non-zero.
+
+**D — stale sshd children accumulating.** The hypothesis on file. Kept because
+it is cheap to test, not because it explains a refused connect. *Confirm:*
+`pgrep -c sshd` ratchets up per short session and never returns to baseline.
+
+**B / C — `MaxStartups` / `MaxSessions`.** Disproven above. Retained only so the
+diagnosis records why, and so `journalctl` is checked for
+`drop connection #N ... [preauth]` — whose *absence* over 14 days, given
+repeated wedges, is close to conclusive.
+
+## A load source nobody counted
+
+`infra/controllers/democratic-csi/values.yaml` still sets `driver:
+truenas-iscsi`, which resolves to `FreeNASSshDriver`. **Every volume provision,
+expand and delete opens an SSH session from the cluster into hestia's sshd**,
+and expand runs `sudo sh -c "echo 1 > .../resync_size"`. The GHA runner and the
+immich rsync jobs are further automated clients.
+
+So "4 short-lived interactive sessions" is very likely undercounting the real
+session rate by a wide margin — the interactive sessions may be the straw rather
+than the load. `docs/plans/2026-06-28-democratic-csi-ssh-to-api-driver.md`
+(blocked on TrueNAS 26.x) now has a second, independent justification.
+
+## Prior art
+
+- `docs/operations/incidents/2026-04-25-hifiberry-ui-tcp-socket-exhaustion.md` —
+  **closest structural analogue.** A listener that was `active (running)` in
+  systemd but functionally dead because sockets accumulated in `CLOSE_WAIT`
+  until the accept backlog filled. `/proc/net/tcp` inspection was the definitive
+  diagnostic, and `systemctl restart` hung where `kill -9` plus auto-restart
+  worked. **Different in one crucial respect:** that failure presented as
+  *filtered* (SYNs dropped). This one presents as *refused* (RST).
+- `docs/operations/hifiberry-os-watchdog.md` — directly reusable mitigation
+  shape (cron probes localhost, restarts the stuck service, logs via `logger`).
+- `docs/operations/2026-05-14-truenas-app-update-quirk.md` — precedent that
+  TrueNAS middleware reports `SUCCESS` on operations that did not take effect.
+  Relevant to trusting a UI-driven SSH restart.
+- **No incident postmortem exists for this**, and `docs/STATUS.md` does not
+  mention it. That is why it has been re-diagnosed from scratch across multiple
+  sessions.
+
+## Diagnosis
+
+### The evidence only exists while wedged, and we keep destroying it
+
+Restarting the SSH service is the first thing anyone does, and it erases the
+state. That has now happened four or five times. **The next wedge is the
+opportunity.**
+
+SSH is by definition unavailable, so capture out of band:
+
+1. **TrueNAS UI → System Settings → Shell**, over 443, which is confirmed to
+   stay OPEN during the wedge. *Verify this path works while healthy, before
+   needing it.*
+2. **IPMI at `10.42.2.13`** (ASRock BMC) → HTML5 console, if the web UI is also
+   impaired.
+
+Minimum capture, in this order, **before touching restart**:
+
+```bash
+systemctl status ssh.service ssh.socket --no-pager -l
+systemctl show ssh.socket -p Accept -p MaxConnections -p TriggerLimitBurst -p NRefused -p Result
+ss -ltnp 'sport = :22'
+ss -tan 'sport = :22' | awk '{print $1}' | sort | uniq -c
+pgrep -c sshd; who | wc -l
+nft list ruleset | grep -nE 'reject|dport 22'
+sysctl net.ipv4.tcp_abort_on_overflow
+journalctl -u ssh.service -u ssh.socket --since '-1h' --no-pager | tail -100
+```
+
+`systemctl status ssh.socket` is the single highest-value line: it decides
+between H and everything else.
+
+### Healthy baseline — one batched session
+
+Run once, healthy, changing nothing, so the wedged capture has something to diff
+against. **One `ssh` invocation feeding a script on stdin** — never a loop of
+short connections, which is the thing that appears to trigger the fault.
+
+Capture: unit topology (`systemctl cat ssh.service ssh.socket`), effective
+config as sshd parses it (`sshd -T | grep -iE 'maxstartups|maxsessions|clientalive'`),
+process and session counts, socket states on :22, fd headroom against
+`LimitNOFILE`, the nft ruleset, 14 days of `journalctl -u ssh`, `midclt call
+ssh.config`, and a per-source histogram of accepted connections over 24h to
+quantify the automated clients.
+
+### Flight recorder — the highest-value action available
+
+A 30-second sampler appending `date`, `pgrep -c sshd`, listener presence, socket
+state counts, `systemctl is-active ssh.service ssh.socket`, and the master's fd
+count to a rolling file on `/mnt/main`.
+
+When it wedges, read the file **over NFS/SMB from any machine, with no shell
+access at all**, and get the *trajectory into* the wedge rather than a post-hoc
+snapshot.
+
+Install it as a **TrueNAS UI → System Settings → Advanced → Cron Job**, not a
+hand-rolled systemd timer: cron jobs live in the middleware config DB and are
+included in config backups, whereas anything written into `/etc` is discarded
+when the OS dataset is swapped on upgrade.
+
+It changes nothing about how sshd behaves.
+
+## Mitigations, ranked
+
+1. **Formalise the batch-into-one-session discipline.** Zero change on hestia,
+   fully reversible, survives upgrades trivially. Write it into
+   `hosts/hestia/README.md` as a hard rule: every interaction is one
+   `ssh … 'bash -s' <<EOS` invocation, never a loop of short ones. Optionally
+   `ControlMaster auto` / `ControlPersist 10m` for `10.42.2.10` in
+   `~/.ssh/config` to make it automatic. *Caveat:* multiplexing collapses N
+   sessions onto one connection and N channels — helps against connection-rate
+   limits, hurts against `MaxSessions` (default 10). Given C is near-ruled-out,
+   net win.
+2. **Flight recorder** (above). Trivially reversible, near-zero blast radius.
+3. **External TCP probe + alert.** The cluster runs kube-prometheus-stack but has
+   **no blackbox exporter**. A TCP probe of `10.42.2.10:22` every 30s converts
+   "George notices" into a timestamped onset. Must carry a `severity` label —
+   the default route receiver is `null` and unlabelled alerts are silently
+   dropped.
+4. **Reduce automated session churn** — quantify the CSI driver's rate first;
+   see above.
+5. **sshd tuning via SCALE UI → Services → SSH → Auxiliary Parameters.** The one
+   supported path for arbitrary directives; stored in the middleware config DB
+   and re-emitted on every regeneration, so it survives upgrades. **Moderate-to-high
+   risk: a malformed parameter can stop sshd starting and lock you out.**
+   Preconditions: web Shell open in a browser tab and IPMI reachable before
+   applying. Candidates *contingent on diagnosis*: `ClientAliveInterval 60` +
+   `ClientAliveCountMax 3` (the reaper, if D confirms), `LoginGraceTime 30`.
+6. **Watchdog cron** probing `127.0.0.1:22`, recovering via
+   `midclt call service.control RESTART ssh` (the middleware owns the service;
+   `systemctl restart` skips its bookkeeping). Require **3 consecutive
+   failures**, `logger`-tag every action. Deploy it *with* the flight recorder,
+   never instead of it, or a diagnosable failure becomes an invisible one.
+7. **Hand-editing `/etc/ssh/sshd_config` or a systemd drop-in.** Listed only to
+   be rejected: SCALE regenerates `sshd_config` from
+   `sshd_config.mako` against the config DB on every service start, so edits are
+   reverted or ignored, and `/etc` does not survive an upgrade. If a
+   systemd-level change is genuinely required (H's `TriggerLimitBurst`), that is
+   an iX bug report, not a local hand-edit.
+
+**The correct first step is 1 + 2 + 3 and nothing else.** Every server-side knob
+currently on the table aims at a hypothesis the refused signature already argues
+against.
+
+## Verification
+
+There is **no quantitative reproduction yet**, which means there is currently no
+way to claim a fix is a fix.
+
+1. **Build one.** With web Shell and IPMI already open, run N sequential short
+   ssh invocations with a TCP probe between each; record the connection index at
+   which refusal begins and `pgrep -c sshd` throughout. Anecdotally 4–6. Run it
+   twice to check the number is stable.
+2. **Post-change gate:** the same burst at **5× the failure count** (wedges at 5
+   → run 25), with `pgrep -c sshd` returning to baseline afterwards. Necessary,
+   not sufficient.
+3. **Soak:** the blackbox probe showing **zero refusals over 7 days** of normal
+   workload, including at least one democratic-csi volume operation and one GHA
+   deploy run — a burst test does not exercise the automated clients.
+4. **Flight recorder stays running through the soak.** If it wedges anyway, we
+   get the trajectory instead of starting over for the sixth time.
+
+Do not declare it fixed on a quiet afternoon. The bar is the original signature
+confirmed gone under conditions that previously produced it.
+
+Record the outcome as
+`docs/operations/incidents/2026-08-XX-hestia-sshd-refused.md` and add a
+`docs/STATUS.md` Known-issues line in the same PR.
+
+## Open questions
+
+- **Is ssh socket-activated on TrueNAS SCALE 26.x?** The entire ranking pivots
+  on this and it is one `systemctl status ssh.socket` away.
+- **Is the refusal a genuine RST, or a probe artefact?** "REFUSED" from `nc`
+  means RST, which is what rules out `MaxStartups`. If some observations came
+  from `ssh` reporting `Connection closed by remote host`, that is a *different*
+  signature and reopens B. Confirm which tool produced the word.
+- **Does the TrueNAS web Shell actually work while sshd is refusing?** The whole
+  evidence plan depends on it. Test while healthy.
+- **How many SSH sessions per hour does democratic-csi actually open?**
+- **Is 26.x recent enough that a middleware regression (G) is likely?** If so the
+  response is a bug report, not local tuning.
+- **What happened in the 15-minutes-after-restart recurrence with 6 users?** No
+  current hypothesis explains it well. The journal from that window would settle
+  whether this is a rate limit or a slow leak.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -79,10 +79,12 @@ see `scripts/plans-index/`).
 | [2026-05-02-critique-remediation.md](2026-05-02-critique-remediation.md) | 2026-05-04 | IaC hardening — close the 22 findings from the 2026-05-02 critique |
 | [2026-03-14-navidrome-snapcast-mopidy.md](2026-03-14-navidrome-snapcast-mopidy.md) | 2026-06-10 | Navidrome → Mopidy → Snapcast → HifiBerry audio pipeline — draft PR #426 open, not yet on master |
 
-### Planned (16)
+### Planned (18)
 
 | File | Last modified | Summary |
 | :--- | :--- | :--- |
+| [2026-08-18-hestia-sshd-refused-diagnosis.md](2026-08-18-hestia-sshd-refused-diagnosis.md) | 2026-08-18 | hestia's sshd intermittently refuses port 22 while every other service stays up; the MaxStartups theory carried across sessions is disproven, so collect wedged-state evidence before changing any setting — **blocked:** Evidence from the wedged state, which has been destroyed 4-5 times by restarting the service before capturing it. Next wedge: capture from the TrueNAS web Shell over 443 BEFORE restarting. |
+| [2026-08-18-hestia-deploy-monitoring-gap.md](2026-08-18-hestia-deploy-monitoring-gap.md) | 2026-08-18 | hestia has no per-container metrics and no signal when the GitHub runner dies, so deploys failed silently for days; close it with an off-cluster canary, post-apply verification, and a container probe on the heartbeat that already exists |
 | [2026-08-09-local-deadman-mesh.md](2026-08-09-local-deadman-mesh.md) | 2026-08-09 | Cross-monitor k8s, hestia and alcatraz so each reports the others' death, with healthchecks.io as the arbiter that tells one-box failure from a site event — **blocked:** Operator: are the Talos nodes, hestia and alcatraz on the same UPS/circuit? Determines how much this buys. |
 | [2026-08-08-alertmanager-local-durability.md](2026-08-08-alertmanager-local-durability.md) | 2026-08-09 | Gap 2 (deadman) resolved 2026-08-09; the remaining open item is node-local volumes for state across a simultaneous restart |
 | [2026-08-05-alertmanager-alert-history.md](2026-08-05-alertmanager-alert-history.md) | 2026-08-05 | Fired-alert history: Grafana state-timeline over Prometheus ALERTS vs. a notification-log webhook receiver |


### PR DESCRIPTION
Two plans from tonight's incidents. **Neither proposes changing anything on the
box yet** — both are about being able to see what's happening first.

## 1. Deploy monitoring gap

A merge sat queued because the self-hosted runner was crash-looping on
`Runner version v2.334.0 is deprecated` — **RestartCount 11894** — and nothing
alerted. An earlier Renovate deploy had been queued unnoticed for longer.

**Four gaps, not one:**

- hestia has **no per-container metrics at all** — verified live,
  `count({__name__=~"container_.*", instance="hestia"})` returns empty. No
  cAdvisor, no docker exporter. Not even host metrics: its node-exporter runs
  `--collector.disable-defaults --collector.textfile`.
- `ContainerCrashLoopBackOff` *reads* like coverage but is
  `kube_pod_container_status_*` — pods only. hestia isn't in the cluster.
- homelabscope's "last success + max-age" model structurally cannot cover a
  push-triggered pipeline.
- A queued run never fails, so GitHub never emails.

**It was self-concealing.** `DISABLE_AUTO_UPDATE: "true"` means the runner
can't upgrade itself, and `hosts/hestia/actions-runner/` is excluded from
`deploy-hestia.yml` — so the fix for the broken deploy path was gated behind a
manual step nobody was nagged about.

**Drift is already real and invisible:** `thermalscope` is
`x-deploy.archived: true` in the repo and `up=1` on the box right now.

Proposal: an hourly canary workflow (off-cluster, proves the whole dispatch
path, no new PAT), post-apply verification in `truenas-update-app.sh` (turns
the documented silent no-op into a red run GitHub *does* email about), and a
container probe on the `homelabscope-heartbeat` that already runs privileged,
is already scraped, and is already watched by an existing `absent()` guard.

## 2. sshd refused-connection diagnosis

**The hypothesis we've carried across sessions is disproven.** `MaxStartups`
drops happen in `drop_connection()` *after* `accept()` returns — the client
sees a completed handshake then a reset, **never `ECONNREFUSED`** — and it
self-clears as connections drain rather than needing a restart. `MaxSessions`
governs channels inside an authenticated connection and cannot affect a new
connect at all.

Our signature is *refused*, which is a kernel RST. New leading candidate:
**systemd socket activation tripping a trigger limit** — `ssh.socket` enters
`failed`, no listener exists, every connect is refused, only a restart re-arms
it. That fits refused-not-filtered, burst-triggered, one-long-session-is-fine,
and restart-only-recovery *simultaneously*.

Also records a load source nobody counted: **democratic-csi still uses the SSH
driver**, so every volume provision/expand/delete opens an SSH session into
hestia. The interactive sessions may be the straw, not the load.

First step is explicitly **collect evidence, change nothing**. The
discriminating data exists only while wedged and we've destroyed it 4–5 times
by restarting first. Next wedge gets captured from the TrueNAS web Shell over
443 before anything is touched.

---

`make plans-index` regenerated; `plans-index-check` passes (57 plans).