### PR TITLE
fix(homelabscope): scope container alerts to an explicit must-run allowlist

### DIFF
--- a/infra/configs/homelabscope/prometheus-rule.yaml
+++ b/infra/configs/homelabscope/prometheus-rule.yaml
@@ -303,7 +303,27 @@ spec:
         # deploy-hestia app.update recreate (seconds) and an operator Stop/Start,
         # and is >2 probe intervals so a single latched sample can't fire it.
         - alert: HomelabscopeContainerDown
-          expr: homelabscope_container_running{name!="gha-runner"} == 0
+          # EXPLICIT MUST-RUN ALLOWLIST -- not `name!="gha-runner"`.
+          #
+          # The probe is generic over EVERY container the daemon knows, running
+          # or not. A negative matcher therefore sweeps up long-dead one-shots:
+          # on 2026-08-20 this fired pending for 8 of them -- apfs, apfs-reader,
+          # capsule-copy, gdrive-dd, macmini-import, macmini-photo-manifest,
+          # ix-radarr-permissions-1 (an init container that exits 0 by design)
+          # and ix-rmlint-rmlint-1, several exited SIX WEEKS earlier. All eight
+          # would have paged +critical@.
+          #
+          # Deliberately excluded and why:
+          #   thermalscope  -- carries x-deploy.archived: true yet is up=1; the
+          #                    plan proves x-deploy.archived untrustworthy, so it
+          #                    is neither reliably should-run nor should-not-run.
+          #   ix-*          -- TrueNAS Apps manages its own lifecycle; init
+          #                    containers legitimately sit exited.
+          #   gha-runner    -- covered by the ephemeral arm below.
+          #
+          # Adding a service here is the deliberate act of declaring it
+          # must-always-run. Keep it sorted.
+          expr: homelabscope_container_running{name=~"github-mirror|homelabscope-heartbeat|immich-photos-backup|ipmi-exporter|libation|netscope|node-exporter|qbittorrent"} == 0
           for: 15m
           labels:
             # `lifecycle` splits the two arms of each pair. It is not routed on
@@ -371,7 +391,7 @@ spec:
         # This is the plan's original threshold and it is correct HERE — it is
         # only wrong for the ephemeral runner, which is split out below.
         - alert: HomelabscopeContainerRestartLoop
-          expr: increase(homelabscope_container_restarts_total{name!="gha-runner"}[1h]) > 5
+          expr: increase(homelabscope_container_restarts_total{name=~"github-mirror|homelabscope-heartbeat|immich-photos-backup|ipmi-exporter|libation|netscope|node-exporter|qbittorrent"}[1h]) > 5
           for: 10m
           labels:
             lifecycle: long-lived


### PR DESCRIPTION
`HomelabscopeContainerDown` went `state=pending` within minutes of #1322 merging, for **eight** containers, and would have paged `+critical@` when the 15m window closed.

**None were failures.** The probe is generic over every container the daemon knows, running or not — by design, since `x-deploy.archived` is proven untrustworthy. So `name!="gha-runner"` swept up long-dead one-shots:

| container | status |
|---|---|
| `ix-radarr-permissions-1` | Exited (0) 37h — init container, exits by design |
| `capsule-copy`, `macmini-import`, `macmini-photo-manifest`, `gdrive-dd` | Exited (0) 6 weeks — one-off migration jobs |
| `apfs`, `apfs-reader` | Exited (255) 6 weeks |
| `ix-rmlint-rmlint-1` | Exited (0) 2 months |

Replaces the negative matcher on **both** long-lived arms with an explicit sorted allowlist.

**This was a known gap, not a surprise.** The plan says *"an absent() guard over an explicit must-exist list is required"*, and #1321's own follow-up item 5 was *"decide the explicit must-be-running watchlist"*. It was merged without one — my error. The alert caught it within minutes, which is the system working.

Exclusions documented inline: `thermalscope` (archived yet `up=1` — neither reliably should-run nor should-not), `ix-*` (TrueNAS owns their lifecycle), `gha-runner` (ephemeral arm).

⚠️ Merge promptly — the pending alert is live.