### PR TITLE
feat(homelabscope): probe hestia containers from the heartbeat

### DIFF
--- a/hosts/hestia/monitoring/README.md
+++ b/hosts/hestia/monitoring/README.md
@@ -11,7 +11,7 @@ node-exporter DaemonSet).
 | `docker-compose.yml` | thermalscope — Prometheus thermal/GPU exporter on `:9102` (archived; GPUs sold) |
 | `docker-compose-ipmi-exporter.yml` | prometheus-ipmi-exporter — BMC fans/temps on `:9290` |
 | `docker-compose-node-exporter.yml` | node-exporter (textfile collector only) on `:9100` — serves the homelabscope `.prom` files |
-| `docker-compose-homelabscope-heartbeat.yml` | homelabscope-heartbeat — SSH-reads the alcatraz pull log + ZFS snapshot freshness, writes `.prom` files (archived until its image is built) |
+| `docker-compose-homelabscope-heartbeat.yml` | homelabscope-heartbeat — SSH-reads the alcatraz pull log + ZFS snapshot freshness, probes the Docker socket for per-container state, writes `.prom` files |
 
 ## homelabscope
 
@@ -24,9 +24,60 @@ collector at `/var/lib/node-exporter/textfile` on `:9100`; the cluster-side
 `:9100` scraper on hestia, so `immich-photos-backup`'s textfile metric was
 orphaned — this is what fixes that.
 
-`homelabscope-heartbeat` ships `x-deploy.archived: true` until its image is
-built by `build-homelabscope-heartbeat.yml`; then pin the `@sha256` digest and
-flip `archived: false`.
+When the image changes, `build-homelabscope-heartbeat.yml` publishes a new tag
+on push to `master`; pin it in the compose in a follow-up PR (this repo does not
+auto-track tags).
+
+### `homelabscope_container_*` — per-container state on hestia
+
+The heartbeat also carries a **second, unrelated family**: a probe over the local
+Docker socket. hestia has no cAdvisor and no docker exporter, so before this
+there was no signal at all when a hestia container died or crash-looped — the
+blind spot that let the GitHub Actions runner sit dead for days on 2026-08-18.
+Rationale for extending the heartbeat rather than adding a new exporter is in
+[`docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`](../../../docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md)
+section A — short version: it is already privileged, already scraped, already
+alerted on, the dashboard is generic over the family, and **the watcher is
+already watched**.
+
+| Series | Meaning |
+|---|---|
+| `homelabscope_container_running{name}` | 1 = running, 0 = not |
+| `homelabscope_container_restarts_total{name}` | Docker `RestartCount` (counter; resets on recreate) |
+| `homelabscope_container_health{name}` | 1 healthy / 0 unhealthy / 2 starting — **absent** when the container declares no healthcheck |
+| `homelabscope_container_started_seconds{name}` | Unix ts the current instance started |
+| `homelabscope_container_last_exit_code{name}` | `State.ExitCode` of the previous instance |
+| `homelabscope_container_probe_success` | 1/0 — distinguishes "Docker unreachable" from "every container gone" |
+
+It reports **every** container the daemon knows about, running or not — not a
+curated watchlist. `x-deploy.archived` is not a trustworthy "should be running"
+source (thermalscope is archived in the repo and `up=1` in reality), so the
+collector reports what *is* and the `PrometheusRule` decides what *must* be.
+`CONTAINER_EXCLUDE_REGEX` suppresses churn (e.g. buildx builders the runner
+spawns) without an image rebuild.
+
+**Why `last_exit_code` and `started_seconds` exist.** The `gha-runner` container
+is *ephemeral*: its entrypoint tests `[ -n "$EPHEMERAL" ]`, so the compose's
+`EPHEMERAL: "false"` — a non-empty string — still activates `--ephemeral`. It
+completes one job, deregisters, exits 0, and is restarted by `unless-stopped`:
+roughly **one restart per job** (`RestartCount` 0 → 9 across a 10-job deploy).
+So restart rate alone cannot tell *restarting and doing work* from *restarting
+and completing nothing* — the 11894-restart crash loop. Exit code and instance
+uptime can: a crash loop is `restarts high AND last_exit_code != 0`, or
+equivalently a `time() - started_seconds` that never grows past seconds.
+
+A true completed-jobs counter is **not** cheaply observable from polled Docker
+state and is deliberately not faked — `docker inspect` exposes only the *last*
+exit, not a history. The exact source would be the `/events` stream (`die`
+carries `exitCode`), which needs a second long-lived process and cross-restart
+counter persistence. That is the escalation path if exit code proves
+insufficient in practice. `restarts_total` is already the starts signal
+(`starts = restarts + 1`), so a separate `..._starts_total` would add nothing.
+
+The container probe polls on `CONTAINER_INTERVAL_SECONDS` (default 60s), not the
+600s the SSH/ZFS jobs use: `ExitCode` is a point-in-time sample, and the tight
+cadence is what makes it catch a fast crash loop mid-failure while not misreading
+a multi-minute job as a flap.
 
 ## Deployment
 

--- a/images/homelabscope-heartbeat/Dockerfile
+++ b/images/homelabscope-heartbeat/Dockerfile
@@ -1,6 +1,10 @@
 # homelabscope-heartbeat — hestia-side collector for scheduled jobs that can't
 # run their own exporter (alcatraz-photos-pull over SSH + ZFS snapshot freshness).
 #
+# It also carries the homelabscope_container_* probe, which reads the local
+# Docker socket — see the comment block in heartbeat.sh and
+# docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md section A.
+#
 # Designed to run on hestia as a TrueNAS Custom App. Compose at
 # hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml.
 #
@@ -23,6 +27,12 @@ FROM debian:bookworm-slim
 #                   we only need the read-only zfs/zpool CLI.
 # bash, coreutils — the script uses bash-isms + GNU `date -d`
 # ca-certificates — general TLS hygiene
+# curl, jq       — the container probe talks to the Docker Engine API over
+#                  /var/run/docker.sock (`curl --unix-socket`) and parses the
+#                  inspect JSON. Deliberately NOT the docker CLI: the CLI pulls
+#                  in ~30MB and a third-party apt repo to answer questions the
+#                  REST API answers in two GETs, and curl+jq add ~3MB from
+#                  Debian's own archive.
 RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
         sed -i 's/^Components: main$/Components: main contrib/' /etc/apt/sources.list.d/debian.sources; \
     else \
@@ -34,6 +44,8 @@ RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
         bash \
         coreutils \
         ca-certificates \
+        curl \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY heartbeat.sh /usr/local/bin/heartbeat.sh

--- a/images/homelabscope-heartbeat/heartbeat.sh
+++ b/images/homelabscope-heartbeat/heartbeat.sh
@@ -17,6 +17,19 @@
 #                          (falling back to the .zfs/snapshot control dir if the
 #                          zfs userland can't talk to /dev/zfs in-container).
 #
+# It ALSO carries a second, unrelated metric family: a per-container probe over
+# the local Docker socket, emitting homelabscope_container_*. hestia has no
+# cAdvisor and no docker exporter, so there is currently no signal at all when a
+# hestia container dies or crash-loops -- the blind spot that let the GitHub
+# Actions runner sit dead for days in the 2026-08-18 incident. See
+# docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md section A for why this
+# extends the heartbeat instead of adding a new exporter: the heartbeat is
+# already privileged, already scraped, already alerted on, the Grafana dashboard
+# is generic over the family, and -- decisively -- the watcher is already
+# watched (HomelabscopeJobMetricAbsent guards the ZFS jobs it writes, so a dead
+# heartbeat pages on its own). A new exporter would need that liveness story
+# built from scratch.
+#
 # Every source normalizes into the homelabscope metric family and is written to
 # the node-exporter textfile collector dir; the hestia node-exporter (:9100)
 # serves it and the infra/configs/homelabscope ScrapeConfig scrapes it. Writes
@@ -48,6 +61,20 @@ ZFS_SNAP_TZ="${ZFS_SNAP_TZ:-America/Los_Angeles}"
 # Staleness budgets (seconds). All watched jobs here are daily → 30h tolerates
 # one fully-missed window before HomelabscopeJobStale fires.
 MAX_AGE_DAILY="${MAX_AGE_DAILY:-108000}"
+# ----------------------------------------------------------------------------
+
+# ---- Container probe (Docker socket) ---------------------------------------
+# Polled far more often than the SSH/ZFS jobs above: it is a handful of local
+# unix-socket calls, and a tight interval is what makes State.ExitCode a usable
+# signal (see collect_containers). The slow jobs still run on INTERVAL_SECONDS.
+CONTAINER_PROBE_ENABLED="${CONTAINER_PROBE_ENABLED:-1}"
+CONTAINER_INTERVAL_SECONDS="${CONTAINER_INTERVAL_SECONDS:-60}"
+DOCKER_SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
+# Optional ERE of container names to skip. Default empty = report every
+# container the daemon knows about, running or not. Exists so the operator can
+# suppress churn (e.g. buildx builder containers the runner spawns through the
+# socket it already mounts) without rebuilding the image.
+CONTAINER_EXCLUDE_REGEX="${CONTAINER_EXCLUDE_REGEX:-}"
 # ----------------------------------------------------------------------------
 
 log() { echo "$(date -u +%FT%TZ) $*"; }
@@ -144,10 +171,202 @@ collect_zfs_snapshots() {
   done
 }
 
+# ---------------------------------------------------------------------------
+# Container probe -- homelabscope_container_* over the Docker socket.
+#
+# Deliberately generic over EVERY container the daemon knows about (running or
+# exited), not a curated watchlist: the plan's open question about a "must be
+# running" list is answered by the alert side, not here. `x-deploy.archived` is
+# known-untrustworthy as a should-be-running source (thermalscope is archived in
+# the repo and up=1 in reality), so the collector reports what IS and lets the
+# PrometheusRule decide what MUST be.
+#
+# WHAT WE CAN SEE, AND WHAT WE CANNOT
+#
+# The runner container is EPHEMERAL. Its image entrypoint tests `[ -n "$EPHEMERAL" ]`,
+# so the compose's `EPHEMERAL: "false"` -- a non-empty string -- still activates
+# `--ephemeral`. The runner therefore completes ONE job, deregisters, exits 0,
+# and is restarted by `unless-stopped`: roughly one restart PER JOB. RestartCount
+# was observed going 0 -> 9 across a single 10-job deploy.
+#
+# That breaks a naive restart-rate alert. `increase(restarts_total[1h]) > 5` --
+# the threshold the plan sketches -- is tripped by a perfectly healthy busy
+# afternoon. Restart rate alone cannot tell "restarting and doing work" from
+# "restarting and completing nothing" (the 11894-restart crash loop).
+#
+# A true completed-jobs counter is NOT cheaply observable from polled Docker
+# state, and this collector does not fake one. `docker inspect` exposes only the
+# LAST exit -- .State.ExitCode and .State.FinishedAt -- not a history. Between
+# two polls N restarts may have occurred with mixed outcomes, and inventing a
+# per-poll clean-exit counter from a single observed exit code would attribute
+# all N to the last one. The only exact source is the `/events` stream
+# (`die` carries an exitCode attribute), which means a second long-lived
+# streaming process and cross-restart counter persistence -- out of scope here,
+# and recorded as the follow-up option if exit code proves insufficient.
+#
+# What we emit instead are two EXACT, non-fabricated observations that let an
+# alert make the distinction:
+#
+#   homelabscope_container_last_exit_code  .State.ExitCode -- how the previous
+#       instance of this container ended. An ephemeral runner that finished a
+#       job reads 0; a runner dying on "version deprecated" reads non-zero. So
+#       "crash-looping" is `restarts high AND last_exit_code != 0`, and a busy
+#       deploy is `restarts high AND last_exit_code == 0`.
+#
+#   homelabscope_container_started_seconds  .State.StartedAt as an epoch --
+#       how long the CURRENT instance has been up. A container doing work runs
+#       for the length of a job (minutes); a crash loop turns over in seconds.
+#       `time() - started_seconds` is the flap detector, independent of exit
+#       codes entirely, and it needs no history.
+#
+# Both are point-in-time samples, hence CONTAINER_INTERVAL_SECONDS=60 rather
+# than the 600s the SSH/ZFS jobs use: at 60s a container restarting every few
+# seconds is caught mid-failure on essentially every sample, while a multi-minute
+# job is not misread as a flap.
+#
+# homelabscope_container_restarts_total is Docker's own RestartCount, which is
+# monotonic per container and resets only when the container is recreated --
+# a genuine counter, safe under increase()/rate(). It is also already the
+# "starts" signal: starts = restarts + 1 for a given container instance, so a
+# separate homelabscope_container_starts_total series would carry no
+# information RestartCount does not already carry.
+# ---------------------------------------------------------------------------
+
+# docker_api <path> -- GET against the Docker Engine API over the unix socket.
+# Unversioned path: the daemon answers with its own current API version, so this
+# cannot break on a TrueNAS Docker upgrade the way a pinned /v1.41 prefix would.
+docker_api() {
+  curl -sS --fail --max-time 10 --unix-socket "${DOCKER_SOCK}" "http://localhost$1"
+}
+
+# Encoding for homelabscope_container_health. Emitted ONLY for containers that
+# actually declare a healthcheck -- a container with none has no health, and
+# emitting 0 ("unhealthy") for it would make every unmonitored container look
+# broken.
+#   1 = healthy   0 = unhealthy   2 = starting (inside start_period)
+health_value() {
+  case "$1" in
+    healthy)   echo 1 ;;
+    unhealthy) echo 0 ;;
+    starting)  echo 2 ;;
+    *)         return 1 ;;
+  esac
+}
+
+CONTAINER_PROBE_LAST_OK=""
+
+# emit_family <name> <type> <help> <samples>
+# Prints a HELP/TYPE header plus its samples, and prints NOTHING when there are
+# no samples: a bare TYPE line with no series is a needless edge case for the
+# textfile parser, and samples are grouped per family (rather than interleaved
+# per container) because that is the canonical exposition layout.
+emit_family() {
+  local name="$1" type="$2" help="$3" samples="$4"
+  [[ -z "${samples}" ]] && return 0
+  echo "# HELP ${name} ${help}"
+  echo "# TYPE ${name} ${type}"
+  printf '%s' "${samples}"
+}
+
+collect_containers() {
+  local out="${TEXTFILE_DIR}/homelabscope-containers.prom"
+  local ids id json probe_ok=1 name running restarts health started exitcode
+  local hv epoch
+  local s_running="" s_restarts="" s_exit="" s_started="" s_health=""
+
+  # An empty container list is a successful probe with zero series, not a
+  # failure — on this host that state is itself the alarm, and the absent()
+  # guard is what says so.
+  ids="$(docker_api '/containers/json?all=1' 2>/dev/null | jq -r '.[].Id' 2>/dev/null)" || probe_ok=0
+
+  if [[ "${probe_ok}" -eq 1 ]]; then
+    for id in ${ids}; do
+      json="$(docker_api "/containers/${id}/json" 2>/dev/null)" || continue
+      IFS=$'\t' read -r name running restarts health started exitcode < <(
+        jq -r '[
+          (.Name // "" | ltrimstr("/")),
+          (if .State.Running then 1 else 0 end),
+          (.RestartCount // 0),
+          (.State.Health.Status // "none"),
+          (.State.StartedAt // ""),
+          (.State.ExitCode // 0)
+        ] | @tsv' <<<"${json}" 2>/dev/null
+      )
+      [[ -z "${name}" ]] && continue
+      if [[ -n "${CONTAINER_EXCLUDE_REGEX}" ]] && [[ "${name}" =~ ${CONTAINER_EXCLUDE_REGEX} ]]; then
+        continue
+      fi
+
+      s_running+="homelabscope_container_running{name=\"${name}\"} ${running}"$'\n'
+      s_restarts+="homelabscope_container_restarts_total{name=\"${name}\"} ${restarts}"$'\n'
+      s_exit+="homelabscope_container_last_exit_code{name=\"${name}\"} ${exitcode}"$'\n'
+
+      # Docker reports StartedAt as 0001-01-01T00:00:00Z for a container that
+      # has never run -- not a real epoch, so leave the series absent.
+      if [[ -n "${started}" && "${started}" != 0001-* ]]; then
+        epoch="$(date -u -d "${started}" +%s 2>/dev/null)"
+        [[ -n "${epoch}" ]] && \
+          s_started+="homelabscope_container_started_seconds{name=\"${name}\"} ${epoch}"$'\n'
+      fi
+
+      if hv="$(health_value "${health}")"; then
+        s_health+="homelabscope_container_health{name=\"${name}\"} ${hv}"$'\n'
+      fi
+    done
+  fi
+
+  # Log only on transition so a persistent failure doesn't flood the log.
+  if [[ "${probe_ok}" != "${CONTAINER_PROBE_LAST_OK}" ]]; then
+    if [[ "${probe_ok}" -eq 1 ]]; then
+      log "container-probe: docker socket reachable at ${DOCKER_SOCK}"
+    else
+      log "container-probe: cannot reach docker socket ${DOCKER_SOCK} — emitting probe_success 0"
+    fi
+    CONTAINER_PROBE_LAST_OK="${probe_ok}"
+  fi
+
+  # Atomic write, same discipline as emit_job: node-exporter must never read a
+  # half-written file. Written unconditionally, including on probe failure, so
+  # probe_success tells "docker is unreachable" apart from "every container is
+  # gone" — two states that would otherwise look identical (both drop the
+  # per-container series).
+  {
+    echo "# HELP homelabscope_container_probe_success Whether the last Docker socket probe succeeded (1=yes, 0=no)."
+    echo "# TYPE homelabscope_container_probe_success gauge"
+    echo "homelabscope_container_probe_success ${probe_ok}"
+    emit_family homelabscope_container_running gauge \
+      "Whether the container is currently running (1=yes, 0=no)." "${s_running}"
+    emit_family homelabscope_container_restarts_total counter \
+      "Docker RestartCount for the container (monotonic; resets on recreate)." "${s_restarts}"
+    emit_family homelabscope_container_last_exit_code gauge \
+      "Exit code of the container's previous instance (0 while it has never exited)." "${s_exit}"
+    emit_family homelabscope_container_started_seconds gauge \
+      "Unix timestamp the current container instance started." "${s_started}"
+    emit_family homelabscope_container_health gauge \
+      "Docker healthcheck state (1=healthy, 0=unhealthy, 2=starting); absent when the container declares no healthcheck." "${s_health}"
+  } > "${out}.tmp"
+  mv "${out}.tmp" "${out}"
+}
+
 mkdir -p "${TEXTFILE_DIR}"
 log "homelabscope-heartbeat starting; interval=${INTERVAL_SECONDS}s textfile=${TEXTFILE_DIR}"
+log "container-probe: enabled=${CONTAINER_PROBE_ENABLED} interval=${CONTAINER_INTERVAL_SECONDS}s sock=${DOCKER_SOCK}"
+
+# Two cadences in one loop: the SSH/ZFS jobs watch once-a-day work and stay on
+# INTERVAL_SECONDS; the container probe is local socket calls and runs on the
+# much tighter CONTAINER_INTERVAL_SECONDS (see the comment block above for why
+# the tighter cadence is load-bearing, not cosmetic). last_slow=0 forces the
+# slow jobs to run on the first pass.
+last_slow=0
 while true; do
-  collect_alcatraz_pull || true
-  collect_zfs_snapshots || true
-  sleep "${INTERVAL_SECONDS}"
+  now="$(date +%s)"
+  if (( now - last_slow >= INTERVAL_SECONDS )); then
+    collect_alcatraz_pull || true
+    collect_zfs_snapshots || true
+    last_slow="${now}"
+  fi
+  if [[ "${CONTAINER_PROBE_ENABLED}" == "1" ]]; then
+    collect_containers || true
+  fi
+  sleep "${CONTAINER_INTERVAL_SECONDS}"
 done


### PR DESCRIPTION
## Why

hestia has **no cAdvisor and no docker exporter** — `count({__name__=~"container_.*", instance="hestia"})` is an empty vector. There is no signal at all when a hestia container dies or crash-loops. That is the blind spot that let the GitHub Actions runner sit dead for days on 2026-08-18 with `RestartCount = 11894` and nothing alerting.

Implements section **A** of [`docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`](https://github.com/gjcourt/homelab/blob/master/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md) (merged in #1315).

## Approach: extend the heartbeat, don't add an exporter

Straight from the plan. `homelabscope-heartbeat` is already `privileged: true` with `/dev/zfs`, so a `docker.sock` mount raises no privilege bar; it is already scraped, already alerted on, and the Grafana dashboard is generic over the family so new series appear with zero dashboard work. Decisively: **the watcher is already watched** — `HomelabscopeJobMetricAbsent` guards the ZFS jobs it writes, so a dead heartbeat pages on its own. A new exporter would need that liveness story built from scratch.

## What it emits

Generic over **every** container the daemon knows about, running or not — not a curated watchlist. `x-deploy.archived` is known-untrustworthy as a "should be running" source (thermalscope is archived in the repo and `up=1` in reality), so the collector reports what *is* and the `PrometheusRule` decides what *must* be.

```
# HELP homelabscope_container_probe_success Whether the last Docker socket probe succeeded (1=yes, 0=no).
# TYPE homelabscope_container_probe_success gauge
homelabscope_container_probe_success 1
# HELP homelabscope_container_running Whether the container is currently running (1=yes, 0=no).
# TYPE homelabscope_container_running gauge
homelabscope_container_running{name="gha-runner"} 1
homelabscope_container_running{name="libation"} 0
# HELP homelabscope_container_restarts_total Docker RestartCount for the container (monotonic; resets on recreate).
# TYPE homelabscope_container_restarts_total counter
homelabscope_container_restarts_total{name="gha-runner"} 9
homelabscope_container_restarts_total{name="thermalscope"} 11894
# HELP homelabscope_container_last_exit_code Exit code of the container's previous instance (0 while it has never exited).
# TYPE homelabscope_container_last_exit_code gauge
homelabscope_container_last_exit_code{name="gha-runner"} 0
homelabscope_container_last_exit_code{name="thermalscope"} 1
# HELP homelabscope_container_started_seconds Unix timestamp the current container instance started.
# TYPE homelabscope_container_started_seconds gauge
homelabscope_container_started_seconds{name="gha-runner"} 1787054400
# HELP homelabscope_container_health Docker healthcheck state (1=healthy, 0=unhealthy, 2=starting); absent when the container declares no healthcheck.
# TYPE homelabscope_container_health gauge
homelabscope_container_health{name="gha-runner"} 1
```

## The one fact the plan did not have: the runner is ephemeral

The runner image's `/entrypoint.sh` tests `[ -n "$EPHEMERAL" ]`, so the compose's `EPHEMERAL: "false"` — a *non-empty string* — still activates `--ephemeral`. The container completes one job, deregisters, **exits 0**, and is restarted by `unless-stopped`: roughly **one restart per job**. `RestartCount` went 0 → 9 across a single 10-job deploy.

**This breaks the plan's sketched alert.** `increase(restarts_total[1h]) > 5` fires on a perfectly healthy busy afternoon. Restart rate alone cannot separate *restarting and doing work* from *restarting and completing nothing* (the 11894-restart crash loop).

So two extra series, both exact reads of Docker state rather than derived guesses:

| Series | Discriminates by |
|---|---|
| `..._last_exit_code` | crash loop is `restarts high AND last_exit_code != 0`; busy deploy is `restarts high AND last_exit_code == 0` |
| `..._started_seconds` | `time() - started_seconds` never grows past seconds in a flap; a real job runs for minutes. Works with no exit codes at all |

Hence `CONTAINER_INTERVAL_SECONDS=60`, not the SSH/ZFS jobs' 600s: `ExitCode` is a point-in-time sample, and the tight cadence is what catches a crash loop mid-failure while not misreading a multi-minute job as a flap. The slow jobs keep their 600s cadence in the same loop.

### A completed-jobs counter is NOT observable here, and is not faked

`docker inspect` exposes only the **last** exit — `.State.ExitCode` / `.State.FinishedAt` — not a history. Between two polls N restarts may have occurred with mixed outcomes; minting a per-poll clean-exit counter from one observed exit code would attribute all N to the last one. That is fabrication, so it is not done.

The exact source is the `/events` stream (`die` carries an `exitCode` attribute), which needs a second long-lived streaming process plus cross-restart counter persistence. Recorded in-code as the escalation path if exit code proves insufficient in practice.

`homelabscope_container_starts_total` is also **not** emitted: `RestartCount` already *is* the starts signal (`starts = restarts + 1` per container instance), so a second series would carry no information.

## Notes

- `probe_success` separates "Docker unreachable" from "every container gone" — two states that both drop the per-container series and would otherwise look identical.
- `homelabscope_container_health` is **absent** for containers with no healthcheck, rather than 0. Emitting "unhealthy" for a container that declares no health would make every unmonitored container look broken.
- `CONTAINER_EXCLUDE_REGEX` (default empty) lets the operator suppress churn — e.g. buildx builder containers the runner spawns through the socket it already mounts — without an image rebuild.
- `curl` + `jq` over the socket rather than the docker CLI: ~3MB from Debian's own archive instead of ~30MB and a third-party apt repo, to answer questions the REST API answers in two GETs.
- Writes are atomic (`.tmp` then `mv`), same discipline as `emit_job`, so node-exporter never reads a half-written file.
- Cardinality: ~5 series × ~8 containers. Compare cAdvisor, which the plan explicitly rejects on exactly this ground.

## Testing

- `bash -n` clean; `shellcheck -s bash` clean on all new code (one pre-existing SC2012 *info* on untouched `ls`).
- Probe driven against synthetic Docker API responses covering: running + healthy, stopped + never-started (`StartedAt = 0001-01-01`, correctly omitted), crash-looping with `starting` health, no-healthcheck container, socket-unreachable, and `CONTAINER_EXCLUDE_REGEX`.
- Output parsed with `prometheus_client.parser` — 6 families, 18 samples, no errors.

## Scope — this is PR 1 of 2

Per the plan's step 3, **image only**. The follow-up must:

1. Add `- /var/run/docker.sock:/var/run/docker.sock:ro` to `docker-compose-homelabscope-heartbeat.yml`
2. Pin the digest this PR's build publishes
3. Add the alert pair to `infra/configs/homelabscope/prometheus-rule.yaml` — `running == 0 for 10m`, and a restart-rate arm written against `last_exit_code` / `started_seconds` so the ephemeral runner does not false-fire. Both `severity: critical` (warnings route behind a skip-inbox filter this repo documents as effectively unread).
4. Add the `absent()` guards **once the series are confirmed live** — guarding a not-yet-present series is a guaranteed false critical.
5. Decide the watchlist for (3)/(4). Explicit list; `x-deploy.archived` is not usable for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA