### PR TITLE
feat(renovate): add a shared preset for the gjcourt repos

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1,0 +1,75 @@
+# Shared Renovate preset
+
+`default.json` is the shared Renovate configuration for the `gjcourt/*` repos.
+Consumer repos extend it instead of each carrying their own drifting copy.
+
+## Consuming it
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>gjcourt/homelab//renovate/default"]
+}
+```
+
+## Why `.json` and not `.json5`
+
+**Subdirectory presets only resolve `.json`.** `github>gjcourt/homelab//renovate/default`
+resolves to `renovate/default.json`; Renovate does not try `.json5` for an
+implicit filename. Explicit extensions are documented only for the root-level
+`owner/repo:file.json5` form, not for the `//path/file` form — so a `.json5`
+preset here would rely on undocumented behaviour.
+
+The cost is that JSON has no comments, which is why every rule carries a
+`description` field and the reasoning lives in this file.
+
+## The rules, and the failures that produced them
+
+### `postUpdateOptions: ["gomodTidy"]`
+
+Renovate rewrites `go.mod` and **adds** the new `go.sum` hashes, but never
+prunes the superseded ones. Any repo with a `go mod tidy && git diff --exit-code`
+check therefore fails on every single Go dependency PR.
+
+Worse, the failure is not fixable in place: pushing a tidy commit onto a
+`renovate/*` branch is discarded when Renovate rebuilds that branch, so each
+failure had to be closed and replaced with a hand-built PR. That happened twice
+before this preset existed. `gomodTidy` runs `go mod tidy` as a post-update step
+so the PR arrives clean.
+
+Tidying is opt-in and `config:recommended` does not enable it. It needs no extra
+configuration on the official `renovate/renovate` image, which is Containerbase-
+based and defaults to `binarySource=install`.
+
+### Grouping GitHub Actions
+
+One PR per cycle for action `uses:` bumps instead of one per action.
+
+### Pulling language runtimes back out of that group
+
+`actions/setup-python`'s `python-version` is a `uses-with` dependency, and
+Renovate classifies `3.12` -> `3.14` as **minor** — Python's `3.x` *is* the minor
+field. Without this rule a two-release interpreter jump ships inside a routine
+non-major grouped PR and gets none of the scrutiny a major would.
+
+Interpreter and runtime bumps are breaking in practice regardless of what semver
+says. `groupName: null` pulls them out of the inherited group and
+`additionalBranchPrefix` gives them a standalone, reviewable branch.
+
+**Rule order matters.** Package rules apply in order and the last match wins, so
+the runtime rule must stay *after* the grouping rule. `groupName: null` as a
+group-removal mechanism is maintainer-endorsed but not documented as a named
+feature — do not reorder these two rules casually.
+
+## Merge semantics
+
+`packageRules` is a mergeable array: a consumer repo's own rules are **appended
+to** the preset's, not substituted for them. Repository config outranks a
+resolved preset, so a repo can still override any scalar it sets explicitly.
+
+This matters for `homelab` itself, whose `renovate.json` carries an `automerge`
+rule for `digest`/`pin`/`patch`/`minor` that survives adoption of this preset.
+
+`postUpdateOptions` mergeability is not conclusively documented; if a consumer
+needs to *remove* an option rather than add one, verify the behaviour rather
+than assuming.

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -14,11 +14,16 @@ Consumer repos extend it instead of each carrying their own drifting copy.
 
 ## Why `.json` and not `.json5`
 
