### PR TITLE
feat(monitoring): hestia container health alerts + gha-runner runbook

### DIFF
--- a/docs/operations/apps/gha-runner.md
+++ b/docs/operations/apps/gha-runner.md
@@ -104,15 +104,25 @@ node-exporter textfile collector and scraped through the existing
 `hestia-homelabscope` ScrapeConfig.
 
 ```
-homelabscope_container_running{name="gha-runner"}         1 = running, 0 = not
-homelabscope_container_restarts_total{name="gha-runner"}  docker RestartCount (counter)
-homelabscope_container_health{name="gha-runner"}          docker healthcheck status
+homelabscope_container_running{name="gha-runner"}          1 = running, 0 = not
+homelabscope_container_restarts_total{name="gha-runner"}   docker RestartCount (counter)
+homelabscope_container_last_exit_code{name="gha-runner"}   docker .State.ExitCode
+homelabscope_container_started_seconds{name="gha-runner"}  current instance start, epoch
+homelabscope_container_health{name="gha-runner"}           1 healthy / 0 unhealthy /
+                                                           2 starting; absent with no
+                                                           healthcheck
+homelabscope_container_probe_success                       1 = docker socket reachable
 ```
+
+There is **no** completed-jobs counter and there will not be one. `docker
+inspect` exposes only the *last* exit, never a history, so N restarts between
+two polls would all be attributed to one observed exit code — the emitter
+refuses to fabricate that and publishes `last_exit_code` instead.
 
 | Alert | Expression | For | Severity |
 |---|---|---|---|
 | `HomelabscopeContainerDown` (`lifecycle: ephemeral`) | `homelabscope_container_running{name="gha-runner"} == 0` | 30m | critical |
-| `HomelabscopeContainerRestartLoop` (`lifecycle: ephemeral`) | `increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100 unless increase(homelabscope_container_jobs_completed_total{name="gha-runner"}[1h]) > 0` | 10m | critical |
+| `HomelabscopeContainerRestartLoop` (`lifecycle: ephemeral`) | `increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100 or (increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 10 and max_over_time(homelabscope_container_last_exit_code{name="gha-runner"}[5m]) > 0)` | 10m | critical |
 | `HomelabscopeContainerMetricAbsent` | `absent(homelabscope_container_running{name="gha-runner"}) or absent(...{name="homelabscope-heartbeat"})` | 1h | critical |
 
 Long-lived hestia containers get the same pair with `lifecycle: long-lived`, a
@@ -121,36 +131,66 @@ Long-lived hestia containers get the same pair with `lifecycle: long-lived`, a
 **Why the runner's numbers differ so much from every other container:**
 
 - **`for: 30m` on down.** The real gap between ephemeral jobs is a few *seconds*,
-  but the probe latches whatever it sampled for a full emit interval (600s), so
-  one unlucky mid-restart sample pins `running=0` for ten minutes of series. 30m
-  needs roughly three consecutive unlucky samples — implausible for a
-  seconds-wide window — while still catching a dead runner inside the hour.
-- **`> 100` restarts/hour.** One restart per job is the *success* path.
-  `deploy-hestia.yml` is the only workflow on this runner; even a Renovate merge
-  storm plus the hourly canary is tens of jobs an hour, not hundreds. The
-  observed crash loop ran ~1 restart/sec ≈ 3600/hour. 100 sits ~2× above the
-  busiest plausible legitimate hour and ~36× below the observed loop.
+  but the probe latches whatever it sampled for a full emit interval (60s for
+  the container probe), so one unlucky mid-restart sample pins `running=0` for a
+  minute of series. 30m needs a long unbroken run of such samples — implausible
+  for a seconds-wide window — while still catching a dead runner inside the
+  hour. Note this rule **cannot** see a crash loop: Docker reports
+  `.State.Running = true` while a container sits in restart backoff, so a
+  looping runner still reads `running=1`. The restart-loop rule covers that.
 - **`increase()`, not `delta()` or `resets()`.** `increase()` applies
   counter-reset detection, so it survives `RestartCount` returning to 0 when the
   container is *recreated* (image bump, SCALE `app.update`). `delta()` has no
   reset detection and goes negative across a recreate, masking exactly the event
   you want. `resets()` counts recreates only and would have scored **zero** on
   2026-08-18, which was restart-policy churn within one container life.
-- **The `unless` arm.** A runner that restarts *and completes work* is healthy by
-  definition; restarting while completing nothing is the incident signature. It
-  is a **soft** dependency: if the emitter does not publish
-  `homelabscope_container_jobs_completed_total`, the right-hand vector is empty,
-  `unless` suppresses nothing, and the rule degrades to the bare 100/hour
-  threshold. Fail-open, so a missing optional series can never silence the alert.
+- **Two arms, not one threshold.** For an ephemeral runner a restart is the
+  *success* path, so rate alone cannot separate "restarting and doing work" from
+  "restarting and completing nothing". The exit code can, exactly:
 
-**Known residual gap:** a slow crash loop that hits Docker's 60s restart-backoff
-cap tops out near 60/hour and stays under the threshold. That case is covered
-off-cluster by the runner-canary workflow (plan §B), which goes red within ~2h.
-Narrowing the threshold would trade a real off-cluster catch for guaranteed
-false pages on busy deploy hours.
+  | | restarts/hour | `last_exit_code` | arm |
+  |---|---|---|---|
+  | healthy 10-job deploy | ~9 | `0` | neither — silent |
+  | Renovate merge storm | tens | `0` | neither — silent |
+  | slow loop at the 60s backoff cap | ~60 | non-zero | **qualified (`> 10`)** |
+  | fast loop, ~1 restart/sec | ~3600 | non-zero | **rate-only (`> 100`)** |
 
-`homelabscope_container_health` is deliberately **not** alerted on: its value
-encoding (none / starting / healthy / unhealthy) is the emitter's to define.
+- **Why the exit code discriminates.** Docker zeroes `.State.ExitCode` when a
+  container enters the running state and sets it to the real code while the
+  container sits in restart backoff — so a non-zero sample means "in crash
+  backoff right now". The rule does not depend on that reading being exact:
+  even if the previous code were latched across the running window, a healthy
+  `--ephemeral` runner exits **0** after every completed job (measured:
+  `RestartCount` 0 → 9 across a 10-job deploy), so non-zero can only come from
+  an abnormal exit. Healthy busy is `0` either way.
+- **`> 10` on the qualified arm.** 10/hour is safe *only* because of the
+  exit-code conjunction — a 10-job deploy is 9 restarts at exit 0 and fails both
+  conjuncts. It is reached ~10 minutes into a 60s-cap loop, so with `for: 10m`
+  the alert pages ~20 minutes in.
+- **`> 100` on the rate-only arm, kept.** It catches a pathological loop whose
+  exits are 0, and it is what the rule degrades to if `last_exit_code` ever
+  stops being emitted. 100/hour is ~2× above the busiest plausible legitimate
+  hour and ~36× below the observed fast loop (`RestartCount` hit 11894).
+- **`max_over_time(...[5m])` with `for: 10m`, window deliberately shorter than
+  the `for:`.** A single non-zero sample at time *s* makes the exit-code half
+  true only for `[s, s+5m]` — five minutes, which cannot satisfy a ten-minute
+  `for:`. So a one-off abnormal exit during a busy deploy hour can never page;
+  firing requires abnormal exits *recurring* across >10 minutes. `max_over_time`
+  rather than an instant read or `min_over_time` because at the 60s cap roughly
+  1 sample in 60 lands mid-exec and reads 0, which would flap the `for:` timer.
+
+**The backoff-cap gap is closed.** The previous bare `> 100` could not see a
+slow crash loop pinned at Docker's 60s restart-backoff cap: it tops out near
+60/hour and stayed under the threshold forever, leaving the case to the
+off-cluster runner-canary workflow (plan §B) and its ~2h latency. The qualified
+arm catches it in ~20 minutes. The canary stays — it is off-cluster and
+therefore survives failures this rule cannot see — but it is no longer the only
+thing standing between a slow loop and a silent deploy queue.
+
+`homelabscope_container_health` is deliberately **not** alerted on. The encoding
+is now settled (1 healthy / 0 unhealthy / 2 starting, **absent** when the
+container declares no healthcheck), but no hestia container this rule file
+targets declares a healthcheck yet, so there is nothing for it to watch.
 
 Routing: `severity: critical` → `email-critical` → `gjcourt+critical@gmail.com`,
 `repeat_interval` 4h. It pages.

--- a/docs/operations/apps/gha-runner.md
+++ b/docs/operations/apps/gha-runner.md
@@ -1,0 +1,236 @@
+# gha-runner — self-hosted GitHub Actions runner on hestia
+
+## 1. Overview
+
+`gha-runner` is the self-hosted GitHub Actions runner that applies every
+`hosts/hestia/**/docker-compose*.yml` change to the TrueNAS Apps subsystem. It
+is the **only** path by which hestia Custom Apps get deployed from Git — if it
+is down, every hestia deploy silently queues instead of failing.
+
+| Attribute | Value |
+|---|---|
+| Host | hestia (`10.42.2.10`), TrueNAS SCALE Custom App |
+| Compose | [`hosts/hestia/actions-runner/docker-compose.yml`](../../../hosts/hestia/actions-runner/docker-compose.yml) |
+| Bootstrap / token rotation | [`hosts/hestia/actions-runner/README.md`](../../../hosts/hestia/actions-runner/README.md) |
+| Image | `myoung34/github-runner` (digest-pinned) |
+| Container name | `gha-runner` (docker: `ix-gha-runner-runner-1`) |
+| Runner name / labels | `hestia` / `hestia`, `truenas` |
+| Consumer | `.github/workflows/deploy-hestia.yml`, job on `runs-on: [self-hosted, hestia]` |
+| Design | [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../plans/2026-05-02-hestia-gha-runner.md) |
+| Monitoring | [`docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`](../../plans/2026-08-18-hestia-deploy-monitoring-gap.md) |
+
+## 2. The two facts that make this runner surprising
+
+### 2.1 It is ephemeral, so constant restarting is NORMAL
+
+The image's `/entrypoint.sh` gates on **variable presence, not truth**:
+
+```sh
+if [ -n "${EPHEMERAL}" ]; then
+  ARGS+=("--ephemeral")
+fi
+if [ -n "${DISABLE_AUTO_UPDATE}" ]; then
+  ARGS+=("--disableupdate")
+fi
+```
+
+`[ -n "$VAR" ]` is true for *any non-empty string*. `EPHEMERAL: "false"` in the
+compose file is a non-empty string, so **`--ephemeral` is active** despite the
+value reading `false`.
+
+Consequence: the runner registers, executes **exactly one job**, deregisters,
+exits 0, and `restart: unless-stopped` starts a fresh container for the next
+job. Measured: `RestartCount` went **0 → 9 across a single 10-job deploy**.
+
+**Do not read a rising `RestartCount` as a fault.** Tens of restarts per hour is
+a busy deploy day. Thousands is a crash loop. See §4 for where the line is.
+
+### 2.2 Auto-update is disabled, and "false" will not turn it back on
+
+Same presence-test bug: setting `DISABLE_AUTO_UPDATE: "false"` still passes
+`--disableupdate`. **The only way to re-enable auto-update is to REMOVE the
+variable from the compose file entirely** — not to set it to `false`.
+
+This matters because GitHub hard-deprecates old runner versions. With
+`--disableupdate` the runner cannot climb past the minimum version on its own,
+so the fix is a digest bump in Git — and `hosts/hestia/actions-runner/` is
+**unconditionally excluded** from `deploy-hestia.yml` (chicken-and-egg: the
+runner cannot reliably recreate its own container mid-job). So the runner can
+neither self-update nor self-deploy its own fix. Upgrades are manual (§6).
+
+## 3. The 2026-08-18 incident (why this runbook exists)
+
+A merge to `master` touching `hosts/hestia/**` produced a `deploy-hestia.yml`
+run that sat **queued indefinitely**. The runner was crash-looping:
+
+```
+Current runner version: '2.334.0'
+An error occurred: Runner version v2.334.0 is deprecated and cannot receive messages.
+RestartCount = 11894
+```
+
+It registered successfully every time, was told its version was too old, exited,
+and was restarted forever. GitHub reported the runner `status=offline`. An
+earlier Renovate deploy run had been sitting queued, unnoticed, for well over a
+day.
+
+**Nothing alerted**, for four independent reasons:
+
+1. **hestia has no per-container metrics.** Its four scrape targets are
+   node-exporter (`:9100`), netscope (`:9101`), thermalscope (`:9102`),
+   ipmi-exporter (`:9290`). There is no cAdvisor and no docker exporter —
+   `count({__name__=~"container_.*", instance="hestia"})` returns an empty
+   vector. The node-exporter runs `--collector.disable-defaults
+   --collector.textfile`; it is a textfile courier, deliberately.
+2. **The Kubernetes-shaped alerts create false confidence.**
+   `ContainerCrashLoopBackOff` / `ContainerOOMKilled` / `ContainerHighCPU` in
+   `infra/configs/alerts/prometheus-rules.yaml` read `kube_pod_container_status_*`
+   and cAdvisor. hestia is not a node in this cluster. Those alert *names* read
+   as coverage that does not exist.
+3. **homelabscope's job model does not fit an event-driven pipeline.**
+   `homelabscope_job_*` is "last success + max-age budget". `deploy-hestia.yml`
+   fires on push: no cadence, no expected freshness, nothing to be late against.
+4. **A queued run is not a failed run.** GitHub emails on workflow *failure*. A
+   run nobody picks up never fails. Runner `status=offline` lives only in a
+   Settings page that nothing polls.
+
+## 4. Monitoring
+
+Alerts live in
+[`infra/configs/homelabscope/prometheus-rule.yaml`](../../../infra/configs/homelabscope/prometheus-rule.yaml),
+group `homelabscope.containers`. They are fed by the `homelabscope-heartbeat`
+container probe on hestia (docker socket, read-only), written to the
+node-exporter textfile collector and scraped through the existing
+`hestia-homelabscope` ScrapeConfig.
+
+```
+homelabscope_container_running{name="gha-runner"}         1 = running, 0 = not
+homelabscope_container_restarts_total{name="gha-runner"}  docker RestartCount (counter)
+homelabscope_container_health{name="gha-runner"}          docker healthcheck status
+```
+
+| Alert | Expression | For | Severity |
+|---|---|---|---|
+| `HomelabscopeContainerDown` (`lifecycle: ephemeral`) | `homelabscope_container_running{name="gha-runner"} == 0` | 30m | critical |
+| `HomelabscopeContainerRestartLoop` (`lifecycle: ephemeral`) | `increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100 unless increase(homelabscope_container_jobs_completed_total{name="gha-runner"}[1h]) > 0` | 10m | critical |
+| `HomelabscopeContainerMetricAbsent` | `absent(homelabscope_container_running{name="gha-runner"}) or absent(...{name="homelabscope-heartbeat"})` | 1h | critical |
+
+Long-lived hestia containers get the same pair with `lifecycle: long-lived`, a
+15m `for:`, and a `> 5` restart threshold.
+
+**Why the runner's numbers differ so much from every other container:**
+
+- **`for: 30m` on down.** The real gap between ephemeral jobs is a few *seconds*,
+  but the probe latches whatever it sampled for a full emit interval (600s), so
+  one unlucky mid-restart sample pins `running=0` for ten minutes of series. 30m
+  needs roughly three consecutive unlucky samples — implausible for a
+  seconds-wide window — while still catching a dead runner inside the hour.
+- **`> 100` restarts/hour.** One restart per job is the *success* path.
+  `deploy-hestia.yml` is the only workflow on this runner; even a Renovate merge
+  storm plus the hourly canary is tens of jobs an hour, not hundreds. The
+  observed crash loop ran ~1 restart/sec ≈ 3600/hour. 100 sits ~2× above the
+  busiest plausible legitimate hour and ~36× below the observed loop.
+- **`increase()`, not `delta()` or `resets()`.** `increase()` applies
+  counter-reset detection, so it survives `RestartCount` returning to 0 when the
+  container is *recreated* (image bump, SCALE `app.update`). `delta()` has no
+  reset detection and goes negative across a recreate, masking exactly the event
+  you want. `resets()` counts recreates only and would have scored **zero** on
+  2026-08-18, which was restart-policy churn within one container life.
+- **The `unless` arm.** A runner that restarts *and completes work* is healthy by
+  definition; restarting while completing nothing is the incident signature. It
+  is a **soft** dependency: if the emitter does not publish
+  `homelabscope_container_jobs_completed_total`, the right-hand vector is empty,
+  `unless` suppresses nothing, and the rule degrades to the bare 100/hour
+  threshold. Fail-open, so a missing optional series can never silence the alert.
+
+**Known residual gap:** a slow crash loop that hits Docker's 60s restart-backoff
+cap tops out near 60/hour and stays under the threshold. That case is covered
+off-cluster by the runner-canary workflow (plan §B), which goes red within ~2h.
+Narrowing the threshold would trade a real off-cluster catch for guaranteed
+false pages on busy deploy hours.
+
+`homelabscope_container_health` is deliberately **not** alerted on: its value
+encoding (none / starting / healthy / unhealthy) is the emitter's to define.
+
+Routing: `severity: critical` → `email-critical` → `gjcourt+critical@gmail.com`,
+`repeat_interval` 4h. It pages.
+
+## 5. Diagnosis
+
+Symptoms in rough order of how you'll notice them:
+
+| Symptom | Check |
+|---|---|
+| A `deploy-hestia` run is stuck **Queued** | `gh run list --workflow=deploy-hestia.yml` |
+| Runner shows **Offline** | `https://github.com/gjcourt/homelab/settings/actions/runners` |
+| Deploy "succeeded" but nothing changed | §7 |
+
+```bash
+# Is it running, and how many times has it restarted?
+ssh truenas_admin@10.42.2.10 \
+  'docker inspect ix-gha-runner-runner-1 --format "{{.State.Status}} restarts={{.RestartCount}} image={{.Config.Image}}"'
+
+# What is it saying on each start?
+ssh truenas_admin@10.42.2.10 'docker logs --tail 100 ix-gha-runner-runner-1'
+```
+
+Log signatures:
+
+| Log line | Meaning | Fix |
+|---|---|---|
+| `Runner version vX is deprecated and cannot receive messages` | GitHub raised its minimum version; `--disableupdate` blocks self-upgrade | §6 — bump the digest, manual deploy |
+| `curl: (22) The requested URL returned error: 403` | `ACCESS_TOKEN` lacks `Administration` (fine-grained) / `repo` (classic) | Rotate the PAT with correct scopes |
+| `Listening for Jobs` then immediate exit | Normal ephemeral completion, not a fault | Nothing |
+| Nothing at all / container absent | App stopped or removed in SCALE | Start it; check `HomelabscopeContainerMetricAbsent` |
+
+## 6. Recovery — upgrading a deprecated runner
+
+The runner cannot deploy its own fix. This is manual, by design.
+
+1. Find the current digest for the pinned tag:
+   ```bash
+   docker manifest inspect myoung34/github-runner:ubuntu-noble \
+     | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest'
+   ```
+2. Update the `image:` pin in `hosts/hestia/actions-runner/docker-compose.yml`,
+   branch + PR + merge as normal. **The merge will not deploy it** — the path is
+   excluded from `deploy-hestia.yml`.
+3. Apply it by hand, either:
+   - SCALE UI → Apps → `gha-runner` → Edit → paste the updated compose → Save; or
+   - from a machine with network access to hestia:
+     ```bash
+     TRUENAS_API_KEY=… scripts/truenas-update-app.sh gha-runner hosts/hestia/actions-runner/docker-compose.yml
+     ```
+     (`--dry-run` first to see the diff without calling `app.update`.)
+4. Verify the runner returns to **Idle** at
+   `https://github.com/gjcourt/homelab/settings/actions/runners`, then re-run any
+   queued deploy: `gh run list --workflow=deploy-hestia.yml`, `gh run rerun <id>`.
+
+**Do not "fix" this by setting `DISABLE_AUTO_UPDATE: "false"`.** It is
+presence-tested (§2.2) and will change nothing. Remove the variable if you want
+auto-update back — accepting that the runner then drifts from the digest pinned
+in Git, which is why it is disabled today.
+
+## 7. Related failure: a deploy that reports success and does nothing
+
+`app.update` can return `SUCCESS` without taking effect against a crash-looping
+container — a known, documented quirk
+([`docs/operations/2026-05-14-truenas-app-update-quirk.md`](../2026-05-14-truenas-app-update-quirk.md)).
+Confirm what is actually running rather than trusting the workflow's green tick:
+
+```bash
+ssh truenas_admin@10.42.2.10 'docker inspect ix-<app>-<service>-1 --format "{{.Config.Image}}"'
+```
+
+Diff against the compose file in Git. Post-apply verification inside
+`scripts/truenas-update-app.sh` is plan §C1; the drift check is §C2.
+
+## 8. Escalation / graduation
+
+When ≥2 self-hosted-runner workflows exist, or this Custom App becomes a
+maintenance burden, replace it with
+[`actions-runner-controller`](https://github.com/actions/actions-runner-controller)
+in `melodic-muse` — see
+[the design plan's graduation path](../../plans/2026-05-02-hestia-gha-runner.md#graduation-path--option-2b-actions-runner-controller-in-talos).
+That removes both surprises in §2 at once: ARC's ephemeral model is explicit, and
+runner version management stops being a manual digest bump on an excluded path.

--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -18,6 +18,19 @@
 #      the family. No new exporter — kube-state-metrics already exposes it.
 #   3. (future) anything else that can write the family directly.
 #
+# A SECOND, independent family covers hestia CONTAINER health (the
+# homelabscope.containers group at the bottom of this file):
+#
+#   homelabscope_container_running{name}         1=running, 0=not
+#   homelabscope_container_restarts_total{name}  docker RestartCount (counter)
+#   homelabscope_container_health{name}          docker healthcheck status
+#
+# It answers a different question — "is this thing up", not "did this thing
+# finish on time" — for a host that has no cAdvisor and is not a cluster node.
+# Same emitter (homelabscope-heartbeat), same textfile courier, same
+# ScrapeConfig, same Stale/MetricAbsent alert shape. See
+# docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md section A.
+#
 # Alerting is a single templated pair over the whole family (see the
 # homelabscope.alerts group): a generic staleness alert that compares each
 # job's age to its own max_age budget, plus an absence alert that catches a
@@ -215,3 +228,222 @@ spec:
             summary: "Homelabscope job {{ $labels.job }} heartbeat is absent"
             description: >
               No homelabscope_job_last_success_seconds series exists for job {{ $labels.job }} for >1h. Its heartbeat has vanished entirely (textfile no longer written / exporter down, or the CronJob was removed) — distinct from "stale", which needs the series to still exist. Check the hestia node-exporter (:9100) and the homelabscope-heartbeat Custom App, or `kubectl get cronjob -A` for the CronJob-backed jobs.
+
+    # -----------------------------------------------------------------------
+    # Container health on hestia — homelabscope_container_* family.
+    #
+    # WHY THIS EXISTS. On 2026-08-18 a merge to master touching hosts/hestia/**
+    # produced a deploy-hestia.yml run that sat QUEUED INDEFINITELY. The
+    # self-hosted runner on hestia was crash-looping (RestartCount 11894) on
+    # "Runner version v2.334.0 is deprecated and cannot receive messages": it
+    # registered, was refused work, exited, and `restart: unless-stopped` put it
+    # straight back. Nothing alerted — not the crash loop, not the offline
+    # runner, not the queued run, not the image drift that accumulated behind
+    # it. Full diagnosis: docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
+    # (section A is what these rules implement). Runbook:
+    # docs/operations/apps/gha-runner.md.
+    #
+    # Why nothing existing covered it:
+    #   * ContainerCrashLoopBackOff / ContainerOOMKilled / ContainerHighCPU in
+    #     infra/configs/alerts/prometheus-rules.yaml read
+    #     kube_pod_container_status_* and cAdvisor. hestia is NOT a node in this
+    #     cluster and runs no cAdvisor — verified live,
+    #     count({__name__=~"container_.*", instance="hestia"}) is an EMPTY
+    #     vector. Those alert NAMES read as coverage the cluster does not have.
+    #   * The homelabscope_job_* family is "last success + max-age budget",
+    #     which is right for the 11 scheduled jobs it covers and structurally
+    #     wrong for a push-triggered pipeline: no cadence, so no freshness
+    #     budget to be late against.
+    #
+    # METRIC CONTRACT. Emitted by the homelabscope-heartbeat container probe on
+    # hestia (already privileged, gains /var/run/docker.sock:ro), written to the
+    # node-exporter textfile collector and scraped through the SAME
+    # hestia-homelabscope ScrapeConfig as the job family. Generic over hestia
+    # containers, keyed on `name` — NOT runner-specific, so every future hestia
+    # container is covered with no rule change:
+    #
+    #   homelabscope_container_running{name}         1 = running, 0 = not
+    #   homelabscope_container_restarts_total{name}  docker RestartCount, COUNTER
+    #   homelabscope_container_health{name}          docker healthcheck status
+    #
+    # homelabscope_container_health is DELIBERATELY NOT ALERTED ON here. Its
+    # value encoding (none / starting / healthy / unhealthy) is the emitter's to
+    # define and is not yet fixed; a rule written against a guessed encoding is
+    # worse than no rule. Add it in a follow-up once the encoding is settled.
+    #
+    # The probe's emit interval (INTERVAL_SECONDS, 600s today) — not the 60s
+    # scrape — is the real detection granularity: a value is latched in the
+    # .prom for a full interval. Every `for:` below is sized against 600s, not
+    # against the scrape.
+    # -----------------------------------------------------------------------
+    - name: homelabscope.containers
+      rules:
+        # ---- Not running -----------------------------------------------------
+        # The primary "not doing its job" signal. A container that is down stays
+        # down; `== 0` sustained is unambiguous in a way restart-rate is not.
+        #
+        # LONG-LIVED containers (everything except the runner). 15m rides out a
+        # deploy-hestia app.update recreate (seconds) and an operator Stop/Start,
+        # and is >2 probe intervals so a single latched sample can't fire it.
+        - alert: HomelabscopeContainerDown
+          expr: homelabscope_container_running{name!="gha-runner"} == 0
+          for: 15m
+          labels:
+            # `lifecycle` splits the two arms of each pair. It is not routed on
+            # (Alertmanager matches severity/namespace only) — it exists so the
+            # two rules that share an alert name never produce an identical
+            # label set, which promtool's duplicate-rule lint rejects, and so a
+            # silence or dashboard can target one lifecycle without the other.
+            lifecycle: long-lived
+            # critical because only severity=critical reaches the inbox:
+            # 'email-critical' -> gjcourt+critical@gmail.com, repeat_interval 4h.
+            # severity=warning routes to 'email-warning' (+alerts@), which a
+            # Gmail filter skips out of the inbox — a daily nag, not a page.
+            # No severity label at all falls through to the 'null' receiver and
+            # is silently discarded, so every rule here carries one. The
+            # `namespace =~ ".+-stage"` warning mute cannot apply: these series
+            # carry no namespace label.
+            severity: critical
+          annotations:
+            summary: "hestia container {{ $labels.name }} is not running"
+            description: >
+              Container {{ $labels.name }} on hestia has been not-running for >15m. hestia has no cAdvisor and is not a cluster node, so this family is the ONLY thing that can see it. Check `docker ps -a` on 10.42.2.10, `docker logs ix-{{ $labels.name }}-*`, and the app's state in the SCALE UI. Runbook: docs/operations/apps/gha-runner.md (runner) / hosts/hestia/README.md (Custom App model).
+
+        # THE RUNNER IS EPHEMERAL and needs its own, longer, `for:`.
+        # The image's /entrypoint.sh gates on PRESENCE, not truth:
+        #   if [ -n "${EPHEMERAL}" ]; then ARGS+=("--ephemeral"); fi
+        # so `EPHEMERAL: "false"` in hosts/hestia/actions-runner/docker-compose.yml
+        # STILL activates --ephemeral. The container therefore completes exactly
+        # one job, deregisters, exits 0, and is restarted by `unless-stopped`.
+        # (Measured: RestartCount 0 -> 9 across a 10-job deploy.)
+        #
+        # The real gap between jobs is a few SECONDS, but the probe latches
+        # whatever it sampled for a full 600s interval — so one unlucky sample
+        # taken mid-restart pins running=0 for 10 minutes of series. `for: 30m`
+        # requires roughly three consecutive unlucky samples, which a
+        # seconds-wide window cannot plausibly produce, while still catching a
+        # genuinely dead runner well inside the hour.
+        - alert: HomelabscopeContainerDown
+          expr: homelabscope_container_running{name="gha-runner"} == 0
+          for: 30m
+          labels:
+            lifecycle: ephemeral
+            severity: critical
+          annotations:
+            summary: "hestia gha-runner is not running"
+            description: >
+              The self-hosted GitHub Actions runner container on hestia has been not-running for >30m. The runner is ephemeral (one job per container life), so brief gaps are normal and 30m is not — deploy-hestia.yml runs are queueing with nobody to pick them up, which GitHub does NOT email about because a queued run never fails. Runbook: docs/operations/apps/gha-runner.md.
+
+        # ---- Restart loop ----------------------------------------------------
+        # increase(), NOT delta() and NOT resets(), on purpose:
+        #   * increase() applies counter-reset detection from the sample values,
+        #     so it survives RestartCount going back to 0 when the container is
+        #     RECREATED (image bump, SCALE app.update) rather than restarted.
+        #   * delta() has no reset detection and goes NEGATIVE across a recreate,
+        #     masking exactly the event we want to see.
+        #   * resets() counts recreates only. It would have scored ZERO on the
+        #     2026-08-18 incident, which was restart-policy churn on a single
+        #     container life — the whole failure mode.
+        #
+        # LONG-LIVED containers: >5 restarts in an hour is already pathological.
+        # This is the plan's original threshold and it is correct HERE — it is
+        # only wrong for the ephemeral runner, which is split out below.
+        - alert: HomelabscopeContainerRestartLoop
+          expr: increase(homelabscope_container_restarts_total{name!="gha-runner"}[1h]) > 5
+          for: 10m
+          labels:
+            lifecycle: long-lived
+            severity: critical
+          annotations:
+            summary: "hestia container {{ $labels.name }} is restarting repeatedly"
+            description: >
+              Container {{ $labels.name }} on hestia restarted {{ $value | printf "%.0f" }} times in the last hour. These containers are long-lived services; >5 restarts/hour is a crash loop, not churn. Check `docker logs ix-{{ $labels.name }}-*` on 10.42.2.10 for the repeating exit.
+
+        # THE RUNNER'S THRESHOLD IS DIFFERENT BY AN ORDER OF MAGNITUDE, because
+        # for an ephemeral runner a restart is the SUCCESS path, not a fault.
+        # Sizing, with margin deliberately wide on both sides:
+        #   legit ceiling  ~1 restart per job. deploy-hestia.yml is the only
+        #                  workflow on `runs-on: [self-hosted, hestia]`; even a
+        #                  Renovate merge storm plus the hourly canary is tens of
+        #                  jobs an hour, not hundreds.
+        #   observed loop  ~1 restart/sec => ~3600/hour (RestartCount hit 11894).
+        # 100/hour sits ~2x above the busiest plausible legitimate hour and ~36x
+        # below the observed loop, and is crossed ~100s into a fast loop.
+        #
+        # THE `unless` ARM is the precision half: a runner that is restarting
+        # AND completing work is healthy by definition; a runner that is
+        # restarting and completing NOTHING is the 2026-08-18 incident exactly
+        # (it registered, was refused work, and completed zero jobs).
+        #
+        # IT IS A SOFT DEPENDENCY, ON PURPOSE. If the emitter does not publish
+        # homelabscope_container_jobs_completed_total (or publishes it under a
+        # different name, or with a label set that doesn't match), the right-hand
+        # vector is EMPTY, `unless` suppresses nothing, and this rule degrades
+        # cleanly to the bare 100/hour threshold — which is already safe on its
+        # own. Fail-open was chosen over fail-closed so a missing optional series
+        # can never silence the alert. If the emitter lands the counter under
+        # another name, change it here; nothing breaks in the meantime.
+        #
+        # KNOWN RESIDUAL GAP, stated rather than papered over: a SLOW crash
+        # loop that hits Docker's 60s restart backoff cap tops out near
+        # 60/hour and stays under this threshold. It is not silent — the
+        # runner-canary workflow (plan section B) goes red off-cluster within
+        # ~2h on exactly that case, which is why the canary is step 1 of the
+        # plan and this rule is step 3. Narrowing the threshold instead would
+        # trade a real off-cluster catch for guaranteed false pages on busy
+        # deploy hours.
+        - alert: HomelabscopeContainerRestartLoop
+          expr: >
+            increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100
+            unless
+            increase(homelabscope_container_jobs_completed_total{name="gha-runner"}[1h]) > 0
+          for: 10m
+          labels:
+            lifecycle: ephemeral
+            severity: critical
+          annotations:
+            summary: "hestia gha-runner is crash-looping"
+            description: >
+              The hestia GitHub Actions runner restarted {{ $value | printf "%.0f" }} times in the last hour while completing no jobs. The runner is ephemeral so restarts are normal — this rate is not, and zero completed work alongside it means the deploy path is dead and runs are silently queueing. Most likely cause is the 2026-08-18 signature - GitHub refusing a deprecated runner version, which the runner CANNOT self-heal because --disableupdate is active and CANNOT self-deploy because hosts/hestia/actions-runner/ is excluded from deploy-hestia.yml. Check `docker logs ix-gha-runner-runner-1` on 10.42.2.10. Runbook: docs/operations/apps/gha-runner.md.
+
+        # ---- The series vanished entirely ------------------------------------
+        # `== 0` cannot see a REMOVED container: it emits nothing at all, and a
+        # comparison over an absent series matches nothing and stays silent.
+        # This is the same lesson HomelabscopeJobMetricAbsent already encodes,
+        # and it is the specific shape of the 2026-08-18 failure — absence read
+        # as health.
+        #
+        # SCOPE DISCIPLINE (the #1066 lesson): absent() may only guard a series
+        # that is ACTUALLY LIVE in Prometheus. Guarding a not-yet-emitted series
+        # turns this into a guaranteed false critical the moment the rule lands,
+        # which is why this PR must merge AFTER the emitter is deployed and the
+        # series confirmed present — never alongside it.
+        #
+        # The shipped list is deliberately minimal: the two containers the
+        # emitter must see if it is working at all.
+        #   gha-runner             the container this whole mechanism exists for
+        #   homelabscope-heartbeat the emitter's own container. Circular by
+        #                          design and harmless: if the heartbeat dies
+        #                          both arms fire, and "the watcher is already
+        #                          watched" is precisely why the plan extends
+        #                          the heartbeat instead of adding an exporter.
+        #
+        # The remaining non-archived hestia containers — github-mirror,
+        # immich-photos-backup, netscope, qbittorrent, node-exporter,
+        # ipmi-exporter — are all long-lived and all WANT this guard, but each
+        # must be confirmed emitting before it is added. Do that as a follow-up,
+        # one confirmed batch, same two-step pattern. Do NOT derive the list from
+        # x-deploy.archived: the plan documents thermalscope as archived: true in
+        # the repo and up=1 on the box right now, so that field is not a
+        # trustworthy should-be-running source.
+        - alert: HomelabscopeContainerMetricAbsent
+          expr: >
+            absent(homelabscope_container_running{name="gha-runner"})
+            or absent(homelabscope_container_running{name="homelabscope-heartbeat"})
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "hestia container metric {{ $labels.name }} is absent"
+            description: >
+              No homelabscope_container_running series exists for {{ $labels.name }} on hestia for >1h. The container was removed, or the homelabscope-heartbeat probe stopped writing its textfile — distinct from "not running", which needs the series to still exist. A removed container emits nothing, so this is the only rule that can see it. Check the homelabscope-heartbeat Custom App and the hestia node-exporter textfile dir (/var/lib/node-exporter/textfile) on 10.42.2.10.

--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -21,9 +21,11 @@
 # A SECOND, independent family covers hestia CONTAINER health (the
 # homelabscope.containers group at the bottom of this file):
 #
-#   homelabscope_container_running{name}         1=running, 0=not
-#   homelabscope_container_restarts_total{name}  docker RestartCount (counter)
-#   homelabscope_container_health{name}          docker healthcheck status
+#   homelabscope_container_running{name}          1=running, 0=not
+#   homelabscope_container_restarts_total{name}   docker RestartCount (counter)
+#   homelabscope_container_last_exit_code{name}   last observed .State.ExitCode
+#   homelabscope_container_started_seconds{name}  current instance start, epoch
+#   homelabscope_container_health{name}           docker healthcheck status
 #
 # It answers a different question — "is this thing up", not "did this thing
 # finish on time" — for a host that has no cAdvisor and is not a cluster node.
@@ -262,19 +264,34 @@ spec:
     # containers, keyed on `name` — NOT runner-specific, so every future hestia
     # container is covered with no rule change:
     #
-    #   homelabscope_container_running{name}         1 = running, 0 = not
-    #   homelabscope_container_restarts_total{name}  docker RestartCount, COUNTER
-    #   homelabscope_container_health{name}          docker healthcheck status
+    #   homelabscope_container_running{name}          1 = running, 0 = not
+    #   homelabscope_container_restarts_total{name}   docker RestartCount, COUNTER
+    #   homelabscope_container_last_exit_code{name}   .State.ExitCode, GAUGE
+    #   homelabscope_container_started_seconds{name}  .State.StartedAt as epoch
+    #   homelabscope_container_health{name}           1 healthy / 0 unhealthy /
+    #                                                 2 starting; ABSENT when the
+    #                                                 container has no healthcheck
+    #   homelabscope_container_probe_success          1 = docker socket reachable
     #
-    # homelabscope_container_health is DELIBERATELY NOT ALERTED ON here. Its
-    # value encoding (none / starting / healthy / unhealthy) is the emitter's to
-    # define and is not yet fixed; a rule written against a guessed encoding is
-    # worse than no rule. Add it in a follow-up once the encoding is settled.
+    # There is NO jobs-completed counter in this family and there will not be:
+    # docker inspect exposes only the LAST exit, never a history, so a per-poll
+    # completed-jobs counter would be fabricated data. last_exit_code is the
+    # honest substitute — see the ephemeral restart-loop rule below.
     #
-    # The probe's emit interval (INTERVAL_SECONDS, 600s today) — not the 60s
-    # scrape — is the real detection granularity: a value is latched in the
-    # .prom for a full interval. Every `for:` below is sized against 600s, not
-    # against the scrape.
+    # homelabscope_container_health is DELIBERATELY NOT ALERTED ON here. The
+    # encoding above is now settled by the emitter, but "absent when the
+    # container declares no healthcheck" means an alert has to distinguish
+    # unhealthy from unmonitored, and no hestia container this rule file targets
+    # declares a healthcheck yet. Add it in a follow-up, once there is something
+    # for it to watch.
+    #
+    # The probe's emit interval — not the scrape — is the real detection
+    # granularity: a value is latched in the .prom for a full interval. The
+    # container probe runs on CONTAINER_INTERVAL_SECONDS (60s), tighter than the
+    # 600s INTERVAL_SECONDS the SSH/ZFS job families use, precisely so a
+    # point-in-time exit-code/started-at sample is trustworthy. The `for:`
+    # values below were sized conservatively against the 600s figure and are
+    # left as they are: at 60s granularity they simply carry more margin.
     # -----------------------------------------------------------------------
     - name: homelabscope.containers
       rules:
@@ -318,11 +335,16 @@ spec:
         # (Measured: RestartCount 0 -> 9 across a 10-job deploy.)
         #
         # The real gap between jobs is a few SECONDS, but the probe latches
-        # whatever it sampled for a full 600s interval — so one unlucky sample
-        # taken mid-restart pins running=0 for 10 minutes of series. `for: 30m`
-        # requires roughly three consecutive unlucky samples, which a
-        # seconds-wide window cannot plausibly produce, while still catching a
-        # genuinely dead runner well inside the hour.
+        # whatever it sampled for a full emit interval (60s for the container
+        # probe) — so one unlucky sample taken mid-restart pins running=0 for a
+        # minute of series. `for: 30m` requires a long unbroken run of such
+        # samples, which a seconds-wide window cannot plausibly produce, while
+        # still catching a genuinely dead runner well inside the hour.
+        #
+        # NOTE this rule cannot see a crash loop, by design and by Docker:
+        # .State.Running is TRUE while a container sits in restart backoff, so a
+        # looping runner reads running=1 here. The restart-loop rule below is
+        # what covers that case.
         - alert: HomelabscopeContainerDown
           expr: homelabscope_container_running{name="gha-runner"} == 0
           for: 30m
@@ -359,44 +381,93 @@ spec:
             description: >
               Container {{ $labels.name }} on hestia restarted {{ $value | printf "%.0f" }} times in the last hour. These containers are long-lived services; >5 restarts/hour is a crash loop, not churn. Check `docker logs ix-{{ $labels.name }}-*` on 10.42.2.10 for the repeating exit.
 
-        # THE RUNNER'S THRESHOLD IS DIFFERENT BY AN ORDER OF MAGNITUDE, because
-        # for an ephemeral runner a restart is the SUCCESS path, not a fault.
-        # Sizing, with margin deliberately wide on both sides:
-        #   legit ceiling  ~1 restart per job. deploy-hestia.yml is the only
-        #                  workflow on `runs-on: [self-hosted, hestia]`; even a
-        #                  Renovate merge storm plus the hourly canary is tens of
-        #                  jobs an hour, not hundreds.
-        #   observed loop  ~1 restart/sec => ~3600/hour (RestartCount hit 11894).
-        # 100/hour sits ~2x above the busiest plausible legitimate hour and ~36x
-        # below the observed loop, and is crossed ~100s into a fast loop.
+        # THE RUNNER'S EPHEMERAL ARM DISCRIMINATES ON EXIT CODE, NOT ON RATE
+        # ALONE, because for an ephemeral runner a restart is the SUCCESS path,
+        # not a fault. Rate alone cannot separate "restarting and doing work"
+        # from "restarting and completing nothing" — but the exit code can, and
+        # exactly, so this rule is a two-armed `or`:
         #
-        # THE `unless` ARM is the precision half: a runner that is restarting
-        # AND completing work is healthy by definition; a runner that is
-        # restarting and completing NOTHING is the 2026-08-18 incident exactly
-        # (it registered, was refused work, and completed zero jobs).
+        #   arm 1  increase(restarts[1h]) > 100                   — rate only
+        #   arm 2  increase(restarts[1h]) > 10  AND  a nonzero
+        #          last_exit_code seen in the last 5m             — qualified
         #
-        # IT IS A SOFT DEPENDENCY, ON PURPOSE. If the emitter does not publish
-        # homelabscope_container_jobs_completed_total (or publishes it under a
-        # different name, or with a label set that doesn't match), the right-hand
-        # vector is EMPTY, `unless` suppresses nothing, and this rule degrades
-        # cleanly to the bare 100/hour threshold — which is already safe on its
-        # own. Fail-open was chosen over fail-closed so a missing optional series
-        # can never silence the alert. If the emitter lands the counter under
-        # another name, change it here; nothing breaks in the meantime.
+        # WHY THE EXIT CODE IS AN EXACT DISCRIMINATOR. The probe emits
+        # homelabscope_container_last_exit_code from docker inspect's
+        # .State.ExitCode. Docker zeroes that field when a container enters the
+        # running state and sets it to the real code while the container sits in
+        # restart backoff — and .State.Running is TRUE during backoff, which is
+        # why HomelabscopeContainerDown above can never see a crash loop and why
+        # this rule has to exist at all. So under Docker's semantics a nonzero
+        # sample means "in crash backoff right now".
         #
-        # KNOWN RESIDUAL GAP, stated rather than papered over: a SLOW crash
-        # loop that hits Docker's 60s restart backoff cap tops out near
-        # 60/hour and stays under this threshold. It is not silent — the
-        # runner-canary workflow (plan section B) goes red off-cluster within
-        # ~2h on exactly that case, which is why the canary is step 1 of the
-        # plan and this rule is step 3. Narrowing the threshold instead would
-        # trade a real off-cluster catch for guaranteed false pages on busy
-        # deploy hours.
+        # The rule does not actually depend on that reading being exact. Even if
+        # a Docker version latched the previous code across the running window,
+        # the discrimination holds: a healthy --ephemeral runner exits 0 after
+        # every completed job (measured: RestartCount 0 -> 9 across a 10-job
+        # deploy, every exit 0), so a nonzero value can only come from an
+        # abnormal exit. Under both readings, healthy busy == 0 and crash loop
+        # != 0.
+        #
+        # THERE IS NO COMPLETED-JOBS COUNTER IN THIS FAMILY AND THERE WILL NOT
+        # BE ONE — do not write a rule arm against one. It is not observable
+        # from polled Docker state: inspect exposes only the LAST exit, never a
+        # history, so N restarts between two polls would all be attributed to
+        # one observed exit code. The emitter
+        # (images/homelabscope-heartbeat/heartbeat.sh) refuses to fabricate it
+        # and publishes last_exit_code instead. An earlier draft of this rule
+        # carried an `unless` arm against such a series; because the series does
+        # not exist the right-hand vector was ALWAYS empty, the `unless`
+        # suppressed nothing, and the rule silently degraded to a bare > 100.
+        #
+        # WHY max_over_time(...[5m]) AND NOT AN INSTANT READ. At the 60s restart
+        # backoff cap the container is in backoff for ~60s of every ~60s cycle,
+        # so the 60s container probe reads nonzero on essentially every sample —
+        # but "essentially" is not "always", and an instant read (or a
+        # min_over_time) would flap on the ~1-in-60 sample that lands mid-exec
+        # and reset the `for:` timer, possibly forever. max_over_time is stable
+        # across that.
+        #
+        # WHY THE WINDOW (5m) IS SHORTER THAN THE `for:` (10m). This is the
+        # guard against a ONE-OFF abnormal exit — a transient registration or
+        # network failure during an otherwise healthy deploy hour. A single
+        # nonzero sample at time s makes the max_over_time arm true only for
+        # [s, s+5m]: a 5-minute interval, which cannot satisfy a 10-minute
+        # `for:`. Firing therefore requires abnormal exits that RECUR across
+        # >10 minutes, which is a loop and not a blip. A real crash loop
+        # produces one every ~60s and holds the condition indefinitely.
+        #
+        # THRESHOLD: 100 -> 10 ON THE QUALIFIED ARM, AND THAT CLOSES THE
+        # DOCUMENTED BACKOFF-CAP GAP. The old bare 100/hour could not see a slow
+        # crash loop pinned at Docker's 60s backoff cap: that tops out near
+        # 60 restarts/hour and slipped under 100 forever. 10/hour is reached
+        # ~10 minutes into such a loop, so with `for: 10m` it pages ~20 minutes
+        # in instead of never. 10 is safe only BECAUSE of the exit-code
+        # conjunction — a healthy 10-job deploy is 9 restarts at exit 0 and
+        # fails both conjuncts, and even a Renovate merge storm at tens of jobs
+        # an hour never satisfies the exit-code half.
+        #
+        # ARM 1 IS KEPT AT 100 AS AN EXIT-CODE-INDEPENDENT BACKSTOP. It is what
+        # catches a pathological loop whose exits are 0, and it is what the rule
+        # degrades to if last_exit_code ever stops being emitted — the same
+        # fail-open property the old `unless` was reaching for, except this
+        # version actually has a live series on the other side. 100/hour is
+        # ~2x above the busiest plausible legitimate hour and ~36x below the
+        # observed fast loop (~1 restart/sec, RestartCount hit 11894), and is
+        # crossed ~100s into a fast loop.
+        #
+        # `and`/`or` match on the full label set, deliberately: both families
+        # come from the same .prom file on the same node-exporter target, so
+        # {name, instance, job} are identical by construction and an exact match
+        # is stricter than `on(name)` for free.
         - alert: HomelabscopeContainerRestartLoop
           expr: >
             increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100
-            unless
-            increase(homelabscope_container_jobs_completed_total{name="gha-runner"}[1h]) > 0
+            or
+            (
+            increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 10
+            and
+            max_over_time(homelabscope_container_last_exit_code{name="gha-runner"}[5m]) > 0
+            )
           for: 10m
           labels:
             lifecycle: ephemeral
@@ -404,7 +475,7 @@ spec:
           annotations:
             summary: "hestia gha-runner is crash-looping"
             description: >
-              The hestia GitHub Actions runner restarted {{ $value | printf "%.0f" }} times in the last hour while completing no jobs. The runner is ephemeral so restarts are normal — this rate is not, and zero completed work alongside it means the deploy path is dead and runs are silently queueing. Most likely cause is the 2026-08-18 signature - GitHub refusing a deprecated runner version, which the runner CANNOT self-heal because --disableupdate is active and CANNOT self-deploy because hosts/hestia/actions-runner/ is excluded from deploy-hestia.yml. Check `docker logs ix-gha-runner-runner-1` on 10.42.2.10. Runbook: docs/operations/apps/gha-runner.md.
+              The hestia GitHub Actions runner restarted {{ $value | printf "%.0f" }} times in the last hour, with a non-zero exit code on its restarts (or at a rate no legitimate deploy hour reaches). The runner is ephemeral so restarts are normal and a clean restart exits 0 — restarts that exit non-zero mean it is not completing work, the deploy path is dead, and runs are silently queueing. Most likely cause is the 2026-08-18 signature - GitHub refusing a deprecated runner version, which the runner CANNOT self-heal because --disableupdate is active and CANNOT self-deploy because hosts/hestia/actions-runner/ is excluded from deploy-hestia.yml. Check `docker logs ix-gha-runner-runner-1` on 10.42.2.10; `docker inspect ix-gha-runner-runner-1` shows the same State.ExitCode this rule fired on. Runbook: docs/operations/apps/gha-runner.md.
 
         # ---- The series vanished entirely ------------------------------------
         # `== 0` cannot see a REMOVED container: it emits nothing at all, and a


### PR DESCRIPTION
Implements **section A** of [`docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`](https://github.com/gjcourt/homelab/blob/master/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md) (#1315).

## ⚠️ MERGE ORDER — this PR must land SECOND

`HomelabscopeContainerMetricAbsent` uses `absent()`. **No `homelabscope_container_*` series exists in Prometheus today** — the heartbeat container probe that emits them is not written, not merged, and has no open PR. Merging this before the emitter is deployed is a **guaranteed false critical page** within the hour, which is precisely the #1066 lesson the existing `HomelabscopeJobMetricAbsent` comment already documents.

Land in this order:

1. The `homelabscope-heartbeat` container probe (docker socket mount + emitter), image built and digest pinned.
2. Confirm live in Prometheus: `homelabscope_container_running{name="gha-runner"}` and `{name="homelabscope-heartbeat"}` both return a sample.
3. **Then** this PR.

Plan step 1 (runner-canary workflow) and step 2 (post-apply verification in `truenas-update-app.sh`) are independent and can land in parallel. The plan's own precondition still stands: the runner must be healthy first, or the canary is born red.

## What's here

**`infra/configs/homelabscope/prometheus-rule.yaml`** — a new `homelabscope.containers` group, structurally identical to the existing `Stale` / `MetricAbsent` pair.

| Alert | `lifecycle` | Expr | For | Severity |
|---|---|---|---|---|
| `HomelabscopeContainerDown` | `long-lived` | `homelabscope_container_running{name!="gha-runner"} == 0` | 15m | critical |
| `HomelabscopeContainerDown` | `ephemeral` | `homelabscope_container_running{name="gha-runner"} == 0` | 30m | critical |
| `HomelabscopeContainerRestartLoop` | `long-lived` | `increase(homelabscope_container_restarts_total{name!="gha-runner"}[1h]) > 5` | 10m | critical |
| `HomelabscopeContainerRestartLoop` | `ephemeral` | `increase(homelabscope_container_restarts_total{name="gha-runner"}[1h]) > 100 unless increase(homelabscope_container_jobs_completed_total{name="gha-runner"}[1h]) > 0` | 10m | critical |
| `HomelabscopeContainerMetricAbsent` | — | `absent(homelabscope_container_running{name="gha-runner"}) or absent(homelabscope_container_running{name="homelabscope-heartbeat"})` | 1h | critical |

**`docs/operations/apps/gha-runner.md`** — new runbook.

## The threshold correction (the part most likely to ship broken)

The plan proposes `increase(restarts_total[1h]) > 5` for everything. **That false-fires on the runner**, because the runner is ephemeral:

```sh
# myoung34/github-runner /entrypoint.sh — verified upstream
if [ -n "${EPHEMERAL}" ]; then ARGS+=("--ephemeral"); fi
```

`[ -n ... ]` is a **presence** test. `EPHEMERAL: "false"` is a non-empty string, so `--ephemeral` is active regardless. The container completes one job, deregisters, exits 0, and restarts. Measured: `RestartCount` 0 → 9 across a single 10-job deploy. A busy deploy hour trivially exceeds 5.

So the pair is split by lifecycle. The plan's `> 5` is kept and is correct for every long-lived container; the runner gets its own arm:

- **`> 100` / 1h.** Legit ceiling is ~1 restart per job, and `deploy-hestia.yml` is the only workflow on `runs-on: [self-hosted, hestia]` — even a Renovate merge storm plus the plan's hourly canary is *tens* of jobs an hour. The observed loop ran ~1 restart/sec ≈ **3600/hour** (`RestartCount` hit 11894). 100 sits ~2× above the busiest plausible legitimate hour and ~36× below the observed loop, and is crossed ~100s into a fast loop.
- **`increase()`, not `delta()` or `resets()`.** `increase()` applies counter-reset detection from sample values, so it survives `RestartCount` returning to 0 on container *recreate* (image bump, SCALE `app.update`). `delta()` has no reset detection and goes **negative** across a recreate, masking exactly the event we want. `resets()` counts recreates only and would have scored **zero** here — 2026-08-18 was restart-policy churn within one container life.
- **`running == 0` is the primary signal**, per the brief. `for: 30m` on the runner: the real inter-job gap is a few *seconds*, but the probe latches a sample for a full 600s emit interval, so one unlucky mid-restart sample pins `running=0` for ten minutes of series. 30m needs ~three consecutive unlucky samples.
- **The `unless` arm is a SOFT dependency.** `homelabscope_container_jobs_completed_total` is the completed-work counter the emitter has been asked to add. If it never lands, or lands under a different name or label set, the right-hand vector is empty, `unless` suppresses nothing, and the rule degrades cleanly to the bare 100/hour threshold — which is already safe alone. Fail-open was chosen deliberately so a missing optional series can never *silence* the alert.

**Known residual gap, stated not papered over:** a slow crash loop that hits Docker's 60s restart-backoff cap tops out near 60/hour and stays under the threshold. It is not silent — the runner-canary workflow (plan §B) catches exactly that case off-cluster within ~2h, which is why the canary is plan step 1 and this is step 3. Narrowing the threshold would trade a real off-cluster catch for guaranteed false pages.

## Scope decisions

- **`homelabscope_container_health` is not alerted on.** Its value encoding (none / starting / healthy / unhealthy) is the emitter's to define and isn't fixed yet. A rule against a guessed encoding is worse than no rule.
- **The `absent()` list is deliberately minimal** — `gha-runner` and `homelabscope-heartbeat` only. The other non-archived hestia containers (`github-mirror`, `immich-photos-backup`, `netscope`, `qbittorrent`, `node-exporter`, `ipmi-exporter`) all want this guard, but each must be confirmed emitting first. Follow-up, one confirmed batch.
- **The list is not derived from `x-deploy.archived`.** The plan documents `thermalscope` as `archived: true` in the repo and `up=1` on the box right now, so that field is not a trustworthy should-be-running source.
- **A `lifecycle` label** distinguishes the two arms of each pair. It is not routed on (Alertmanager matches `severity`/`namespace` only); it exists so two rules sharing an alert name never emit an identical label set — promtool's duplicate-rule lint rejects that — and so a silence can target one arm.

## Runbook highlights

`docs/operations/apps/gha-runner.md` covers the incident, the monitoring contract, log-signature diagnosis, and the manual upgrade path. The load-bearing gotcha:

> `DISABLE_AUTO_UPDATE` is presence-tested exactly like `EPHEMERAL`. Setting it to `"false"` **still** passes `--disableupdate`. The only way to re-enable auto-update is to **remove the variable entirely**.

Combined with `hosts/hestia/actions-runner/` being unconditionally excluded from `deploy-hestia.yml`, the runner can neither self-update nor self-deploy its own fix — which is why 2026-08-18 was self-concealing.

## Validation

- `kustomize build infra/configs` — passes (the flux-test CI gate).
- `yamllint -c .yamllint .` — clean (the lint CI gate).
- `promtool check rules` on the extracted groups — `SUCCESS: 20 rules found` (was 15). Not a CI gate; run locally.
- Upstream `entrypoint.sh` presence-test independently verified against `myoung34/docker-github-actions-runner@master`, lines 161 and 166.
- No cluster was touched.

## Not in this PR

Plan steps 1 (canary), 2 (post-apply verification), 4 (drift check), 5 (`docs/STATUS.md` known-issues entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA