### PR TITLE
feat(alerts): alert on the GitHub Actions runner and write its runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ The historical `docs/apps/`, `docs/guides/`, `docs/incidents/`, and `docs/infra/
 
 ### Per-app runbooks
 
-See [`operations/apps/`](operations/apps/) — Adguard, Audiobookshelf, Authelia, Excalidraw, Flashcards, Golinks, Hermes, Homepage, Immich, Jellyfin, Linkding, Mealie, Memos, Navidrome, Netscope, Snapcast, Vitals.
+See [`operations/apps/`](operations/apps/) — Adguard, Audiobookshelf, Authelia, Excalidraw, Flashcards, GHA Runner, Golinks, Hermes, Homepage, Immich, Jellyfin, Linkding, Mealie, Memos, Navidrome, Netscope, Snapcast, Vitals.
 
 ### Infrastructure component reference
 

--- a/docs/operations/apps/gha-runner.md
+++ b/docs/operations/apps/gha-runner.md
@@ -1,0 +1,235 @@
+# GHA Runner
+
+## 1. Overview
+`gha-runner` is the self-hosted GitHub Actions runner that gives this repo hands on the two boxes that are **not** Kubernetes nodes. It is the mechanism by which a merge to `master` becomes a change on a physical host:
+
+- **hestia** (TrueNAS SCALE, `10.42.2.10`) — [`hosts/hestia/actions-runner/`](../../../hosts/hestia/actions-runner/). Runs [`deploy-hestia.yml`](../../../.github/workflows/deploy-hestia.yml), which applies `hosts/hestia/**/docker-compose*.yml` changes through the TrueNAS WebSocket API (`app.update`) via [`scripts/truenas-update-app.sh`](../../../scripts/truenas-update-app.sh).
+- **alcatraz** (Synology DSM, `10.42.2.11`) — [`hosts/alcatraz/actions-runner/`](../../../hosts/alcatraz/actions-runner/). Runs [`alcatraz-deploy.yaml`](../../../.github/workflows/alcatraz-deploy.yaml), which applies `hosts/alcatraz/**` changes with a direct `docker compose up -d` against a bind-mounted Docker socket (Synology has no TrueNAS API).
+
+Both register against `gjcourt/homelab` at repo scope, both are the *one* compose on their host that an operator brings up by hand, and both are labelled by hostname (`hestia,truenas` / `alcatraz`).
+
+Design docs: [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../plans/2026-05-02-hestia-gha-runner.md), [`docs/plans/2026-06-26-alcatraz-gitops-docker.md`](../../plans/2026-06-26-alcatraz-gitops-docker.md). Per-host bootstrap: [`hosts/hestia/actions-runner/README.md`](../../../hosts/hestia/actions-runner/README.md), [`hosts/alcatraz/actions-runner/README.md`](../../../hosts/alcatraz/actions-runner/README.md).
+
+### The runner is deliberately excluded from auto-deploy
+This is the single most important fact about operating it.
+
+`deploy-hestia.yml` **unconditionally excludes** `hosts/hestia/actions-runner/` from its discover matrix, and `alcatraz-deploy.yaml` does the same for `hosts/alcatraz/actions-runner/`. The reason is chicken-and-egg: a runner cannot reliably deploy a compose change that recreates its own container — it would be killing the process executing the job that is doing the killing, mid-apply, with no way to report the result.
+
+**Consequence: runner upgrades are manual.** Renovate will happily open and merge a digest bump for the runner image, CI will go green, and *nothing will apply it*. The repo says one thing and the box runs another until a human opens the SCALE UI. This is not a bug to fix; it is a trade-off that has to be *watched*, which is what §7 is for.
+
+The self-concealing shape of it: when the runner is broken, the fix for the runner is itself gated behind the broken thing. See §8.
+
+## 2. Architecture
+```
+   git push master
+        │
+        ▼
+   GitHub Actions ──────dispatch──────▶ ┌──────────────────────────────┐
+   (deploy-hestia.yml)                  │ hestia (TrueNAS SCALE)       │
+        ▲                               │                              │
+        │  runner long-polls for work   │  ┌────────────────────────┐  │
+        └───────────────────────────────┼──│ gha-runner (Custom App)│  │
+                                        │  │ myoung34/github-runner │  │
+                                        │  │ restart: unless-stopped│  │
+                                        │  └───────────┬────────────┘  │
+                                        │              │ docker.sock   │
+                                        │              ▼               │
+                                        │  truenas-update-app.sh       │
+                                        │  → midclt app.update         │
+                                        │  → 9 other Custom Apps       │
+                                        └──────────────────────────────┘
+```
+
+- **Image**: `myoung34/github-runner`, pinned **tag + digest** — `:ubuntu-noble@sha256:de596f58...`. Both halves matter; see §9.
+- **Deployment shape on hestia**: a TrueNAS SCALE **Custom App** named `gha-runner`, container `ix-gha-runner-runner-1`. SCALE stores the compose in an app database (`app.config`) and renders it to disk; the rendered file is not the source of truth (§6).
+- **Restart policy**: `restart: unless-stopped`. This is what turns a persistent startup failure into an unbounded crash loop rather than a stopped container — a stopped container is at least visible in `docker ps -a`, a crash loop looks "running" at any given instant.
+- **Persistence**: `/mnt/main/apps/actions-runner/work` (registration state `.runner` lives here).
+- **Privilege**: `/var/run/docker.sock` is bind-mounted. The runner can do anything Docker can do on hestia.
+- **Healthcheck**: `pgrep -f Runner.Listener`, 60s interval. Note this bought us **nothing** during the incident — nothing queries the healthcheck result, and a crash-looping container reports `starting` rather than `unhealthy`, so the one signal it emits is the wrong one.
+- **Auto-update**: `DISABLE_AUTO_UPDATE: "false"` (see §9).
+
+## 3. URLs
+- **Runner status**: https://github.com/gjcourt/homelab/settings/actions/runners — the authoritative view of `Idle` / `Active` / `Offline`.
+- **Workflow runs**: https://github.com/gjcourt/homelab/actions/workflows/deploy-hestia.yml
+- **TrueNAS SCALE UI**: https://10.42.2.10 → Apps → `gha-runner`
+- **Prometheus**: https://prometheus.burntbytes.com — `homelab_gha_runner_up`, `homelab_gha_runner_restart_count`, `homelab_gha_runner_last_check_timestamp_seconds`
+- **Alertmanager**: https://alertmanager.burntbytes.com
+
+## 4. Configuration
+Canonical compose lives in the repo; the values of the two secrets never do.
+
+| Variable | Purpose | Where the value lives |
+|----------|---------|-----------------------|
+| `ACCESS_TOKEN` | PAT / GitHub App token used to mint a short-lived registration token at startup. Needs repo **Administration: read/write** (or classic `repo`) — `Contents` alone yields `curl: (22) ... 403`. | Masked env var, SCALE UI (hestia) / `.env` (alcatraz) |
+| `TRUENAS_API_KEY` | Used by `truenas-update-app.sh` to call the WebSocket API. hestia only. | Masked env var, SCALE UI |
+| `REPO_URL`, `RUNNER_NAME`, `RUNNER_SCOPE`, `LABELS` | Registration identity. `LABELS` is what `runs-on:` matches. | Compose, committed |
+| `EPHEMERAL` | `"false"` — the runner is long-lived, not job-scoped. | Compose, committed |
+| `DISABLE_AUTO_UPDATE` | `"false"` — the runner self-updates its *software* when GitHub requires a newer version. | Compose, committed |
+
+### Updating the image
+Find the digest for the **tag you intend**, never for `latest`:
+```bash
+docker manifest inspect myoung34/github-runner:ubuntu-noble \
+  | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
+```
+Edit the `image:` line in both `hosts/hestia/actions-runner/docker-compose.yml` and `hosts/alcatraz/actions-runner/docker-compose.yml`, keeping `:ubuntu-noble@sha256:...` intact. Merge — then **apply it by hand** (§6), because nothing will apply it for you.
+
+## 5. Usage Instructions
+The runner has no UI. You interact with it through GitHub and through `docker` on the host.
+
+```bash
+# Is it registered and idle? (authoritative)
+open https://github.com/gjcourt/homelab/settings/actions/runners
+
+# What is it actually running?
+ssh truenas_admin@10.42.2.10 'docker inspect ix-gha-runner-runner-1 \
+  --format "{{.Config.Image}} restarts={{.RestartCount}} state={{.State.Status}}"'
+
+# Recent log — "Listening for Jobs" is the healthy steady state
+ssh truenas_admin@10.42.2.10 'docker logs --tail 50 ix-gha-runner-runner-1'
+
+# What TrueNAS believes the app should be (the source of truth)
+ssh truenas_admin@10.42.2.10 'sudo midclt call app.config gha-runner' | jq .
+```
+
+Pause it: SCALE UI → Apps → `gha-runner` → Stop. Workflows queue at GitHub until it comes back — they do **not** fail.
+
+Re-register from scratch: delete `/mnt/main/apps/actions-runner/work/.runner`, restart the app.
+
+## 6. Testing
+A runner is working when all three of these hold. Checking only the first is how a day of queued deploys goes unnoticed.
+
+1. **Registered**: the runner shows `Idle` at the settings URL above, with the expected labels.
+2. **Stable**: `RestartCount` is flat across two observations a minute apart, and the log's last lines are `Listening for Jobs` with no `deprecated` line.
+3. **Actually executing**: re-run the most recent `deploy-hestia.yml` run and watch it pick up. This is the only check that proves the whole path — GitHub dispatch → runner accept → apply → report. A container that is `running` proves none of it.
+
+```bash
+gh run list --workflow=deploy-hestia.yml --limit 5
+gh run rerun <run-id> --repo gjcourt/homelab
+```
+
+Verify the running image matches the repo after any change:
+```bash
+grep image: hosts/hestia/actions-runner/docker-compose.yml
+ssh truenas_admin@10.42.2.10 'docker inspect ix-gha-runner-runner-1 --format "{{.Image}} {{.Config.Image}}"'
+```
+
+## 7. Monitoring & Alerting
+Three alerts in the `gha-runner` group of [`infra/configs/alerts/prometheus-rules.yaml`](../../../infra/configs/alerts/prometheus-rules.yaml), over a metric family emitted by the container probe on hestia and exported via the node-exporter textfile collector:
+
+```
+homelab_gha_runner_up{runner}                            1 = healthy, 0 = not
+homelab_gha_runner_restart_count{runner}                 docker RestartCount, gauge
+homelab_gha_runner_last_check_timestamp_seconds{runner}  unix seconds
+```
+
+**Routing.** `severity: critical` → `email-critical` → `gjcourt+critical@gmail.com`, 4h repeat, no Gmail skip-inbox filter — it reaches the inbox, i.e. it **pages**. `severity: warning` → `email-warning` → `gjcourt+alerts@gmail.com`, 24h repeat, filtered out of the inbox — an opt-in nag. An alert with **no** `severity` label falls through to the default `null` receiver and is discarded silently. A genuinely broken runner is therefore critical by construction.
+
+| Alert | Expression | Severity | Meaning and response |
+|-------|-----------|----------|----------------------|
+| `GHARunnerDown` | `homelab_gha_runner_up == 0` for 10m | **critical** (pages) | The runner is not healthy. Every workflow targeting it is now **queued, not failed** — GitHub will never email about this, so this alert is the only signal. **Response:** confirm at the runners settings page (`Offline`?); `docker logs --tail 50 ix-gha-runner-runner-1`; if the container is gone or stopped, SCALE UI → Apps → `gha-runner` → Start. If it comes up and immediately dies, treat it as a crash loop below. Once healthy, **re-run every queued/skipped `deploy-hestia.yml` run** — the queue does not drain retroactively for runs GitHub already cancelled. |
+| `GHARunnerCrashLooping` | `increase(homelab_gha_runner_restart_count[15m]) > 5` for 5m | **critical** (pages) | The container is exiting and being restarted forever by `unless-stopped`. This is the 2026-08-19 detector; it fires in ~6 minutes. **Response:** `docker logs --tail 50 ix-gha-runner-runner-1 \| grep -iE 'deprecated\|error'`. If it is the deprecation signature (§8), the runner image is too old *and* cannot self-update — go to §8's recovery. Otherwise look for a bad `ACCESS_TOKEN` (403 at registration) or a missing `/mnt/main/apps/actions-runner/work`. |
+| `GHARunnerMetricStale` | `time() - homelab_gha_runner_last_check_timestamp_seconds > 900` for 10m | warning (filtered mailbox) | The probe has stopped reporting. The runner may be perfectly fine — what has failed is our **ability to see it**, which means the two critical alerts above are now blind. **Response:** check the probe container on hestia and the node-exporter textfile collector at `:9100`; confirm the `.prom` file is being written and is fresh. Until it is fixed, verify the runner by hand (§6) rather than trusting silence. |
+
+### What this does not cover yet
+- **Absent series.** All three expressions need the series to exist. If the emitter vanishes entirely rather than going stale, `== 0` matches nothing and the staleness maths has nothing to evaluate. The fix is an `absent()` guard mirroring `HomelabscopeJobMetricAbsent`; it is deliberately deferred until the series are confirmed live in Prometheus, because `absent()` over a not-yet-existing series is a guaranteed false critical the moment it lands. Same two-PR pattern the homelabscope guards already use.
+- **A run stuck queued while the runner looks healthy.** Covered by the proposed hourly canary workflow (an off-cluster healthchecks.io check driven by a job that actually runs on the runner), not by these metrics. See [`docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`](../../plans/2026-08-18-hestia-deploy-monitoring-gap.md) §B.
+- **A deploy that reports success and does nothing.** That is the separate, documented `app.update` no-op quirk — [`docs/operations/2026-05-14-truenas-app-update-quirk.md`](../2026-05-14-truenas-app-update-quirk.md).
+- **The Kubernetes container alerts do not apply here.** `ContainerCrashLoopBackOff`, `ContainerOOMKilled` and `ContainerHighCPU` read `kube_pod_container_status_*` / cAdvisor. hestia is not a node in this cluster and runs no cAdvisor. Those alert *names* read as coverage that does not exist for this host.
+
+## 8. Disaster Recovery
+
+### The 2026-08-19 incident
+A merge to `master` touching `hosts/hestia/**` produced a `deploy-hestia.yml` run that sat **queued for over a day**. The runner had restarted **13,173 times**. Nothing alerted — not the crash loop, not the offline runner, not the queued run.
+
+Log signature:
+```
+Current runner version: '2.334.0'
+An error occurred: Runner version v2.334.0 is deprecated and cannot receive messages.
+```
+
+The loop: the runner registered with GitHub successfully, was told its version was too old, exited 1, and `restart: unless-stopped` started it again. Forever. It could not self-heal because `DISABLE_AUTO_UPDATE` was `"true"`, pinning it to whatever runner binary the image shipped. And it could not deploy its own fix, because `hosts/hestia/actions-runner/` is excluded from `deploy-hestia.yml` (§1). Every layer of repair was downstream of the broken thing.
+
+`ACCESS_TOKEN` and registration were fine throughout. **A runner that registers successfully can still be completely unable to do work** — do not stop at "it's registered".
+
+### The trap that cost the most time: bare digest, no tag
+Fixing the deprecation uncovered a second fault, and this is the part worth remembering.
+
+The compose pinned a **bare digest with no tag**. Renovate therefore had no tag to track and defaulted to `:latest` — and for `myoung34/github-runner`, `:latest` is **Ubuntu focal**. So a routine "digest bump" PR, which looks like a no-op to any reviewer, silently moved the runner's **base OS back two LTS releases**:
+
+```
+old 420562d4   Ubuntu 24.04 noble   Python 3.12.3   pip 24.0     runner 2.334.0
+new 56e9f5c5   Ubuntu 20.04 focal   Python 3.8.10   pip 20.0.2   runner 2.336.0
+```
+
+`scripts/truenas-update-app.sh` hardcoded `--break-system-packages`, a pip flag introduced in **pip 23.0.1** (PEP 668) and required on noble. focal's pip 20.0.2 does not merely ignore it — it **rejects** it, exits 2, and fails the apply. Every one of the nine hestia apps failed to deploy, with a misleading trace (the script's `echo` printed a command that did not match the one it actually ran).
+
+Two fixes, belt and braces, both in `c168ce9b` (#1318):
+
+1. **Pin tag + digest** — `myoung34/github-runner:ubuntu-noble@sha256:de596f58...`. The tag is what stops Renovate wandering between base-OS variants; the digest still gives reproducibility. **Never pin a bare digest.** A digest alone tells Renovate nothing about which lineage you meant to be on.
+2. **Detect the flag instead of assuming it** — probe `python3 -m pip install --help` for `--break-system-packages` and pass it only when supported. The script is now correct on both old and new pip, so a future variant drift degrades instead of breaking.
+
+The general lesson: **a digest bump is not a safe change when the tag is implicit.** The reviewable unit was a hex string, and the actual change was the operating system.
+
+### Recovery when the runner is down and cannot deploy its own fix
+This is the deadlock. The change that repairs the runner lives in a repo whose only path to hestia is the runner. Break it by hand.
+
+⚠️ **Read the warning at the end of this section before you start.**
+
+```bash
+ssh truenas_admin@10.42.2.10
+
+# 1. Confirm the failure mode
+docker inspect ix-gha-runner-runner-1 --format '{{.Config.Image}} restarts={{.RestartCount}}'
+docker logs --tail 50 ix-gha-runner-runner-1 | grep -iE 'deprecated|error'
+
+# 2. Patch the RENDERED compose in place
+sudo vi /mnt/.ix-apps/app_configs/gha-runner/versions/1.0.0/templates/rendered/docker-compose.yaml
+#    → set image: to the intended tag+digest, e.g.
+#      myoung34/github-runner:ubuntu-noble@sha256:de596f58...
+#    → set DISABLE_AUTO_UPDATE: "false"
+
+# 3. Bring it up from that file
+cd /mnt/.ix-apps/app_configs/gha-runner/versions/1.0.0/templates/rendered
+sudo docker compose -p ix-gha-runner up -d
+
+# 4. Verify: 2.336.0+ and "Listening for Jobs", no deprecation line, restarts flat
+docker logs --tail 30 ix-gha-runner-runner-1
+docker inspect ix-gha-runner-runner-1 --format '{{.Config.Image}} restarts={{.RestartCount}}'
+```
+
+Then re-run the failed/queued workflow runs (`gh run rerun <id>`) and confirm the applies go green.
+
+> ⚠️ **This is a TEMPORARY layer, not the fix.**
+> TrueNAS's stored `app.config` is **authoritative**. The rendered compose you just edited is an output, and SCALE regenerates it from `app.config` on any redeploy — clicking Edit → Save, an app update, or in some cases a reboot will **revert your patch and restore the crash loop**, with no warning.
+>
+> The durable fix is **SCALE UI → Apps → `gha-runner` → Edit**: update the compose YAML there (image tag+digest, `DISABLE_AUTO_UPDATE`) and Save. Confirm it took with:
+> ```bash
+> ssh truenas_admin@10.42.2.10 'sudo midclt call app.config gha-runner' | jq -r '.. | .image? // empty'
+> ```
+> If that still shows the old digest, you are running on borrowed time. Note also that `app.update` is known to return `SUCCESS` without recreating a crash-looping container — see [`2026-05-14-truenas-app-update-quirk.md`](../2026-05-14-truenas-app-update-quirk.md) — so always verify against `docker inspect`, never against the job status.
+>
+> Finally: mirror whatever you set into the repo compose. If the box and `hosts/hestia/actions-runner/docker-compose.yml` disagree, git has stopped describing reality and the next person debugging this starts from a lie.
+
+### `DISABLE_AUTO_UPDATE` is now `false`
+This is the durable half of the fix, and the reason a future deprecation should not become an outage.
+
+Pinning a current image clears **today's** deprecation. Auto-update is what stops the **next** one becoming an incident. The outage was not caused by the runner being old — it was caused by the runner being **unable to stop being old**. With `DISABLE_AUTO_UPDATE: "false"`, GitHub's runner self-updates its own binary in place when a minimum version is enforced, and the crash loop never starts.
+
+The cost is honest and worth naming: the running runner *software* version will now drift from the pinned image, so any strict image↔runtime drift check must exempt the runner binary. What auto-update replaces is the runner software inside the container — **not** the image, not its OS packages. That matters for alcatraz specifically, whose apply step needs the `docker-compose-plugin` layer from the image; a self-update leaves that layer intact.
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Workflow runs sit **queued** forever, never fail | Runner offline or crash-looping. GitHub does not email on queued runs. | §8 recovery. Check `RestartCount` first — it is the fastest discriminator. |
+| `Runner version vX.Y.Z is deprecated and cannot receive messages` | Image ships a runner GitHub no longer accepts, and auto-update is off. | Confirm `DISABLE_AUTO_UPDATE: "false"`; bump image tag+digest; §8 recovery to apply. |
+| Runner registers, then exits 1 immediately, repeatedly | Same as above. Registration succeeding proves nothing about job dispatch. | Read the log line *after* registration, not the registration line. |
+| `--break-system-packages: no such option` / pip exits 2 during apply; all hestia apps fail | Image drifted to focal (pip 20.0.2). Almost always a bare-digest Renovate bump. | Verify with `docker exec ix-gha-runner-runner-1 cat /etc/os-release`. Re-pin `:ubuntu-noble@sha256:...`. The script now detects the flag, so this should degrade rather than break. |
+| Repo compose and running container disagree | The runner is excluded from auto-deploy — a merged change was never applied. | Apply by hand via SCALE UI → Edit. Expect this after every Renovate runner bump. |
+| Fix applied, works, then silently reverts later | You patched the *rendered* compose only; `app.config` overwrote it. | Set it in SCALE UI → Apps → `gha-runner` → Edit. See the warning in §8. |
+| `app.update` returns `SUCCESS` but nothing changed | Known TrueNAS quirk with crash-looping containers. | [`2026-05-14-truenas-app-update-quirk.md`](../2026-05-14-truenas-app-update-quirk.md) — stop and start the app explicitly. |
+| Runner never appears in GitHub; log shows `curl: (22) ... 403` | `ACCESS_TOKEN` lacks repo **Administration** (or classic `repo`). `Contents` is not enough. | Regenerate the PAT with the right scopes, update the masked env var. |
+| `truenas-update-app.sh` returns 401 | Bad or rotated `TRUENAS_API_KEY`. | SCALE UI → Settings → API Keys; update the masked env var. |
+| Runner offline after a host reboot | Persistence path missing. | Confirm `/mnt/main/apps/actions-runner/work` exists and is writable. |
+| Alerts silent while the runner is visibly broken | `GHARunnerMetricStale` firing (or the series is absent entirely — not yet guarded). | Fix the probe / textfile collector. Verify the runner by hand meanwhile (§6). |

--- a/infra/configs/alerts/prometheus-rules.yaml
+++ b/infra/configs/alerts/prometheus-rules.yaml
@@ -284,3 +284,145 @@ spec:
             summary: "Flux GitRepository {{ $labels.exported_namespace }}/{{ $labels.name }} not ready"
             description: >
               GitRepository {{ $labels.exported_namespace }}/{{ $labels.name }} has been Ready=False for >15m — Flux can't fetch the source, so every Kustomization downstream is frozen at its last-applied revision. Check credentials and connectivity to the Git remote.
+
+    # -------------------------------------------------------------------------
+    # Self-hosted GitHub Actions runner (hestia, alcatraz)
+    #
+    # Added after the 2026-08-19 incident: the hestia runner crash-looped 13,173
+    # times and a deploy job sat queued for over a day with NOTHING alerting.
+    # Runner 2.334.0 had been deprecated by GitHub ("Runner version v2.334.0 is
+    # deprecated and cannot receive messages"), so it registered, was refused
+    # work, exited 1, and was restarted forever by `restart: unless-stopped`. It
+    # could not self-heal because DISABLE_AUTO_UPDATE was "true", and it could
+    # not deploy its own fix because hosts/hestia/actions-runner/ is excluded
+    # from deploy-hestia.yml by design. See docs/operations/apps/gha-runner.md
+    # and docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md.
+    #
+    # Why the existing rules did not cover this: ContainerCrashLoopBackOff and
+    # friends read kube_pod_container_status_* / cAdvisor. hestia is not a node
+    # in this cluster and runs no cAdvisor, so those alert NAMES read as
+    # coverage the cluster does not have. And homelabscope's
+    # "last success + max-age budget" model does not fit a push-triggered deploy
+    # pipeline, which has no cadence to be late against.
+    #
+    # METRIC CONTRACT (emitted by the hestia container probe, exported through
+    # the node-exporter textfile collector on hestia). These names are frozen:
+    #
+    #   homelab_gha_runner_up{runner}                            1 = healthy, 0 = not
+    #   homelab_gha_runner_restart_count{runner}                 docker RestartCount, GAUGE
+    #   homelab_gha_runner_last_check_timestamp_seconds{runner}  unix seconds
+    #
+    # Deliberately NOT filtered to runner="hestia": alcatraz has the identical
+    # blind spot by construction, and templating {{ $labels.runner }} means its
+    # emitter is covered the day it lands with no rule change. Same shape as the
+    # homelabscope family, which is generic over {job}.
+    #
+    # ROUTING — verified against the Alertmanager config in
+    # infra/controllers/kube-prometheus-stack/values.yaml:
+    #   severity: critical -> receiver 'email-critical' -> gjcourt+critical@gmail.com,
+    #     repeat_interval 4h, send_resolved. +critical has NO Gmail skip-inbox
+    #     filter, so it reaches the inbox — i.e. a critical PAGES.
+    #   severity: warning  -> receiver 'email-warning'  -> gjcourt+alerts@gmail.com,
+    #     repeat_interval 24h, send_resolved:false. A Gmail filter labels and
+    #     SKIPS THE INBOX, so warnings are an opt-in daily nag, not a page.
+    #   No severity label at all -> falls through to the default receiver 'null'
+    #     and is silently discarded. Every rule below therefore carries one.
+    #   The `namespace =~ ".+-stage"` warning mute does not apply here: these
+    #     series carry no namespace label.
+    # A genuinely broken runner is a dead deploy path, so both runner-health
+    # rules are critical and page. Only the watchdog-on-the-watchdog is warning.
+    #
+    # KNOWN GAP, deliberately unguarded for now: all three expressions need the
+    # series to EXIST. If the emitter vanishes entirely the series go absent,
+    # `== 0` matches nothing and `time() - <gauge>` has nothing to evaluate, so
+    # GHARunnerMetricStale is the only thing standing between us and silence —
+    # and staleness itself stops working if the series disappears rather than
+    # going stale. The fix is an absent() guard, exactly like
+    # HomelabscopeJobMetricAbsent. It is NOT added here because the emitter is
+    # still being built: absent() over a series that is not yet live is a
+    # guaranteed false critical the moment the rule lands (the #1066 lesson).
+    # Add it as a follow-up PR once the series are confirmed live in Prometheus,
+    # which is the same two-PR pattern the homelabscope guards already use.
+    # -------------------------------------------------------------------------
+    - name: gha-runner
+      rules:
+        # The runner is not healthy: container down, not registered, or wedged
+        # so Runner.Listener is gone. 10m rides out a normal image bump /
+        # SCALE app recreate (seconds) and an operator restart, without letting
+        # a real outage sit unseen the way the 2026-08-19 one did for a day.
+        - alert: GHARunnerDown
+          expr: homelab_gha_runner_up == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "GitHub Actions runner {{ $labels.runner }} is down"
+            description: >
+              Self-hosted runner {{ $labels.runner }} has reported unhealthy for >10m. Every workflow targeting it (deploy-hestia.yml on hestia, alcatraz-deploy.yaml on alcatraz) will sit QUEUED rather than fail, so GitHub will not email about it — this alert is the only signal. Runbook: docs/operations/apps/gha-runner.md. Check: ssh truenas_admin@10.42.2.10 'docker logs --tail 50 ix-gha-runner-runner-1'
+
+        # The 2026-08-19 detector. A crash loop restarting on `unless-stopped`
+        # keeps up=0 only intermittently (it is briefly "running" on each
+        # attempt), so restart VELOCITY is the durable signal, not up/down and
+        # not a log string — GitHub can reword the deprecation message, but a
+        # container that exits 1 forever always increments RestartCount.
+        #
+        # GAUGE ON PURPOSE, and increase() on purpose. RestartCount is docker's
+        # own counter, which resets to 0 whenever the container is RECREATED
+        # (image bump, SCALE UI redeploy, `compose up -d`), so the series drops
+        # e.g. 13173 -> 0. increase() applies counter-reset correction: on a
+        # sample lower than its predecessor it adds the predecessor as a
+        # correction, so the window evaluates to the POST-reset climb only,
+        # never a spurious 13173-sized spike and never a negative.
+        #
+        # Verified with `promtool test rules` over a 15-sample window holding a
+        # 13173 -> 0 recreate:
+        #   increase()                        ->      0   (correct, no fire)
+        #   delta()                           -> -14113   (nonsense, and would
+        #                                                  mask a real loop)
+        #   max_over_time - min_over_time     ->  13173   (SPURIOUS CRITICAL)
+        # and over the same recreate followed by a genuine loop (0,3,8,...,59):
+        #   increase()                        ->     63   (fires, correct)
+        # and over a flat healthy counter: no sample, no fire.
+        # So delta() is the gauge-native trap and max-min is the worse one;
+        # increase() is the only form that is both reset-safe and sensitive.
+        # `> 5` is additionally immune to negatives by construction.
+        #
+        # increase() extrapolates to the window edges, so a young series can
+        # read slightly high (4 real restarts in 5m of data reads as ~12). That
+        # bias is toward firing on a crash loop, which is the correct direction.
+        #
+        # 5 restarts in 15m is already pathological: healthy operation is a
+        # flat counter, and the incident ran at roughly one restart per second.
+        # for:5m matches the ContainerCrashLoopBackOff convention and means a
+        # fresh crash loop pages in ~6 minutes rather than after a day.
+        - alert: GHARunnerCrashLooping
+          expr: increase(homelab_gha_runner_restart_count[15m]) > 5
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "GitHub Actions runner {{ $labels.runner }} is crash-looping"
+            description: >
+              Runner {{ $labels.runner }} restarted {{ $value | printf "%.0f" }} times in the last 15m and is being restarted forever by `restart: unless-stopped`. The 2026-08-19 signature is a GitHub-side version deprecation ("Runner version vX.Y.Z is deprecated and cannot receive messages") — check the container log for it first. Runbook: docs/operations/apps/gha-runner.md. Check: ssh truenas_admin@10.42.2.10 'docker logs --tail 50 ix-gha-runner-runner-1 | grep -i deprecated'
+
+        # Watchdog on the watchdog. If the probe stops writing its textfile the
+        # two rules above go quiet and the silence is indistinguishable from a
+        # healthy runner — the exact failure class this whole group exists to
+        # kill. 900s is a wide margin over the probe's own loop interval, and
+        # for:10m matches HomelabscopeJobStale, so a single missed write or a
+        # scrape blip cannot trip it.
+        #
+        # warning, not critical: this says "we can no longer see the runner",
+        # not "the runner is broken". It routes to +alerts@ behind the
+        # skip-inbox filter as a 24h nag. Accepted trade-off, with eyes open —
+        # if a stale watchdog is ever found to have masked a real outage,
+        # promote it to critical rather than adding another rule.
+        - alert: GHARunnerMetricStale
+          expr: time() - homelab_gha_runner_last_check_timestamp_seconds > 900
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "GitHub Actions runner {{ $labels.runner }} health metric is stale"
+            description: >
+              No fresh health check for runner {{ $labels.runner }} in {{ $value | humanizeDuration }} (budget 15m). The runner itself may be fine — what has failed is our ability to see it, which also means GHARunnerDown and GHARunnerCrashLooping are now blind. Check the probe that emits homelab_gha_runner_* on hestia and the node-exporter textfile collector at :9100. Runbook: docs/operations/apps/gha-runner.md


### PR DESCRIPTION
## Why

On 2026-08-19 the hestia runner crash-looped **13,173 times** and a deploy job sat queued for over a day. **Nothing alerted.** Runner 2.334.0 had been deprecated by GitHub (`Runner version v2.334.0 is deprecated and cannot receive messages`), so it registered, was refused work, exited 1, and was restarted forever by `restart: unless-stopped`. It could not self-heal (`DISABLE_AUTO_UPDATE=true`) and could not deploy its own fix (`hosts/hestia/actions-runner/` is excluded from `deploy-hestia.yml` by design).

#1318 fixed the runner. This PR closes the reason nobody found out.

## Part 1 — alerts

New `gha-runner` group in `infra/configs/alerts/prometheus-rules.yaml`, over the frozen metric contract (emitter landing separately). Deliberately **not** scoped to `runner="hestia"`, so alcatraz is covered the day its emitter lands, same as the homelabscope family is generic over `{job}`.

| Alert | Expression | `for` | Severity |
|---|---|---|---|
| `GHARunnerDown` | `homelab_gha_runner_up == 0` | 10m | **critical** |
| `GHARunnerCrashLooping` | `increase(homelab_gha_runner_restart_count[15m]) > 5` | 5m | **critical** |
| `GHARunnerMetricStale` | `time() - homelab_gha_runner_last_check_timestamp_seconds > 900` | 10m | warning |

### Does a broken runner page?

Yes. Verified against the Alertmanager config in `infra/controllers/kube-prometheus-stack/values.yaml`:

- `severity: critical` → receiver `email-critical` → `gjcourt+critical@gmail.com`, `repeat_interval: 4h`. That alias has **no Gmail skip-inbox filter**, so it lands in the inbox — it pages.
- `severity: warning` → receiver `email-warning` → `gjcourt+alerts@gmail.com`, `repeat_interval: 24h`, behind a skip-inbox filter — an opt-in nag.
- **No** `severity` label → falls through to the default `null` receiver and is discarded silently. All three rules carry one.
- The `namespace =~ ".+-stage"` warning mute does not apply; these series carry no `namespace` label.

### The gauge-reset trap, measured rather than assumed

`restart_count` is a gauge that resets to 0 when the container is recreated, which makes the function choice load-bearing. Verified with `promtool test rules` over a 15-sample window containing a `13173 → 0` recreate:

| Function | Result | Verdict |
|---|---|---|
| `increase()` | `0` | correct — no fire |
| `delta()` | `-14113` | nonsense, and masks a real loop across the boundary |
| `max_over_time - min_over_time` | `13173` | **spurious critical** |

Over the same recreate followed by a genuine loop (`0,3,8,…,59`), `increase()` → `63`, so it stays sensitive; over a flat healthy counter it produces no sample. `increase()` applies counter-reset correction, making it the only form that is both reset-safe and sensitive. `> 5` is additionally immune to negatives by construction. The rationale is written into the rule comment so the next person doesn't "fix" it to `delta()`.

### Known gap, deliberately deferred

All three expressions need the series to **exist**. If the emitter vanishes rather than going stale, `== 0` matches nothing and the staleness maths has nothing to evaluate. The fix is an `absent()` guard mirroring `HomelabscopeJobMetricAbsent` — **not** added here, because the emitter is being built in parallel and `absent()` over a not-yet-live series is a guaranteed false critical the moment this merges (the #1066 lesson). Deferred to a follow-up once the series are confirmed live, matching the two-PR pattern the homelabscope guards already use. Documented in both the rule comment and the runbook rather than hidden.

## Part 2 — runbook

`docs/operations/apps/gha-runner.md`, standard 9-section shape. Covers:

- Both hosts, and why the runner is **excluded from auto-deploy** — a runner cannot reliably recreate its own container mid-job — so **runner upgrades are manual**. Renovate will merge a digest bump, CI will go green, and nothing will apply it.
- The 2026-08-19 incident with its exact log signature. Note that `ACCESS_TOKEN` and registration were fine throughout: **a runner that registers successfully can still be completely unable to do work.**
- **The trap that cost the most time:** the compose pinned a **bare digest with no tag**, so Renovate tracked `:latest` — which is Ubuntu **focal**. A routine-looking digest bump moved the base OS back **two LTS releases** from noble. That broke `scripts/truenas-update-app.sh`, which passed `--break-system-packages` (pip ≥ 23.0.1); focal ships pip 20.0.2, which *rejects* the flag, exits 2, and failed all nine hestia applies. Fixed by pinning tag + digest and detecting the flag. The general lesson: a digest bump is not a safe change when the tag is implicit — the reviewable unit was a hex string, the actual change was the operating system.
- **Recovery for the deadlock case** where the runner is down and therefore cannot deploy its own fix: patch the *rendered* compose at `/mnt/.ix-apps/app_configs/gha-runner/versions/1.0.0/templates/rendered/docker-compose.yaml` and `docker compose -p ix-gha-runner up -d` — flagged clearly as a **temporary layer**, because TrueNAS's stored `app.config` is authoritative and a SCALE UI redeploy reverts it. The durable fix is **Apps → gha-runner → Edit**, cross-referenced to the known `app.update` no-op quirk.
- `DISABLE_AUTO_UPDATE` is now `false`, with the honest cost named: runner *software* will drift from the pinned image, so a strict drift check must exempt the binary. Auto-update replaces the runner software inside the container, not the image or its OS packages — which is why alcatraz's `docker-compose-plugin` layer survives.
- Per-alert response actions for all three alerts, plus what is still uncovered (queued-run canary, deploy no-op verification, and the fact that the Kubernetes `Container*` alerts read as coverage hestia does not have).

Also adds GHA Runner to the hand-maintained per-app list in `docs/README.md`.

## Verification

- `yamllint -c .yamllint infra/configs/alerts/prometheus-rules.yaml` — clean
- `kubectl kustomize infra/configs` — renders
- `promtool check rules` on the extracted groups — `SUCCESS: 16 rules found`
- `promtool test rules` — the three reset-behaviour cases above
- All 12 relative links in the runbook resolve

No cluster changes, no SOPS files touched, no emitter code (that lands separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA