### PR TITLE
feat(openwebui): gate chat.burntbytes.com behind Authelia SSO

### DIFF
--- a/apps/base/openwebui/configmap.yaml
+++ b/apps/base/openwebui/configmap.yaml
@@ -10,9 +10,39 @@ data:
   OPENAI_API_BASE_URL: "http://10.42.2.10:8000/v1"
   # llama.cpp does not validate API keys; field is required by Open WebUI
   OPENAI_API_KEY: "not-needed"
-  # Use Open WebUI's built-in auth (Authelia SSO is redundant with its own login)
-  WEBUI_AUTH: "True"
   WEBUI_NAME: "Chat"
   DEFAULT_MODELS: "Qwen3.6-35B-A3B"
   # Store all data under the mounted PVC
   DATA_DIR: "/app/backend/data"
+
+  # --- Authentication hardening (defence in depth) ---
+  # chat.burntbytes.com is gated at the gateway by Authelia ext_authz
+  # (one_factor — see apps/production/authelia/configuration.yaml and
+  # docs/architecture/gateway-auth.md). Everything below is the second layer,
+  # so a request that somehow reaches the pod still cannot mint an account.
+  # Names verified against backend/open_webui/{env,config}.py at the upstream
+  # v0.9.5 tag, which is the digest pinned in deployment.yaml.
+
+  # Most of the vars below are upstream "PersistentConfig" values: they are read
+  # from the environment on FIRST launch only, then stored in the DB on the PVC
+  # and served from there on every later boot. The PVC already holds a database
+  # from the pre-2026-05 run, so without this the hardening below would be
+  # silently ignored. False makes the environment authoritative on every boot.
+  # Trade-off: settings changed in the Admin UI that also appear here are reset
+  # on restart — intentional, this file is the source of truth.
+  ENABLE_PERSISTENT_CONFIG: "False"
+
+  # Require a login; do not run in open single-user mode.
+  WEBUI_AUTH: "True"
+  # No self-registration. A visitor who reaches the login page cannot create an
+  # account; accounts are provisioned by an admin.
+  ENABLE_SIGNUP: "False"
+  # Same for the OAuth path (already the upstream default; pinned explicitly so
+  # it cannot drift or be flipped from the Admin UI).
+  ENABLE_OAUTH_SIGNUP: "False"
+  # Any account that does get created lands with no access until an admin
+  # promotes it (upstream default; pinned explicitly).
+  DEFAULT_USER_ROLE: "pending"
+  # Non-admin users cannot mint Open WebUI API keys, which would otherwise be a
+  # gateway-bypassing credential for the backend (upstream default; pinned).
+  ENABLE_API_KEYS: "False"

--- a/apps/base/openwebui/configmap.yaml
+++ b/apps/base/openwebui/configmap.yaml
@@ -24,6 +24,14 @@ data:
   # v0.9.5 tag, which is the digest pinned in deployment.yaml.
 
   # Most of the vars below are upstream "PersistentConfig" values: they are read
+
+  # Blast radius is wider than the auth vars: this bypasses the entire
+
+  # PERSISTENT_CONFIG_REGISTRY, so EVERY Admin-UI setting from the previous run
+
+  # (model lists, RAG config, prompt templates, WEBUI_URL) reverts to its
+
+  # upstream default on boot -- not just the five settings below.
   # from the environment on FIRST launch only, then stored in the DB on the PVC
   # and served from there on every later boot. The PVC already holds a database
   # from the pre-2026-05 run, so without this the hardening below would be

--- a/apps/production/authelia/configuration.yaml
+++ b/apps/production/authelia/configuration.yaml
@@ -24,6 +24,10 @@ access_control:
       policy: one_factor
     - domain: "finance.burntbytes.com"
       policy: one_factor
+    # Open WebUI (chat.burntbytes.com) fronts a funded Anthropic API key, so the
+    # gateway must authenticate every request before it reaches the pod.
+    - domain: "chat.burntbytes.com"
+      policy: one_factor
     - domain: "auth.burntbytes.com"
       policy: bypass
       resources:

--- a/apps/production/openwebui/httproute.yaml
+++ b/apps/production/openwebui/httproute.yaml
@@ -1,3 +1,9 @@
+# LAN-only front door: https://chat.burntbytes.com via the Cilium gateway.
+# NOT published through the Cloudflare tunnel (see
+# apps/production/cloudflare-tunnel/config.yaml) — LAN reachable only.
+# Authelia ext_authz on the gateway gates every route; the one_factor rule for
+# this host lives in apps/production/authelia/configuration.yaml. See
+# docs/architecture/gateway-auth.md.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/apps/staging/authelia/configuration.yaml
+++ b/apps/staging/authelia/configuration.yaml
@@ -16,6 +16,8 @@ access_control:
   rules:
     - domain: "music.stage.burntbytes.com"
       policy: one_factor
+    - domain: "chat.stage.burntbytes.com"
+      policy: one_factor
     - domain: "auth.stage.burntbytes.com"
       policy: bypass
       resources:

--- a/apps/staging/openwebui/httproute.yaml
+++ b/apps/staging/openwebui/httproute.yaml
@@ -1,3 +1,7 @@
+# Staging front door: https://chat.stage.burntbytes.com via the Cilium gateway.
+# Authelia ext_authz on the staging gateway gates every route; the one_factor
+# rule for this host lives in apps/staging/authelia/configuration.yaml. See
+# docs/architecture/gateway-auth.md.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:


### PR DESCRIPTION
## Why

`chat.burntbytes.com` routed straight to the Open WebUI pod with **no gateway auth**, and the app's own config allowed **open self-registration**. Open WebUI is about to be restarted with a funded Anthropic API key behind it, so anyone who can reach the host could sign up and spend the credits. Auth lands before the key does.

## Gateway layer — the house pattern, unchanged

Per `docs/architecture/gateway-auth.md`, the global `CiliumClusterwideEnvoyConfig` `ext_authz` filter already forwards **every** request through the gateway to Authelia, whose `default_policy` is `bypass`. Protecting a host therefore means one thing: adding a `one_factor` rule to `access_control`. There is no per-route filter, no `ExtensionRef`, and the doc explains why not.

Copied verbatim from the **ladder** precedent — `apps/base/ladder/httproute.yaml` plus its rule in `apps/production/authelia/configuration.yaml`. `finance-dashboard` is wired the same way. The HTTPRoutes here are unchanged apart from a header comment pointing at the rule, matching how those two document theirs.

```yaml
- domain: "chat.burntbytes.com"
  policy: one_factor
```

**Staging is covered.** Staging runs its own Authelia and its own CEC, and `music.stage.burntbytes.com` is already protected there, so the pattern does extend to staging. `chat.stage.burntbytes.com` gets the equivalent rule in `apps/staging/authelia/configuration.yaml`.

## App layer — defence in depth

Second layer, so a request that somehow reaches the pod still cannot mint an account. Names verified against `backend/open_webui/env.py` and `backend/open_webui/config.py` at the upstream **`v0.9.5` tag** — the exact digest pinned in `deployment.yaml` — not from memory.

| Var | Value | Effect |
|---|---|---|
| `ENABLE_SIGNUP` | `False` | No self-registration |
| `ENABLE_OAUTH_SIGNUP` | `False` | Same for the OAuth path (also the upstream default; pinned so it can't drift) |
| `DEFAULT_USER_ROLE` | `pending` | Any account created has no access until an admin promotes it |
| `ENABLE_API_KEYS` | `False` | No user-minted API keys, which would be a gateway-bypassing credential |
| `ENABLE_PERSISTENT_CONFIG` | `False` | See below |
| `WEBUI_AUTH` | `True` | Unchanged; kept explicit |

**`ENABLE_PERSISTENT_CONFIG=False` is load-bearing, not decoration.** The other four are upstream `PersistentConfig` values: read from the environment on *first launch only*, then stored in the SQLite DB on the PVC and served from there on every later boot. That PVC already holds a database from the pre-2026-05 run, so **without this flag the hardening above would be silently ignored** and the config would look correct while doing nothing. `False` makes this file authoritative on every boot.

Trade-off worth knowing: settings changed in the Admin UI that also appear in the ConfigMap are now reset on restart. That is intentional — the repo is the source of truth.

Also removed the stale comment claiming Authelia is redundant with Open WebUI's own login. They're layers, not alternatives.

## Exposure note (corrects a premise)

`chat.burntbytes.com` is **not** published through the Cloudflare tunnel — it is absent from `apps/production/cloudflare-tunnel/config.yaml`, so the gateway serves it on the LAN only. The host is reachable from the home network, not the open internet. That lowers the blast radius but doesn't change the fix: a funded API key behind an unauthenticated endpoint is still wrong, and LAN-only is a property of the tunnel config that a future PR could flip in one line.

## Deliberately left out

- **`replicas` stays `0`**, image unchanged, no backend/API-key config. Follow-up PRs.
- **No SOPS file touched.** Nothing here needs a secret; when the Anthropic key lands it will need one, and that is operator-only.
- **`ENABLE_LOGIN_FORM`** — verified to exist, deliberately not set. `False` hides the local login form to force SSO, but Open WebUI has no OIDC client configured here, so setting it would lock everyone out.
- **`WEBUI_AUTH_TRUSTED_EMAIL_HEADER`** and friends — verified to exist. This would turn Authelia's `Remote-Email` into true header-injected SSO with auto-provisioning, which is genuinely attractive. Not done here because it only works safely if the proxy is guaranteed to **strip** a client-supplied `Remote-*` header before injecting its own, and the current CEC's `allowed_upstream_headers` doesn't establish that. Forgeable headers on an auto-provisioning path is a worse failure than the one being fixed. Separate PR, with the CEC audited alongside it.
- **`ENABLE_PASSWORD_AUTH`, `ENABLE_API_KEYS_ENDPOINT_RESTRICTIONS`, `USER_PERMISSIONS_FEATURES_API_KEYS`** — these appear on the (unversioned) docs hardening page but could **not** be confirmed in `config.py`/`env.py` at the `v0.9.5` tag. Left out rather than guessed.

## Known caveat, flagged not fixed

`infra/configs/gateway/cilium-envoy-config-production.yaml` carries a standing comment that HTTP-filter injection into Cilium 1.15+ Gateway API listeners is broken (cilium/cilium#32793), with a TODO. If that is still true in the running cluster, the `one_factor` rule is correct-in-Git but may not be enforced at runtime. **This PR follows the documented pattern rather than inventing a second one**, but the gateway filter should be confirmed live — `curl -sI https://chat.burntbytes.com` should return a 302 to `auth.burntbytes.com` — before the funded key is attached. If it doesn't redirect, the app-layer vars in this PR are the only thing standing between a visitor and the credits, which is why they're here and not deferred.

## Validation

- `kustomize build` passes: `apps/production/openwebui`, `apps/staging/openwebui`, `apps/production/authelia`, `apps/staging/authelia`
- `yamllint -c .yamllint --strict` clean on every changed file
- Rendered output confirms `replicas: 0` and the image digest are untouched
- Note: `envFrom` has no content hash, so the ConfigMap change won't itself trigger a rollout — irrelevant at `replicas: 0`, the scale-up PR picks it up.
