### PR TITLE
feat(ci): hourly off-cluster canary for the hestia GHA runner

### DIFF
--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -1,0 +1,125 @@
+name: Runner canary
+
+# Hourly liveness proof for the self-hosted GitHub Actions runner on hestia.
+#
+# WHY THIS EXISTS
+# On 2026-08-18 a merge to master produced a `deploy-hestia.yml` run that sat
+# QUEUED INDEFINITELY: the runner container was crash-looping on a deprecated
+# runner version and GitHub reported it `status=offline`. Nothing alerted.
+# GitHub emails on workflow *failure*; a run nobody ever picks up never fails.
+# Runner `status=offline` is visible only in a Settings page nothing polls.
+#
+# WHAT IT PROVES
+# Strictly more than "the container is running". A green check proves the whole
+# path that was broken: GitHub can dispatch a run -> the runner is online and
+# picks the job up -> the runner executes a step. Only the last of those three
+# is observable from inside hestia.
+#
+# WHY IT LIVES OFF-CLUSTER
+# Every other alert for this blind spot is in-cluster: a container writes a
+# textfile, node-exporter serves it, Prometheus scrapes it, a rule evaluates.
+# On 2026-08-13 Prometheus' PVC went read-only and it kept evaluating rules
+# while ingesting nothing — every in-cluster alert sat silently "healthy" on
+# frozen data. This canary shares no failure domain with the cluster: the
+# scheduler is GitHub's, the executor is hestia's, and the judge is
+# healthchecks.io. It is the only piece of this that survives Prometheus going
+# mute, which is also why it must never be reimplemented as a Prometheus rule.
+#
+# FAILURE SEMANTICS — two independent, complementary signals:
+#   1. Runner offline / run stuck queued / GitHub can't dispatch
+#      => no ping arrives => healthchecks.io goes red and emails.
+#         Detection <= Period + Grace = ~2h. This is the case GitHub is
+#         structurally silent about, and the reason the canary exists.
+#   2. Runner ran but the ping failed (no egress, healthchecks.io down,
+#      secret missing or wrong)
+#      => this workflow exits non-zero => GitHub emails on workflow failure,
+#         reusing a notification path that already works.
+#   Note the asymmetry: (2) also eventually triggers (1), because a failed
+#   ping is an absent ping. There is no state where both go quiet.
+#
+# See docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md section B, and
+# docs/reference/monitoring.md section 7.
+
+on:
+  schedule:
+    # Hourly at :17 — deliberately off the hour. Scheduled workflows queue
+    # behind GitHub's global on-the-hour spike, and a canary whose own start is
+    # routinely delayed teaches you to ignore it.
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+# The canary needs no repository access at all. An empty permissions block
+# drops GITHUB_TOKEN to zero scopes, so a job that runs on a box reachable from
+# the LAN cannot touch this repo even if the step were compromised.
+permissions: {}
+
+concurrency:
+  group: runner-canary
+  # If the runner is down, hourly runs pile up in the queue. cancel-in-progress
+  # collapses that backlog to a single pending run, so recovery replays one
+  # canary rather than a dozen. Runs are an hour apart and take seconds, so
+  # this never cancels genuine in-flight work.
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    name: Ping healthchecks.io from hestia
+    # The label pair is the entire test. Reaching this step at all means
+    # GitHub dispatched and the hestia runner picked it up.
+    runs-on: [self-hosted, hestia]
+    # Bounds a wedged job so it cannot hold the runner against the next hour's
+    # canary. Note this covers EXECUTION time only — time spent queued is not
+    # counted, which is precisely the failure mode the absent ping catches.
+    timeout-minutes: 5
+
+    steps:
+      # No actions/checkout: the canary tests the runner, not the repo, and a
+      # checkout would make an unrelated git failure look like a dead runner.
+      - name: Ping the canary check
+        env:
+          # Repo secret — see hosts/hestia/actions-runner/README.md for the
+          # two manual setup steps. Never inline the URL: it is a capability,
+          # and anyone holding it can keep the check green and mask an outage.
+          PING_URL: ${{ secrets.HEALTHCHECKS_RUNNER_CANARY_URL }}
+        run: |
+          set -euo pipefail
+
+          # Fail loudly and specifically when the secret is unset. Without this
+          # curl would report "no URL specified", which reads as a curl bug
+          # rather than a missing secret. A fork or a re-created repo silently
+          # has no secrets, so this is the likeliest first-run failure.
+          if [ -z "${PING_URL}" ]; then
+            echo "::error::HEALTHCHECKS_RUNNER_CANARY_URL is not set."
+            echo "Create the repo secret (Settings -> Secrets and variables -> Actions)."
+            echo "See hosts/hestia/actions-runner/README.md, 'Runner canary'."
+            exit 1
+          fi
+
+          # -f  non-2xx becomes a non-zero exit (a 404 from a deleted check
+          #     must be a red run, not a silent success)
+          # -sS quiet, but still print the error on failure
+          # -m 10 / --retry 3 / --retry-connrefused: healthchecks.io's own
+          #     documented client recipe — absorbs a transient WAN blip without
+          #     masking a real outage, since a genuinely dead path still burns
+          #     every retry and then fails the run.
+          # No `set -x`, no echo of the URL. GitHub masks registered secrets in
+          # logs, but the ping URL should not be one command away from a paste.
+          curl -fsS -m 10 --retry 3 --retry-connrefused \
+            --user-agent "homelab-runner-canary" \
+            "${PING_URL}" > /dev/null
+
+          echo "Canary ping delivered from $(hostname)."
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Runner canary"
+            echo ""
+            echo "- Runner: \`$(hostname)\`"
+            echo "- Result: \`${{ job.status }}\`"
+            echo ""
+            echo "A red check on healthchecks.io means no ping arrived — the"
+            echo "runner is offline or runs are stuck queued. A red *run* here"
+            echo "means the runner executed but could not reach hc-ping.com."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -62,6 +62,8 @@ Access Grafana and verify that data is populating in the default dashboards.
 
 Both email receivers use Gmail SMTP (`smtp.gmail.com:587`, STARTTLS, auth `gjcourt@gmail.com`). Secrets are SOPS-encrypted in the `monitoring` namespace and mounted via `alertmanagerSpec.secrets`: `alertmanager-smtp` → `/etc/alertmanager/secrets/alertmanager-smtp/password` (`smtp_auth_password_file`), and `alertmanager-deadman` → `/etc/alertmanager/secrets/alertmanager-deadman/ping-url` (`url_file`).
 
