### PR TITLE
feat(homelabscope): mount docker.sock and pin the container-probe image

### DIFF
--- a/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
+++ b/hosts/hestia/monitoring/docker-compose-homelabscope-heartbeat.yml
@@ -27,7 +27,7 @@ x-deploy:
 
 services:
   homelabscope-heartbeat:
-    image: ghcr.io/gjcourt/homelabscope-heartbeat:2026-07-07
+    image: ghcr.io/gjcourt/homelabscope-heartbeat:2026-08-20
     container_name: homelabscope-heartbeat
     restart: unless-stopped
     # Root + privileged + /dev/zfs so `zfs list -t snapshot` can talk to the
@@ -51,6 +51,15 @@ services:
       - /mnt/main/apps/immich-photos-backup/ssh/known_hosts:/root/.ssh/known_hosts
       # Shared textfile collector dir — heartbeat writes homelabscope-*.prom here.
       - /var/lib/node-exporter/textfile:/var/lib/node-exporter/textfile
+      # Container probe (2026-08-20). Read-only: the probe only calls GET on the
+      # Docker REST API (/containers/json, /containers/<id>/json). It never
+      # starts, stops or creates anything.
+      #
+      # Added after the 2026-08-19 outage in which the gha-runner crash-looped
+      # 13,173 times with a deploy queued for over a day and NOTHING alerted --
+      # hestia had no per-container metrics at all. See
+      # docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md section A.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       # ZFS snapshot fallback source (read-only) when `zfs list` is unavailable.
       - /mnt/main/family:/mnt/main/family:ro
       - /mnt/main/homes:/mnt/main/homes:ro


### PR DESCRIPTION
Second half of the container probe from #1321.

That PR shipped the probe code in the heartbeat image but **deliberately left this compose untouched** — `hosts/hestia/**` auto-deploys on merge, so mounting the socket against the *old* image would have redeployed for no benefit. Mount and image belong together.

- image `2026-07-07` → `2026-08-20` (the build #1321 published)
- `/var/run/docker.sock` mounted **read-only**

Read-only is sufficient and deliberate: the probe issues only `GET` against `/containers/json` and `/containers/<id>/json`. It never starts, stops or creates anything. The heartbeat is already privileged with `/dev/zfs`, so this raises no privilege bar — which is the plan's argument for extending this container instead of adding an exporter.

## ⚠️ Merging this deploys

It's the step that brings the `homelabscope_container_*` series live, which is the **precondition for #1322** — those alerts carry an `absent()` guard that fires on merge if the series don't exist yet.

**Merge order:** this → verify series live → #1322.

## Context

On 2026-08-19 the gha-runner crash-looped **13,173 times** with a deploy job queued for over a day, and nothing alerted — hestia has no per-container metrics at all (verified live: `count({__name__=~"container_.*", instance="hestia"})` returns an empty vector). See `docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md` §A.