### PR TITLE
ci: add reusable Go CI workflow for the gjcourt Go repos

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -345,7 +345,14 @@ jobs:
 #              - run: |
 #                  r='${{ needs.go-ci.outputs.test }}'
 #                  echo "reusable Test job: $r"
-#                  [ "$r" = success ] || [ "$r" = skipped ]
+#                  [ "$r" = success ]
 #
 # Alias jobs cost a few seconds of runner time each and must use `if: always()`
 # so they still run (and fail) when the upstream job failed.
+#
+# Assert `success` ONLY -- do not also accept `skipped`. A required status check
+# is a branch-protection control; if the alias passes on `skipped`, then setting
+# `test: false` in a caller's `with:` block turns that required check green with
+# nothing having run. That converts a gate only a repo admin can change into one
+# any repo writer can switch off from a workflow file. To genuinely retire a job,
+# remove it from the required contexts (step 5), do not silently satisfy it.

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,351 @@
+# Reusable Go CI for the gjcourt Go repos.
+#
+# This workflow is `workflow_call`-only on purpose: homelab is a GitOps repo
+# with no Go code, so this file must never run standalone here. It exists so a
+# change like "bump go-arch-lint" is one line in one place instead of six PRs.
+#
+# Canonical job names (these become the `<caller-job> / <job>` check contexts):
+#   Build, Test, Format, Vet, Lint, Module tidy, and the arch job whose name is
+#   caller-supplied via `arch-job-name` (repos disagree: arch-guard / arch-lint /
+#   Architecture guard).
+#
+# Minimal usage in a consumer repo's .github/workflows/ci.yml:
+#
+#   jobs:
+#     go-ci:
+#       uses: gjcourt/homelab/.github/workflows/go-ci.yml@master
+#       with:
+#         arch-job-name: arch-lint
+#
+# Every job also publishes its result as a workflow output (build, test, format,
+# vet, lint, tidy, arch) so a consumer can keep its existing required status
+# check names with thin alias jobs and avoid a branch-protection edit. See the
+# "Alias jobs" section at the bottom of this file.
+
+name: Go CI
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Explicit Go version (e.g. "1.27"). Empty means use go-version-file.'
+        type: string
+        default: ''
+      go-version-file:
+        description: 'File to read the Go version from when go-version is empty.'
+        type: string
+        default: 'go.mod'
+      golangci-lint-version:
+        description: 'golangci-lint version passed to golangci/golangci-lint-action.'
+        type: string
+        default: 'v2.13.1'
+      go-arch-lint-version:
+        description: 'go-arch-lint version. v1.16.0 cannot read Go 1.27 export data.'
+        type: string
+        default: 'v1.18.0'
+      arch-check:
+        description: 'Run the architecture boundary check.'
+        type: boolean
+        default: true
+      arch-job-name:
+        description: 'Display name of the architecture job (varies per repo).'
+        type: string
+        default: 'Architecture guard'
+      build:
+        description: 'Run the Build job.'
+        type: boolean
+        default: true
+      test:
+        description: 'Run the Test job.'
+        type: boolean
+        default: true
+      format:
+        description: 'Run the Format job (gofmt -l).'
+        type: boolean
+        default: true
+      vet:
+        description: 'Run the Vet job.'
+        type: boolean
+        default: true
+      lint:
+        description: 'Run the Lint job (golangci-lint).'
+        type: boolean
+        default: true
+      tidy:
+        description: 'Run the Module tidy job.'
+        type: boolean
+        default: true
+      build-command:
+        description: 'Command run by the Build job.'
+        type: string
+        default: 'go build ./...'
+      test-command:
+        description: 'Command run by the Test job.'
+        type: string
+        default: 'go test -race -count=1 -timeout 120s ./...'
+      lint-args:
+        description: 'Extra args for golangci-lint.'
+        type: string
+        default: '--timeout=5m'
+      apt-packages:
+        description: 'Space-separated apt packages to install before every job (e.g. libasound2-dev).'
+        type: string
+        default: ''
+      cache:
+        description: 'Enable the setup-go module/build cache.'
+        type: boolean
+        default: true
+      runs-on:
+        description: 'Runner label.'
+        type: string
+        default: 'ubuntu-latest'
+      working-directory:
+        description: 'Directory holding the Go module.'
+        type: string
+        default: '.'
+    outputs:
+      build:
+        description: 'Result of the Build job (success/failure/skipped/cancelled).'
+        value: ${{ jobs.build.result }}
+      test:
+        description: 'Result of the Test job.'
+        value: ${{ jobs.test.result }}
+      format:
+        description: 'Result of the Format job.'
+        value: ${{ jobs.format.result }}
+      vet:
+        description: 'Result of the Vet job.'
+        value: ${{ jobs.vet.result }}
+      lint:
+        description: 'Result of the Lint job.'
+        value: ${{ jobs.lint.result }}
+      tidy:
+        description: 'Result of the Module tidy job.'
+        value: ${{ jobs.tidy.result }}
+      arch:
+        description: 'Result of the architecture job.'
+        value: ${{ jobs.arch.result }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    if: inputs.build
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt packages
+        if: inputs.apt-packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: Build
+        run: ${{ inputs.build-command }}
+
+  test:
+    name: Test
+    if: inputs.test
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt packages
+        if: inputs.apt-packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: Test
+        run: ${{ inputs.test-command }}
+
+  format:
+    name: Format
+    if: inputs.format
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt'd:"
+            echo "$unformatted"
+            echo ""
+            gofmt -d .
+            echo "Run 'go fmt ./...' to fix."
+            exit 1
+          fi
+
+  vet:
+    name: Vet
+    if: inputs.vet
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt packages
+        if: inputs.apt-packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: go vet
+        run: go vet ./...
+
+  lint:
+    name: Lint
+    if: inputs.lint
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt packages
+        if: inputs.apt-packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          args: ${{ inputs.lint-args }}
+          working-directory: ${{ inputs.working-directory }}
+
+  tidy:
+    name: Module tidy
+    if: inputs.tidy
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          if ! git diff --quiet -- go.mod; then
+            echo "go.mod out of sync - run 'go mod tidy'"
+            git diff -- go.mod
+            exit 1
+          fi
+          if [ -f go.sum ] && ! git diff --quiet -- go.sum; then
+            echo "go.sum out of sync - run 'go mod tidy'"
+            git diff -- go.sum
+            exit 1
+          fi
+
+  arch:
+    name: ${{ inputs.arch-job-name }}
+    if: inputs.arch-check
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt packages
+        if: inputs.apt-packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version == '' && format('{0}/{1}', inputs.working-directory, inputs.go-version-file) || '' }}
+          cache: ${{ inputs.cache }}
+          cache-dependency-path: |
+            ${{ inputs.working-directory }}/go.sum
+            ${{ inputs.working-directory }}/go.mod
+      - name: Install go-arch-lint
+        run: go install github.com/fe3dback/go-arch-lint@${{ inputs.go-arch-lint-version }}
+      - name: Add GOPATH bin to PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Check hexagonal boundaries
+        run: go-arch-lint check
+
+# ── Alias jobs ────────────────────────────────────────────────────────────────
+#
+# A reusable workflow's checks are always reported as `<caller-job> / <job>`
+# (e.g. `go-ci / Test`). There is no way to emit a single-segment context name
+# from a called workflow, so a repo whose required status checks are bare names
+# (`test`, `lint`, `arch-guard`, `Format Check`, ...) has two choices:
+#
+#   1. Update branch protection to the new `go-ci / <name>` contexts, or
+#   2. Keep the old names alive with alias jobs that assert this workflow's
+#      outputs. No protection edit needed:
+#
+#        jobs:
+#          go-ci:
+#            uses: gjcourt/homelab/.github/workflows/go-ci.yml@master
+#            with:
+#              arch-job-name: arch-guard
+#          test:
+#            name: test
+#            needs: go-ci
+#            if: always()
+#            runs-on: ubuntu-latest
+#            steps:
+#              - run: |
+#                  r='${{ needs.go-ci.outputs.test }}'
+#                  echo "reusable Test job: $r"
+#                  [ "$r" = success ] || [ "$r" = skipped ]
+#
+# Alias jobs cost a few seconds of runner time each and must use `if: always()`
+# so they still run (and fail) when the upstream job failed.


### PR DESCRIPTION
## What

Adds `.github/workflows/go-ci.yml`: a **reusable** (`workflow_call`-only) Go CI workflow for the six gjcourt Go repos — golinks, vitals, soundbyte, Pingo, llmux, drift. Today each carries a hand-maintained `ci.yml` with the same shape; bumping `go-arch-lint` or `golangci-lint` is six near-identical PRs. After migration it is one line here.

homelab already hosts the shared Renovate preset at `renovate/default.json`, so it is the config control plane by convention.

**Phase 1 only.** No consumer repo is touched in this PR. Migration lands separately, after this is on `master`.

### Why it can't run standalone here

`on:` is `workflow_call` and nothing else. homelab is a GitOps repo with no Go code — this file must never fire on push or PR here. The four existing gates (`yaml-lint`, `validate-kustomize`, `plans-index`, `validate-homeassistant-yaml`) are untouched; the new file is only additional YAML under `.github/workflows/`, which `yamllint` covers and passes.

## Shape

Derived from the six existing workflows, not invented. Seven jobs, canonical names:

`Build` · `Test` · `Format` · `Vet` · `Lint` · `Module tidy` · *arch* (name is caller-supplied)

Each is individually switchable, so a repo that today has only lint/test/arch can adopt without inheriting gates it isn't ready for. llmux and drift keep their extra jobs in their own `ci.yml` alongside the caller job.

## `inputs` surface

| input | type | default | notes |
|---|---|---|---|
| `go-version` | string | `''` | explicit version; empty means use `go-version-file` |
| `go-version-file` | string | `go.mod` | |
| `golangci-lint-version` | string | `v2.13.1` | |
| `go-arch-lint-version` | string | `v1.18.0` | v1.16.0 cannot read Go 1.27 export data — three repos are still pinned to it |
| `arch-check` | boolean | `true` | |
| `arch-job-name` | string | `Architecture guard` | repos disagree: `arch-guard` / `arch-lint` / `Architecture guard` |
| `build` `test` `format` `vet` `lint` `tidy` | boolean | `true` | per-job on/off |
| `build-command` | string | `go build ./...` | |
| `test-command` | string | `go test -race -count=1 -timeout 120s ./...` | |
| `lint-args` | string | `--timeout=5m` | |
| `apt-packages` | string | `''` | soundbyte needs `libasound2-dev` |
| `cache` | boolean | `true` | |
| `runs-on` | string | `ubuntu-latest` | |
| `working-directory` | string | `.` | |

Cache key globs both `go.sum` and `go.mod` so llmux (no `go.sum`) doesn't trip `setup-go`'s "paths were not resolved" error.

### Outputs

Every job publishes its result — `build`, `test`, `format`, `vet`, `lint`, `tidy`, `arch`. These exist specifically to solve the job-name problem below.

## The hard constraint: job names vs. required status checks

A reusable workflow's checks are always reported as `<caller-job> / <called-job>` — e.g. `go-ci / Test`. **There is no way to emit a single-segment context name from a called workflow.** Every one of the six repos has required contexts that are bare names, and they differ per repo:

| repo | default branch | required contexts |
|---|---|---|
| golinks | master | `test`, `lint`, `arch-guard` |
| vitals | master | `lint`, `test`, `arch-lint` |
| soundbyte | main | `lint`, `test`, `arch-lint` |
| Pingo | main | `Test`, `Format Check`, `Lint` |
| llmux | master | `Build`, `Format`, `Lint`, `Module tidy`, `Test`, `Vet` |
| drift | main | `Build`, `Test`, `Format`, `Vet`, `Lint`, `Module tidy`, `Architecture guard` |

All six have `strict: true` (branch must be up to date). A required context that never reports is a permanently unmergeable branch, so ordering matters.

## Migration path — no lockout window

Per repo, in this order. **No branch-protection change is required at all** if you stop after step 3.

1. **Land this PR** on homelab `master`. Nothing in any consumer repo changes; nothing can break yet.
2. **Open a consumer PR** that replaces the inline jobs with (a) one `go-ci:` caller job and (b) **alias jobs whose `name:` is exactly each existing required context**, asserting the corresponding output:

   ```yaml
   jobs:
     go-ci:
       uses: gjcourt/homelab/.github/workflows/go-ci.yml@master
       with:
         arch-job-name: arch-guard
         test-command: make test
     test:
       name: test
       needs: go-ci
       if: always()
       runs-on: ubuntu-latest
       steps:
         - run: |
             r='${{ needs.go-ci.outputs.test }}'
             [ "$r" = success ] || [ "$r" = skipped ]
   ```

   Every required context keeps reporting for the whole life of this PR, so it is mergeable under the existing protection with no protection edit and no window in which a required check is missing.
3. **Merge.** The repo is now on the shared workflow with its original contexts intact. This is a valid steady state — stopping here is fine, and it's the recommended stopping point for the first pass.
4. *(Optional cleanup, to drop the aliases.)* Let the new `go-ci / *` contexts report at least once on a live PR so GitHub has seen the names and you can confirm they are green.
5. With that PR still open and its `go-ci / *` checks green, **edit protection once** to swap the required list from the old bare names to the `go-ci / *` names. At no instant is a required context one that cannot report.
6. **Merge a follow-up PR deleting the alias jobs.** Safe because the required list no longer references them.

The two invariants: never delete a job while its name is still in the required list, and never add a name to the required list before it has reported at least once. Rollback from step 5 is a one-call revert of the protection payload — the aliases still exist until step 6.

**No protection changes are made by this PR.**

### Per-repo notes

- **llmux, drift** — job names already match the canonical set exactly; only the `go-ci / ` prefix differs. Cheapest migration. llmux sets `arch-check: false`, `build-command: go build .`.
- **golinks, vitals, soundbyte** — lowercase `test`/`lint` plus a repo-specific arch name; `arch-job-name` covers the arch case, the other two need aliases (or the step-5 swap). soundbyte adds `apt-packages: libasound2-dev`. All three set `test-command: make test`. golinks and soundbyte also get a free `go-arch-lint` bump v1.16.0 → v1.18.0; drift too.
- **Pingo** — the awkward one, but not blocked. Two wrinkles: its required `Format Check` cannot be produced by the reusable workflow (the job is named `Format`), and its arch check is currently *nested inside* the `Lint` job, so splitting arch into its own job means arch failures would stop failing the required `Lint` context. Both are handled by step 2 aliases: a `Format Check` alias on `outputs.format`, and a `Lint` alias asserting **both** `outputs.lint` and `outputs.arch`. Without aliases, Pingo is the one repo that would need a protection edit to avoid silently losing its arch gate.

No repo is impossible to migrate without a protection edit.

## Validation

- `yamllint -c .yamllint -s .` — clean, whole repo.
- `actionlint` — clean, with one known false positive: it reports `property "result" is not defined` for `jobs.<id>.result` in `on.workflow_call.outputs`. That property is documented in GitHub's `jobs` context (available in reusable workflows, values `success`/`failure`/`cancelled`/`skipped`); actionlint models the context as `{outputs: {}}` only.