+Alertmanager's deadman is not the only off-cluster check: a second healthchecks.io check is pinged hourly by the hestia GitHub Actions runner itself — see [Runner canary](#runner-canary--off-cluster-proof-the-hestia-deploy-path-is-alive) below.
+
 Note the default route receiver is `null`, so an alert carrying no `severity` label is silently dropped. Note also that the deadman proves the *webhook* leg only — a broken SMTP path would leave the check green while email alerts fail. See [plans/2026-06-17-alertmanager-smtp-alerting.md](../plans/2026-06-17-alertmanager-smtp-alerting.md).
 
 ### Dead man's switch — verified timings
@@ -102,6 +104,69 @@ Fail-closed test, **verified 2026-08-16** (procedure in the
 | Silence expired → resumed | 09:36:34Z → 09:41:11Z = **4m37s** |
 | Reported downtime | 8m59s |
 | Ping accounting | healthchecks.io "Total Pings" matched the Alertmanager counter at both points — **zero loss** cluster → endpoint |
+
+### Runner canary — off-cluster proof the hestia deploy path is alive
+
+`.github/workflows/runner-canary.yml` runs hourly (`cron: 17 * * * *`) on
+`runs-on: [self-hosted, hestia]` and `curl`s a **second, separate**
+healthchecks.io check. It is the only monitoring in this repo that observes
+hestia's GitHub Actions runner, and the only one that observes anything from
+outside the cluster.
+
+**Why it is not a Prometheus rule.** Everything else covering this blind spot is
+in-cluster: a container writes a textfile, node-exporter serves it, Prometheus
+scrapes it, a rule evaluates it. On
+[2026-08-13](../operations/incidents/2026-08-13-iscsi-readonly-remount-monitoring-blind.md)
+Prometheus' PVC remounted read-only and it kept evaluating rules while ingesting
+nothing — every in-cluster alert sat silently "healthy" on frozen data. This
+canary shares no failure domain with that: GitHub schedules it, hestia executes
+it, healthchecks.io judges it. Reimplementing it as a PromQL rule would delete
+the only property that makes it worth having.
+
+**What a green check proves** — strictly more than "the runner container is
+up": GitHub could dispatch a run, the runner was online and picked the job up,
+and the runner executed a step. That is the entire path that was dead during the
+2026-08-18 incident (design: `docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md`, landing separately), where
+a `deploy-hestia.yml` run sat queued indefinitely against a crash-looping
+runner. GitHub emails on workflow *failure*; a run nobody picks up never fails,
+so GitHub is structurally silent about exactly that state.
+
+| | |
+|---|---|
+| Check config | Simple schedule, **Period 1h, Grace 1h** → ≤2h worst-case detection |
+| Ping URL | repo secret `HEALTHCHECKS_RUNNER_CANARY_URL` (Settings → Secrets and variables → Actions) — **not** SOPS; a GitHub-hosted schedule cannot read a cluster secret |
+| Notifications | `gjcourt+critical@gmail.com`, same reasoning as the deadman |
+
+Two independent failure signals, and they cannot both go quiet:
+
+- **No ping arrives** (runner offline, run stuck queued, GitHub cannot
+  dispatch) → the check goes red and healthchecks.io emails. This is the case
+  nothing else catches.
+- **The run itself fails** (no egress from hestia, healthchecks.io down, secret
+  missing or wrong) → the workflow exits non-zero and GitHub emails on failure.
+  A failed ping is also an absent ping, so this eventually trips the first
+  signal too.
+
+Operational notes:
+
+- **The runner is ephemeral**, so the canary costs **one runner container
+  restart per hour**. The `myoung34/github-runner` entrypoint *presence-tests*
+  `EPHEMERAL`, so the compose's `EPHEMERAL: "false"` still enables ephemeral
+  mode — the value is irrelevant, only the variable being set matters. Read any
+  hestia restart-rate alert with that hourly baseline in mind; the planned
+  `increase(homelabscope_container_restarts_total[1h]) > 5` arm sits well above
+  it.
+- **`concurrency: cancel-in-progress: true`** means a backlog built up while the
+  runner was down collapses to a single pending run, so recovery replays one
+  canary rather than a dozen.
+- **GitHub disables `schedule` triggers after 60 days of repository inactivity.**
+  This repo is kept active by Renovate, but a long quiet period would stop the
+  canary silently — the check going red is what surfaces it.
+- **Two checks now share one healthchecks.io account.** A lapsed or closed
+  account silently kills both, and nothing in-cluster notices, because a dead
+  check cannot alert on itself.
+
+Setup and troubleshooting: [`hosts/hestia/actions-runner/README.md`](../../hosts/hestia/actions-runner/README.md).
 
 ## 8. Disaster Recovery
 - **Backup Strategy**:

--- a/hosts/hestia/actions-runner/README.md
+++ b/hosts/hestia/actions-runner/README.md
@@ -7,7 +7,7 @@ Self-hosted GHA runner that lives on hestia and applies hestia Custom App compos
 | Image | `myoung34/github-runner` (digest-pinned) |
 | Runner name | `hestia` |
 | Labels | `hestia`, `truenas` |
-| Workflow target | `gjcourt/homelab` (push to `master`, paths `hosts/hestia/**/docker-compose*.yml`) |
+| Workflow target | `gjcourt/homelab` — `deploy-hestia.yml` (push to `master`, paths `hosts/hestia/**/docker-compose*.yml`) and `runner-canary.yml` (hourly) |
 | Persistence | `/mnt/main/apps/actions-runner/work` |
 
 ## One-time bootstrap
@@ -36,6 +36,102 @@ The runner is the *only* hestia Custom App that gets pasted into SCALE UI by han
      - `TRUENAS_API_KEY` = the API key from step 2
    - Click **Install**
 5. **Verify** — within ~30s the runner should appear at `https://github.com/gjcourt/homelab/settings/actions/runners` with status **Idle** and labels `hestia`, `truenas`.
+
+## Runner canary
+
+`.github/workflows/runner-canary.yml` runs hourly on this runner and `curl`s a
+healthchecks.io check. **It is the only thing that notices when this runner
+dies.**
+
+### Why it exists
+
+On 2026-08-18 a merge to `master` produced a `deploy-hestia.yml` run that sat
+**queued indefinitely**: this container was crash-looping on a deprecated runner
+version (`RestartCount = 11894`) and GitHub reported it `status=offline`.
+Nothing alerted, for a structural reason — GitHub emails on workflow *failure*,
+and a run nobody ever picks up never fails. `status=offline` is visible only in
+a Settings page nothing polls. An earlier Renovate deploy run had been queued,
+unnoticed, since well before that.
+
+A green canary proves more than "the container is running": GitHub could
+dispatch, this runner was online and picked the job up, and it executed a step —
+the whole path that was broken. It lives entirely off-cluster (GitHub schedules,
+hestia executes, healthchecks.io judges), so unlike every Prometheus-based alert
+it survives the cluster's monitoring going mute.
+
+### Operator setup — two manual steps
+
+Both are one-time and neither can be committed to this repo.
+
+1. **Create the healthchecks.io check.** Same account as the Alertmanager
+   deadman (`gjcourt@gmail.com`).
+   - Add Check → Schedule: **Simple** (not Cron)
+   - Name: `hestia GHA runner canary`
+   - **Period: 1 hour · Grace: 1 hour** → ≤2h worst-case detection
+   - Notifications: `gjcourt+critical@gmail.com` — **not** `+alerts`, which is
+     the skip-inbox tier documented as unread. Prefer at least one non-email
+     channel too.
+   - Copy the ping URL (`https://hc-ping.com/<uuid>`).
+2. **Add the repo secret.** GitHub → repo **Settings → Secrets and variables →
+   Actions → New repository secret**:
+   - Name: `HEALTHCHECKS_RUNNER_CANARY_URL`
+   - Value: the ping URL from step 1
+
+   A **repo secret, not SOPS** — the workflow is scheduled by GitHub and cannot
+   read a cluster secret. Never paste the URL into a shell, a chat window, or
+   anything that keeps a transcript: it is a capability, and anyone holding it
+   can keep the check green and mask a dead runner.
+
+**Precondition: do this only while the runner is healthy**, or the check is born
+red and you start by debugging the monitoring instead of the thing it monitors.
+Confirm **Idle** at
+<https://github.com/gjcourt/homelab/settings/actions/runners> first.
+
+Verify with `gh workflow run runner-canary.yml` (the workflow carries a
+`workflow_dispatch` trigger for exactly this) and confirm the check flips to
+**up**. Do this **after** the workflow is on `master`: GitHub evaluates
+`schedule` only on the default branch, and `workflow_dispatch` needs the file
+present there too, so the canary cannot be exercised from a PR branch.
+
+### Reading the signals
+
+| Signal | Means | First check |
+|---|---|---|
+| **Check red on healthchecks.io** | No ping arrived — the runner is offline, crash-looping, or runs are stuck queued. **The canary's whole reason for existing.** | `docker logs gha-runner`, then the runners Settings page |
+| **Canary workflow run red** | The runner *ran* but the ping failed — no egress from hestia, healthchecks.io down, or the secret is missing/wrong | The run log; the step names the missing-secret case explicitly |
+| **Both** | A failed ping is also an absent ping, so a persistent red run drags the check red behind it | Treat as the run-red case |
+
+Silence from both is the only healthy state. There is no failure mode where both
+go quiet.
+
+### Cost: one restart per hour
+
+**This runner is ephemeral**, so every canary run re-registers it and the
+container restarts. The `myoung34/github-runner` entrypoint *presence-tests*
+`EPHEMERAL`, so the `EPHEMERAL: "false"` in `docker-compose.yml` still enables
+ephemeral mode — only the variable being set matters, not its value. Do not read
+`false` as "off".
+
+Consequence: expect a **~1/hour restart baseline** on this container, plus one
+per deploy. Any hestia restart-rate alert must sit above that; the planned
+`increase(homelabscope_container_restarts_total[1h]) > 5` arm does. Sustained
+counts far above ~2/hour mean a genuine crash loop, which is exactly what the
+2026-08-18 incident looked like at 11894.
+
+Two more things that will bite eventually:
+
+- **GitHub disables `schedule` triggers after 60 days of repository
+  inactivity.** Renovate keeps this repo active, but a long quiet stretch stops
+  the canary — the check going red is what surfaces it.
+- **Two checks now share one healthchecks.io account.** If it lapses, both the
+  Alertmanager deadman and this canary die silently; nothing in-cluster
+  notices, because a dead check cannot alert on itself.
+
+Design: `docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md` section B (lands
+separately). Reference: [`docs/reference/monitoring.md`](../../../docs/reference/monitoring.md) §7.
+Incident that motivated it:
+[`2026-08-13-iscsi-readonly-remount-monitoring-blind.md`](../../../docs/operations/incidents/2026-08-13-iscsi-readonly-remount-monitoring-blind.md)
+is the Prometheus-goes-mute precedent this canary is designed to survive.
 
 ## Operations
 
@@ -79,8 +175,10 @@ docker manifest inspect myoung34/github-runner:ubuntu-noble \
 | Runner never appears in GitHub | Bad `ACCESS_TOKEN` | Check container logs: `docker logs ix-gha-runner-runner-1`; regenerate PAT |
 | Runner offline after reboot | Persistence missing | Confirm `/mnt/main/apps/actions-runner/work` exists and is writable |
 | Workflow hangs | Runner busy/stuck | SCALE UI → Stop → Start; or check `docker logs` for last action |
+| Canary check red, no obvious cause | Runner offline / runs queued | Runners Settings page + `docker logs gha-runner`; see [Runner canary](#runner-canary) |
+| Canary run red with `HEALTHCHECKS_RUNNER_CANARY_URL is not set` | Repo secret missing | Re-do operator setup step 2 |
 | `truenas-update-app.sh` (D3) returns 401 | Bad `TRUENAS_API_KEY` | Rotate the key, update env var |
 
 ## Graduation path
 
-When ≥2 self-hosted-runner workflows exist or this Custom App becomes a maintenance burden, replace with [`actions-runner-controller`](https://github.com/actions/actions-runner-controller) running in `melodic-muse`. See [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../../docs/plans/2026-05-02-hestia-gha-runner.md#graduation-path--option-2b-actions-runner-controller-in-talos) for the migration steps.
+The original trigger — **≥2 self-hosted-runner workflows** — is now met: `deploy-hestia.yml` and `runner-canary.yml` both target this runner. Treat that as a counter, not a mandate; the canary is a few seconds of work an hour and adds no maintenance surface. Migrate when this Custom App genuinely becomes a burden, replacing it with [`actions-runner-controller`](https://github.com/actions/actions-runner-controller) running in `melodic-muse`. See [`docs/plans/2026-05-02-hestia-gha-runner.md`](../../../docs/plans/2026-05-02-hestia-gha-runner.md#graduation-path--option-2b-actions-runner-controller-in-talos) for the migration steps.


### PR DESCRIPTION
Step 1 of `docs/plans/2026-08-18-hestia-deploy-monitoring-gap.md` — section B, "the runner is offline or a run is stuck queued". Smallest change, biggest coverage, off-cluster.

## The gap

On 2026-08-18 a merge to `master` produced a `deploy-hestia.yml` run that sat **queued indefinitely**. The runner on hestia was crash-looping on a deprecated runner version (`RestartCount = 11894`); GitHub reported it `status=offline`. An earlier Renovate deploy run had been queued, unnoticed, since well before that. **Nothing alerted.**

That silence is structural, not an oversight. GitHub emails on workflow *failure*, and a run nobody ever picks up never fails. `status=offline` is visible only in a Settings page nothing polls. GitHub's own tooling is silent about precisely this state.

## Why this one first

Everything else in the plan is in-cluster: a container writes a textfile, node-exporter serves it, Prometheus scrapes it, a rule evaluates it. On [2026-08-13](https://github.com/gjcourt/homelab/blob/master/docs/operations/incidents/2026-08-13-iscsi-readonly-remount-monitoring-blind.md) Prometheus' PVC remounted read-only and it **kept evaluating rules while ingesting nothing** — every alert sat silently "healthy" on frozen data.

This canary shares no failure domain with that. GitHub schedules it, hestia executes it, healthchecks.io judges it. It is the only piece of the plan that survives Prometheus going mute — which is also why it must never be reimplemented as a PromQL rule.

It is also strictly stronger than "the container is running": a green check proves GitHub could **dispatch**, the runner was **online and picked the job up**, and the runner **executed** — the whole path that was broken.

## What's here

`.github/workflows/runner-canary.yml` — hourly `cron: 17 * * * *` (plus `workflow_dispatch`), one job on `runs-on: [self-hosted, hestia]`, whose only real step `curl`s a second healthchecks.io check.

Two independent signals, and they cannot both go quiet:

| Failure | Signal | Detection |
|---|---|---|
| Runner offline / run stuck queued / GitHub can't dispatch | **No ping** → check goes red, healthchecks.io emails | ≤ Period + Grace = **2h** |
| Runner ran but the ping failed (no egress, hc.io down, secret missing/wrong) | **Run exits non-zero** → GitHub emails on workflow failure | next hour |

A failed ping is also an absent ping, so the second case eventually trips the first.

Design choices worth a reviewer's eye:

- **Repo secret, not SOPS.** `HEALTHCHECKS_RUNNER_CANARY_URL`. A GitHub-hosted schedule cannot read a cluster secret, so the deadman's `url_file`/SOPS pattern does not transfer. No URL is committed. The step fails with a named error when the secret is unset — curl's bare "no URL specified" reads as a curl bug rather than a missing secret, and a fork or re-created repo silently has no secrets.
- **`:17`, deliberately off the hour.** Scheduled runs queue behind GitHub's on-the-hour spike, and a canary whose own start is routinely delayed teaches you to ignore it.
- **`cancel-in-progress: true`.** If the runner is down, hourly runs pile up; this collapses the backlog to one pending run, so recovery replays a single canary rather than a dozen. Runs are an hour apart and take seconds, so it never cancels real work.
- **`permissions: {}` and no `actions/checkout`.** The canary needs zero repo access, and a checkout would make an unrelated git failure look like a dead runner.
- **`curl -fsS -m 10 --retry 3 --retry-connrefused`** — healthchecks.io's own documented client recipe. `-f` matters: a 404 from a deleted check must be a red run, not a silent success.

## ⚠️ Precondition — read before merging

**The runner must be healthy when the check is created, or the check is born red** and you start by debugging the monitoring instead of the thing it monitors.

Verified healthy at time of writing: runner `2.336.0`, **online**, restart count flat. Re-confirm at <https://github.com/gjcourt/homelab/settings/actions/runners> before doing the operator steps.

## Operator steps (2, both manual, neither committable)

1. **Create the healthchecks.io check** — same account as the Alertmanager deadman.
   Schedule **Simple** (not Cron) · Name `hestia GHA runner canary` · **Period 1 hour, Grace 1 hour** · notifications to `gjcourt+critical@gmail.com` (**not** `+alerts`, the skip-inbox tier this repo documents as unread).
2. **Add the repo secret** — Settings → Secrets and variables → Actions → New repository secret. Name `HEALTHCHECKS_RUNNER_CANARY_URL`, value the ping URL.

Then `gh workflow run runner-canary.yml` and confirm the check flips to **up**.

Order is flexible, but do both promptly: with the workflow merged and the secret absent, the hourly run is red every hour until step 2 lands.

## Known and documented, so it doesn't read as a fault later

- **The runner is ephemeral, so this costs ~1 container restart per hour.** The `myoung34/github-runner` entrypoint *presence-tests* `EPHEMERAL`, so the compose's `EPHEMERAL: "false"` still enables ephemeral mode — only the variable being set matters, not its value. The plan's `increase(homelabscope_container_restarts_total[1h]) > 5` arm (step 3) sits well above a 1/hour baseline, but this is written down in both docs so a future reader doesn't mistake the baseline for a crash loop.
- **GitHub disables `schedule` triggers after 60 days of repository inactivity.** Renovate keeps this repo active; a long quiet stretch would stop the canary silently.
- **Two checks now share one healthchecks.io account.** A lapsed account kills both, and nothing in-cluster notices — a dead check cannot alert on itself. This is an open question in the plan, recorded rather than solved here.
- **`deploy-hestia.yml` was the only `[self-hosted, hestia]` workflow; this is the second**, which trips the runner README's graduation-path counter (≥2 workflows → `actions-runner-controller`). Noted there as a counter, not a mandate — the canary adds seconds of work an hour and no maintenance surface.

## Docs

- `docs/reference/monitoring.md` §7 — new "Runner canary" subsection: why it is not a Prometheus rule, what green proves, check config, the two failure signals, and the operational notes above. Cross-referenced from the receiver table.
- `hosts/hestia/actions-runner/README.md` — full operator setup, a "Reading the signals" table (what a red *check* means vs a red *run*), the ephemeral restart cost, and two new troubleshooting rows.

The plan doc itself lands separately, so it is referenced by plain path rather than a link that would dangle on `master`.

## Validation

- `yamllint -c .yamllint -s .` — clean, repo-wide (this is the CI gate).
- Workflow parses; `on`, `runs-on`, `permissions`, `concurrency` confirmed by round-trip.
- Both `run` bodies extracted and `shellcheck`-clean.
- No secret values, no `*.sops.yaml` touched, no cluster or hestia access.

**NOT exercised end to end.** GitHub evaluates `schedule` and `workflow_dispatch` only on the default branch, so the canary cannot fire from a PR branch. First real proof is the post-merge `workflow_dispatch` in operator step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA
