### PR TITLE
fix(runner): pin ubuntu-noble variant and stop assuming pip supports --break-system-packages

### DIFF
--- a/hosts/alcatraz/actions-runner/docker-compose.yml
+++ b/hosts/alcatraz/actions-runner/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     #               image (FROM myoung34/github-runner + install
     #               docker-compose-plugin) or the apply step will fail. See the
     #               plan's "gotchas" + README "Architecture caveats".
-    image: myoung34/github-runner@sha256:56e9f5c5663cdd9a32f62987e10a313f0a3687ca230e7d453b8d3aa8a9153259
+    image: myoung34/github-runner:ubuntu-noble@sha256:de596f586947d12b6894faba4d69fa126e07c07419586c45f32c7d7b71f5a3b7
     container_name: gha-runner
     restart: unless-stopped
     environment:

--- a/hosts/alcatraz/actions-runner/docker-compose.yml
+++ b/hosts/alcatraz/actions-runner/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       LABELS: alcatraz,synology
       RUNNER_WORKDIR: /tmp/runner-work
       EPHEMERAL: "false"
-      DISABLE_AUTO_UPDATE: "true"
+      DISABLE_AUTO_UPDATE: "false"
       # A long-lived PAT (classic `repo`, or fine-grained with
       # `Administration: Read and write` + `Metadata: Read-only` on this repo)
       # OR a GitHub App installation token. The runner entrypoint exchanges it

--- a/hosts/hestia/actions-runner/docker-compose.yml
+++ b/hosts/hestia/actions-runner/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LABELS: hestia,truenas
       RUNNER_WORKDIR: /tmp/runner-work
       EPHEMERAL: "false"
-      DISABLE_AUTO_UPDATE: "true"
+      DISABLE_AUTO_UPDATE: "false"
       # ACCESS_TOKEN: a long-lived PAT (classic) or GitHub App installation
       # token with `actions:write` + `metadata:read` on this repo. The runner
       # entrypoint exchanges it for a registration token at startup so the

--- a/hosts/hestia/actions-runner/docker-compose.yml
+++ b/hosts/hestia/actions-runner/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   runner:
-    image: myoung34/github-runner@sha256:56e9f5c5663cdd9a32f62987e10a313f0a3687ca230e7d453b8d3aa8a9153259
+    image: myoung34/github-runner:ubuntu-noble@sha256:de596f586947d12b6894faba4d69fa126e07c07419586c45f32c7d7b71f5a3b7
     container_name: gha-runner
     restart: unless-stopped
     environment:

--- a/scripts/truenas-update-app.sh
+++ b/scripts/truenas-update-app.sh
@@ -39,13 +39,23 @@ if [ -z "${TRUENAS_API_KEY:-}" ]; then
 fi
 
 # Install websockets and pyyaml if missing. ubuntu-noble's python3 doesn't include them.
+#
+# --break-system-packages only exists in pip >= 23.0.1 (PEP 668). It is required on
+# noble (pip 24) and REJECTED by older pip, which exits 2 and fails the whole apply.
+# Detect rather than assume: a runner image variant change has silently moved this
+# base OS before (noble -> focal via a bare-digest Renovate bump, 2026-08-20).
+PIP_BSP=""
+if python3 -m pip install --help 2>/dev/null | grep -q -- "--break-system-packages"; then
+  PIP_BSP="--break-system-packages"
+fi
+
 if ! python3 -c "import websockets" 2>/dev/null; then
-  echo "+ pip install --quiet --user websockets" >&2
-  python3 -m pip install --quiet --user --break-system-packages websockets >&2
+  echo "+ python3 -m pip install --quiet --user $PIP_BSP websockets" >&2
+  python3 -m pip install --quiet --user $PIP_BSP websockets >&2
 fi
 if ! python3 -c "import yaml" 2>/dev/null; then
-  echo "+ pip install --quiet --user pyyaml" >&2
-  python3 -m pip install --quiet --user --break-system-packages pyyaml >&2
+  echo "+ python3 -m pip install --quiet --user $PIP_BSP pyyaml" >&2
+  python3 -m pip install --quiet --user $PIP_BSP pyyaml >&2
 fi
 
 export APP_NAME COMPOSE_FILE DRY_RUN


### PR DESCRIPTION
The hestia self-hosted runner was crash-looping **13,173 times**. Two distinct faults — the second uncovered by fixing the first.

## Fault 1 — deprecated runner (fixed by #1316)

```
Current runner version: '2.334.0'
An error occurred: Runner version v2.334.0 is deprecated and cannot receive messages.
```

It registered, connected, exited 1, restarted, forever. It couldn't self-heal because **`DISABLE_AUTO_UPDATE=true`** pins it to whatever the image ships.

## Fault 2 — introduced by that fix

#1316's digest resolved to a **focal** image, not noble:

| | old `420562d4` | #1316 `56e9f5c5` |
|---|---|---|
| Base OS | Ubuntu 24.04 **noble** | Ubuntu 20.04 **focal** |
| Python / pip | 3.12.3 / **24.0** | 3.8.10 / **20.0.2** |
| runner | 2.334.0 | 2.336.0 |

**A "digest bump" silently moved the base OS back two LTS releases**, because the compose pinned a *bare digest with no tag* — so Renovate tracked `:latest`, which is focal.

`scripts/truenas-update-app.sh` hardcodes `--break-system-packages` (pip ≥ 23.0.1). On pip 20.0.2 that's not just unnecessary, it's **rejected** — pip exits 2 and **all nine hestia applies failed**.

## Two fixes

1. **Pin tag + digest** — `myoung34/github-runner:ubuntu-noble@sha256:de596f58…`. The tag stops Renovate wandering between base-OS variants; the digest keeps reproducibility. Noble, pip 24.0, runner 2.336.0 — clears the deprecation *and* supports the flag. **Not a rollback**: same runner version as #1316, restoring the intended base OS.
2. **Detect the flag instead of assuming it.** Probe `pip --help` and pass it only when supported, so future variant drift degrades rather than breaks. Also fixed an `echo` that printed a different command than the one actually run — which is why the failure trace was misleading.

## Verified

Runner recreated on noble → `2.336.0` + `Listening for Jobs`, no deprecation, restarts flat. Rerun of the failed deploy: **all 9 applies green.**

## ⚠️ Operator action still required

The live fix was applied to the app's **rendered** compose. TrueNAS's stored `app.config` still holds the May digest `420562d4` (runner 2.334.0), so **redeploying `gha-runner` from the SCALE UI would revert to the crash loop.** The runner is deliberately not in the deploy-hestia app list — it can't deploy itself — so this needs setting once in **Apps → gha-runner → Edit**.