-**Subdirectory presets only resolve `.json`.** `github>gjcourt/homelab//renovate/default`
-resolves to `renovate/default.json`; Renovate does not try `.json5` for an
-implicit filename. Explicit extensions are documented only for the root-level
-`owner/repo:file.json5` form, not for the `//path/file` form — so a `.json5`
-preset here would rely on undocumented behaviour.
+**The implicit `default` lookup resolves `.json` only.** In Renovate's
+`fetchPreset` (`lib/config/presets/util.ts`), a preset whose filename is exactly
+`default` is fetched as `<path>/default.json`, with a single deprecated fallback
+to `<path>/renovate.json`. `default.json5` is never attempted. So
+`github>gjcourt/homelab//renovate/default` requires the file to be `default.json`.
+
+A `.json5` file would work, but only if every consumer spelled the extension out —
+`github>gjcourt/homelab//renovate/default.json5` — because the explicit-filename
+branch does accept `.json5`. That trades a clean, uniform `extends` line across ten
+repos for comment support in one file. Not worth it.
 
 The cost is that JSON has no comments, which is why every rule carries a
 `description` field and the reasoning lives in this file.

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate defaults for gjcourt repos. Extend with: github>gjcourt/homelab//renovate/default — see renovate/README.md for the rationale behind each rule.",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions bumps into a single PR per cycle instead of one per action.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Language/interpreter runtimes get their own branch and are never grouped or auto-merged. Renovate classifies a setup-python 3.12->3.14 bump as updateType 'minor' (Python's 3.x IS the minor field), so without this it rides inside the routine github-actions group. Interpreter bumps are breaking in practice regardless of what semver says. This rule must stay AFTER the grouping rule above: package rules apply in order and the last match wins.",
+      "matchDepNames": ["python", "go", "golang", "node", "java", "ruby", "dotnet-sdk"],
+      "groupName": null,
+      "additionalBranchPrefix": "runtime-",
+      "separateMinorPatch": true,
+      "automerge": false,
+      "labels": ["dependencies", "runtime-upgrade"],
+      "commitMessageTopic": "{{depName}} runtime"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `renovate/default.json` — a shared Renovate preset for the `gjcourt/*` repos — plus `renovate/README.md` carrying the rationale.

**No consumer repo is changed by this PR.** The preset must exist on `master` before any repo can `extends` it; a repo pointing at a preset that 404s makes Renovate error for that repo.

## Why

Ten repos, ten `renovate.json` files. Audited today:

| Config | Repos |
| --- | --- |
| Bare `$schema` only | `golinks`, `llmux`, `Pingo`, `vitals`, `drift`, `python-nginx-signing` |
| No file at all | `soundbyte` |
| `config:recommended` | `tempo-interview` |
| `config:recommended` + labels + grouping | `toppingctl` |
| Substantive (k8s fileMatch + automerge) | `homelab` |

Every fix has to be made ten times. In practice it gets made once and forgotten — which is exactly how the `gomodTidy` gap survived.

## The consumer line

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>gjcourt/homelab//renovate/default"]
}
```

Applies to all ten. `tempo-interview` is **private** while `homelab` is public — a private repo extending a public preset needs no extra token scope, since the existing PAT already reads both. (The blocked direction is public→private, which is a deliberate Renovate security restriction and isn't what we're doing.)

## Why `.json`, not `.json5`

**The implicit `default` lookup resolves `.json` only.** Verified against Renovate's `fetchPreset` (`lib/config/presets/util.ts`, renovate 42.99.0): a preset whose filename is exactly `default` is fetched as `<path>/default.json`, with one deprecated fallback to `<path>/renovate.json`. `default.json5` is never attempted.

A `.json5` file *would* resolve, but only if every consumer spelled the extension out — `github>gjcourt/homelab//renovate/default.json5` — since the explicit-filename branch does accept `.json5`. That trades a clean, uniform `extends` line across ten repos for comments in one file. Not worth it.

JSON has no comments, so every rule carries a `description` and the reasoning lives in `renovate/README.md`.

## Validation

`renovate-config-validator --no-global` → `Validating renovate/default.json as repo config` → **success**.

The `--no-global` flag matters: the default mode validates against the *global* config schema and will happily pass a file that fails as repo config. Same trap that bit the local lint gates earlier today.

`yamllint`, `kustomize build`, and `make plans-index` all clean.

## Follow-up, not in this PR

**Six open PRs add `postUpdateOptions: ["gomodTidy"]` per-repo** — `drift#37`, `Pingo#44`, `vitals#64`, `llmux#23`, `golinks#67`, `soundbyte#36`. Once this lands they're redundant. Those branches are `chore/*`, not `renovate/*`, so they can be amended in place to use `extends` rather than closed and reopened — the PR number and its green CI carry forward.

**`homelab`'s own `renovate.json` has `automerge: true`** for `digest`/`pin`/`patch`/`minor`, which overlaps the Python automerge cron in `infra/controllers/renovate-automerge/`. Two independent automerge mechanisms with different classification logic and no awareness of each other. `packageRules` is a mergeable array so that rule survives adoption of this preset — but the overlap is worth resolving separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHWNeycrGmSHSSN6ek4KiA

