### PR TITLE
feat(renovate): onboard gjcourt/toppingctl

### DIFF
--- a/infra/controllers/renovate-automerge/configmap.yaml
+++ b/infra/controllers/renovate-automerge/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: renovate-automerge-env
   namespace: renovate
 data:
-  GITHUB_REPOS: gjcourt/homelab,gjcourt/golinks,gjcourt/llmux,gjcourt/Pingo,gjcourt/soundbyte,gjcourt/tempo-interview,gjcourt/vitals,gjcourt/drift,gjcourt/python-nginx-signing
+  GITHUB_REPOS: gjcourt/homelab,gjcourt/golinks,gjcourt/llmux,gjcourt/Pingo,gjcourt/soundbyte,gjcourt/tempo-interview,gjcourt/vitals,gjcourt/drift,gjcourt/python-nginx-signing,gjcourt/toppingctl
   EMAIL_TO: gjcourt@gmail.com
   SMTP_HOST: smtp.gmail.com
   SMTP_PORT: "587"

--- a/infra/controllers/renovate/cronjob.yaml
+++ b/infra/controllers/renovate/cronjob.yaml
@@ -27,6 +27,7 @@ spec:
                 - gjcourt/vitals
                 - gjcourt/soundbyte
                 - gjcourt/python-nginx-signing
+                - gjcourt/toppingctl
 
               env:
                 # Re-expose the platform token by name so it can be interpolated


### PR DESCRIPTION
Adds the **tenth repository** to the self-hosted Renovate CronJob's explicit list. `RENOVATE_AUTODISCOVER` is `false` by design, so a new repo is invisible until it appears in `args:`.

[`gjcourt/toppingctl`](https://github.com/gjcourt/toppingctl) is a newly created public repo — local control for Topping DACs over USB HID. Its dependency surface is two GitHub Actions and two Python packages installed in CI. Small, but actions are exactly the class of thing that goes stale silently.

**No onboarding PR should appear.** Renovate treats a repo that already carries a config file as onboarded, and `renovate.json` was committed in that repo's initial commit specifically so this would be a no-op rather than a prompt.

## ⚠️ One thing this change can't verify by itself

**Whether `RENOVATE_TOKEN` actually has access to the new repo.**

- A **classic** PAT with `repo` scope covers every repository automatically → nothing more to do.
- A **fine-grained** token requires the repository to be selected explicitly → it will 404 until someone adds it.

The token is in a SOPS-encrypted secret and isn't readable from here, so this is empirical rather than static: **after merge, the next daily run either processes `toppingctl` or logs a permission error against it.** That's the signal.

```bash
kubectl -n renovate logs job/<latest> | grep -i toppingctl
```
