### PR TITLE
fix(runner): remove DISABLE_AUTO_UPDATE, make EPHEMERAL honest

### DIFF
--- a/docs/plans/2026-05-02-hestia-gha-runner.md
+++ b/docs/plans/2026-05-02-hestia-gha-runner.md
@@ -62,7 +62,7 @@ services:
       RUNNER_NAME: hestia
       LABELS: hestia,truenas
       RUNNER_WORKDIR: /tmp/runner-work
-      EPHEMERAL: "false"
+      EPHEMERAL: "true"   # corrected 2026-08-19 — see note below
       # ACCESS_TOKEN and TRUENAS_API_KEY are set in SCALE UI as masked env vars.
       # Do NOT commit values; YAML in git stays clean.
       ACCESS_TOKEN: ""
@@ -71,6 +71,14 @@ services:
       - /mnt/main/apps/actions-runner/work:/tmp/runner-work
       - /var/run/docker.sock:/var/run/docker.sock
 ```
+
+> **Corrected 2026-08-19.** The sketch above originally read `EPHEMERAL: "false"`.
+> That never disabled ephemeral mode: the image entrypoint tests the variable
+> with `[ -n "${EPHEMERAL}" ]`, so any non-empty value — `"false"` included —
+> adds `--ephemeral`. The same presence-test trap applies to
+> `DISABLE_AUTO_UPDATE`, which is why that variable is now **absent** from
+> `hosts/hestia/actions-runner/docker-compose.yml` rather than set to `"false"`.
+> Ephemeral is kept, now stated honestly. See the comment block in that file.
 
 README covers:
 - One-time bootstrap: paste this YAML into SCALE UI → Apps → Custom App; set `ACCESS_TOKEN` (PAT) and `TRUENAS_API_KEY` as masked env vars; click Install.

--- a/docs/plans/2026-06-26-alcatraz-gitops-docker.md
+++ b/docs/plans/2026-06-26-alcatraz-gitops-docker.md
@@ -282,8 +282,15 @@ deliverable sequencing.
     (pin per P3).
   - `environment`: `REPO_URL`, `RUNNER_NAME: alcatraz`, `RUNNER_SCOPE: repo`,
     `LABELS: alcatraz,synology`, `RUNNER_WORKDIR: /tmp/runner-work`,
-    `EPHEMERAL: "false"`, `DISABLE_AUTO_UPDATE: "true"`, empty `ACCESS_TOKEN: ""`
-    (set in Container Manager UI as a masked value — **never commit**).
+    `EPHEMERAL: "true"`, **no `DISABLE_AUTO_UPDATE` at all**, empty
+    `ACCESS_TOKEN: ""` (set in Container Manager UI as a masked value —
+    **never commit**).
+    > **Corrected 2026-08-19.** As originally written this line said
+    > `EPHEMERAL: "false"`, `DISABLE_AUTO_UPDATE: "true"`. The entrypoint
+    > presence-tests both (`[ -n "${VAR}" ]`), so `"false"` ENABLES a flag —
+    > `EPHEMERAL: "false"` was never non-ephemeral, and the only way to disable
+    > auto-update-blocking is to omit the variable. Ephemeral is now explicit
+    > and intentional; `DISABLE_AUTO_UPDATE` is removed.
   - `volumes`: `/volume1/docker/actions-runner/work:/tmp/runner-work` and
     `/var/run/docker.sock:/var/run/docker.sock`.
   - `restart: unless-stopped`; healthcheck on `pgrep -f Runner.Listener`.
@@ -431,8 +438,12 @@ A small, defensive wrapper the workflow calls per matrix entry:
   account's group membership on this DSM build; Synology occasionally relocates
   package data across DSM versions.
 - **Auto-update of packages.** If DSM auto-updates Container Manager, the Docker
-  Engine version can change under the runner. Pin nothing you can't, and keep
-  `DISABLE_AUTO_UPDATE: "true"` on the runner image itself.
+  Engine version can change under the runner. Pin nothing you can't.
+  > **Corrected 2026-08-19.** This originally advised keeping
+  > `DISABLE_AUTO_UPDATE: "true"` on the runner image. Do not: it pins the
+  > runner below GitHub's mandated minimum and takes the deploy path down at
+  > the next deprecation (as it did on hestia). The variable is now removed
+  > from both runner composes.
 - **Image arch.** Every target app image (and the runner image) must have a tag
   for alcatraz's arch (P3). An x86-only image fails to pull on an ARM unit — the
   wrapper's explicit `pull` step turns that into a clear job failure.

--- a/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
+++ b/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
@@ -61,8 +61,14 @@ structurally silent about precisely this state.
 
 ### The failure was self-concealing
 
-`DISABLE_AUTO_UPDATE: "true"` means the runner cannot upgrade past GitHub's
-minimum version on its own. The fix is a digest bump, which Renovate does open
+> **Correction (2026-08-19).** The variable's *value* was never the mechanism.
+> The image entrypoint tests it with `[ -n "${DISABLE_AUTO_UPDATE}" ]` — a
+> presence test — so `"true"`, `"false"`, `"0"` and `""` all behave identically
+> except the empty string. The flag is disabled only by REMOVING the variable,
+> which this repo now does. See `hosts/hestia/actions-runner/docker-compose.yml`.
+
+Setting `DISABLE_AUTO_UPDATE` at all means the runner cannot upgrade past
+GitHub's minimum version on its own. The fix is a digest bump, which Renovate does open
 and merge — but `hosts/hestia/actions-runner/` is **unconditionally excluded**
 from `deploy-hestia.yml`. So the repair for the broken deploy path was itself
 gated behind a manual step nobody was nagged about, and the runner could not
@@ -217,11 +223,14 @@ deploy its own fix.
 
 ## Open questions
 
-- **`DISABLE_AUTO_UPDATE: "true"` — keep or flip?** Keeping it is deterministic
-  and Renovate-pinnable but **guarantees this recurs** at the next deprecation.
-  Flipping it self-heals but makes the runner permanently diverge from its
-  pinned digest, turning the C2 drift check into permanent noise for that app.
-  These conflict; pick one and write down which.
+- ~~**`DISABLE_AUTO_UPDATE: "true"` — keep or flip?**~~ **RESOLVED 2026-08-19:
+  removed.** Keeping it guaranteed a repeat at the next deprecation, which is
+  not an acceptable trade for digest determinism on the one container that
+  gates every deploy. Note there is no "flip" — the entrypoint presence-tests
+  the variable, so `"false"` keeps the flag ON. The variable is now absent from
+  both runner composes. The runner self-updating past its pinned digest is
+  expected; exempt `gha-runner` from the C2 drift check rather than reading it
+  as drift.
 - **Should `hosts/hestia/actions-runner/` stay excluded from auto-apply?**
   Recommended: keep manual, rely on the C2 nag. The alternative is a two-phase
   detached self-deploy with a real risk of bricking the deploy path.

--- a/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
+++ b/docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md
@@ -63,13 +63,13 @@ structurally silent about precisely this state.
 
 > **Correction (2026-08-19).** The variable's *value* was never the mechanism.
 > The image entrypoint tests it with `[ -n "${DISABLE_AUTO_UPDATE}" ]` — a
-> presence test — so `"true"`, `"false"`, `"0"` and `""` all behave identically
-> except the empty string. The flag is disabled only by REMOVING the variable,
+> presence test — so every non-empty value (`"true"`, `"false"`, `"0"`) turns
+> the flag ON, identically. The flag is disabled only by REMOVING the variable,
 > which this repo now does. See `hosts/hestia/actions-runner/docker-compose.yml`.
 
 Setting `DISABLE_AUTO_UPDATE` at all means the runner cannot upgrade past
-GitHub's minimum version on its own. The fix is a digest bump, which Renovate does open
-and merge — but `hosts/hestia/actions-runner/` is **unconditionally excluded**
+GitHub's minimum version on its own. The fix is a digest bump, which Renovate
+does open and merge — but `hosts/hestia/actions-runner/` is **unconditionally excluded**
 from `deploy-hestia.yml`. So the repair for the broken deploy path was itself
 gated behind a manual step nobody was nagged about, and the runner could not
 deploy its own fix.

--- a/hosts/alcatraz/actions-runner/docker-compose.yml
+++ b/hosts/alcatraz/actions-runner/docker-compose.yml
@@ -43,8 +43,44 @@ services:
       # descriptive second label. Never overlaps the hestia runner's labels.
       LABELS: alcatraz,synology
       RUNNER_WORKDIR: /tmp/runner-work
-      EPHEMERAL: "false"
-      DISABLE_AUTO_UPDATE: "false"
+      # =====================================================================
+      # TRAP — READ BEFORE EDITING THE TWO VARIABLES BELOW.
+      #
+      # The image entrypoint tests these for PRESENCE, not truthiness:
+      #
+      #   /entrypoint.sh:161  if [ -n "${EPHEMERAL}" ];           then ARGS+=("--ephemeral")
+      #   /entrypoint.sh:166  if [ -n "${DISABLE_AUTO_UPDATE}" ]; then ARGS+=("--disableupdate")
+      #
+      # `[ -n ... ]` is "non-empty string". ANY non-empty value turns the flag
+      # ON — including the strings "false", "no" and "0". The ONLY way to turn
+      # one of these OFF is to REMOVE the variable entirely.
+      #
+      # This already cost an outage. `DISABLE_AUTO_UPDATE` was set here, so the
+      # runner ran with `--disableupdate` and could not upgrade past GitHub's
+      # mandated minimum version. On 2026-08-19 runner 2.334.0 was deprecated,
+      # GitHub refused to dispatch jobs to it, the runner exited 1, and
+      # `restart: unless-stopped` looped it 13,173 times while every deploy sat
+      # queued. The follow-up "fix" changed the value from "true" to "false"
+      # and changed NOTHING, because "false" is still a non-empty string.
+      #
+      # So: DO NOT reintroduce `DISABLE_AUTO_UPDATE` here, in any form. Not
+      # "false", not "", not "0". Its ABSENCE below is the fix — it is what
+      # lets the runner self-update at the next deprecation.
+      # =====================================================================
+
+      # Deliberately ON. This container bind-mounts /var/run/docker.sock and is
+      # therefore root-equivalent on the host; a fresh runner per job, with its
+      # registration credentials removed after each one, is the posture GitHub
+      # recommends for exactly that exposure.
+      #
+      # Consequence: the container exits 0 and restarts after EVERY job, so a
+      # restart count that tracks job count is normal here and is NOT a crash
+      # loop. Container alerting distinguishes the two via a `lifecycle` label
+      # that gives ephemeral runners a different restart threshold from
+      # long-lived containers, so do not flip this to off (i.e. delete it)
+      # without re-tuning those thresholds.
+      EPHEMERAL: "true"
+
       # A long-lived PAT (classic `repo`, or fine-grained with
       # `Administration: Read and write` + `Metadata: Read-only` on this repo)
       # OR a GitHub App installation token. The runner entrypoint exchanges it

--- a/hosts/hestia/actions-runner/docker-compose.yml
+++ b/hosts/hestia/actions-runner/docker-compose.yml
@@ -9,8 +9,44 @@ services:
       RUNNER_SCOPE: repo
       LABELS: hestia,truenas
       RUNNER_WORKDIR: /tmp/runner-work
-      EPHEMERAL: "false"
-      DISABLE_AUTO_UPDATE: "false"
+      # =====================================================================
+      # TRAP — READ BEFORE EDITING THE TWO VARIABLES BELOW.
+      #
+      # The image entrypoint tests these for PRESENCE, not truthiness:
+      #
+      #   /entrypoint.sh:161  if [ -n "${EPHEMERAL}" ];           then ARGS+=("--ephemeral")
+      #   /entrypoint.sh:166  if [ -n "${DISABLE_AUTO_UPDATE}" ]; then ARGS+=("--disableupdate")
+      #
+      # `[ -n ... ]` is "non-empty string". ANY non-empty value turns the flag
+      # ON — including the strings "false", "no" and "0". The ONLY way to turn
+      # one of these OFF is to REMOVE the variable entirely.
+      #
+      # This already cost an outage. `DISABLE_AUTO_UPDATE` was set here, so the
+      # runner ran with `--disableupdate` and could not upgrade past GitHub's
+      # mandated minimum version. On 2026-08-19 runner 2.334.0 was deprecated,
+      # GitHub refused to dispatch jobs to it, the runner exited 1, and
+      # `restart: unless-stopped` looped it 13,173 times while every deploy sat
+      # queued. The follow-up "fix" changed the value from "true" to "false"
+      # and changed NOTHING, because "false" is still a non-empty string.
+      #
+      # So: DO NOT reintroduce `DISABLE_AUTO_UPDATE` here, in any form. Not
+      # "false", not "", not "0". Its ABSENCE below is the fix — it is what
+      # lets the runner self-update at the next deprecation.
+      # =====================================================================
+
+      # Deliberately ON. This container bind-mounts /var/run/docker.sock and is
+      # therefore root-equivalent on the host; a fresh runner per job, with its
+      # registration credentials removed after each one, is the posture GitHub
+      # recommends for exactly that exposure.
+      #
+      # Consequence: the container exits 0 and restarts after EVERY job, so a
+      # restart count that tracks job count is normal here and is NOT a crash
+      # loop. Container alerting distinguishes the two via a `lifecycle` label
+      # that gives ephemeral runners a different restart threshold from
+      # long-lived containers, so do not flip this to off (i.e. delete it)
+      # without re-tuning those thresholds.
+      EPHEMERAL: "true"
+
       # ACCESS_TOKEN: a long-lived PAT (classic) or GitHub App installation
       # token with `actions:write` + `metadata:read` on this repo. The runner
       # entrypoint exchanges it for a registration token at startup so the


### PR DESCRIPTION
## The bug

`myoung34/github-runner`'s entrypoint tests both variables for **presence, not truthiness** (verified against upstream `entrypoint.sh`, exact lines):

```
/entrypoint.sh:161  if [ -n "${EPHEMERAL}" ];           then ARGS+=("--ephemeral")
/entrypoint.sh:166  if [ -n "${DISABLE_AUTO_UPDATE}" ]; then ARGS+=("--disableupdate")
```

`[ -n ... ]` is a **non-empty string** test. `"false"` is a non-empty string, so **`"false"` turns the flag ON.**

Both runner composes carried `EPHEMERAL: "false"` and `DISABLE_AUTO_UPDATE: "false"`, so both runners were in fact running `--ephemeral --disableupdate`.

### Why this matters

1. **`--disableupdate` was active**, so the runner could not upgrade past GitHub's mandated minimum version. That is the root cause of the **2026-08-19 outage**: runner 2.334.0 was deprecated, GitHub refused to dispatch jobs, the runner exited 1, and `restart: unless-stopped` looped it **13,173 times** while deploys sat queued. The follow-up change from `"true"` to `"false"` was believed to fix this. **It did not** — and the next deprecation would have repeated the outage verbatim.
2. **`--ephemeral` was active**, so the runner already completes one job, deregisters, exits 0 and restarts — roughly one restart per job. The config claimed the opposite.

## The change

**`DISABLE_AUTO_UPDATE` — removed entirely** from both composes. Not `"false"`, not `""`, not `"0"`. Only **absence** disables the flag; anything else re-arms the outage.

**`EPHEMERAL` — set explicitly to `"true"`.** This is a *documentation* change, not a behaviour change: it was already on. Keeping it is deliberate — the container bind-mounts `/var/run/docker.sock` and is root-equivalent on the host, so a fresh runner per job with registration credentials removed after each is the posture GitHub recommends for exactly that exposure. It is also what the new container alerting in #1322 is designed around (a `lifecycle` label splits ephemeral restart thresholds from long-lived ones), so silently flipping it would invalidate those rules.

**A prominent comment block above both variables** explains the presence-test trap, names the outage, and says plainly not to set them back to `"false"`. This is the highest-value part of the change: the trap has already cost one outage *and* one incorrect fix.

### Docs corrected

- `docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md` — the open question "`DISABLE_AUTO_UPDATE: "true"` — keep or flip?" is resolved to **removed**, with a note that there is no "flip": `"false"` keeps the flag on. Also annotates the "self-concealing" section — the variable's *value* was never the mechanism.
- `docs/plans/2026-06-26-alcatraz-gitops-docker.md` — the D1 prescription (`EPHEMERAL: "false"`, `DISABLE_AUTO_UPDATE: "true"`) and the "keep `DISABLE_AUTO_UPDATE: "true"` on the runner image" gotcha are both corrected in place with dated notes.
- `docs/plans/2026-05-02-hestia-gha-runner.md` — the original compose sketch's `EPHEMERAL: "false"` corrected, with a note explaining why it never meant what it said.

`docs/operations/apps/gha-runner.md` **does not exist on master** — it appears to be introduced by the open PR #1322 branch, so it is untouched here. If that PR restates the semantics of either variable, it should be checked against this change before it lands.

## ⚠️ MERGING THIS DOES NOT APPLY IT

`hosts/hestia/actions-runner/` is **unconditionally excluded** from `deploy-hestia.yml` (chicken-and-egg: the runner cannot deploy a change that recreates itself) — see `.github/workflows/deploy-hestia.yml:85-86`. The same exclusion exists for `hosts/alcatraz/actions-runner/` in `alcatraz-deploy.yaml:142-143`.

**The operator must apply this by hand.** A merged-but-unapplied fix is exactly how the original outage stayed hidden.

**hestia — TrueNAS SCALE UI:**
1. **Apps → gha-runner → Edit**
2. Under environment variables, **delete the `DISABLE_AUTO_UPDATE` variable entirely** (do not set it to `false` — that leaves the bug in place)
3. Set **`EPHEMERAL`** to **`true`**
4. **Save** (the app redeploys)
5. Verify: **GitHub → repo Settings → Actions → Runners** shows `hestia` as Idle, and the runner version is at or above GitHub's current minimum

**alcatraz:** the runner is not yet bootstrapped; the corrected compose is what its one-time manual `docker compose up -d` will use. No action needed today.

## Verification

- Upstream `entrypoint.sh` fetched and the two `[ -n ... ]` tests confirmed at lines 161 and 166.
- Both composes parse and round-trip: `EPHEMERAL == "true"`, `DISABLE_AUTO_UPDATE` key absent.
- `yamllint -c .yamllint` and `yamlfmt -lint` clean on both files; `make plans-index-check` passes (57 plans, index up to date).

No cluster or host was touched — repo changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA
